### PR TITLE
feat: implement scode ACP stdio server

### DIFF
--- a/rust/crates/runtime/src/acp_server.rs
+++ b/rust/crates/runtime/src/acp_server.rs
@@ -1,0 +1,739 @@
+//! Minimal Agent Client Protocol (ACP) JSON-RPC server support.
+//!
+//! This module owns the ACP wire protocol and stdio framing. The actual agent
+//! runtime is supplied by the CLI crate so it can reuse the normal provider,
+//! tool, plugin, config, and MCP construction path without adding those
+//! dependencies to `runtime`.
+
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufRead, AsyncWrite, BufReader};
+
+use crate::conversation::RuntimeObserver;
+use crate::jsonrpc_transport::{read_msg, write_msg};
+
+const JSONRPC_VERSION: &str = "2.0";
+const DEFAULT_PROTOCOL_VERSION: i64 = 1;
+const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+const INTERNAL_ERROR: i64 = -32603;
+
+/// Configuration for the ACP JSON-RPC server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpServerOptions {
+    agent_version: String,
+    default_protocol_version: i64,
+}
+
+impl AcpServerOptions {
+    #[must_use]
+    pub fn new(agent_version: impl Into<String>) -> Self {
+        Self {
+            agent_version: agent_version.into(),
+            default_protocol_version: DEFAULT_PROTOCOL_VERSION,
+        }
+    }
+
+    #[must_use]
+    pub fn with_default_protocol_version(mut self, version: i64) -> Self {
+        self.default_protocol_version = version;
+        self
+    }
+}
+
+/// Agent-side operations invoked by the protocol server.
+pub trait AcpAgent {
+    fn new_session(&mut self, cwd: Option<PathBuf>) -> Result<String, AcpError>;
+
+    fn run_prompt(
+        &mut self,
+        session_id: &str,
+        prompt: String,
+        observer: &mut AcpSessionUpdateObserver<'_>,
+    ) -> Result<(), AcpError>;
+}
+
+/// Error type returned by ACP agent implementations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcpError {
+    InvalidParams(String),
+    Internal(String),
+}
+
+impl AcpError {
+    #[must_use]
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::InvalidParams(message.into())
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+
+    fn code(&self) -> i64 {
+        match self {
+            Self::InvalidParams(_) => INVALID_PARAMS,
+            Self::Internal(_) => INTERNAL_ERROR,
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::InvalidParams(message) | Self::Internal(message) => message,
+        }
+    }
+}
+
+impl Display for AcpError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl std::error::Error for AcpError {}
+
+/// Fatal server errors that prevent further ACP processing.
+#[derive(Debug)]
+pub enum AcpServerError {
+    Io(io::Error),
+    Json(serde_json::Error),
+}
+
+impl Display for AcpServerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::Json(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for AcpServerError {}
+
+impl From<io::Error> for AcpServerError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for AcpServerError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
+    }
+}
+
+/// Runtime observer that converts model/tool events to ACP session/update notifications.
+pub struct AcpSessionUpdateObserver<'a> {
+    session_id: String,
+    sink: &'a mut dyn AcpMessageSink,
+    write_error: Option<io::Error>,
+}
+
+impl<'a> AcpSessionUpdateObserver<'a> {
+    fn new(session_id: String, sink: &'a mut dyn AcpMessageSink) -> Self {
+        Self {
+            session_id,
+            sink,
+            write_error: None,
+        }
+    }
+
+    fn finish(self) -> io::Result<()> {
+        match self.write_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    fn notify_update(&mut self, update: Value) {
+        if self.write_error.is_some() {
+            return;
+        }
+        let notification = json!({
+            "jsonrpc": JSONRPC_VERSION,
+            "method": "session/update",
+            "params": {
+                "sessionId": self.session_id,
+                "update": update,
+            },
+        });
+        if let Err(error) = self.sink.send_value(&notification) {
+            self.write_error = Some(error);
+        }
+    }
+}
+
+impl RuntimeObserver for AcpSessionUpdateObserver<'_> {
+    fn on_text_delta(&mut self, delta: &str) {
+        self.notify_update(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {
+                "type": "text",
+                "text": delta,
+            },
+        }));
+    }
+
+    fn on_tool_use(&mut self, id: &str, name: &str, input: &str) {
+        self.notify_update(json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": id,
+            "title": name,
+            "kind": "other",
+            "status": "in_progress",
+            "rawInput": parse_json_or_string(input),
+        }));
+    }
+
+    fn on_tool_result(
+        &mut self,
+        tool_use_id: &str,
+        _tool_name: &str,
+        output: &str,
+        is_error: bool,
+    ) {
+        self.notify_update(json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": tool_use_id,
+            "status": if is_error { "failed" } else { "completed" },
+            "rawOutput": parse_json_or_string(output),
+            "content": [{
+                "type": "content",
+                "content": {
+                    "type": "text",
+                    "text": output,
+                },
+            }],
+        }));
+    }
+}
+
+trait AcpMessageSink {
+    fn send_value(&mut self, value: &Value) -> io::Result<()>;
+}
+
+struct AcpIoSink<'a, W> {
+    runtime: &'a tokio::runtime::Runtime,
+    writer: &'a mut W,
+}
+
+impl<W> AcpMessageSink for AcpIoSink<'_, W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn send_value(&mut self, value: &Value) -> io::Result<()> {
+        let payload = serde_json::to_vec(value).map_err(io::Error::other)?;
+        self.runtime
+            .block_on(write_msg(&mut *self.writer, &payload))
+    }
+}
+
+/// Run the ACP server on process stdin/stdout.
+///
+/// All stdout writes go through JSON-RPC framing. Diagnostics should be
+/// propagated as errors and rendered by callers on stderr.
+pub fn run_acp_stdio_server<A>(agent: A, options: AcpServerOptions) -> Result<(), AcpServerError>
+where
+    A: AcpAgent,
+{
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    run_acp_server_with_io(agent, BufReader::new(stdin), stdout, options)
+}
+
+/// Run the ACP server over supplied framed IO streams.
+pub fn run_acp_server_with_io<A, R, W>(
+    mut agent: A,
+    mut reader: R,
+    mut writer: W,
+    options: AcpServerOptions,
+) -> Result<(), AcpServerError>
+where
+    A: AcpAgent,
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let runtime = tokio::runtime::Runtime::new()?;
+    let mut sink = AcpIoSink {
+        runtime: &runtime,
+        writer: &mut writer,
+    };
+
+    loop {
+        let Some(payload) = runtime.block_on(read_msg(&mut reader))? else {
+            break;
+        };
+        handle_payload(&mut agent, &options, &payload, &mut sink)?;
+    }
+    Ok(())
+}
+
+fn handle_payload<A>(
+    agent: &mut A,
+    options: &AcpServerOptions,
+    payload: &[u8],
+    sink: &mut dyn AcpMessageSink,
+) -> io::Result<()>
+where
+    A: AcpAgent,
+{
+    match serde_json::from_slice::<Value>(payload) {
+        Ok(value) => handle_value(agent, options, value, sink),
+        Err(error) => sink.send_value(&error_response(
+            Value::Null,
+            PARSE_ERROR,
+            format!("parse error: {error}"),
+        )),
+    }
+}
+
+fn handle_value<A>(
+    agent: &mut A,
+    options: &AcpServerOptions,
+    value: Value,
+    sink: &mut dyn AcpMessageSink,
+) -> io::Result<()>
+where
+    A: AcpAgent,
+{
+    let Some(object) = value.as_object() else {
+        return sink.send_value(&error_response(
+            Value::Null,
+            INVALID_REQUEST,
+            "JSON-RPC request must be an object",
+        ));
+    };
+    let id = object.get("id").cloned();
+    let is_notification = id.is_none();
+    let response_id = id.unwrap_or(Value::Null);
+
+    let Some(method) = object.get("method").and_then(Value::as_str) else {
+        if is_notification {
+            return Ok(());
+        }
+        return sink.send_value(&error_response(
+            response_id,
+            INVALID_REQUEST,
+            "JSON-RPC request method must be a string",
+        ));
+    };
+
+    let params = object.get("params");
+    let result = match method {
+        "initialize" => handle_initialize(params, options),
+        "session/new" => handle_session_new(params, agent),
+        "session/prompt" => handle_session_prompt(params, agent, sink),
+        _ => {
+            if is_notification {
+                return Ok(());
+            }
+            Err(AcpError::InvalidParams("__method_not_found__".to_string()))
+        }
+    };
+
+    if is_notification {
+        return Ok(());
+    }
+
+    match result {
+        Ok(result) => sink.send_value(&success_response(response_id, result)),
+        Err(AcpError::InvalidParams(message)) if message == "__method_not_found__" => sink
+            .send_value(&error_response(
+                response_id,
+                METHOD_NOT_FOUND,
+                format!("method not found: {method}"),
+            )),
+        Err(error) => sink.send_value(&error_response(
+            response_id,
+            error.code(),
+            error.message().to_string(),
+        )),
+    }
+}
+
+fn handle_initialize(
+    params: Option<&Value>,
+    options: &AcpServerOptions,
+) -> Result<Value, AcpError> {
+    if params.is_some_and(|value| !value.is_object()) {
+        return Err(AcpError::invalid_params(
+            "initialize params must be an object",
+        ));
+    }
+    let protocol_version = match params.and_then(|value| value.get("protocolVersion")) {
+        Some(value) => value
+            .as_i64()
+            .ok_or_else(|| AcpError::invalid_params("params.protocolVersion must be numeric"))?,
+        None => options.default_protocol_version,
+    };
+
+    Ok(json!({
+        "protocolVersion": protocol_version,
+        "agentInfo": {
+            "name": "scode",
+            "version": options.agent_version,
+        },
+        "agentCapabilities": {
+            "loadSession": false,
+            "promptCapabilities": {
+                "image": false,
+                "audio": false,
+                "embeddedContext": false,
+            },
+            "mcpCapabilities": {
+                "http": false,
+                "sse": false,
+            },
+            "sessionCapabilities": {},
+        },
+        "authMethods": [],
+    }))
+}
+
+fn handle_session_new<A>(params: Option<&Value>, agent: &mut A) -> Result<Value, AcpError>
+where
+    A: AcpAgent,
+{
+    if params.is_some_and(|value| !value.is_object()) {
+        return Err(AcpError::invalid_params(
+            "session/new params must be an object",
+        ));
+    }
+    let cwd = match params.and_then(|value| value.get("cwd")) {
+        Some(value) => {
+            let raw = value
+                .as_str()
+                .ok_or_else(|| AcpError::invalid_params("params.cwd must be a string"))?;
+            let path = PathBuf::from(raw);
+            if !path.is_absolute() {
+                return Err(AcpError::invalid_params(
+                    "params.cwd must be an absolute path",
+                ));
+            }
+            Some(path)
+        }
+        None => None,
+    };
+
+    let session_id = agent.new_session(cwd)?;
+    Ok(json!({ "sessionId": session_id }))
+}
+
+fn handle_session_prompt<A>(
+    params: Option<&Value>,
+    agent: &mut A,
+    sink: &mut dyn AcpMessageSink,
+) -> Result<Value, AcpError>
+where
+    A: AcpAgent,
+{
+    let params = params
+        .and_then(Value::as_object)
+        .ok_or_else(|| AcpError::invalid_params("session/prompt params must be an object"))?;
+    let session_id = params
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AcpError::invalid_params("params.sessionId must be a non-empty string"))?;
+    let prompt = extract_prompt_text(params.get("prompt"))?;
+
+    let mut observer = AcpSessionUpdateObserver::new(session_id.to_string(), sink);
+    let result = agent.run_prompt(session_id, prompt, &mut observer);
+    observer
+        .finish()
+        .map_err(|error| AcpError::internal(error.to_string()))?;
+    result?;
+
+    Ok(json!({ "stopReason": "end_turn" }))
+}
+
+fn extract_prompt_text(prompt: Option<&Value>) -> Result<String, AcpError> {
+    let prompt = prompt.ok_or_else(|| AcpError::invalid_params("params.prompt is required"))?;
+    let content = prompt
+        .as_object()
+        .and_then(|object| object.get("content"))
+        .or_else(|| prompt.as_array().map(|_| prompt))
+        .ok_or_else(|| AcpError::invalid_params("params.prompt.content must be an array"))?;
+    let blocks = content
+        .as_array()
+        .ok_or_else(|| AcpError::invalid_params("params.prompt.content must be an array"))?;
+
+    let text = blocks
+        .iter()
+        .filter_map(extract_text_block)
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.trim().is_empty() {
+        return Err(AcpError::invalid_params(
+            "params.prompt must include at least one text content block",
+        ));
+    }
+    Ok(text)
+}
+
+fn extract_text_block(block: &Value) -> Option<String> {
+    let object = block.as_object()?;
+    match object.get("type").and_then(Value::as_str) {
+        Some("text") => object
+            .get("text")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(ToOwned::to_owned),
+        Some("resource_link") => None,
+        _ => None,
+    }
+}
+
+fn success_response(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": JSONRPC_VERSION,
+        "id": id,
+        "result": result,
+    })
+}
+
+fn error_response(id: Value, code: i64, message: impl Into<String>) -> Value {
+    json!({
+        "jsonrpc": JSONRPC_VERSION,
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message.into(),
+        },
+    })
+}
+
+fn parse_json_or_string(value: &str) -> Value {
+    serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct RecordingSink {
+        messages: Vec<Value>,
+    }
+
+    impl RecordingSink {
+        fn new() -> Self {
+            Self {
+                messages: Vec::new(),
+            }
+        }
+    }
+
+    impl AcpMessageSink for RecordingSink {
+        fn send_value(&mut self, value: &Value) -> io::Result<()> {
+            self.messages.push(value.clone());
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeAgent {
+        sessions: Vec<Option<PathBuf>>,
+        prompts: Vec<(String, String)>,
+    }
+
+    impl AcpAgent for FakeAgent {
+        fn new_session(&mut self, cwd: Option<PathBuf>) -> Result<String, AcpError> {
+            self.sessions.push(cwd);
+            Ok(format!("session-{}", self.sessions.len()))
+        }
+
+        fn run_prompt(
+            &mut self,
+            session_id: &str,
+            prompt: String,
+            observer: &mut AcpSessionUpdateObserver<'_>,
+        ) -> Result<(), AcpError> {
+            if session_id != "session-1" {
+                return Err(AcpError::invalid_params("unknown sessionId"));
+            }
+            self.prompts.push((session_id.to_string(), prompt));
+            observer.on_text_delta("hello ");
+            observer.on_tool_use("toolu_1", "read_file", r#"{"file_path":"Cargo.toml"}"#);
+            observer.on_tool_result("toolu_1", "read_file", r#"{"ok":true}"#, false);
+            Ok(())
+        }
+    }
+
+    fn request(id: i64, method: &str, params: Value) -> Value {
+        json!({
+            "jsonrpc": JSONRPC_VERSION,
+            "id": id,
+            "method": method,
+            "params": params,
+        })
+    }
+
+    #[test]
+    fn initialize_echoes_protocol_version_and_capabilities() {
+        let mut agent = FakeAgent::default();
+        let options = AcpServerOptions::new("1.2.3");
+        let mut sink = RecordingSink::new();
+
+        handle_value(
+            &mut agent,
+            &options,
+            request(1, "initialize", json!({ "protocolVersion": 42 })),
+            &mut sink,
+        )
+        .expect("initialize should handle");
+
+        let response = sink.messages.pop().expect("response");
+        assert_eq!(response["id"], 1);
+        assert_eq!(response["result"]["protocolVersion"], 42);
+        assert_eq!(response["result"]["agentInfo"]["name"], "scode");
+        assert_eq!(response["result"]["agentInfo"]["version"], "1.2.3");
+        assert_eq!(
+            response["result"]["agentCapabilities"]["loadSession"],
+            false
+        );
+        assert_eq!(
+            response["result"]["agentCapabilities"]["mcpCapabilities"]["http"],
+            false
+        );
+        assert_eq!(response["result"]["authMethods"], json!([]));
+    }
+
+    #[test]
+    fn notifications_do_not_receive_responses() {
+        let mut agent = FakeAgent::default();
+        let options = AcpServerOptions::new("1.2.3");
+        let mut sink = RecordingSink::new();
+
+        handle_value(
+            &mut agent,
+            &options,
+            json!({ "jsonrpc": JSONRPC_VERSION, "method": "unknown/notification" }),
+            &mut sink,
+        )
+        .expect("notification should handle");
+
+        assert!(sink.messages.is_empty());
+    }
+
+    #[test]
+    fn unknown_request_method_returns_method_not_found() {
+        let mut agent = FakeAgent::default();
+        let options = AcpServerOptions::new("1.2.3");
+        let mut sink = RecordingSink::new();
+
+        handle_value(
+            &mut agent,
+            &options,
+            request(7, "missing/method", json!({})),
+            &mut sink,
+        )
+        .expect("unknown method should handle");
+
+        let response = sink.messages.pop().expect("response");
+        assert_eq!(response["id"], 7);
+        assert_eq!(response["error"]["code"], METHOD_NOT_FOUND);
+    }
+
+    #[test]
+    fn session_new_rejects_relative_cwd() {
+        let mut agent = FakeAgent::default();
+        let options = AcpServerOptions::new("1.2.3");
+        let mut sink = RecordingSink::new();
+
+        handle_value(
+            &mut agent,
+            &options,
+            request(2, "session/new", json!({ "cwd": "relative/path" })),
+            &mut sink,
+        )
+        .expect("session/new should handle");
+
+        let response = sink.messages.pop().expect("response");
+        assert_eq!(response["error"]["code"], INVALID_PARAMS);
+        assert!(agent.sessions.is_empty());
+    }
+
+    #[test]
+    fn session_prompt_extracts_text_and_emits_updates_before_response() {
+        let mut agent = FakeAgent::default();
+        agent.sessions.push(None);
+        let options = AcpServerOptions::new("1.2.3");
+        let mut sink = RecordingSink::new();
+
+        handle_value(
+            &mut agent,
+            &options,
+            request(
+                3,
+                "session/prompt",
+                json!({
+                    "sessionId": "session-1",
+                    "prompt": {
+                        "content": [
+                            { "type": "text", "text": "First" },
+                            { "type": "resource_link", "uri": "file:///tmp/a.txt" },
+                            { "type": "text", "text": "Second" }
+                        ]
+                    }
+                }),
+            ),
+            &mut sink,
+        )
+        .expect("session/prompt should handle");
+
+        assert_eq!(
+            agent.prompts,
+            vec![("session-1".to_string(), "First\nSecond".to_string())]
+        );
+        assert_eq!(sink.messages.len(), 4);
+        assert_eq!(sink.messages[0]["method"], "session/update");
+        assert_eq!(
+            sink.messages[0]["params"]["update"]["sessionUpdate"],
+            "agent_message_chunk"
+        );
+        assert_eq!(
+            sink.messages[1]["params"]["update"]["rawInput"],
+            json!({ "file_path": "Cargo.toml" })
+        );
+        assert_eq!(
+            sink.messages[2]["params"]["update"]["rawOutput"],
+            json!({ "ok": true })
+        );
+        assert_eq!(sink.messages[3]["result"]["stopReason"], "end_turn");
+    }
+
+    #[test]
+    fn session_prompt_rejects_prompts_without_text_blocks() {
+        let mut agent = FakeAgent::default();
+        let options = AcpServerOptions::new("1.2.3");
+        let mut sink = RecordingSink::new();
+
+        handle_value(
+            &mut agent,
+            &options,
+            request(
+                4,
+                "session/prompt",
+                json!({
+                    "sessionId": "session-1",
+                    "prompt": {
+                        "content": [{ "type": "resource_link", "uri": "file:///tmp/a.txt" }]
+                    }
+                }),
+            ),
+            &mut sink,
+        )
+        .expect("session/prompt should handle");
+
+        let response = sink.messages.pop().expect("response");
+        assert_eq!(response["error"]["code"], INVALID_PARAMS);
+        assert!(agent.prompts.is_empty());
+    }
+}

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -4,6 +4,7 @@
 //! MCP plumbing, tool-facing file operations, and the core conversation loop
 //! that drives interactive and one-shot turns.
 
+pub mod acp_server;
 mod bash;
 pub mod bash_validation;
 mod bootstrap;
@@ -50,6 +51,10 @@ mod trust_resolver;
 mod usage;
 pub mod worker_boot;
 
+pub use acp_server::{
+    run_acp_server_with_io, run_acp_stdio_server, AcpAgent, AcpError, AcpServerError,
+    AcpServerOptions, AcpSessionUpdateObserver,
+};
 pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -16,7 +16,7 @@ mod init;
 mod input;
 mod render;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::env;
 use std::fs;
 use std::io::{self, IsTerminal, Read, Write};
@@ -49,12 +49,12 @@ use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
     check_base_commit, format_stale_base_warning, format_usd, load_oauth_credentials,
-    load_system_prompt, pricing_for_model, resolve_expected_base, resolve_sandbox_status,
-    ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
-    ContentBlock, ConversationMessage, ConversationRuntime, McpServer, McpServerManager,
-    McpServerSpec, McpTool, MessageRole, ModelPricing, PermissionMode, PermissionPolicy,
-    ProjectContext, PromptCacheEvent, ResolvedPermissionMode, RuntimeError, Session, TokenUsage,
-    ToolError, ToolExecutor, UsageTracker,
+    load_system_prompt, pricing_for_model, resolve_expected_base, resolve_sandbox_status, AcpError,
+    AcpSessionUpdateObserver, ApiClient, ApiRequest, AssistantEvent, CompactionConfig,
+    ConfigLoader, ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, McpServer,
+    McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, PermissionMode,
+    PermissionPolicy, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, RuntimeError,
+    Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
 };
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
@@ -416,7 +416,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
         }
         CliAction::Doctor { output_format } => run_doctor(output_format)?,
-        CliAction::Acp { output_format } => print_acp_status(output_format)?,
+        CliAction::Acp {
+            model,
+            model_flag_raw,
+            allowed_tools,
+            permission_mode_override,
+            reasoning_effort,
+        } => run_acp_server(
+            model,
+            model_flag_raw,
+            allowed_tools,
+            permission_mode_override,
+            reasoning_effort,
+        )?,
         CliAction::State { output_format } => run_worker_state(output_format)?,
         CliAction::Init { output_format } => run_init(output_format)?,
         // #146: dispatch pure-local introspection. Text mode uses existing
@@ -540,7 +552,11 @@ enum CliAction {
         output_format: CliOutputFormat,
     },
     Acp {
-        output_format: CliOutputFormat,
+        model: String,
+        model_flag_raw: Option<String>,
+        allowed_tools: Option<AllowedToolSet>,
+        permission_mode_override: Option<PermissionMode>,
+        reasoning_effort: Option<String>,
     },
     State {
         output_format: CliOutputFormat,
@@ -949,7 +965,14 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             }
         }
         "system-prompt" => parse_system_prompt_args(&rest[1..], output_format),
-        "acp" => parse_acp_args(&rest[1..], output_format),
+        "acp" => parse_acp_args(
+            &rest[1..],
+            model,
+            model_flag_raw,
+            allowed_tools,
+            permission_mode_override,
+            reasoning_effort,
+        ),
         "login" | "logout" => Err(removed_auth_surface_error(rest[0].as_str())),
         "init" => Ok(CliAction::Init { output_format }),
         "export" => parse_export_args(&rest[1..], output_format),
@@ -1153,10 +1176,29 @@ fn removed_auth_surface_error(command_name: &str) -> String {
     )
 }
 
