### PR TITLE
fix: stop trimming trailing newlines in TUI markdown renderer

### DIFF
--- a/rust/crates/rusty-claude-cli/src/render.rs
+++ b/rust/crates/rusty-claude-cli/src/render.rs
@@ -267,7 +267,7 @@ impl TerminalRenderer {
             );
         }
 
-        output.trim_end().to_string()
+        output
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary
- Remove `trim_end()` call from `render_markdown()` output in `render.rs`
- The `trim_end()` was stripping essential newlines between streamed blocks (e.g., between a paragraph and a table), breaking TUI rendering

## Test plan
- [x] All existing tests in `render.rs` pass
- [ ] Manual verification: stream markdown with consecutive blocks (paragraph + table) and confirm newlines are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)