### PR TITLE
feat: rebrand session storage paths to .scode/sessions/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ archive/
 # Sudo Code local artifacts
 .nexus/sudocode/settings.local.json
 .nexus/sudocode/sessions/
+.scode/sessions/
 .sudocodehip/
 status-help.txt

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -4,4 +4,5 @@ target/
 # Sudo Code local artifacts
 .nexus/sudocode/settings.local.json
 .nexus/sudocode/sessions/
+.scode/sessions/
 .sudocodehip/

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -81,8 +81,8 @@ struct SessionPersistence {
 /// Persisted conversational state for the runtime and CLI session manager.
 ///
 /// `workspace_root` binds the session to the worktree it was created in. The
-/// global session store under `~/.local/share/opencode` is shared across every
-/// `opencode serve` instance, so without an explicit workspace root parallel
+/// global session store under `~/.nexus/sudocode` is shared across every
+/// `scode serve` instance, so without an explicit workspace root parallel
 /// lanes can race and report success while writes land in the wrong CWD. See
 /// ROADMAP.md item 41 (Phantom completions root cause) for the full
 /// background.
@@ -1491,7 +1491,7 @@ mod tests {
 
 /// Per-worktree session isolation: returns a session directory namespaced
 /// by the workspace fingerprint of the given working directory.
-/// This prevents parallel `opencode serve` instances from colliding.
+/// This prevents parallel `scode serve` instances from colliding.
 /// Called by external consumers (e.g. sudocodehip) to enumerate sessions for a CWD.
 #[allow(dead_code)]
 pub fn workspace_sessions_dir(cwd: &std::path::Path) -> Result<std::path::PathBuf, SessionError> {

--- a/rust/crates/runtime/src/session_control.rs
+++ b/rust/crates/runtime/src/session_control.rs
@@ -8,7 +8,7 @@ use std::time::UNIX_EPOCH;
 use crate::session::{Session, SessionError};
 
 /// Per-worktree session store that namespaces on-disk session files by
-/// workspace fingerprint so that parallel `opencode serve` instances never
+/// workspace fingerprint so that parallel `scode serve` instances never
 /// collide.
 ///
 /// Create via [`SessionStore::from_cwd`] (derives the store path from the
@@ -19,7 +19,7 @@ use crate::session::{Session, SessionError};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionStore {
     /// Resolved root of the session namespace, e.g.
-    /// `/home/user/project/.nexus/sudocode/sessions/a1b2c3d4e5f60718/`.
+    /// `/home/user/project/.scode/sessions/a1b2c3d4e5f60718/`.
     sessions_root: PathBuf,
     /// The canonical workspace path that was fingerprinted.
     workspace_root: PathBuf,
@@ -28,7 +28,7 @@ pub struct SessionStore {
 impl SessionStore {
     /// Build a store from the server's current working directory.
     ///
-    /// The on-disk layout becomes `<cwd>/.nexus/sudocode/sessions/<workspace_hash>/`.
+    /// The on-disk layout becomes `<cwd>/.scode/sessions/<workspace_hash>/`.
     pub fn from_cwd(cwd: impl AsRef<Path>) -> Result<Self, SessionControlError> {
         let cwd = cwd.as_ref();
         // #151: canonicalize so equivalent paths (symlinks, relative vs
@@ -37,8 +37,7 @@ impl SessionStore {
         // fails (e.g. the directory doesn't exist yet).
         let canonical_cwd = fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
         let sessions_root = canonical_cwd
-            .join(".nexus")
-            .join("sudocode")
+            .join(".scode")
             .join("sessions")
             .join(workspace_fingerprint(&canonical_cwd));
         fs::create_dir_all(&sessions_root)?;
@@ -132,7 +131,7 @@ impl SessionStore {
                 return Ok(path);
             }
         }
-        if let Some(legacy_root) = self.legacy_sessions_root() {
+        for legacy_root in self.legacy_sessions_roots() {
             for extension in [PRIMARY_SESSION_EXTENSION, LEGACY_SESSION_EXTENSION] {
                 let path = legacy_root.join(format!("{session_id}.{extension}"));
                 if !path.exists() {
@@ -151,9 +150,12 @@ impl SessionStore {
     pub fn list_sessions(&self) -> Result<Vec<ManagedSessionSummary>, SessionControlError> {
         let mut sessions = Vec::new();
         self.collect_sessions_from_dir(&self.sessions_root, &mut sessions)?;
-        if let Some(legacy_root) = self.legacy_sessions_root() {
+        for legacy_root in self.legacy_sessions_roots() {
             self.collect_sessions_from_dir(&legacy_root, &mut sessions)?;
         }
+        // Deduplicate by session ID: primary (first added) wins.
+        let mut seen = std::collections::HashSet::new();
+        sessions.retain(|s| seen.insert(s.id.clone()));
         sort_managed_sessions(&mut sessions);
         Ok(sessions)
     }
@@ -204,11 +206,53 @@ impl SessionStore {
         })
     }
 
-    fn legacy_sessions_root(&self) -> Option<PathBuf> {
-        self.sessions_root
-            .parent()
-            .filter(|parent| parent.file_name().is_some_and(|name| name == "sessions"))
-            .map(Path::to_path_buf)
+    /// Returns legacy session roots to search for backward compatibility.
+    ///
+    /// Covers:
+    /// 1. Flat `.scode/sessions/` (parent of fingerprinted dir)
+    /// 2. Fingerprinted `.nexus/sudocode/sessions/<hash>/` (old project-local)
+    /// 3. Flat `.nexus/sudocode/sessions/` (old project-local)
+    /// 4. Global fingerprinted `~/.nexus/sudocode/sessions/<hash>/`
+    /// 5. Global flat `~/.nexus/sudocode/sessions/`
+    fn legacy_sessions_roots(&self) -> Vec<PathBuf> {
+        let mut roots = Vec::new();
+        // 1. Flat .scode/sessions/ (parent of the fingerprinted primary dir)
+        if let Some(parent) = self.sessions_root.parent() {
+            if parent.file_name().is_some_and(|name| name == "sessions") {
+                roots.push(parent.to_path_buf());
+            }
+        }
+        // 2. Fingerprinted .nexus/sudocode/sessions/<hash>/ (old project-local)
+        let old_fingerprinted = self
+            .workspace_root
+            .join(".nexus")
+            .join("sudocode")
+            .join("sessions")
+            .join(workspace_fingerprint(&self.workspace_root));
+        if old_fingerprinted != self.sessions_root {
+            roots.push(old_fingerprinted);
+        }
+        // 3. Flat .nexus/sudocode/sessions/ (old project-local)
+        let old_flat = self
+            .workspace_root
+            .join(".nexus")
+            .join("sudocode")
+            .join("sessions");
+        roots.push(old_flat);
+        // 4 & 5. Global paths via default_config_home()
+        let global_home = crate::config::default_config_home();
+        let global_fingerprinted = global_home
+            .join("sessions")
+            .join(workspace_fingerprint(&self.workspace_root));
+        if global_fingerprinted != self.sessions_root {
+            roots.push(global_fingerprinted);
+        }
+        let global_flat = global_home.join("sessions");
+        // Avoid duplicates with old_flat (which may equal global_flat when cwd == $HOME)
+        if !roots.contains(&global_flat) {
+            roots.push(global_flat);
+        }
+        roots
     }
 
     fn validate_loaded_session(
@@ -218,6 +262,9 @@ impl SessionStore {
     ) -> Result<(), SessionControlError> {
         let Some(actual) = session.workspace_root() else {
             if path_is_within_workspace(session_path, &self.workspace_root) {
+                return Ok(());
+            }
+            if path_is_within_global_sessions(session_path) {
                 return Ok(());
             }
             return Err(SessionControlError::Format(
@@ -523,24 +570,24 @@ fn session_id_from_path(path: &Path) -> Option<String> {
 }
 
 fn format_missing_session_reference(reference: &str, sessions_root: &Path) -> String {
-    // #80: show the actual workspace-fingerprint directory instead of lying about .nexus/sudocode/sessions/
+    // #80: show the actual workspace-fingerprint directory instead of a generic path
     let fingerprint_dir = sessions_root
         .file_name()
         .and_then(|f| f.to_str())
         .unwrap_or("<unknown>");
     format!(
-        "session not found: {reference}\nHint: managed sessions live in .nexus/sudocode/sessions/{fingerprint_dir}/ (workspace-specific partition).\nTry `{LATEST_SESSION_REFERENCE}` for the most recent session or `/session list` in the REPL."
+        "session not found: {reference}\nHint: managed sessions live in .scode/sessions/{fingerprint_dir}/ (workspace-specific partition).\nTry `{LATEST_SESSION_REFERENCE}` for the most recent session or `/session list` in the REPL."
     )
 }
 
 fn format_no_managed_sessions(sessions_root: &Path) -> String {
-    // #80: show the actual workspace-fingerprint directory instead of lying about .nexus/sudocode/sessions/
+    // #80: show the actual workspace-fingerprint directory instead of a generic path
     let fingerprint_dir = sessions_root
         .file_name()
         .and_then(|f| f.to_str())
         .unwrap_or("<unknown>");
     format!(
-        "no managed sessions found in .nexus/sudocode/sessions/{fingerprint_dir}/\nStart `scode` to create a session, then rerun with `--resume {LATEST_SESSION_REFERENCE}`.\nNote: scode partitions sessions per workspace fingerprint; sessions from other CWDs are invisible."
+        "no managed sessions found in .scode/sessions/{fingerprint_dir}/\nStart `scode` to create a session, then rerun with `--resume {LATEST_SESSION_REFERENCE}`.\nNote: scode partitions sessions per workspace fingerprint; sessions from other CWDs are invisible."
     )
 }
 
@@ -565,6 +612,11 @@ fn canonicalize_for_compare(path: &Path) -> PathBuf {
 
 fn path_is_within_workspace(path: &Path, workspace_root: &Path) -> bool {
     canonicalize_for_compare(path).starts_with(canonicalize_for_compare(workspace_root))
+}
+
+fn path_is_within_global_sessions(path: &Path) -> bool {
+    let global_sessions = crate::config::default_config_home().join("sessions");
+    canonicalize_for_compare(path).starts_with(canonicalize_for_compare(&global_sessions))
 }
 
 #[cfg(test)]
@@ -1023,6 +1075,43 @@ mod tests {
             forked.handle.path.starts_with(store.sessions_dir()),
             "forked session path must be inside the store namespace"
         );
+        fs::remove_dir_all(base).expect("temp dir should clean up");
+    }
+
+    #[test]
+    fn session_store_discovers_sessions_in_old_nexus_path() {
+        // given — a session stored at the old .nexus/sudocode/sessions/ location
+        let base = temp_dir();
+        fs::create_dir_all(&base).expect("base dir should exist");
+        let base = fs::canonicalize(&base).unwrap_or(base);
+        let store = SessionStore::from_cwd(&base).expect("store should build");
+
+        // Place a session in the old .nexus/sudocode/sessions/ path (flat, no fingerprint)
+        let old_sessions = base.join(".nexus").join("sudocode").join("sessions");
+        fs::create_dir_all(&old_sessions).expect("old sessions dir should exist");
+        let session = Session::new().with_workspace_root(base.clone());
+        let session_id = session.session_id.clone();
+        let file_path = old_sessions.join(format!("{session_id}.jsonl"));
+        let session = session.with_persistence_path(file_path.clone());
+        session
+            .save_to_path(&file_path)
+            .expect("old session should persist");
+
+        // when — the store lists sessions
+        let sessions = store.list_sessions().expect("list sessions");
+
+        // then — the old nexus session should be discovered
+        assert!(
+            sessions.iter().any(|s| s.id == session_id),
+            "session from .nexus/sudocode/sessions/ should be discovered"
+        );
+
+        // also test resolve_managed_path finds it
+        let path = store
+            .resolve_managed_path(&session_id)
+            .expect("old nexus session should resolve");
+        assert_eq!(path, file_path);
+
         fs::remove_dir_all(base).expect("temp dir should clean up");
     }
 }

--- a/rust/crates/rusty-claude-cli/src/init.rs
+++ b/rust/crates/rusty-claude-cli/src/init.rs
@@ -9,9 +9,10 @@ const STARTER_CONFIG_JSON: &str = concat!(
     "}\n",
 );
 const GITIGNORE_COMMENT: &str = "# Sudo Code local artifacts";
-const GITIGNORE_ENTRIES: [&str; 3] = [
+const GITIGNORE_ENTRIES: [&str; 4] = [
     ".nexus/sudocode/settings.local.json",
     ".nexus/sudocode/sessions/",
+    ".scode/sessions/",
     ".sudocodehip/",
 ];
 
@@ -421,6 +422,7 @@ mod tests {
         let gitignore = fs::read_to_string(root.join(".gitignore")).expect("read gitignore");
         assert!(gitignore.contains(".nexus/sudocode/settings.local.json"));
         assert!(gitignore.contains(".nexus/sudocode/sessions/"));
+        assert!(gitignore.contains(".scode/sessions/"));
         assert!(gitignore.contains(".sudocodehip/"));
         let claude_md = fs::read_to_string(root.join("CLAUDE.md")).expect("read claude md");
         assert!(claude_md.contains("Languages: Rust."));
@@ -463,6 +465,7 @@ mod tests {
             1
         );
         assert_eq!(gitignore.matches(".nexus/sudocode/sessions/").count(), 1);
+        assert_eq!(gitignore.matches(".scode/sessions/").count(), 1);
         assert_eq!(gitignore.matches(".sudocodehip/").count(), 1);
 
         fs::remove_dir_all(root).expect("cleanup temp dir");

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3045,7 +3045,7 @@ fn render_resume_usage() -> String {
     format!(
         "Resume
   Usage            /resume <session-path|session-id|{LATEST_SESSION_REFERENCE}>
-  Auto-save        .nexus/sudocode/sessions/<session-id>.{PRIMARY_SESSION_EXTENSION}
+  Auto-save        .scode/sessions/<session-id>.{PRIMARY_SESSION_EXTENSION}
   Tip              use /session list to inspect saved sessions"
     )
 }
@@ -5651,7 +5651,7 @@ fn render_repl_help() -> String {
         "  Tab                  Complete commands, modes, and recent sessions".to_string(),
         "  Ctrl-C               Clear input (or exit on empty prompt)".to_string(),
         "  Shift+Enter/Ctrl+J   Insert a newline".to_string(),
-        "  Auto-save            .nexus/sudocode/sessions/<session-id>.jsonl".to_string(),
+        "  Auto-save            .scode/sessions/<session-id>.jsonl".to_string(),
         "  Resume latest        /resume latest".to_string(),
         "  Browse sessions      /session list".to_string(),
         "  Show prompt history  /history [count]".to_string(),
@@ -5763,7 +5763,7 @@ fn status_json_value(
             "session": context.session_path.as_ref().map_or_else(|| "live-repl".to_string(), |path| path.display().to_string()),
             "session_id": context.session_path.as_ref().and_then(|path| {
                 // Session files are named <session-id>.jsonl directly under
-                // .nexus/sudocode/sessions/. Extract the stem (drop the .jsonl extension).
+                // .scode/sessions/. Extract the stem (drop the .jsonl extension).
                 path.file_stem().map(|n| n.to_string_lossy().into_owned())
             }),
             "loaded_config_files": context.loaded_config_files,
@@ -6061,7 +6061,7 @@ fn render_help_topic(topic: LocalHelpTopic) -> String {
   Aliases          scode --acp · scode -acp
   Purpose          run the ACP JSON-RPC agent server over stdio for editor integrations
   Transport        LSP-style Content-Length framed JSON-RPC on stdin/stdout
-  Sessions         session/new creates managed .nexus/sudocode sessions for the requested cwd
+  Sessions         session/new creates managed .scode sessions for the requested cwd
   Related          scode --help"
             .to_string(),
         LocalHelpTopic::Init => "Init
@@ -6084,7 +6084,7 @@ fn render_help_topic(topic: LocalHelpTopic) -> String {
         LocalHelpTopic::Export => "Export
   Usage            scode export [--session <id|latest>] [--output <path>] [--output-format <format>]
   Purpose          serialize a managed session to JSON for review, transfer, or archival
-  Defaults         --session latest (most recent managed session in .nexus/sudocode/sessions/)
+  Defaults         --session latest (most recent managed session in .scode/sessions/)
   Formats          text (default), json
   Related          /session list · scode --resume latest"
             .to_string(),
@@ -9208,7 +9208,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "Session shortcuts:")?;
     writeln!(
         out,
-        "  REPL turns auto-save to .nexus/sudocode/sessions/<session-id>.{PRIMARY_SESSION_EXTENSION}"
+        "  REPL turns auto-save to .scode/sessions/<session-id>.{PRIMARY_SESSION_EXTENSION}"
     )?;
     writeln!(
         out,
@@ -11599,7 +11599,7 @@ mod tests {
         assert!(help.contains("/agents"));
         assert!(help.contains("/skills"));
         assert!(help.contains("/exit"));
-        assert!(help.contains("Auto-save            .nexus/sudocode/sessions/<session-id>.jsonl"));
+        assert!(help.contains("Auto-save            .scode/sessions/<session-id>.jsonl"));
         assert!(help.contains("Resume latest        /resume latest"));
     }
 
@@ -12344,7 +12344,7 @@ UU conflicted.rs",
     fn resume_usage_mentions_latest_shortcut() {
         let usage = render_resume_usage();
         assert!(usage.contains("/resume <session-path|session-id|latest>"));
-        assert!(usage.contains(".nexus/sudocode/sessions/<session-id>.jsonl"));
+        assert!(usage.contains(".scode/sessions/<session-id>.jsonl"));
         assert!(usage.contains("/session list"));
     }
 


### PR DESCRIPTION
## Summary
- New sessions are now created at `.scode/sessions/<hash>/` instead of `.nexus/sudocode/sessions/<hash>/`
- Legacy `.nexus/sudocode/sessions/` paths (project-local and global `~/.nexus/sudocode/`) remain readable via backward-compatible fallback discovery
- Session listing deduplicates across all roots (primary wins), and help text / `.gitignore` entries updated to reference the new path

## Test plan
- [x] All 946 existing tests pass (including legacy backward-compat tests)
- [x] New test `session_store_discovers_sessions_in_old_nexus_path` verifies old-path discovery
- [x] `cargo fmt` and `cargo clippy` clean (no new warnings)
- [ ] Manual: `scode acp` → create session → verify file at `.scode/sessions/<hash>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)