-fn parse_acp_args(args: &[String], output_format: CliOutputFormat) -> Result<CliAction, String> {
+fn parse_acp_args(
+    args: &[String],
+    model: String,
+    model_flag_raw: Option<String>,
+    allowed_tools: Option<AllowedToolSet>,
+    permission_mode_override: Option<PermissionMode>,
+    reasoning_effort: Option<String>,
+) -> Result<CliAction, String> {
     match args {
-        [] => Ok(CliAction::Acp { output_format }),
-        [subcommand] if subcommand == "serve" => Ok(CliAction::Acp { output_format }),
+        [] => Ok(CliAction::Acp {
+            model,
+            model_flag_raw,
+            allowed_tools,
+            permission_mode_override,
+            reasoning_effort,
+        }),
+        [subcommand] if subcommand == "serve" => Ok(CliAction::Acp {
+            model,
+            model_flag_raw,
+            allowed_tools,
+            permission_mode_override,
+            reasoning_effort,
+        }),
         _ => Err(String::from(
             "unsupported ACP invocation. Use `scode acp`, `scode acp serve`, `scode --acp`, or `scode -acp`.",
         )),
@@ -3772,6 +3814,183 @@ impl Drop for BuiltRuntime {
     }
 }
 
+struct AcpCliSession {
+    cwd: PathBuf,
+    handle: SessionHandle,
+    runtime: BuiltRuntime,
+}
+
+struct AcpCliAgent {
+    model: String,
+    model_flag_raw: Option<String>,
+    allowed_tools: Option<AllowedToolSet>,
+    permission_mode_override: Option<PermissionMode>,
+    reasoning_effort: Option<String>,
+    sessions: HashMap<String, AcpCliSession>,
+}
+
+impl AcpCliAgent {
+    fn new(
+        model: String,
+        model_flag_raw: Option<String>,
+        allowed_tools: Option<AllowedToolSet>,
+        permission_mode_override: Option<PermissionMode>,
+        reasoning_effort: Option<String>,
+    ) -> Self {
+        Self {
+            model,
+            model_flag_raw,
+            allowed_tools,
+            permission_mode_override,
+            reasoning_effort,
+            sessions: HashMap::new(),
+        }
+    }
+
+    fn build_session(&self, cwd: PathBuf) -> Result<AcpCliSession, AcpError> {
+        let cwd = canonical_session_cwd(cwd)?;
+        let model = self.resolve_model_for_cwd(&cwd)?;
+        let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
+        let system_prompt = build_system_prompt_for(&cwd).map_err(|error| {
+            AcpError::internal(format!("failed to build system prompt: {error}"))
+        })?;
+        let session_state = new_cli_session_for(&cwd)
+            .map_err(|error| AcpError::internal(format!("failed to create session: {error}")))?;
+        let handle = create_managed_session_handle_for(&cwd, &session_state.session_id).map_err(
+            |error| AcpError::internal(format!("failed to create session handle: {error}")),
+        )?;
+        let mut runtime = build_runtime_for_cwd(
+            &cwd,
+            session_state.with_persistence_path(handle.path.clone()),
+            &handle.id,
+            model,
+            system_prompt,
+            true,
+            false,
+            self.allowed_tools.clone(),
+            permission_mode,
+            None,
+        )
+        .map_err(|error| AcpError::internal(format!("failed to build runtime: {error}")))?;
+        if let Some(runtime) = runtime.runtime.as_mut() {
+            runtime
+                .api_client_mut()
+                .set_reasoning_effort(self.reasoning_effort.clone());
+        }
+        runtime
+            .session()
+            .save_to_path(&handle.path)
+            .map_err(|error| AcpError::internal(format!("failed to persist session: {error}")))?;
+
+        Ok(AcpCliSession {
+            cwd,
+            handle,
+            runtime,
+        })
+    }
+
+    fn resolve_model_for_cwd(&self, cwd: &Path) -> Result<String, AcpError> {
+        if self.model_flag_raw.is_some() {
+            return Ok(self.model.clone());
+        }
+        let _guard = ScopedCurrentDir::change_to(cwd)
+            .map_err(|error| AcpError::internal(format!("failed to enter cwd: {error}")))?;
+        Ok(resolve_repl_model(self.model.clone()))
+    }
+
+    fn resolve_permission_mode_for_cwd(&self, cwd: &Path) -> Result<PermissionMode, AcpError> {
+        if let Some(mode) = self.permission_mode_override {
+            return Ok(mode);
+        }
+        let _guard = ScopedCurrentDir::change_to(cwd)
+            .map_err(|error| AcpError::internal(format!("failed to enter cwd: {error}")))?;
+        Ok(default_permission_mode())
+    }
+}
+
+impl runtime::AcpAgent for AcpCliAgent {
+    fn new_session(&mut self, cwd: Option<PathBuf>) -> Result<String, AcpError> {
+        let cwd = cwd
+            .map(Ok)
+            .unwrap_or_else(env::current_dir)
+            .map_err(|error| AcpError::internal(format!("failed to resolve cwd: {error}")))?;
+        let session = self.build_session(cwd)?;
+        let session_id = session.handle.id.clone();
+        self.sessions.insert(session_id.clone(), session);
+        Ok(session_id)
+    }
+
+    fn run_prompt(
+        &mut self,
+        session_id: &str,
+        prompt: String,
+        observer: &mut AcpSessionUpdateObserver<'_>,
+    ) -> Result<(), AcpError> {
+        let session = self
+            .sessions
+            .get_mut(session_id)
+            .ok_or_else(|| AcpError::invalid_params(format!("unknown sessionId: {session_id}")))?;
+        let _guard = ScopedCurrentDir::change_to(&session.cwd)
+            .map_err(|error| AcpError::internal(format!("failed to enter session cwd: {error}")))?;
+        session
+            .runtime
+            .run_turn(prompt, None, Some(observer))
+            .map_err(|error| AcpError::internal(error.to_string()))?;
+        session
+            .runtime
+            .session()
+            .save_to_path(&session.handle.path)
+            .map_err(|error| AcpError::internal(format!("failed to persist session: {error}")))?;
+        Ok(())
+    }
+}
+
+struct ScopedCurrentDir {
+    previous: PathBuf,
+}
+
+impl ScopedCurrentDir {
+    fn change_to(cwd: &Path) -> io::Result<Self> {
+        let previous = env::current_dir()?;
+        env::set_current_dir(cwd)?;
+        Ok(Self { previous })
+    }
+}
+
+impl Drop for ScopedCurrentDir {
+    fn drop(&mut self) {
+        let _ = env::set_current_dir(&self.previous);
+    }
+}
+
+fn canonical_session_cwd(cwd: PathBuf) -> Result<PathBuf, AcpError> {
+    let canonical = fs::canonicalize(&cwd).map_err(|error| {
+        AcpError::invalid_params(format!("params.cwd is not accessible: {error}"))
+    })?;
+    if !canonical.is_dir() {
+        return Err(AcpError::invalid_params("params.cwd must be a directory"));
+    }
+    Ok(canonical)
+}
+
+fn run_acp_server(
+    model: String,
+    model_flag_raw: Option<String>,
+    allowed_tools: Option<AllowedToolSet>,
+    permission_mode_override: Option<PermissionMode>,
+    reasoning_effort: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let agent = AcpCliAgent::new(
+        model,
+        model_flag_raw,
+        allowed_tools,
+        permission_mode_override,
+        reasoning_effort,
+    );
+    runtime::run_acp_stdio_server(agent, runtime::AcpServerOptions::new(VERSION))?;
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 struct ToolSearchRequest {
     query: String,
@@ -5236,13 +5455,27 @@ fn current_session_store() -> Result<runtime::SessionStore, Box<dyn std::error::
 }
 
 fn new_cli_session() -> Result<Session, Box<dyn std::error::Error>> {
-    Ok(Session::new().with_workspace_root(env::current_dir()?))
+    new_cli_session_for(&env::current_dir()?)
+}
+
+fn new_cli_session_for(cwd: &Path) -> Result<Session, Box<dyn std::error::Error>> {
+    Ok(Session::new().with_workspace_root(cwd.to_path_buf()))
 }
 
 fn create_managed_session_handle(
     session_id: &str,
 ) -> Result<SessionHandle, Box<dyn std::error::Error>> {
-    let handle = current_session_store()?.create_handle(session_id);
+    let cwd = env::current_dir()?;
+    create_managed_session_handle_for(&cwd, session_id)
+}
+
+fn create_managed_session_handle_for(
+    cwd: &Path,
+    session_id: &str,
+) -> Result<SessionHandle, Box<dyn std::error::Error>> {
+    let handle = runtime::SessionStore::from_cwd(cwd)
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?
+        .create_handle(session_id);
     Ok(SessionHandle {
         id: handle.id,
         path: handle.path,
@@ -5824,12 +6057,12 @@ fn render_help_topic(topic: LocalHelpTopic) -> String {
   Related          /doctor · scode --resume latest /doctor"
             .to_string(),
         LocalHelpTopic::Acp => "ACP / Zed
-  Usage            scode acp [serve] [--output-format <format>]
+  Usage            scode acp [serve]
   Aliases          scode --acp · scode -acp
-  Purpose          explain the current editor-facing ACP/Zed launch contract without starting the runtime
-  Status           discoverability only; `serve` is a status alias and does not launch a daemon yet
-  Formats          text (default), json
-  Related          ROADMAP #64a (discoverability) · ROADMAP #76 (real ACP support) · scode --help"
+  Purpose          run the ACP JSON-RPC agent server over stdio for editor integrations
+  Transport        LSP-style Content-Length framed JSON-RPC on stdin/stdout
+  Sessions         session/new creates managed .nexus/sudocode sessions for the requested cwd
+  Related          scode --help"
             .to_string(),
         LocalHelpTopic::Init => "Init
   Usage            scode init [--output-format <format>]
@@ -5888,39 +6121,6 @@ fn render_help_topic(topic: LocalHelpTopic) -> String {
 
 fn print_help_topic(topic: LocalHelpTopic) {
     println!("{}", render_help_topic(topic));
-}
-
-fn print_acp_status(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
-    let message = "ACP/Zed editor integration is not implemented in sudo-code yet. `scode acp serve` is only a discoverability alias today; it does not launch a daemon or Zed-specific protocol endpoint. Use the normal terminal surfaces for now and track ROADMAP #76 for real ACP support.";
-    match output_format {
-        CliOutputFormat::Text => {
-            println!(
-                "ACP / Zed\n  Status           discoverability only\n  Launch           `scode acp serve` / `scode --acp` / `scode -acp` report status only; no editor daemon is available yet\n  Today            use `scode prompt`, the REPL, or `scode doctor` for local verification\n  Tracking         ROADMAP #76\n  Message          {message}"
-            );
-        }
-        CliOutputFormat::Json => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&json!({
-                    "kind": "acp",
-                    "status": "discoverability_only",
-                    "supported": false,
-                    "serve_alias_only": true,
-                    "message": message,
-                    "launch_command": serde_json::Value::Null,
-                    "aliases": ["acp", "--acp", "-acp"],
-                    "discoverability_tracking": "ROADMAP #64a",
-                    "tracking": "ROADMAP #76",
-                    "recommended_workflows": [
-                        "scode prompt TEXT",
-                        "scode",
-                        "scode doctor"
-                    ],
-                }))?
-            );
-        }
-    }
-    Ok(())
 }
 
 fn render_config_report(section: Option<&str>) -> Result<String, Box<dyn std::error::Error>> {
@@ -6860,8 +7060,12 @@ fn short_tool_id(id: &str) -> String {
 }
 
 fn build_system_prompt() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    build_system_prompt_for(&env::current_dir()?)
+}
+
+fn build_system_prompt_for(cwd: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     Ok(load_system_prompt(
-        env::current_dir()?,
+        cwd.to_path_buf(),
         DEFAULT_DATE,
         env::consts::OS,
         "unknown",
@@ -7284,7 +7488,39 @@ fn build_runtime(
     permission_mode: PermissionMode,
     progress_reporter: Option<InternalPromptProgressReporter>,
 ) -> Result<BuiltRuntime, Box<dyn std::error::Error>> {
-    let runtime_plugin_state = build_runtime_plugin_state()?;
+    let cwd = env::current_dir()?;
+    build_runtime_for_cwd(
+        &cwd,
+        session,
+        session_id,
+        model,
+        system_prompt,
+        enable_tools,
+        emit_output,
+        allowed_tools,
+        permission_mode,
+        progress_reporter,
+    )
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::too_many_arguments)]
+fn build_runtime_for_cwd(
+    cwd: &Path,
+    session: Session,
+    session_id: &str,
+    model: String,
+    system_prompt: Vec<String>,
+    enable_tools: bool,
+    emit_output: bool,
+    allowed_tools: Option<AllowedToolSet>,
+    permission_mode: PermissionMode,
+    progress_reporter: Option<InternalPromptProgressReporter>,
+) -> Result<BuiltRuntime, Box<dyn std::error::Error>> {
+    let loader = ConfigLoader::default_for(cwd);
+    let runtime_config = loader.load()?;
+    let runtime_plugin_state =
+        build_runtime_plugin_state_with_loader(cwd, &loader, &runtime_config)?;
     build_runtime_with_plugin_state(
         session,
         session_id,
@@ -8903,7 +9139,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "  scode acp [serve]")?;
     writeln!(
         out,
-        "      Show ACP/Zed editor integration status (currently unsupported; aliases: --acp, -acp)"
+        "      Run the ACP JSON-RPC stdio server for editor integrations (aliases: --acp, -acp)"
     )?;
     writeln!(out, "      Source of truth: {OFFICIAL_REPO_SLUG}")?;
     writeln!(
@@ -10136,30 +10372,63 @@ mod tests {
 
     #[test]
     fn parses_acp_command_surfaces() {
+        let expected = CliAction::Acp {
+            model: DEFAULT_MODEL.to_string(),
+            model_flag_raw: None,
+            allowed_tools: None,
+            permission_mode_override: None,
+            reasoning_effort: None,
+        };
         assert_eq!(
             parse_args(&["acp".to_string()]).expect("acp should parse"),
-            CliAction::Acp {
-                output_format: CliOutputFormat::Text,
-            }
+            expected
         );
         assert_eq!(
             parse_args(&["acp".to_string(), "serve".to_string()]).expect("acp serve should parse"),
-            CliAction::Acp {
-                output_format: CliOutputFormat::Text,
-            }
+            expected
         );
         assert_eq!(
             parse_args(&["--acp".to_string()]).expect("--acp should parse"),
-            CliAction::Acp {
-                output_format: CliOutputFormat::Text,
-            }
+            expected
         );
         assert_eq!(
             parse_args(&["-acp".to_string()]).expect("-acp should parse"),
-            CliAction::Acp {
-                output_format: CliOutputFormat::Text,
-            }
+            expected
         );
+    }
+
+    #[test]
+    fn parses_acp_with_runtime_global_options() {
+        match parse_args(&[
+            "--model".to_string(),
+            "sonnet".to_string(),
+            "--allowedTools".to_string(),
+            "read,glob".to_string(),
+            "--permission-mode".to_string(),
+            "read-only".to_string(),
+            "--reasoning-effort".to_string(),
+            "low".to_string(),
+            "acp".to_string(),
+        ])
+        .expect("acp with globals should parse")
+        {
+            CliAction::Acp {
+                model,
+                model_flag_raw,
+                allowed_tools,
+                permission_mode_override,
+                reasoning_effort,
+            } => {
+                assert_eq!(model, resolve_model_alias_with_config("sonnet"));
+                assert_eq!(model_flag_raw.as_deref(), Some("sonnet"));
+                let allowed_tools = allowed_tools.expect("allowed tools");
+                assert!(allowed_tools.contains("read_file"));
+                assert!(allowed_tools.contains("glob_search"));
+                assert_eq!(permission_mode_override, Some(PermissionMode::ReadOnly));
+                assert_eq!(reasoning_effort.as_deref(), Some("low"));
+            }
+            other => panic!("expected CliAction::Acp, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -1,11 +1,12 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use runtime::Session;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -47,21 +48,33 @@ fn status_and_sandbox_emit_json_when_requested() {
 }
 
 #[test]
-fn acp_guidance_emits_json_when_requested() {
-    let root = unique_temp_dir("acp-json");
+fn acp_server_responds_to_framed_initialize() {
+    let root = unique_temp_dir("acp-jsonrpc");
     fs::create_dir_all(&root).expect("temp dir should exist");
 
-    let acp = assert_json_command(&root, &["--output-format", "json", "acp"]);
-    assert_eq!(acp["kind"], "acp");
-    assert_eq!(acp["status"], "discoverability_only");
-    assert_eq!(acp["supported"], false);
-    assert_eq!(acp["serve_alias_only"], true);
-    assert_eq!(acp["discoverability_tracking"], "ROADMAP #64a");
-    assert_eq!(acp["tracking"], "ROADMAP #76");
-    assert!(acp["message"]
-        .as_str()
-        .expect("acp message")
-        .contains("discoverability alias"));
+    let acp = assert_framed_acp_command(
+        &root,
+        &["--output-format", "json", "acp"],
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "protocolVersion": 9 },
+        }),
+    );
+    assert_eq!(acp["id"], 1);
+    assert_eq!(acp["result"]["protocolVersion"], 9);
+    assert_eq!(acp["result"]["agentInfo"]["name"], "scode");
+    assert_eq!(
+        acp["result"]["agentInfo"]["version"],
+        env!("CARGO_PKG_VERSION")
+    );
+    assert_eq!(acp["result"]["agentCapabilities"]["loadSession"], false);
+    assert_eq!(
+        acp["result"]["agentCapabilities"]["mcpCapabilities"]["http"],
+        false
+    );
+    assert_eq!(acp["result"]["authMethods"], json!([]));
 }
 
 #[test]
@@ -406,6 +419,54 @@ fn run_scode(current_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output
         command.env(key, value);
     }
     command.output().expect("scode should launch")
+}
+
+fn assert_framed_acp_command(current_dir: &Path, args: &[&str], request: Value) -> Value {
+    let request = serde_json::to_vec(&request).expect("request should serialize");
+    let frame = format!("Content-Length: {}\r\n\r\n", request.len());
+    let mut child = Command::new(env!("CARGO_BIN_EXE_scode"))
+        .current_dir(current_dir)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("scode should launch");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        stdin
+            .write_all(frame.as_bytes())
+            .expect("frame header should write");
+        stdin.write_all(&request).expect("frame body should write");
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().expect("scode should exit");
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_framed_json(&output.stdout)
+}
+
+fn parse_framed_json(stdout: &[u8]) -> Value {
+    let header_end = stdout
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("stdout should contain JSON-RPC frame headers");
+    let headers = std::str::from_utf8(&stdout[..header_end]).expect("headers should be utf8");
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("Content-Length")
+                .then(|| value.trim().parse::<usize>().expect("valid content length"))
+        })
+        .expect("Content-Length header should exist");
+    let body_start = header_end + 4;
+    let body_end = body_start + content_length;
+    serde_json::from_slice(&stdout[body_start..body_end]).expect("body should be valid json")
 }
 
 fn write_upstream_fixture(root: &Path) -> PathBuf {


### PR DESCRIPTION
## Summary
- Add a runtime ACP JSON-RPC stdio server using the shared `jsonrpc_transport` framing helpers.
- Wire `scode acp`, `scode acp serve`, `scode --acp`, and `scode -acp` to run the server instead of printing discoverability-only status.
- Map ACP `session/prompt` requests into `ConversationRuntime::run_turn` and stream runtime observer events as `session/update` notifications.
- Update ACP help text and output-format contract coverage for framed `initialize`.

## Validation
- `cargo test -p runtime acp`
- `cargo test -p rusty-claude-cli acp`
- `cargo test -p rusty-claude-cli help`