### PR TITLE
feat: add --auth CLI flag with three auth modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When `--auth` is omitted, auto-detection applies: subscription > proxy > api-key
 | Mode | Env vars | Endpoint |
 |------|----------|----------|
 | `api-key` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `DASHSCOPE_API_KEY` | Provider default |
-| `subscription` | `CLAUDE_CODE_OAUTH_TOKEN` | api.anthropic.com |
+| `subscription` | `CLAUDE_CODE_OAUTH_TOKEN` (run `claude setup-token` to get one) | api.anthropic.com |
 | `proxy` | `PROXY_AUTH_TOKEN` + `PROXY_BASE_URL` | `PROXY_BASE_URL` |
 
 ## Model Aliases

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Use `--auth` to explicitly select an auth mode:
 
 ```bash
 scode --auth api-key          # uses ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
+# To get a subscription token, install Claude Code and run:
+#   claude setup-token
+# Then export the token:
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-..."
 scode --auth subscription     # uses CLAUDE_CODE_OAUTH_TOKEN
 scode --auth proxy            # uses PROXY_AUTH_TOKEN + PROXY_BASE_URL
 ```

--- a/README.md
+++ b/README.md
@@ -4,37 +4,65 @@
   <img src="assets/scode-hero.jpeg" alt="Sudo Code" width="300" />
 </p>
 
-**Sudo Code** is a high-performance, autonomous-first AI agent engine written in Rust. It is designed to act as a robust, machine-readable "Operating System" for AI coding swarms.
+**Sudo Code** (`scode`) is an AI coding agent engine written in Rust. Fast boot, headless ACP support, multi-provider auth.
 
 Originally forked from [ultraworkers/claw-code](https://github.com/ultraworkers/claw-code) (last synced: 2026-04-23), Sudo Code has been evolved to support the **Agent Communication Protocol (ACP)** and is the core engine powering the **Sudowork** platform.
-
-## Key Features
-
-- **Native Performance**: Written in Rust for near-instant boot times and minimal resource footprint.
-- **Machine-First (ACP)**: Supports headless JSON-RPC integration via `scode acp` for seamless use in IDEs and GUIs.
-- **Autonomous-Ready**: Built-in state machine and Lane Event system for reliable, multi-agent coordination.
-- **Production Safety**: Strict permission gating, path traversal prevention, and Linux-native sandboxing.
 
 ## Quick Start
 
 ```bash
-# Build the engine
 cd rust
-cargo build --workspace --release
+cargo build --release
 
-# Run a health check
+# Set your credentials (pick one)
+export ANTHROPIC_API_KEY="sk-ant-..."        # direct API key
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-..." # subscription token
+# or use a proxy:
+export PROXY_AUTH_TOKEN="your-token"
+export PROXY_BASE_URL="https://your-proxy.com"
+
+# Interactive REPL
+./target/release/scode
+
+# One-shot prompt
+./target/release/scode "explain this codebase"
+
+# Health check
 ./target/release/scode doctor
+```
 
-# Start a headless ACP server
-./target/release/scode acp
+## Authentication
+
+Use `--auth` to explicitly select an auth mode:
+
+```bash
+scode --auth api-key          # uses ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
+scode --auth subscription     # uses CLAUDE_CODE_OAUTH_TOKEN
+scode --auth proxy            # uses PROXY_AUTH_TOKEN + PROXY_BASE_URL
+```
+
+When `--auth` is omitted, auto-detection applies: subscription > proxy > api-key.
+
+| Mode | Env vars | Endpoint |
+|------|----------|----------|
+| `api-key` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `DASHSCOPE_API_KEY` | Provider default |
+| `subscription` | `CLAUDE_CODE_OAUTH_TOKEN` | api.anthropic.com |
+| `proxy` | `PROXY_AUTH_TOKEN` + `PROXY_BASE_URL` | `PROXY_BASE_URL` |
+
+## Model Aliases
+
+```bash
+scode --model opus      # claude-opus-4-6
+scode --model sonnet    # claude-sonnet-4-6
+scode --model haiku     # claude-haiku-4-5
+scode --model grok      # grok-3 (xAI)
 ```
 
 ## Documentation
 
-- [Rust Workspace](./rust/README.md) — Crate architecture and internals.
+- [Usage Guide](./USAGE.md) — Commands, integration, local models
+- [Rust Workspace](./rust/README.md) — Crate architecture and internals
 
 ---
 
-### Ownership / Affiliation Disclaimer
-- Sudo Code is a community-driven port and does **not** claim ownership of the original Claude Code source material.
-- This repository is **not affiliated with, endorsed by, or maintained by Anthropic**.
+Sudo Code is a community-driven project. Not affiliated with or endorsed by Anthropic.

--- a/rust/README.md
+++ b/rust/README.md
@@ -30,14 +30,23 @@ Set your API credentials:
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
-# Or use a proxy
-export ANTHROPIC_BASE_URL="https://your-proxy.com"
 ```
 
-Or provide an OAuth bearer token directly:
+Or use `--auth` to select a specific auth mode:
 
 ```bash
-export ANTHROPIC_AUTH_TOKEN="anthropic-oauth-or-proxy-bearer-token"
+# Subscription (OAuth)
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-..."
+cargo run -p rusty-claude-cli -- --auth subscription
+
+# Proxy
+export PROXY_AUTH_TOKEN="your-token"
+export PROXY_BASE_URL="https://your-proxy.com"
+cargo run -p rusty-claude-cli -- --auth proxy
+
+# API key (default auto-detect)
+export ANTHROPIC_API_KEY="sk-ant-..."
+cargo run -p rusty-claude-cli -- --auth api-key
 ```
 
 ## Mock parity harness
@@ -80,7 +89,7 @@ Primary artifacts:
 | Feature | Status |
 |---------|--------|
 | Anthropic / OpenAI-compatible provider flows + streaming | ✅ |
-| Direct bearer-token auth via `ANTHROPIC_AUTH_TOKEN` | ✅ |
+| Multi-mode auth (`--auth api-key\|subscription\|proxy`) | ✅ |
 | Interactive REPL (rustyline) | ✅ |
 | Tool system (bash, read, write, edit, grep, glob) | ✅ |
 | Web tools (search, fetch) | ✅ |
@@ -122,6 +131,7 @@ scode [OPTIONS] [COMMAND]
 
 Flags:
   --model MODEL
+  --auth MODE                 Auth mode: subscription, proxy, or api-key
   --output-format text|json
   --permission-mode MODE
   --dangerously-skip-permissions
@@ -195,7 +205,7 @@ rust/
 
 ### Crate Responsibilities
 
-- **api** — provider clients, SSE streaming, request/response types, auth (`ANTHROPIC_API_KEY` + bearer-token support), request-size/context-window preflight
+- **api** — provider clients, SSE streaming, request/response types, multi-mode auth (`--auth` / `AuthMode`), request-size/context-window preflight
 - **commands** — slash command definitions, parsing, help text generation, JSON/text command rendering
 - **compat-harness** — extracts tool/prompt manifests from upstream TS source
 - **mock-anthropic-service** — deterministic `/v1/messages` mock for CLI parity tests and local harness runs

--- a/rust/README.md
+++ b/rust/README.md
@@ -9,19 +9,19 @@ For a task-oriented guide with copy/paste examples, see [`../USAGE.md`](../USAGE
 ```bash
 # Inspect available commands
 cd rust/
-cargo run -p rusty-claude-cli -- --help
+cargo run --bin scode -- --help
 
 # Build the workspace
 cargo build --workspace
 
 # Run the interactive REPL
-cargo run -p rusty-claude-cli -- --model claude-opus-4-6
+cargo run --bin scode -- --model claude-opus-4-6
 
 # One-shot prompt
-cargo run -p rusty-claude-cli -- prompt "explain this codebase"
+cargo run --bin scode -- prompt "explain this codebase"
 
 # JSON output for automation
-cargo run -p rusty-claude-cli -- --output-format json prompt "summarize src/main.rs"
+cargo run --bin scode -- --output-format json prompt "summarize src/main.rs"
 ```
 
 ## Configuration
@@ -37,16 +37,16 @@ Or use `--auth` to select a specific auth mode:
 ```bash
 # Subscription (OAuth)
 export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-..."
-cargo run -p rusty-claude-cli -- --auth subscription
+cargo run --bin scode -- --auth subscription
 
 # Proxy
 export PROXY_AUTH_TOKEN="your-token"
 export PROXY_BASE_URL="https://your-proxy.com"
-cargo run -p rusty-claude-cli -- --auth proxy
+cargo run --bin scode -- --auth proxy
 
 # API key (default auto-detect)
 export ANTHROPIC_API_KEY="sk-ant-..."
-cargo run -p rusty-claude-cli -- --auth api-key
+cargo run --bin scode -- --auth api-key
 ```
 
 ## Mock parity harness
@@ -160,7 +160,7 @@ Top-level commands:
 The command surface is moving quickly. For the canonical live help text, run:
 
 ```bash
-cargo run -p rusty-claude-cli -- --help
+cargo run --bin scode -- --help
 ```
 
 ## Slash Commands (REPL)
@@ -183,7 +183,7 @@ Notable scode-first surfaces now available directly in slash form:
 - `/plugin [list|install <path>|enable <name>|disable <name>|uninstall <id>|update <id>]`
 - `/subagent [list|steer <target> <msg>|kill <id>]`
 
-See [`../USAGE.md`](../USAGE.md) for usage examples and run `cargo run -p rusty-claude-cli -- --help` for the live canonical command list.
+See [`../USAGE.md`](../USAGE.md) for usage examples and run `cargo run --bin scode -- --help` for the live canonical command list.
 
 ## Workspace Layout
 

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -2,7 +2,7 @@ use crate::error::ApiError;
 use crate::prompt_cache::{PromptCache, PromptCacheRecord, PromptCacheStats};
 use crate::providers::anthropic::{self, AnthropicClient, AuthSource};
 use crate::providers::openai_compat::{self, OpenAiCompatClient, OpenAiCompatConfig};
-use crate::providers::{self, ProviderKind};
+use crate::providers::{self, AuthMode, ProviderKind};
 use crate::types::{MessageRequest, MessageResponse, StreamEvent};
 
 #[allow(clippy::large_enum_variant)]
@@ -42,6 +42,51 @@ impl ProviderClient {
                     _ => OpenAiCompatConfig::openai(),
                 };
                 Ok(Self::OpenAi(OpenAiCompatClient::from_env(config)?))
+            }
+        }
+    }
+
+    /// Build a `ProviderClient` using the explicit auth mode. Proxy mode
+    /// always routes through `AnthropicClient` with bearer token +
+    /// `PROXY_BASE_URL`. Subscription mode uses `AnthropicClient` with
+    /// OAuth token + default URL. Api-key mode routes by
+    /// `detect_provider_kind()`.
+    pub fn from_model_and_mode(
+        model: &str,
+        mode: AuthMode,
+        auth: AuthSource,
+    ) -> Result<Self, ApiError> {
+        match mode {
+            AuthMode::Proxy => {
+                let base_url = anthropic::base_url_for_mode(mode);
+                Ok(Self::Anthropic(
+                    AnthropicClient::from_auth_with_mode(auth, Some(mode)).with_base_url(base_url),
+                ))
+            }
+            AuthMode::Subscription => Ok(Self::Anthropic(AnthropicClient::from_auth_with_mode(
+                auth,
+                Some(mode),
+            ))),
+            AuthMode::ApiKey => {
+                let resolved_model = providers::resolve_model_alias(model);
+                match providers::detect_provider_kind(&resolved_model) {
+                    ProviderKind::Anthropic => Ok(Self::Anthropic(
+                        AnthropicClient::from_auth_with_mode(auth, Some(mode))
+                            .with_base_url(anthropic::read_base_url()),
+                    )),
+                    ProviderKind::Xai => Ok(Self::Xai(OpenAiCompatClient::from_env(
+                        OpenAiCompatConfig::xai(),
+                    )?)),
+                    ProviderKind::OpenAi => {
+                        let config = match providers::metadata_for_model(&resolved_model) {
+                            Some(meta) if meta.auth_env == "DASHSCOPE_API_KEY" => {
+                                OpenAiCompatConfig::dashscope()
+                            }
+                            _ => OpenAiCompatConfig::openai(),
+                        };
+                        Ok(Self::OpenAi(OpenAiCompatClient::from_env(config)?))
+                    }
+                }
             }
         }
     }
@@ -130,7 +175,8 @@ impl MessageStream {
 }
 
 pub use anthropic::{
-    oauth_token_is_expired, resolve_saved_oauth_token, resolve_startup_auth_source, OAuthTokenSet,
+    base_url_for_mode, oauth_token_is_expired, resolve_saved_oauth_token,
+    resolve_startup_auth_source, OAuthTokenSet,
 };
 #[must_use]
 pub fn read_base_url() -> String {

--- a/rust/crates/api/src/error.rs
+++ b/rust/crates/api/src/error.rs
@@ -547,7 +547,11 @@ mod tests {
         // given
         let error = ApiError::missing_credentials(
             "Anthropic",
-            &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
+            &[
+                "ANTHROPIC_API_KEY",
+                "CLAUDE_CODE_OAUTH_TOKEN",
+                "PROXY_AUTH_TOKEN",
+            ],
         );
 
         // when
@@ -556,7 +560,7 @@ mod tests {
         // then
         assert!(
             rendered.starts_with(
-                "missing Anthropic credentials; export ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY before calling the Anthropic API"
+                "missing Anthropic credentials; export ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN or PROXY_AUTH_TOKEN before calling the Anthropic API"
             ),
             "rendered error should lead with the canonical missing-credential message: {rendered}"
         );
@@ -571,7 +575,7 @@ mod tests {
         // given
         let error = ApiError::missing_credentials_with_hint(
             "Anthropic",
-            &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
+            &["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "PROXY_AUTH_TOKEN"],
             "I see OPENAI_API_KEY is set — if you meant to use the OpenAI-compat provider, prefix your model name with `openai/` so prefix routing selects it.",
         );
 

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -7,8 +7,9 @@ mod sse;
 mod types;
 
 pub use client::{
-    oauth_token_is_expired, read_base_url, read_xai_base_url, resolve_saved_oauth_token,
-    resolve_startup_auth_source, MessageStream, OAuthTokenSet, ProviderClient,
+    base_url_for_mode, oauth_token_is_expired, read_base_url, read_xai_base_url,
+    resolve_saved_oauth_token, resolve_startup_auth_source, MessageStream, OAuthTokenSet,
+    ProviderClient,
 };
 pub use error::ApiError;
 pub use http_client::{
@@ -19,7 +20,7 @@ pub use prompt_cache::{
     PromptCacheStats,
 };
 pub use providers::anthropic::{
-    is_anthropic_api_key, is_anthropic_auth_token, is_claude_code_oauth_token, AnthropicClient,
+    is_anthropic_api_key, is_claude_code_oauth_token, is_proxy_auth_token, AnthropicClient,
     AnthropicClient as ApiClient, AuthSource, DEFAULT_BASE_URL,
 };
 pub use providers::openai_compat::{
@@ -28,8 +29,9 @@ pub use providers::openai_compat::{
 };
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
-    resolve_model_alias, ProviderKind,
+    resolve_model_alias, AuthMode, ProviderKind,
 };
+pub use providers::{resolve_auth_mode, validate_auth_env};
 pub use sse::{parse_frame, SseParser};
 pub use types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -18,7 +18,9 @@ pub use prompt_cache::{
     CacheBreakEvent, PromptCache, PromptCacheConfig, PromptCachePaths, PromptCacheRecord,
     PromptCacheStats,
 };
-pub use providers::anthropic::{AnthropicClient, AnthropicClient as ApiClient, AuthSource};
+pub use providers::anthropic::{
+    is_claude_code_oauth_token, AnthropicClient, AnthropicClient as ApiClient, AuthSource,
+};
 pub use providers::openai_compat::{
     build_chat_completion_request, flatten_tool_result_content, is_reasoning_model,
     model_rejects_is_error_field, translate_message, OpenAiCompatClient, OpenAiCompatConfig,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -20,7 +20,7 @@ pub use prompt_cache::{
 };
 pub use providers::anthropic::{
     is_anthropic_api_key, is_anthropic_auth_token, is_claude_code_oauth_token, AnthropicClient,
-    AnthropicClient as ApiClient, AuthSource,
+    AnthropicClient as ApiClient, AuthSource, DEFAULT_BASE_URL,
 };
 pub use providers::openai_compat::{
     build_chat_completion_request, flatten_tool_result_content, is_reasoning_model,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -19,7 +19,7 @@ pub use prompt_cache::{
     PromptCacheStats,
 };
 pub use providers::anthropic::{
-    is_anthropic_auth_token, is_claude_code_oauth_token, AnthropicClient,
+    is_anthropic_api_key, is_anthropic_auth_token, is_claude_code_oauth_token, AnthropicClient,
     AnthropicClient as ApiClient, AuthSource,
 };
 pub use providers::openai_compat::{

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -19,7 +19,8 @@ pub use prompt_cache::{
     PromptCacheStats,
 };
 pub use providers::anthropic::{
-    is_claude_code_oauth_token, AnthropicClient, AnthropicClient as ApiClient, AuthSource,
+    is_anthropic_auth_token, is_claude_code_oauth_token, AnthropicClient,
+    AnthropicClient as ApiClient, AuthSource,
 };
 pub use providers::openai_compat::{
     build_chat_completion_request, flatten_tool_result_content, is_reasoning_model,

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -633,6 +633,9 @@ impl AuthSource {
         if let Some(bearer_token) = read_env_non_empty("SCODE_TOKEN")? {
             return Ok(Self::BearerToken(bearer_token));
         }
+        if let Some(bearer_token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {
+            return Ok(Self::BearerToken(bearer_token));
+        }
         if let Some(token_set) = load_saved_oauth_token()? {
             if !oauth_token_is_expired(&token_set) {
                 return Ok(Self::BearerToken(token_set.access_token));
@@ -640,6 +643,14 @@ impl AuthSource {
         }
         Err(anthropic_missing_credentials())
     }
+}
+
+/// Returns `true` when the active auth source comes from `CLAUDE_CODE_OAUTH_TOKEN`.
+pub fn is_claude_code_oauth_token() -> bool {
+    read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")
+        .ok()
+        .flatten()
+        .is_some()
 }
 
 #[must_use]
@@ -660,6 +671,7 @@ pub fn has_auth_from_env_or_saved() -> Result<bool, ApiError> {
     Ok(read_env_non_empty("ANTHROPIC_API_KEY")?.is_some()
         || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")?.is_some()
         || read_env_non_empty("SCODE_TOKEN")?.is_some()
+        || read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")?.is_some()
         || load_saved_oauth_token()?.is_some())
 }
 
@@ -680,6 +692,9 @@ where
         return Ok(AuthSource::BearerToken(bearer_token));
     }
     if let Some(bearer_token) = read_env_non_empty("SCODE_TOKEN")? {
+        return Ok(AuthSource::BearerToken(bearer_token));
+    }
+    if let Some(bearer_token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {
         return Ok(AuthSource::BearerToken(bearer_token));
     }
     if let Some(token_set) = load_saved_oauth_token()? {

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -484,7 +484,7 @@ impl AnthropicClient {
         let request_url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut request_body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut request_body);
-        self.split_system_for_oauth(&mut request_body);
+        self.prepend_oauth_system_prefix(&mut request_body);
         let request_builder = self.build_request(&request_url).json(&request_body);
         request_builder.send().await.map_err(ApiError::from)
     }
@@ -501,37 +501,28 @@ impl AnthropicClient {
         request_builder
     }
 
-    /// When `oauth_system_prefix` is set, transform the `system` field from
-    /// a single string into an array of content blocks so the first block
-    /// contains the exact prefix the server expects for OAuth token access.
-    fn split_system_for_oauth(&self, body: &mut Value) {
+    /// When `oauth_system_prefix` is set, transform the `system` field into
+    /// an array of content blocks with the prefix as the first block. This is
+    /// required for OAuth subscription tokens where the server gates access
+    /// by checking the first system block for an exact match.
+    fn prepend_oauth_system_prefix(&self, body: &mut Value) {
         let Some(prefix) = &self.oauth_system_prefix else {
             return;
         };
         let Some(obj) = body.as_object_mut() else {
             return;
         };
-        let Some(system_val) = obj.remove("system") else {
-            return;
-        };
-        let system_str = match system_val.as_str() {
-            Some(s) => s.to_string(),
-            None => {
-                // Already an array or non-string — put it back.
+        let mut blocks = vec![serde_json::json!({"type": "text", "text": prefix})];
+        if let Some(system_val) = obj.remove("system") {
+            if let Some(s) = system_val.as_str() {
+                if !s.is_empty() {
+                    blocks.push(serde_json::json!({"type": "text", "text": s}));
+                }
+            } else {
+                // Already an array or non-string — put it back as-is.
                 obj.insert("system".to_string(), system_val);
                 return;
             }
-        };
-        let mut blocks = vec![serde_json::json!({"type": "text", "text": prefix})];
-        // Strip the prefix from the full system prompt to get the remainder.
-        let remainder = system_str
-            .strip_prefix(prefix.as_str())
-            .unwrap_or(&system_str);
-        let remainder = remainder
-            .trim_start_matches("\n\n")
-            .trim_start_matches('\n');
-        if !remainder.is_empty() {
-            blocks.push(serde_json::json!({"type": "text", "text": remainder}));
         }
         obj.insert("system".to_string(), Value::Array(blocks));
     }
@@ -581,7 +572,7 @@ impl AnthropicClient {
         );
         let mut request_body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut request_body);
-        self.split_system_for_oauth(&mut request_body);
+        self.prepend_oauth_system_prefix(&mut request_body);
         let response = self
             .build_request(&request_url)
             .json(&request_body)

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -711,6 +711,14 @@ pub fn is_claude_code_oauth_token() -> bool {
         .is_some()
 }
 
+/// Returns `true` when `ANTHROPIC_AUTH_TOKEN` is set and non-empty.
+pub fn is_anthropic_auth_token() -> bool {
+    read_env_non_empty("ANTHROPIC_AUTH_TOKEN")
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 #[must_use]
 pub fn oauth_token_is_expired(token_set: &OAuthTokenSet) -> bool {
     token_set

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -630,6 +630,14 @@ impl AuthSource {
         if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
             return Ok(Self::BearerToken(bearer_token));
         }
+        if let Some(bearer_token) = read_env_non_empty("SCODE_TOKEN")? {
+            return Ok(Self::BearerToken(bearer_token));
+        }
+        if let Some(token_set) = load_saved_oauth_token()? {
+            if !oauth_token_is_expired(&token_set) {
+                return Ok(Self::BearerToken(token_set.access_token));
+            }
+        }
         Err(anthropic_missing_credentials())
     }
 }
@@ -650,14 +658,15 @@ pub fn resolve_saved_oauth_token(config: &OAuthConfig) -> Result<Option<OAuthTok
 
 pub fn has_auth_from_env_or_saved() -> Result<bool, ApiError> {
     Ok(read_env_non_empty("ANTHROPIC_API_KEY")?.is_some()
-        || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")?.is_some())
+        || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")?.is_some()
+        || read_env_non_empty("SCODE_TOKEN")?.is_some()
+        || load_saved_oauth_token()?.is_some())
 }
 
 pub fn resolve_startup_auth_source<F>(load_oauth_config: F) -> Result<AuthSource, ApiError>
 where
     F: FnOnce() -> Result<Option<OAuthConfig>, ApiError>,
 {
-    let _ = load_oauth_config;
     if let Some(api_key) = read_env_non_empty("ANTHROPIC_API_KEY")? {
         return match read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
             Some(bearer_token) => Ok(AuthSource::ApiKeyAndBearer {
@@ -669,6 +678,18 @@ where
     }
     if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
         return Ok(AuthSource::BearerToken(bearer_token));
+    }
+    if let Some(bearer_token) = read_env_non_empty("SCODE_TOKEN")? {
+        return Ok(AuthSource::BearerToken(bearer_token));
+    }
+    if let Some(token_set) = load_saved_oauth_token()? {
+        if let Some(config) = load_oauth_config()? {
+            let resolved = resolve_saved_oauth_token_set(&config, token_set)?;
+            return Ok(AuthSource::BearerToken(resolved.access_token));
+        }
+        if !oauth_token_is_expired(&token_set) {
+            return Ok(AuthSource::BearerToken(token_set.access_token));
+        }
     }
     Err(anthropic_missing_credentials())
 }
@@ -1154,12 +1175,13 @@ mod tests {
     }
 
     #[test]
-    fn auth_source_from_env_or_saved_ignores_saved_oauth_when_env_absent() {
+    fn auth_source_from_env_or_saved_uses_saved_oauth_when_env_absent() {
         let _guard = env_lock();
         let config_home = temp_config_home();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
         std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("SCODE_TOKEN");
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "saved-access-token".to_string(),
             refresh_token: Some("refresh".to_string()),
@@ -1168,8 +1190,8 @@ mod tests {
         })
         .expect("save oauth credentials");
 
-        let error = AuthSource::from_env_or_saved().expect_err("saved oauth should be ignored");
-        assert!(error.to_string().contains("ANTHROPIC_API_KEY"));
+        let auth = AuthSource::from_env_or_saved().expect("saved oauth should be used");
+        assert_eq!(auth.bearer_token(), Some("saved-access-token"));
 
         clear_oauth_credentials().expect("clear credentials");
         std::env::remove_var("SUDO_CODE_CONFIG_HOME");
@@ -1225,12 +1247,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_startup_auth_source_ignores_saved_oauth_without_loading_config() {
+    fn resolve_startup_auth_source_uses_saved_oauth_when_no_env() {
         let _guard = env_lock();
         let config_home = temp_config_home();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
         std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("SCODE_TOKEN");
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "saved-access-token".to_string(),
             refresh_token: Some("refresh".to_string()),
@@ -1239,9 +1262,8 @@ mod tests {
         })
         .expect("save oauth credentials");
 
-        let error = resolve_startup_auth_source(|| panic!("config should not be loaded"))
-            .expect_err("saved oauth should be ignored");
-        assert!(error.to_string().contains("ANTHROPIC_API_KEY"));
+        let auth = resolve_startup_auth_source(|| Ok(None)).expect("saved oauth should be used");
+        assert_eq!(auth.bearer_token(), Some("saved-access-token"));
 
         clear_oauth_credentials().expect("clear credentials");
         std::env::remove_var("SUDO_CODE_CONFIG_HOME");

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -675,6 +675,11 @@ impl AuthSource {
             };
         }
         if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
+            if read_env_non_empty("ANTHROPIC_BASE_URL")?.is_none() {
+                return Err(ApiError::Auth(
+                    "ANTHROPIC_AUTH_TOKEN requires ANTHROPIC_BASE_URL to be set (it is a proxy bearer token).".to_string(),
+                ));
+            }
             return Ok(Self::BearerToken(bearer_token));
         }
         if let Some(bearer_token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -43,17 +43,16 @@ pub enum AuthSource {
 
 impl AuthSource {
     pub fn from_env() -> Result<Self, ApiError> {
-        let api_key = read_env_non_empty("ANTHROPIC_API_KEY")?;
-        let proxy_token = read_env_non_empty("PROXY_AUTH_TOKEN")?;
-        match (api_key, proxy_token) {
-            (Some(api_key), Some(bearer_token)) => Ok(Self::ApiKeyAndBearer {
-                api_key,
-                bearer_token,
-            }),
-            (Some(api_key), None) => Ok(Self::ApiKey(api_key)),
-            (None, Some(bearer_token)) => Ok(Self::BearerToken(bearer_token)),
-            (None, None) => Err(anthropic_missing_credentials()),
+        if let Some(api_key) = read_env_non_empty("ANTHROPIC_API_KEY")? {
+            return Ok(Self::ApiKey(api_key));
         }
+        if let Some(token) = read_env_non_empty("PROXY_AUTH_TOKEN")? {
+            return Ok(Self::BearerToken(token));
+        }
+        if let Some(token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {
+            return Ok(Self::BearerToken(token));
+        }
+        Err(anthropic_missing_credentials())
     }
 
     #[must_use]
@@ -1288,13 +1287,13 @@ mod tests {
     }
 
     #[test]
-    fn auth_source_from_env_combines_api_key_and_bearer_token() {
+    fn auth_source_from_env_prefers_api_key_over_proxy_token() {
         let _guard = env_lock();
-        std::env::set_var("PROXY_AUTH_TOKEN", "auth-token");
-        std::env::set_var("ANTHROPIC_API_KEY", "legacy-key");
+        std::env::set_var("PROXY_AUTH_TOKEN", "proxy-token");
+        std::env::set_var("ANTHROPIC_API_KEY", "api-key");
         let auth = AuthSource::from_env().expect("env auth");
-        assert_eq!(auth.api_key(), Some("legacy-key"));
-        assert_eq!(auth.bearer_token(), Some("auth-token"));
+        assert_eq!(auth.api_key(), Some("api-key"));
+        assert_eq!(auth.bearer_token(), None);
         std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
     }

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -681,9 +681,6 @@ impl AuthSource {
         if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
             return Ok(Self::BearerToken(bearer_token));
         }
-        if let Some(bearer_token) = read_env_non_empty("SCODE_TOKEN")? {
-            return Ok(Self::BearerToken(bearer_token));
-        }
         if let Some(bearer_token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {
             return Ok(Self::BearerToken(bearer_token));
         }
@@ -697,8 +694,8 @@ impl AuthSource {
 }
 
 /// Returns `true` when the active auth source comes from `CLAUDE_CODE_OAUTH_TOKEN`
-/// and no higher-priority auth env var (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
-/// `SCODE_TOKEN`) takes precedence.
+/// and no higher-priority auth env var (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`)
+/// takes precedence.
 pub fn is_claude_code_oauth_token() -> bool {
     // Mirror the precedence in `from_env_or_saved`.
     if read_env_non_empty("ANTHROPIC_API_KEY")
@@ -709,7 +706,6 @@ pub fn is_claude_code_oauth_token() -> bool {
             .ok()
             .flatten()
             .is_some()
-        || read_env_non_empty("SCODE_TOKEN").ok().flatten().is_some()
     {
         return false;
     }
@@ -736,7 +732,6 @@ pub fn resolve_saved_oauth_token(config: &OAuthConfig) -> Result<Option<OAuthTok
 pub fn has_auth_from_env_or_saved() -> Result<bool, ApiError> {
     Ok(read_env_non_empty("ANTHROPIC_API_KEY")?.is_some()
         || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")?.is_some()
-        || read_env_non_empty("SCODE_TOKEN")?.is_some()
         || read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")?.is_some()
         || load_saved_oauth_token()?.is_some())
 }
@@ -755,9 +750,6 @@ where
         };
     }
     if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
-        return Ok(AuthSource::BearerToken(bearer_token));
-    }
-    if let Some(bearer_token) = read_env_non_empty("SCODE_TOKEN")? {
         return Ok(AuthSource::BearerToken(bearer_token));
     }
     if let Some(bearer_token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {
@@ -1262,7 +1254,7 @@ mod tests {
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
         std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
-        std::env::remove_var("SCODE_TOKEN");
+
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "saved-access-token".to_string(),
             refresh_token: Some("refresh".to_string()),
@@ -1334,7 +1326,7 @@ mod tests {
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
         std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
-        std::env::remove_var("SCODE_TOKEN");
+
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "saved-access-token".to_string(),
             refresh_token: Some("refresh".to_string()),

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -122,6 +122,12 @@ pub struct AnthropicClient {
     session_tracer: Option<SessionTracer>,
     prompt_cache: Option<PromptCache>,
     last_prompt_cache_record: Arc<Mutex<Option<PromptCacheRecord>>>,
+    /// When set, the `system` field in outgoing requests is split into an
+    /// array of content blocks: the first block contains this exact prefix
+    /// string, and the second block contains the remainder. This is required
+    /// for OAuth subscription tokens where Anthropic gates access by checking
+    /// the first system block for an exact match.
+    oauth_system_prefix: Option<String>,
 }
 
 impl AnthropicClient {
@@ -138,6 +144,7 @@ impl AnthropicClient {
             session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
+            oauth_system_prefix: None,
         }
     }
 
@@ -154,6 +161,7 @@ impl AnthropicClient {
             session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
+            oauth_system_prefix: None,
         }
     }
 
@@ -272,6 +280,12 @@ impl AnthropicClient {
     #[must_use]
     pub fn with_request_profile(mut self, request_profile: AnthropicRequestProfile) -> Self {
         self.request_profile = request_profile;
+        self
+    }
+
+    #[must_use]
+    pub fn with_oauth_system_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.oauth_system_prefix = Some(prefix.into());
         self
     }
 
@@ -470,6 +484,7 @@ impl AnthropicClient {
         let request_url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut request_body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut request_body);
+        self.split_system_for_oauth(&mut request_body);
         let request_builder = self.build_request(&request_url).json(&request_body);
         request_builder.send().await.map_err(ApiError::from)
     }
@@ -484,6 +499,41 @@ impl AnthropicClient {
             request_builder = request_builder.header(header_name, header_value);
         }
         request_builder
+    }
+
+    /// When `oauth_system_prefix` is set, transform the `system` field from
+    /// a single string into an array of content blocks so the first block
+    /// contains the exact prefix the server expects for OAuth token access.
+    fn split_system_for_oauth(&self, body: &mut Value) {
+        let Some(prefix) = &self.oauth_system_prefix else {
+            return;
+        };
+        let Some(obj) = body.as_object_mut() else {
+            return;
+        };
+        let Some(system_val) = obj.remove("system") else {
+            return;
+        };
+        let system_str = match system_val.as_str() {
+            Some(s) => s.to_string(),
+            None => {
+                // Already an array or non-string — put it back.
+                obj.insert("system".to_string(), system_val);
+                return;
+            }
+        };
+        let mut blocks = vec![serde_json::json!({"type": "text", "text": prefix})];
+        // Strip the prefix from the full system prompt to get the remainder.
+        let remainder = system_str
+            .strip_prefix(prefix.as_str())
+            .unwrap_or(&system_str);
+        let remainder = remainder
+            .trim_start_matches("\n\n")
+            .trim_start_matches('\n');
+        if !remainder.is_empty() {
+            blocks.push(serde_json::json!({"type": "text", "text": remainder}));
+        }
+        obj.insert("system".to_string(), Value::Array(blocks));
     }
 
     async fn preflight_message_request(&self, request: &MessageRequest) -> Result<(), ApiError> {
@@ -531,6 +581,7 @@ impl AnthropicClient {
         );
         let mut request_body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut request_body);
+        self.split_system_for_oauth(&mut request_body);
         let response = self
             .build_request(&request_url)
             .json(&request_body)

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -28,6 +28,7 @@ const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
 const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(128);
 const DEFAULT_MAX_RETRIES: u32 = 8;
+const OAUTH_SYSTEM_PREFIX: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthSource {
@@ -122,12 +123,10 @@ pub struct AnthropicClient {
     session_tracer: Option<SessionTracer>,
     prompt_cache: Option<PromptCache>,
     last_prompt_cache_record: Arc<Mutex<Option<PromptCacheRecord>>>,
-    /// When set, the `system` field in outgoing requests is split into an
-    /// array of content blocks: the first block contains this exact prefix
-    /// string, and the second block contains the remainder. This is required
-    /// for OAuth subscription tokens where Anthropic gates access by checking
-    /// the first system block for an exact match.
-    oauth_system_prefix: Option<String>,
+    /// When true, prepend `OAUTH_SYSTEM_PREFIX` as the first system content
+    /// block. Required for OAuth subscription tokens where the server gates
+    /// access by checking the first system block for an exact match.
+    oauth_system_prefix: bool,
 }
 
 impl AnthropicClient {
@@ -144,13 +143,14 @@ impl AnthropicClient {
             session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
-            oauth_system_prefix: None,
+            oauth_system_prefix: false,
         }
     }
 
     #[must_use]
     pub fn from_auth(auth: AuthSource) -> Self {
-        Self {
+        let is_oauth = is_claude_code_oauth_token();
+        let mut client = Self {
             http: build_http_client_or_default(),
             auth,
             base_url: DEFAULT_BASE_URL.to_string(),
@@ -161,8 +161,15 @@ impl AnthropicClient {
             session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
-            oauth_system_prefix: None,
+            oauth_system_prefix: is_oauth,
+        };
+        if is_oauth {
+            // OAuth subscription tokens require the direct Anthropic API
+            // and the oauth beta header.
+            client.base_url = DEFAULT_BASE_URL.to_string();
+            client.request_profile = client.request_profile.with_beta("oauth-2025-04-20");
         }
+        client
     }
 
     pub fn from_env() -> Result<Self, ApiError> {
@@ -202,7 +209,10 @@ impl AnthropicClient {
 
     #[must_use]
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
-        self.base_url = base_url.into();
+        // OAuth subscription tokens must always use the direct Anthropic API.
+        if !self.oauth_system_prefix {
+            self.base_url = base_url.into();
+        }
         self
     }
 
@@ -280,12 +290,6 @@ impl AnthropicClient {
     #[must_use]
     pub fn with_request_profile(mut self, request_profile: AnthropicRequestProfile) -> Self {
         self.request_profile = request_profile;
-        self
-    }
-
-    #[must_use]
-    pub fn with_oauth_system_prefix(mut self, prefix: impl Into<String>) -> Self {
-        self.oauth_system_prefix = Some(prefix.into());
         self
     }
 
@@ -506,9 +510,10 @@ impl AnthropicClient {
     /// required for OAuth subscription tokens where the server gates access
     /// by checking the first system block for an exact match.
     fn prepend_oauth_system_prefix(&self, body: &mut Value) {
-        let Some(prefix) = &self.oauth_system_prefix else {
+        if !self.oauth_system_prefix {
             return;
-        };
+        }
+        let prefix = OAUTH_SYSTEM_PREFIX;
         let Some(obj) = body.as_object_mut() else {
             return;
         };

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -44,8 +44,8 @@ pub enum AuthSource {
 impl AuthSource {
     pub fn from_env() -> Result<Self, ApiError> {
         let api_key = read_env_non_empty("ANTHROPIC_API_KEY")?;
-        let auth_token = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")?;
-        match (api_key, auth_token) {
+        let proxy_token = read_env_non_empty("PROXY_AUTH_TOKEN")?;
+        match (api_key, proxy_token) {
             (Some(api_key), Some(bearer_token)) => Ok(Self::ApiKeyAndBearer {
                 api_key,
                 bearer_token,
@@ -149,7 +149,20 @@ impl AnthropicClient {
 
     #[must_use]
     pub fn from_auth(auth: AuthSource) -> Self {
-        let is_oauth = is_claude_code_oauth_token();
+        Self::from_auth_with_mode(auth, None)
+    }
+
+    /// Build from an `AuthSource` and an optional explicit `AuthMode`. When
+    /// the mode is `Some(Subscription)` the OAuth system prefix and beta
+    /// header are always applied; when `None` the legacy env-sniffer
+    /// (`is_claude_code_oauth_token`) decides.
+    #[must_use]
+    pub fn from_auth_with_mode(auth: AuthSource, mode: Option<super::AuthMode>) -> Self {
+        let is_subscription = match mode {
+            Some(super::AuthMode::Subscription) => true,
+            Some(_) => false,
+            None => is_claude_code_oauth_token(),
+        };
         let mut client = Self {
             http: build_http_client_or_default(),
             auth,
@@ -161,9 +174,9 @@ impl AnthropicClient {
             session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
-            oauth_system_prefix: is_oauth,
+            oauth_system_prefix: is_subscription,
         };
-        if is_oauth {
+        if is_subscription {
             // OAuth subscription tokens require the direct Anthropic API
             // and the oauth beta header.
             client.base_url = DEFAULT_BASE_URL.to_string();
@@ -666,18 +679,12 @@ fn jitter_for_base(base: Duration) -> Duration {
 impl AuthSource {
     pub fn from_env_or_saved() -> Result<Self, ApiError> {
         if let Some(api_key) = read_env_non_empty("ANTHROPIC_API_KEY")? {
-            return match read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
-                Some(bearer_token) => Ok(Self::ApiKeyAndBearer {
-                    api_key,
-                    bearer_token,
-                }),
-                None => Ok(Self::ApiKey(api_key)),
-            };
+            return Ok(Self::ApiKey(api_key));
         }
-        if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
-            if read_env_non_empty("ANTHROPIC_BASE_URL")?.is_none() {
+        if let Some(bearer_token) = read_env_non_empty("PROXY_AUTH_TOKEN")? {
+            if read_env_non_empty("PROXY_BASE_URL")?.is_none() {
                 return Err(ApiError::Auth(
-                    "ANTHROPIC_AUTH_TOKEN requires ANTHROPIC_BASE_URL to be set (it is a proxy bearer token).".to_string(),
+                    "PROXY_AUTH_TOKEN requires PROXY_BASE_URL to be set.".to_string(),
                 ));
             }
             return Ok(Self::BearerToken(bearer_token));
@@ -692,21 +699,40 @@ impl AuthSource {
         }
         Err(anthropic_missing_credentials())
     }
+
+    /// Build an `AuthSource` for a specific `AuthMode`.
+    pub fn for_mode(mode: super::AuthMode) -> Result<Self, ApiError> {
+        match mode {
+            super::AuthMode::Subscription => {
+                let token = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")?.ok_or_else(|| {
+                    ApiError::Auth(
+                        "CLAUDE_CODE_OAUTH_TOKEN is required for subscription mode.".to_string(),
+                    )
+                })?;
+                Ok(Self::BearerToken(token))
+            }
+            super::AuthMode::Proxy => {
+                let token = read_env_non_empty("PROXY_AUTH_TOKEN")?.ok_or_else(|| {
+                    ApiError::Auth("PROXY_AUTH_TOKEN is required for proxy mode.".to_string())
+                })?;
+                Ok(Self::BearerToken(token))
+            }
+            super::AuthMode::ApiKey => {
+                let api_key = read_env_non_empty("ANTHROPIC_API_KEY")?
+                    .ok_or_else(anthropic_missing_credentials)?;
+                Ok(Self::ApiKey(api_key))
+            }
+        }
+    }
 }
 
 /// Returns `true` when the active auth source comes from `CLAUDE_CODE_OAUTH_TOKEN`
-/// and no higher-priority auth env var (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`)
-/// takes precedence.
+/// and no higher-priority auth env var (`ANTHROPIC_API_KEY`) takes precedence.
 pub fn is_claude_code_oauth_token() -> bool {
-    // Mirror the precedence in `from_env_or_saved`.
     if read_env_non_empty("ANTHROPIC_API_KEY")
         .ok()
         .flatten()
         .is_some()
-        || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")
-            .ok()
-            .flatten()
-            .is_some()
     {
         return false;
     }
@@ -724,9 +750,9 @@ pub fn is_anthropic_api_key() -> bool {
         .is_some()
 }
 
-/// Returns `true` when `ANTHROPIC_AUTH_TOKEN` is set and non-empty.
-pub fn is_anthropic_auth_token() -> bool {
-    read_env_non_empty("ANTHROPIC_AUTH_TOKEN")
+/// Returns `true` when `PROXY_AUTH_TOKEN` is set and non-empty.
+pub fn is_proxy_auth_token() -> bool {
+    read_env_non_empty("PROXY_AUTH_TOKEN")
         .ok()
         .flatten()
         .is_some()
@@ -746,11 +772,14 @@ pub fn resolve_saved_oauth_token(config: &OAuthConfig) -> Result<Option<OAuthTok
     resolve_saved_oauth_token_set(config, token_set).map(Some)
 }
 
-pub fn has_auth_from_env_or_saved() -> Result<bool, ApiError> {
-    Ok(read_env_non_empty("ANTHROPIC_API_KEY")?.is_some()
-        || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")?.is_some()
-        || read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")?.is_some()
-        || load_saved_oauth_token()?.is_some())
+/// Returns `true` when `ANTHROPIC_API_KEY` is set in the environment.
+/// Used by `detect_provider_kind` to check Anthropic auth without
+/// sniffing proxy tokens.
+pub fn has_anthropic_api_key_env() -> bool {
+    read_env_non_empty("ANTHROPIC_API_KEY")
+        .ok()
+        .flatten()
+        .is_some()
 }
 
 pub fn resolve_startup_auth_source<F>(load_oauth_config: F) -> Result<AuthSource, ApiError>
@@ -758,15 +787,9 @@ where
     F: FnOnce() -> Result<Option<OAuthConfig>, ApiError>,
 {
     if let Some(api_key) = read_env_non_empty("ANTHROPIC_API_KEY")? {
-        return match read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
-            Some(bearer_token) => Ok(AuthSource::ApiKeyAndBearer {
-                api_key,
-                bearer_token,
-            }),
-            None => Ok(AuthSource::ApiKey(api_key)),
-        };
+        return Ok(AuthSource::ApiKey(api_key));
     }
-    if let Some(bearer_token) = read_env_non_empty("ANTHROPIC_AUTH_TOKEN")? {
+    if let Some(bearer_token) = read_env_non_empty("PROXY_AUTH_TOKEN")? {
         return Ok(AuthSource::BearerToken(bearer_token));
     }
     if let Some(bearer_token) = read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")? {
@@ -867,14 +890,29 @@ fn read_api_key() -> Result<String, ApiError> {
 
 #[cfg(test)]
 fn read_auth_token() -> Option<String> {
-    read_env_non_empty("ANTHROPIC_AUTH_TOKEN")
+    read_env_non_empty("PROXY_AUTH_TOKEN")
         .ok()
         .and_then(std::convert::identity)
 }
 
+/// Read the base URL. For proxy mode uses `PROXY_BASE_URL`, otherwise
+/// falls back to `ANTHROPIC_BASE_URL` (undocumented test override) or
+/// the default Anthropic API endpoint.
 #[must_use]
 pub fn read_base_url() -> String {
     std::env::var("ANTHROPIC_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string())
+}
+
+/// Return the base URL appropriate for the given auth mode.
+#[must_use]
+pub fn base_url_for_mode(mode: super::AuthMode) -> String {
+    match mode {
+        super::AuthMode::Proxy => {
+            std::env::var("PROXY_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string())
+        }
+        super::AuthMode::Subscription => DEFAULT_BASE_URL.to_string(),
+        super::AuthMode::ApiKey => read_base_url(),
+    }
 }
 
 fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {
@@ -1006,12 +1044,9 @@ const fn is_retryable_status(status: reqwest::StatusCode) -> bool {
 
 /// Anthropic API keys (`sk-ant-*`) are accepted over the `x-api-key` header
 /// and rejected with HTTP 401 "Invalid bearer token" when sent as a Bearer
-/// token via `ANTHROPIC_AUTH_TOKEN`. This happens often enough in the wild
-/// (users copy-paste an `sk-ant-...` key into `ANTHROPIC_AUTH_TOKEN` because
-/// the env var name sounds auth-related) that a bare 401 error is useless.
-/// When we detect this exact shape, append a hint to the error message that
-/// points the user at the one-line fix.
-const SK_ANT_BEARER_HINT: &str = "sk-ant-* keys go in ANTHROPIC_API_KEY (x-api-key header), not ANTHROPIC_AUTH_TOKEN (Bearer header). Move your key to ANTHROPIC_API_KEY.";
+/// token via `PROXY_AUTH_TOKEN`. When we detect this exact shape, append a
+/// hint to the error message that points the user at the one-line fix.
+const SK_ANT_BEARER_HINT: &str = "sk-ant-* keys go in ANTHROPIC_API_KEY (x-api-key header), not PROXY_AUTH_TOKEN (Bearer header). Move your key to ANTHROPIC_API_KEY.";
 
 fn enrich_bearer_auth_error(error: ApiError, auth: &AuthSource) -> ApiError {
     let ApiError::Api {
@@ -1196,7 +1231,7 @@ mod tests {
     #[test]
     fn read_api_key_requires_presence() {
         let _guard = env_lock();
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
         std::env::remove_var("SUDO_CODE_CONFIG_HOME");
         let error = super::read_api_key().expect_err("missing key should error");
@@ -1209,35 +1244,35 @@ mod tests {
     #[test]
     fn read_api_key_requires_non_empty_value() {
         let _guard = env_lock();
-        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "");
+        std::env::set_var("PROXY_AUTH_TOKEN", "");
         std::env::remove_var("ANTHROPIC_API_KEY");
         let error = super::read_api_key().expect_err("empty key should error");
         assert!(matches!(
             error,
             crate::error::ApiError::MissingCredentials { .. }
         ));
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
     }
 
     #[test]
     fn read_api_key_prefers_api_key_env() {
         let _guard = env_lock();
-        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "auth-token");
+        std::env::set_var("PROXY_AUTH_TOKEN", "auth-token");
         std::env::set_var("ANTHROPIC_API_KEY", "legacy-key");
         assert_eq!(
             super::read_api_key().expect("api key should load"),
             "legacy-key"
         );
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
     }
 
     #[test]
     fn read_auth_token_reads_auth_token_env() {
         let _guard = env_lock();
-        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "auth-token");
+        std::env::set_var("PROXY_AUTH_TOKEN", "auth-token");
         assert_eq!(super::read_auth_token().as_deref(), Some("auth-token"));
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
     }
 
     #[test]
@@ -1255,12 +1290,12 @@ mod tests {
     #[test]
     fn auth_source_from_env_combines_api_key_and_bearer_token() {
         let _guard = env_lock();
-        std::env::set_var("ANTHROPIC_AUTH_TOKEN", "auth-token");
+        std::env::set_var("PROXY_AUTH_TOKEN", "auth-token");
         std::env::set_var("ANTHROPIC_API_KEY", "legacy-key");
         let auth = AuthSource::from_env().expect("env auth");
         assert_eq!(auth.api_key(), Some("legacy-key"));
         assert_eq!(auth.bearer_token(), Some("auth-token"));
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
     }
 
@@ -1269,7 +1304,7 @@ mod tests {
         let _guard = env_lock();
         let config_home = temp_config_home();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
 
         save_oauth_credentials(&runtime::OAuthTokenSet {
@@ -1309,7 +1344,7 @@ mod tests {
         let _guard = env_lock();
         let config_home = temp_config_home();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "expired-access-token".to_string(),
@@ -1341,7 +1376,7 @@ mod tests {
         let _guard = env_lock();
         let config_home = temp_config_home();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
 
         save_oauth_credentials(&runtime::OAuthTokenSet {
@@ -1365,7 +1400,7 @@ mod tests {
         let _guard = env_lock();
         let config_home = temp_config_home();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "expired-access-token".to_string(),
@@ -1688,7 +1723,7 @@ mod tests {
         );
         assert!(
             rendered.contains(
-                "sk-ant-* keys go in ANTHROPIC_API_KEY (x-api-key header), not ANTHROPIC_AUTH_TOKEN (Bearer header). Move your key to ANTHROPIC_API_KEY."
+                "sk-ant-* keys go in ANTHROPIC_API_KEY (x-api-key header), not PROXY_AUTH_TOKEN (Bearer header). Move your key to ANTHROPIC_API_KEY."
             ),
             "rendered error should include the sk-ant-* hint: {rendered}"
         );

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -696,8 +696,23 @@ impl AuthSource {
     }
 }
 
-/// Returns `true` when the active auth source comes from `CLAUDE_CODE_OAUTH_TOKEN`.
+/// Returns `true` when the active auth source comes from `CLAUDE_CODE_OAUTH_TOKEN`
+/// and no higher-priority auth env var (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+/// `SCODE_TOKEN`) takes precedence.
 pub fn is_claude_code_oauth_token() -> bool {
+    // Mirror the precedence in `from_env_or_saved`.
+    if read_env_non_empty("ANTHROPIC_API_KEY")
+        .ok()
+        .flatten()
+        .is_some()
+        || read_env_non_empty("ANTHROPIC_AUTH_TOKEN")
+            .ok()
+            .flatten()
+            .is_some()
+        || read_env_non_empty("SCODE_TOKEN").ok().flatten().is_some()
+    {
+        return false;
+    }
     read_env_non_empty("CLAUDE_CODE_OAUTH_TOKEN")
         .ok()
         .flatten()

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -717,9 +717,14 @@ impl AuthSource {
                 Ok(Self::BearerToken(token))
             }
             super::AuthMode::ApiKey => {
-                let api_key = read_env_non_empty("ANTHROPIC_API_KEY")?
-                    .ok_or_else(anthropic_missing_credentials)?;
-                Ok(Self::ApiKey(api_key))
+                // Try ANTHROPIC_API_KEY first.  When it is absent, return
+                // AuthSource::None — non-Anthropic providers (xai, openai)
+                // load their own keys in from_model_and_mode, so the auth
+                // source from here is unused in those paths.
+                match read_env_non_empty("ANTHROPIC_API_KEY")? {
+                    Some(api_key) => Ok(Self::ApiKey(api_key)),
+                    None => Ok(Self::None),
+                }
             }
         }
     }

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -716,6 +716,14 @@ pub fn is_claude_code_oauth_token() -> bool {
         .is_some()
 }
 
+/// Returns `true` when `ANTHROPIC_API_KEY` is set and non-empty.
+pub fn is_anthropic_api_key() -> bool {
+    read_env_non_empty("ANTHROPIC_API_KEY")
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 /// Returns `true` when `ANTHROPIC_AUTH_TOKEN` is set and non-empty.
 pub fn is_anthropic_auth_token() -> bool {
     read_env_non_empty("ANTHROPIC_AUTH_TOKEN")

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -393,7 +393,12 @@ pub(crate) fn anthropic_missing_credentials_hint() -> Option<String> {
 /// signal instead of a generic "missing Anthropic credentials" wall.
 pub(crate) fn anthropic_missing_credentials() -> ApiError {
     const PROVIDER: &str = "Anthropic";
-    const ENV_VARS: &[&str] = &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "SCODE_TOKEN"];
+    const ENV_VARS: &[&str] = &[
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "SCODE_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ];
     match anthropic_missing_credentials_hint() {
         Some(hint) => ApiError::missing_credentials_with_hint(PROVIDER, ENV_VARS, hint),
         None => ApiError::missing_credentials(PROVIDER, ENV_VARS),
@@ -1043,7 +1048,12 @@ NO_EQUALS_LINE
                 assert_eq!(*provider, "Anthropic");
                 assert_eq!(
                     *env_vars,
-                    &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "SCODE_TOKEN"]
+                    &[
+                        "ANTHROPIC_AUTH_TOKEN",
+                        "ANTHROPIC_API_KEY",
+                        "SCODE_TOKEN",
+                        "CLAUDE_CODE_OAUTH_TOKEN"
+                    ]
                 );
                 assert!(
                     hint.is_none(),
@@ -1080,7 +1090,12 @@ NO_EQUALS_LINE
                 assert_eq!(*provider, "Anthropic");
                 assert_eq!(
                     *env_vars,
-                    &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "SCODE_TOKEN"]
+                    &[
+                        "ANTHROPIC_AUTH_TOKEN",
+                        "ANTHROPIC_API_KEY",
+                        "SCODE_TOKEN",
+                        "CLAUDE_CODE_OAUTH_TOKEN"
+                    ]
                 );
                 let hint_value = hint.as_deref().expect("hint should be populated");
                 assert!(

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -10,6 +10,110 @@ use crate::types::{MessageRequest, MessageResponse};
 pub mod anthropic;
 pub mod openai_compat;
 
+/// Explicit auth mode selected via `--auth` CLI flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMode {
+    /// OAuth subscription via `CLAUDE_CODE_OAUTH_TOKEN`.
+    Subscription,
+    /// Proxy bearer token via `PROXY_AUTH_TOKEN` + `PROXY_BASE_URL`.
+    Proxy,
+    /// Direct API key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
+    ApiKey,
+}
+
+impl AuthMode {
+    /// Parse from a CLI string value.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "subscription" => Ok(Self::Subscription),
+            "proxy" => Ok(Self::Proxy),
+            "api-key" => Ok(Self::ApiKey),
+            other => Err(format!(
+                "invalid value for --auth: '{other}'; must be subscription, proxy, or api-key"
+            )),
+        }
+    }
+
+    /// Human-readable label for display in the connected line.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Subscription => "subscription",
+            Self::Proxy => "proxy",
+            Self::ApiKey => "api key",
+        }
+    }
+}
+
+/// Auto-detect the auth mode from the environment when `--auth` is not specified.
+/// Priority: subscription → proxy → api-key.
+pub fn resolve_auth_mode(explicit: Option<AuthMode>) -> Result<AuthMode, ApiError> {
+    if let Some(mode) = explicit {
+        validate_auth_env(mode)?;
+        return Ok(mode);
+    }
+    // Auto-detect: subscription → proxy → api-key
+    if env_present("CLAUDE_CODE_OAUTH_TOKEN") {
+        return Ok(AuthMode::Subscription);
+    }
+    if env_present("PROXY_AUTH_TOKEN") {
+        return Ok(AuthMode::Proxy);
+    }
+    if env_present("ANTHROPIC_API_KEY")
+        || env_present("OPENAI_API_KEY")
+        || env_present("XAI_API_KEY")
+        || env_present("DASHSCOPE_API_KEY")
+        || env_present("GOOGLE_API_KEY")
+    {
+        return Ok(AuthMode::ApiKey);
+    }
+    Err(anthropic_missing_credentials())
+}
+
+/// Validate that the required env vars for the given mode are present.
+pub fn validate_auth_env(mode: AuthMode) -> Result<(), ApiError> {
+    match mode {
+        AuthMode::Subscription => {
+            if !env_present("CLAUDE_CODE_OAUTH_TOKEN") {
+                return Err(ApiError::Auth(
+                    "--auth subscription requires CLAUDE_CODE_OAUTH_TOKEN to be set.".to_string(),
+                ));
+            }
+        }
+        AuthMode::Proxy => {
+            if !env_present("PROXY_AUTH_TOKEN") {
+                return Err(ApiError::Auth(
+                    "--auth proxy requires PROXY_AUTH_TOKEN to be set.".to_string(),
+                ));
+            }
+            if !env_present("PROXY_BASE_URL") {
+                return Err(ApiError::Auth(
+                    "--auth proxy requires PROXY_BASE_URL to be set.".to_string(),
+                ));
+            }
+        }
+        AuthMode::ApiKey => {
+            if !(env_present("ANTHROPIC_API_KEY")
+                || env_present("OPENAI_API_KEY")
+                || env_present("XAI_API_KEY")
+                || env_present("DASHSCOPE_API_KEY")
+                || env_present("GOOGLE_API_KEY"))
+            {
+                return Err(ApiError::Auth(
+                    "--auth api-key requires one of ANTHROPIC_API_KEY, OPENAI_API_KEY, XAI_API_KEY, DASHSCOPE_API_KEY, or GOOGLE_API_KEY to be set.".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn env_present(key: &str) -> bool {
+    std::env::var(key)
+        .ok()
+        .is_some_and(|v| !v.trim().is_empty())
+}
+
 #[allow(dead_code)]
 pub type ProviderFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ApiError>> + Send + 'a>>;
 
@@ -233,7 +337,7 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
     {
         return ProviderKind::OpenAi;
     }
-    if anthropic::has_auth_from_env_or_saved().unwrap_or(false) {
+    if anthropic::has_anthropic_api_key_env() {
         return ProviderKind::Anthropic;
     }
     if openai_compat::has_api_key("OPENAI_API_KEY") {
@@ -394,9 +498,9 @@ pub(crate) fn anthropic_missing_credentials_hint() -> Option<String> {
 pub(crate) fn anthropic_missing_credentials() -> ApiError {
     const PROVIDER: &str = "Anthropic";
     const ENV_VARS: &[&str] = &[
-        "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_OAUTH_TOKEN",
+        "PROXY_AUTH_TOKEN",
     ];
     match anthropic_missing_credentials_hint() {
         Some(hint) => ApiError::missing_credentials_with_hint(PROVIDER, ENV_VARS, hint),
@@ -1048,9 +1152,9 @@ NO_EQUALS_LINE
                 assert_eq!(
                     *env_vars,
                     &[
-                        "ANTHROPIC_AUTH_TOKEN",
                         "ANTHROPIC_API_KEY",
-                        "CLAUDE_CODE_OAUTH_TOKEN"
+                        "CLAUDE_CODE_OAUTH_TOKEN",
+                        "PROXY_AUTH_TOKEN"
                     ]
                 );
                 assert!(
@@ -1089,9 +1193,9 @@ NO_EQUALS_LINE
                 assert_eq!(
                     *env_vars,
                     &[
-                        "ANTHROPIC_AUTH_TOKEN",
                         "ANTHROPIC_API_KEY",
-                        "CLAUDE_CODE_OAUTH_TOKEN"
+                        "CLAUDE_CODE_OAUTH_TOKEN",
+                        "PROXY_AUTH_TOKEN"
                     ]
                 );
                 let hint_value = hint.as_deref().expect("hint should be populated");
@@ -1143,7 +1247,7 @@ NO_EQUALS_LINE
         let _base_url = EnvVarGuard::set("OPENAI_BASE_URL", Some("http://127.0.0.1:11434/v1"));
         let _api_key = EnvVarGuard::set("OPENAI_API_KEY", Some("dummy"));
         let _anthropic_key = EnvVarGuard::set("ANTHROPIC_API_KEY", None);
-        let _anthropic_token = EnvVarGuard::set("ANTHROPIC_AUTH_TOKEN", None);
+        let _proxy_token = EnvVarGuard::set("PROXY_AUTH_TOKEN", None);
 
         // when
         let provider = detect_provider_kind("qwen2.5-coder:7b");

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -396,7 +396,6 @@ pub(crate) fn anthropic_missing_credentials() -> ApiError {
     const ENV_VARS: &[&str] = &[
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_API_KEY",
-        "SCODE_TOKEN",
         "CLAUDE_CODE_OAUTH_TOKEN",
     ];
     match anthropic_missing_credentials_hint() {
@@ -1051,7 +1050,6 @@ NO_EQUALS_LINE
                     &[
                         "ANTHROPIC_AUTH_TOKEN",
                         "ANTHROPIC_API_KEY",
-                        "SCODE_TOKEN",
                         "CLAUDE_CODE_OAUTH_TOKEN"
                     ]
                 );
@@ -1093,7 +1091,6 @@ NO_EQUALS_LINE
                     &[
                         "ANTHROPIC_AUTH_TOKEN",
                         "ANTHROPIC_API_KEY",
-                        "SCODE_TOKEN",
                         "CLAUDE_CODE_OAUTH_TOKEN"
                     ]
                 );

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -393,7 +393,7 @@ pub(crate) fn anthropic_missing_credentials_hint() -> Option<String> {
 /// signal instead of a generic "missing Anthropic credentials" wall.
 pub(crate) fn anthropic_missing_credentials() -> ApiError {
     const PROVIDER: &str = "Anthropic";
-    const ENV_VARS: &[&str] = &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"];
+    const ENV_VARS: &[&str] = &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "SCODE_TOKEN"];
     match anthropic_missing_credentials_hint() {
         Some(hint) => ApiError::missing_credentials_with_hint(PROVIDER, ENV_VARS, hint),
         None => ApiError::missing_credentials(PROVIDER, ENV_VARS),
@@ -1041,7 +1041,10 @@ NO_EQUALS_LINE
                 hint,
             } => {
                 assert_eq!(*provider, "Anthropic");
-                assert_eq!(*env_vars, &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]);
+                assert_eq!(
+                    *env_vars,
+                    &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "SCODE_TOKEN"]
+                );
                 assert!(
                     hint.is_none(),
                     "clean environment should not generate a hint, got {hint:?}"
@@ -1075,7 +1078,10 @@ NO_EQUALS_LINE
                 hint,
             } => {
                 assert_eq!(*provider, "Anthropic");
-                assert_eq!(*env_vars, &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]);
+                assert_eq!(
+                    *env_vars,
+                    &["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "SCODE_TOKEN"]
+                );
                 let hint_value = hint.as_deref().expect("hint should be populated");
                 assert!(
                     hint_value.contains("OPENAI_API_KEY is set"),

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1101,6 +1101,8 @@ pub enum SlashCommand {
         args: Option<String>,
     },
     Doctor,
+    Login,
+    Logout,
     Vim,
     Upgrade,
     Stats,
@@ -1237,6 +1239,8 @@ impl SlashCommand {
             Self::Permissions { .. } => "/permissions",
             Self::Session { .. } => "/session",
             Self::Plugins { .. } => "/plugins",
+            Self::Login => "/login",
+            Self::Logout => "/logout",
             Self::Vim => "/vim",
             Self::Upgrade => "/upgrade",
             Self::Share => "/share",
@@ -1382,6 +1386,13 @@ pub fn validate_slash_command_input(
         "doctor" | "providers" => {
             validate_no_args(command, &args)?;
             SlashCommand::Doctor
+        }
+        "login" | "logout" => {
+            return Err(command_error(
+                "This auth flow was removed. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN instead.",
+                command,
+                "",
+            ));
         }
         "vim" => {
             validate_no_args(command, &args)?;
@@ -4122,6 +4133,8 @@ pub fn handle_slash_command(
         | SlashCommand::Agents { .. }
         | SlashCommand::Skills { .. }
         | SlashCommand::Doctor
+        | SlashCommand::Login
+        | SlashCommand::Logout
         | SlashCommand::Vim
         | SlashCommand::Upgrade
         | SlashCommand::Stats
@@ -4647,6 +4660,14 @@ mod tests {
     }
 
     #[test]
+    fn removed_login_and_logout_commands_report_env_auth_guidance() {
+        let login_error = parse_error_message("/login");
+        assert!(login_error.contains("ANTHROPIC_API_KEY"));
+        let logout_error = parse_error_message("/logout");
+        assert!(logout_error.contains("ANTHROPIC_AUTH_TOKEN"));
+    }
+
+    #[test]
     fn renders_help_from_shared_specs() {
         let help = render_slash_command_help();
         assert!(help.contains("Start here        /status, /diff, /agents, /skills, /commit"));
@@ -4687,6 +4708,8 @@ mod tests {
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help|<skill> [args]]"));
         assert!(help.contains("aliases: /skill"));
+        assert!(!help.contains("/login"));
+        assert!(!help.contains("/logout"));
         assert_eq!(slash_command_specs().len(), 139);
         assert!(resume_supported_slash_commands().len() >= 39);
     }

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -258,6 +258,20 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: true,
     },
     SlashCommandSpec {
+        name: "login",
+        aliases: &[],
+        summary: "Log in with OAuth (browser-based)",
+        argument_hint: None,
+        resume_supported: false,
+    },
+    SlashCommandSpec {
+        name: "logout",
+        aliases: &[],
+        summary: "Clear saved OAuth credentials",
+        argument_hint: None,
+        resume_supported: false,
+    },
+    SlashCommandSpec {
         name: "plan",
         aliases: &[],
         summary: "Toggle or inspect planning mode",
@@ -1387,12 +1401,13 @@ pub fn validate_slash_command_input(
             validate_no_args(command, &args)?;
             SlashCommand::Doctor
         }
-        "login" | "logout" => {
-            return Err(command_error(
-                "This auth flow was removed. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN instead.",
-                command,
-                "",
-            ));
+        "login" => {
+            validate_no_args(command, &args)?;
+            SlashCommand::Login
+        }
+        "logout" => {
+            validate_no_args(command, &args)?;
+            SlashCommand::Logout
         }
         "vim" => {
             validate_no_args(command, &args)?;
@@ -4660,11 +4675,15 @@ mod tests {
     }
 
     #[test]
-    fn removed_login_and_logout_commands_report_env_auth_guidance() {
-        let login_error = parse_error_message("/login");
-        assert!(login_error.contains("ANTHROPIC_API_KEY"));
-        let logout_error = parse_error_message("/logout");
-        assert!(logout_error.contains("ANTHROPIC_AUTH_TOKEN"));
+    fn login_and_logout_commands_parse_successfully() {
+        let login = SlashCommand::parse("/login")
+            .expect("login should parse")
+            .expect("login should be Some");
+        assert_eq!(login.slash_name(), "/login");
+        let logout = SlashCommand::parse("/logout")
+            .expect("logout should parse")
+            .expect("logout should be Some");
+        assert_eq!(logout.slash_name(), "/logout");
     }
 
     #[test]
@@ -4708,9 +4727,9 @@ mod tests {
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help|<skill> [args]]"));
         assert!(help.contains("aliases: /skill"));
-        assert!(!help.contains("/login"));
-        assert!(!help.contains("/logout"));
-        assert_eq!(slash_command_specs().len(), 139);
+        assert!(help.contains("/login"));
+        assert!(help.contains("/logout"));
+        assert_eq!(slash_command_specs().len(), 141);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -258,20 +258,6 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: true,
     },
     SlashCommandSpec {
-        name: "login",
-        aliases: &[],
-        summary: "Log in with OAuth (browser-based)",
-        argument_hint: None,
-        resume_supported: false,
-    },
-    SlashCommandSpec {
-        name: "logout",
-        aliases: &[],
-        summary: "Clear saved OAuth credentials",
-        argument_hint: None,
-        resume_supported: false,
-    },
-    SlashCommandSpec {
         name: "plan",
         aliases: &[],
         summary: "Toggle or inspect planning mode",
@@ -1115,8 +1101,6 @@ pub enum SlashCommand {
         args: Option<String>,
     },
     Doctor,
-    Login,
-    Logout,
     Vim,
     Upgrade,
     Stats,
@@ -1253,8 +1237,6 @@ impl SlashCommand {
             Self::Permissions { .. } => "/permissions",
             Self::Session { .. } => "/session",
             Self::Plugins { .. } => "/plugins",
-            Self::Login => "/login",
-            Self::Logout => "/logout",
             Self::Vim => "/vim",
             Self::Upgrade => "/upgrade",
             Self::Share => "/share",
@@ -1400,14 +1382,6 @@ pub fn validate_slash_command_input(
         "doctor" | "providers" => {
             validate_no_args(command, &args)?;
             SlashCommand::Doctor
-        }
-        "login" => {
-            validate_no_args(command, &args)?;
-            SlashCommand::Login
-        }
-        "logout" => {
-            validate_no_args(command, &args)?;
-            SlashCommand::Logout
         }
         "vim" => {
             validate_no_args(command, &args)?;
@@ -4148,8 +4122,6 @@ pub fn handle_slash_command(
         | SlashCommand::Agents { .. }
         | SlashCommand::Skills { .. }
         | SlashCommand::Doctor
-        | SlashCommand::Login
-        | SlashCommand::Logout
         | SlashCommand::Vim
         | SlashCommand::Upgrade
         | SlashCommand::Stats
@@ -4675,18 +4647,6 @@ mod tests {
     }
 
     #[test]
-    fn login_and_logout_commands_parse_successfully() {
-        let login = SlashCommand::parse("/login")
-            .expect("login should parse")
-            .expect("login should be Some");
-        assert_eq!(login.slash_name(), "/login");
-        let logout = SlashCommand::parse("/logout")
-            .expect("logout should parse")
-            .expect("logout should be Some");
-        assert_eq!(logout.slash_name(), "/logout");
-    }
-
-    #[test]
     fn renders_help_from_shared_specs() {
         let help = render_slash_command_help();
         assert!(help.contains("Start here        /status, /diff, /agents, /skills, /commit"));
@@ -4727,9 +4687,7 @@ mod tests {
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help|<skill> [args]]"));
         assert!(help.contains("aliases: /skill"));
-        assert!(help.contains("/login"));
-        assert!(help.contains("/logout"));
-        assert_eq!(slash_command_specs().len(), 141);
+        assert_eq!(slash_command_specs().len(), 139);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1389,7 +1389,7 @@ pub fn validate_slash_command_input(
         }
         "login" | "logout" => {
             return Err(command_error(
-                "This auth flow was removed. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN instead.",
+                "This auth flow was removed. Set ANTHROPIC_API_KEY or use --auth instead.",
                 command,
                 "",
             ));
@@ -4664,7 +4664,7 @@ mod tests {
         let login_error = parse_error_message("/login");
         assert!(login_error.contains("ANTHROPIC_API_KEY"));
         let logout_error = parse_error_message("/logout");
-        assert!(logout_error.contains("ANTHROPIC_AUTH_TOKEN"));
+        assert!(logout_error.contains("--auth"));
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7734,19 +7734,9 @@ impl AnthropicRuntimeClient {
         let client = match detect_provider_kind(&resolved_model) {
             ProviderKind::Anthropic => {
                 let auth = resolve_cli_auth_source()?;
-                let mut inner = AnthropicClient::from_auth(auth)
+                let inner = AnthropicClient::from_auth(auth)
                     .with_base_url(api::read_base_url())
                     .with_prompt_cache(PromptCache::new(session_id));
-                if api::is_claude_code_oauth_token() {
-                    // OAuth tokens require the direct Anthropic API,
-                    // the oauth beta header, and a magic system prefix.
-                    inner = inner
-                        .with_base_url("https://api.anthropic.com".to_string())
-                        .with_beta("oauth-2025-04-20")
-                        .with_oauth_system_prefix(
-                            "You are Claude Code, Anthropic's official CLI for Claude.",
-                        );
-                }
                 ApiProviderClient::Anthropic(inner)
             }
             ProviderKind::Xai | ProviderKind::OpenAi => {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -49,15 +49,13 @@ use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
     check_base_commit, clear_oauth_credentials, format_stale_base_warning, format_usd,
-    generate_pkce_pair, generate_state, load_oauth_credentials, load_system_prompt,
-    loopback_redirect_uri, parse_oauth_callback_request_target, pricing_for_model,
-    resolve_expected_base, resolve_sandbox_status, save_oauth_credentials, AcpError,
-    AcpSessionUpdateObserver, ApiClient, ApiRequest, AssistantEvent, CompactionConfig,
-    ConfigLoader, ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, McpServer,
-    McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest,
-    OAuthTokenExchangeRequest, OAuthTokenSet, PermissionMode, PermissionPolicy, ProjectContext,
-    PromptCacheEvent, ResolvedPermissionMode, RuntimeError, Session, TokenUsage, ToolError,
-    ToolExecutor, UsageTracker,
+    load_oauth_credentials, load_system_prompt, pricing_for_model, resolve_expected_base,
+    resolve_sandbox_status, AcpError, AcpSessionUpdateObserver, ApiClient, ApiRequest,
+    AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource, ContentBlock,
+    ConversationMessage, ConversationRuntime, McpServer, McpServerManager, McpServerSpec, McpTool,
+    MessageRole, ModelPricing, PermissionMode, PermissionPolicy, ProjectContext, PromptCacheEvent,
+    ResolvedPermissionMode, RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
+    UsageTracker,
 };
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
@@ -2034,102 +2032,27 @@ fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error::Error>> {
 }
 
 fn run_login(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
-    let config = ConfigLoader::default_for(&cwd).load()?;
-    let oauth_config = config.oauth().ok_or(
-        "no OAuth configuration found; add an \"oauth\" section to your scode settings file",
-    )?;
-
-    let pkce = generate_pkce_pair()?;
-    let state = generate_state()?;
-    let port = oauth_config.callback_port.unwrap_or(8160);
-    let redirect_uri = loopback_redirect_uri(port);
-
-    let auth_request =
-        OAuthAuthorizationRequest::from_config(oauth_config, &redirect_uri, &state, &pkce);
-    let authorize_url = auth_request.build_url();
-
-    let listener = TcpListener::bind(format!("127.0.0.1:{port}"))?;
-    eprintln!("Opening browser to log in...");
-    eprintln!("If the browser does not open, visit:\n  {authorize_url}");
-    open_url_in_browser(&authorize_url);
-
-    let (mut stream, _) = listener.accept()?;
-    let mut buf = [0_u8; 4096];
-    let n = io::Read::read(&mut stream, &mut buf)?;
-    let raw_request = String::from_utf8_lossy(&buf[..n]);
-    let request_target = raw_request
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .ok_or("failed to parse HTTP request from OAuth callback")?;
-
-    let params = parse_oauth_callback_request_target(request_target)
-        .map_err(|err| format!("failed to parse callback: {err}"))?;
-
-    if let Some(error) = &params.error {
-        let description = params
-            .error_description
-            .as_deref()
-            .unwrap_or("unknown error");
-        let html_body = format!(
-            "<html><body><h2>Login failed</h2><p>{error}: {description}</p><p>You may close this tab.</p></body></html>"
-        );
-        let response = format!(
-            "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            html_body.len(),
-            html_body,
-        );
-        io::Write::write_all(&mut stream, response.as_bytes())?;
-        return Err(format!("OAuth error: {error} — {description}").into());
+    let claude = find_claude_cli()?;
+    eprintln!("Delegating login to Claude Code...");
+    let status = Command::new(&claude)
+        .args(["auth", "login"])
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()?;
+    if !status.success() {
+        return Err("claude auth login failed".into());
     }
-
-    let code = params
-        .code
-        .ok_or("no authorization code received in callback")?;
-    let returned_state = params.state.as_deref().unwrap_or("");
-    if returned_state != state {
-        return Err("OAuth state mismatch — possible CSRF attack".into());
-    }
-
-    eprintln!("Authorization received, exchanging for token...");
-    let exchange = OAuthTokenExchangeRequest::from_config(
-        oauth_config,
-        &code,
-        &state,
-        &pkce.verifier,
-        &redirect_uri,
-    );
-    let client = AnthropicClient::from_auth(AuthSource::None);
-    let token_set = tokio::runtime::Runtime::new()?
-        .block_on(async { client.exchange_oauth_code(oauth_config, &exchange).await })?;
-
-    save_oauth_credentials(&OAuthTokenSet {
-        access_token: token_set.access_token.clone(),
-        refresh_token: token_set.refresh_token.clone(),
-        expires_at: token_set.expires_at,
-        scopes: token_set.scopes.clone(),
-    })?;
-
-    let html_body =
-        "<html><body><h2>Login successful!</h2><p>You may close this tab and return to the terminal.</p></body></html>";
-    let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        html_body.len(),
-        html_body,
-    );
-    io::Write::write_all(&mut stream, response.as_bytes())?;
-
     match output_format {
         CliOutputFormat::Text => {
-            eprintln!("Login successful! OAuth credentials saved.");
+            eprintln!("Login successful via Claude Code.");
         }
         CliOutputFormat::Json => {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&json!({
                     "status": "ok",
-                    "message": "Login successful",
+                    "message": "Login successful via Claude Code",
                 }))?
             );
         }
@@ -2138,17 +2061,28 @@ fn run_login(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::E
 }
 
 fn run_logout(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
-    clear_oauth_credentials()?;
+    let claude = find_claude_cli()?;
+    let status = Command::new(&claude)
+        .args(["auth", "logout"])
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()?;
+    if !status.success() {
+        return Err("claude auth logout failed".into());
+    }
+    // Also clear any locally saved OAuth credentials.
+    let _ = clear_oauth_credentials();
     match output_format {
         CliOutputFormat::Text => {
-            eprintln!("Logged out. OAuth credentials cleared.");
+            eprintln!("Logged out via Claude Code.");
         }
         CliOutputFormat::Json => {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&json!({
                     "status": "ok",
-                    "message": "Logged out",
+                    "message": "Logged out via Claude Code",
                 }))?
             );
         }
@@ -2156,17 +2090,24 @@ fn run_logout(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::
     Ok(())
 }
 
-fn open_url_in_browser(url: &str) {
-    let result = if cfg!(target_os = "macos") {
-        Command::new("open").arg(url).spawn()
-    } else if cfg!(target_os = "windows") {
-        Command::new("cmd").args(["/c", "start", url]).spawn()
-    } else {
-        Command::new("xdg-open").arg(url).spawn()
-    };
-    if let Err(err) = result {
-        eprintln!("Could not open browser automatically: {err}");
+fn find_claude_cli() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    // Check CLAUDE_BIN env override first, then search PATH.
+    if let Some(bin) = env::var_os("CLAUDE_BIN") {
+        let path = PathBuf::from(bin);
+        if path.is_file() {
+            return Ok(path);
+        }
     }
+    which_command("claude").ok_or_else(|| {
+        "Claude Code CLI (`claude`) not found. Install it first: https://docs.anthropic.com/en/docs/claude-code".into()
+    })
+}
+
+fn which_command(name: &str) -> Option<PathBuf> {
+    let path_var = env::var_os("PATH")?;
+    env::split_paths(&path_var)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.is_file())
 }
 
 fn run_doctor(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -48,13 +48,16 @@ use init::initialize_repo;
 use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
-    check_base_commit, format_stale_base_warning, format_usd, load_oauth_credentials,
-    load_system_prompt, pricing_for_model, resolve_expected_base, resolve_sandbox_status, AcpError,
+    check_base_commit, clear_oauth_credentials, format_stale_base_warning, format_usd,
+    generate_pkce_pair, generate_state, load_oauth_credentials, load_system_prompt,
+    loopback_redirect_uri, parse_oauth_callback_request_target, pricing_for_model,
+    resolve_expected_base, resolve_sandbox_status, save_oauth_credentials, AcpError,
     AcpSessionUpdateObserver, ApiClient, ApiRequest, AssistantEvent, CompactionConfig,
     ConfigLoader, ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, McpServer,
-    McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, PermissionMode,
-    PermissionPolicy, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, RuntimeError,
-    Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
+    McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest,
+    OAuthTokenExchangeRequest, OAuthTokenSet, PermissionMode, PermissionPolicy, ProjectContext,
+    PromptCacheEvent, ResolvedPermissionMode, RuntimeError, Session, TokenUsage, ToolError,
+    ToolExecutor, UsageTracker,
 };
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
@@ -480,6 +483,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
         )?,
+        CliAction::Login { output_format } => run_login(output_format)?,
+        CliAction::Logout { output_format } => run_logout(output_format)?,
         CliAction::HelpTopic(topic) => print_help_topic(topic),
         CliAction::Help { output_format } => print_help(output_format)?,
     }
@@ -585,6 +590,12 @@ enum CliAction {
         base_commit: Option<String>,
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
+    },
+    Login {
+        output_format: CliOutputFormat,
+    },
+    Logout {
+        output_format: CliOutputFormat,
     },
     HelpTopic(LocalHelpTopic),
     // prompt-mode formatting is only supported for non-interactive runs
@@ -973,7 +984,8 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             permission_mode_override,
             reasoning_effort,
         ),
-        "login" | "logout" => Err(removed_auth_surface_error(rest[0].as_str())),
+        "login" => Ok(CliAction::Login { output_format }),
+        "logout" => Ok(CliAction::Logout { output_format }),
         "init" => Ok(CliAction::Init { output_format }),
         "export" => parse_export_args(&rest[1..], output_format),
         "prompt" => {
@@ -1093,7 +1105,7 @@ fn parse_single_word_command_alias(
     let verb = &rest[0];
     let is_diagnostic = matches!(
         verb.as_str(),
-        "help" | "version" | "status" | "sandbox" | "doctor" | "state"
+        "help" | "version" | "status" | "sandbox" | "doctor" | "state" | "login" | "logout"
     );
 
     if is_diagnostic && rest.len() > 1 {
@@ -1131,6 +1143,8 @@ fn parse_single_word_command_alias(
         "sandbox" => Some(Ok(CliAction::Sandbox { output_format })),
         "doctor" => Some(Ok(CliAction::Doctor { output_format })),
         "state" => Some(Ok(CliAction::State { output_format })),
+        "login" => Some(Ok(CliAction::Login { output_format })),
+        "logout" => Some(Ok(CliAction::Logout { output_format })),
         // #146: let `config` and `diff` fall through to parse_subcommand
         // where they are wired as pure-local introspection, instead of
         // producing the "is a slash command" guidance. Zero-arg cases
@@ -1168,12 +1182,6 @@ fn bare_slash_command_guidance(command_name: &str) -> Option<String> {
         )
     };
     Some(guidance)
-}
-
-fn removed_auth_surface_error(command_name: &str) -> String {
-    format!(
-        "`scode {command_name}` has been removed. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN instead."
-    )
 }
 
 fn parse_acp_args(
@@ -2025,6 +2033,142 @@ fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error::Error>> {
     })
 }
 
+fn run_login(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    let config = ConfigLoader::default_for(&cwd).load()?;
+    let oauth_config = config.oauth().ok_or(
+        "no OAuth configuration found; add an \"oauth\" section to your scode settings file",
+    )?;
+
+    let pkce = generate_pkce_pair()?;
+    let state = generate_state()?;
+    let port = oauth_config.callback_port.unwrap_or(8160);
+    let redirect_uri = loopback_redirect_uri(port);
+
+    let auth_request =
+        OAuthAuthorizationRequest::from_config(oauth_config, &redirect_uri, &state, &pkce);
+    let authorize_url = auth_request.build_url();
+
+    let listener = TcpListener::bind(format!("127.0.0.1:{port}"))?;
+    eprintln!("Opening browser to log in...");
+    eprintln!("If the browser does not open, visit:\n  {authorize_url}");
+    open_url_in_browser(&authorize_url);
+
+    let (mut stream, _) = listener.accept()?;
+    let mut buf = [0_u8; 4096];
+    let n = io::Read::read(&mut stream, &mut buf)?;
+    let raw_request = String::from_utf8_lossy(&buf[..n]);
+    let request_target = raw_request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .ok_or("failed to parse HTTP request from OAuth callback")?;
+
+    let params = parse_oauth_callback_request_target(request_target)
+        .map_err(|err| format!("failed to parse callback: {err}"))?;
+
+    if let Some(error) = &params.error {
+        let description = params
+            .error_description
+            .as_deref()
+            .unwrap_or("unknown error");
+        let html_body = format!(
+            "<html><body><h2>Login failed</h2><p>{error}: {description}</p><p>You may close this tab.</p></body></html>"
+        );
+        let response = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            html_body.len(),
+            html_body,
+        );
+        io::Write::write_all(&mut stream, response.as_bytes())?;
+        return Err(format!("OAuth error: {error} — {description}").into());
+    }
+
+    let code = params
+        .code
+        .ok_or("no authorization code received in callback")?;
+    let returned_state = params.state.as_deref().unwrap_or("");
+    if returned_state != state {
+        return Err("OAuth state mismatch — possible CSRF attack".into());
+    }
+
+    eprintln!("Authorization received, exchanging for token...");
+    let exchange = OAuthTokenExchangeRequest::from_config(
+        oauth_config,
+        &code,
+        &state,
+        &pkce.verifier,
+        &redirect_uri,
+    );
+    let client = AnthropicClient::from_auth(AuthSource::None);
+    let token_set = tokio::runtime::Runtime::new()?
+        .block_on(async { client.exchange_oauth_code(oauth_config, &exchange).await })?;
+
+    save_oauth_credentials(&OAuthTokenSet {
+        access_token: token_set.access_token.clone(),
+        refresh_token: token_set.refresh_token.clone(),
+        expires_at: token_set.expires_at,
+        scopes: token_set.scopes.clone(),
+    })?;
+
+    let html_body =
+        "<html><body><h2>Login successful!</h2><p>You may close this tab and return to the terminal.</p></body></html>";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        html_body.len(),
+        html_body,
+    );
+    io::Write::write_all(&mut stream, response.as_bytes())?;
+
+    match output_format {
+        CliOutputFormat::Text => {
+            eprintln!("Login successful! OAuth credentials saved.");
+        }
+        CliOutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "status": "ok",
+                    "message": "Login successful",
+                }))?
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_logout(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+    clear_oauth_credentials()?;
+    match output_format {
+        CliOutputFormat::Text => {
+            eprintln!("Logged out. OAuth credentials cleared.");
+        }
+        CliOutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "status": "ok",
+                    "message": "Logged out",
+                }))?
+            );
+        }
+    }
+    Ok(())
+}
+
+fn open_url_in_browser(url: &str) {
+    let result = if cfg!(target_os = "macos") {
+        Command::new("open").arg(url).spawn()
+    } else if cfg!(target_os = "windows") {
+        Command::new("cmd").args(["/c", "start", url]).spawn()
+    } else {
+        Command::new("xdg-open").arg(url).spawn()
+    };
+    if let Err(err) = result {
+        eprintln!("Could not open browser automatically: {err}");
+    }
+}
+
 fn run_doctor(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
     let report = render_doctor_report()?;
     let message = report.render();
@@ -2174,7 +2318,7 @@ fn check_auth_health() -> DiagnosticCheck {
                     token_set.scopes.join(",")
                 }
             ),
-            "Suggested action  set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN; `scode login` is removed"
+            "Suggested action  set ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or SCODE_TOKEN; or run `scode login`"
                 .to_string(),
         ])
         .with_data(Map::from_iter([
@@ -4748,9 +4892,15 @@ impl LiveCli {
                 println!("{}", format_cost_report(usage));
                 false
             }
-            SlashCommand::Login
-            | SlashCommand::Logout
-            | SlashCommand::Vim
+            SlashCommand::Login => {
+                run_login(CliOutputFormat::Text)?;
+                false
+            }
+            SlashCommand::Logout => {
+                run_logout(CliOutputFormat::Text)?;
+                false
+            }
+            SlashCommand::Vim
             | SlashCommand::Upgrade
             | SlashCommand::Share
             | SlashCommand::Feedback
@@ -10093,11 +10243,19 @@ mod tests {
     }
 
     #[test]
-    fn removed_login_and_logout_subcommands_error_helpfully() {
-        let login = parse_args(&["login".to_string()]).expect_err("login should be removed");
-        assert!(login.contains("ANTHROPIC_API_KEY"));
-        let logout = parse_args(&["logout".to_string()]).expect_err("logout should be removed");
-        assert!(logout.contains("ANTHROPIC_AUTH_TOKEN"));
+    fn login_and_logout_subcommands_parse_successfully() {
+        assert_eq!(
+            parse_args(&["login".to_string()]).expect("login should parse"),
+            CliAction::Login {
+                output_format: CliOutputFormat::Text,
+            }
+        );
+        assert_eq!(
+            parse_args(&["logout".to_string()]).expect("logout should parse"),
+            CliAction::Logout {
+                output_format: CliOutputFormat::Text,
+            }
+        );
         assert_eq!(
             parse_args(&["doctor".to_string()]).expect("doctor should parse"),
             CliAction::Doctor {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1652,6 +1652,8 @@ fn format_connected_line(model: &str) -> String {
         " (subscription)"
     } else if api::is_anthropic_auth_token() {
         " (proxy)"
+    } else if api::is_anthropic_api_key() {
+        " (api key)"
     } else {
         ""
     };
@@ -11659,7 +11661,7 @@ mod tests {
 
         let line = format_connected_line(model);
 
-        assert_eq!(line, "Connected: claude-sonnet-4-6 via anthropic");
+        assert!(line.starts_with("Connected: claude-sonnet-4-6 via anthropic"));
     }
 
     #[test]
@@ -11668,7 +11670,7 @@ mod tests {
 
         let line = format_connected_line(model);
 
-        assert_eq!(line, "Connected: grok-3 via xai");
+        assert!(line.starts_with("Connected: grok-3 via xai"));
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -48,14 +48,13 @@ use init::initialize_repo;
 use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
-    check_base_commit, clear_oauth_credentials, format_stale_base_warning, format_usd,
-    load_oauth_credentials, load_system_prompt, pricing_for_model, resolve_expected_base,
-    resolve_sandbox_status, AcpError, AcpSessionUpdateObserver, ApiClient, ApiRequest,
-    AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource, ContentBlock,
-    ConversationMessage, ConversationRuntime, McpServer, McpServerManager, McpServerSpec, McpTool,
-    MessageRole, ModelPricing, PermissionMode, PermissionPolicy, ProjectContext, PromptCacheEvent,
-    ResolvedPermissionMode, RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
-    UsageTracker,
+    check_base_commit, format_stale_base_warning, format_usd, load_oauth_credentials,
+    load_system_prompt, pricing_for_model, resolve_expected_base, resolve_sandbox_status, AcpError,
+    AcpSessionUpdateObserver, ApiClient, ApiRequest, AssistantEvent, CompactionConfig,
+    ConfigLoader, ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, McpServer,
+    McpServerManager, McpServerSpec, McpTool, MessageRole, ModelPricing, PermissionMode,
+    PermissionPolicy, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, RuntimeError,
+    Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
 };
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
@@ -481,8 +480,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
         )?,
-        CliAction::Login { output_format } => run_login(output_format)?,
-        CliAction::Logout { output_format } => run_logout(output_format)?,
         CliAction::HelpTopic(topic) => print_help_topic(topic),
         CliAction::Help { output_format } => print_help(output_format)?,
     }
@@ -588,12 +585,6 @@ enum CliAction {
         base_commit: Option<String>,
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
-    },
-    Login {
-        output_format: CliOutputFormat,
-    },
-    Logout {
-        output_format: CliOutputFormat,
     },
     HelpTopic(LocalHelpTopic),
     // prompt-mode formatting is only supported for non-interactive runs
@@ -982,8 +973,6 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             permission_mode_override,
             reasoning_effort,
         ),
-        "login" => Ok(CliAction::Login { output_format }),
-        "logout" => Ok(CliAction::Logout { output_format }),
         "init" => Ok(CliAction::Init { output_format }),
         "export" => parse_export_args(&rest[1..], output_format),
         "prompt" => {
@@ -1103,7 +1092,7 @@ fn parse_single_word_command_alias(
     let verb = &rest[0];
     let is_diagnostic = matches!(
         verb.as_str(),
-        "help" | "version" | "status" | "sandbox" | "doctor" | "state" | "login" | "logout"
+        "help" | "version" | "status" | "sandbox" | "doctor" | "state"
     );
 
     if is_diagnostic && rest.len() > 1 {
@@ -1141,8 +1130,6 @@ fn parse_single_word_command_alias(
         "sandbox" => Some(Ok(CliAction::Sandbox { output_format })),
         "doctor" => Some(Ok(CliAction::Doctor { output_format })),
         "state" => Some(Ok(CliAction::State { output_format })),
-        "login" => Some(Ok(CliAction::Login { output_format })),
-        "logout" => Some(Ok(CliAction::Logout { output_format })),
         // #146: let `config` and `diff` fall through to parse_subcommand
         // where they are wired as pure-local introspection, instead of
         // producing the "is a slash command" guidance. Zero-arg cases
@@ -2042,85 +2029,6 @@ fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error::Error>> {
     })
 }
 
-fn run_login(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
-    let claude = find_claude_cli()?;
-    eprintln!("Delegating login to Claude Code...");
-    let status = Command::new(&claude)
-        .args(["auth", "login"])
-        .stdin(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .status()?;
-    if !status.success() {
-        return Err("claude auth login failed".into());
-    }
-    match output_format {
-        CliOutputFormat::Text => {
-            eprintln!("Login successful via Claude Code.");
-        }
-        CliOutputFormat::Json => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&json!({
-                    "status": "ok",
-                    "message": "Login successful via Claude Code",
-                }))?
-            );
-        }
-    }
-    Ok(())
-}
-
-fn run_logout(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
-    let claude = find_claude_cli()?;
-    let status = Command::new(&claude)
-        .args(["auth", "logout"])
-        .stdin(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .status()?;
-    if !status.success() {
-        return Err("claude auth logout failed".into());
-    }
-    // Also clear any locally saved OAuth credentials.
-    let _ = clear_oauth_credentials();
-    match output_format {
-        CliOutputFormat::Text => {
-            eprintln!("Logged out via Claude Code.");
-        }
-        CliOutputFormat::Json => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&json!({
-                    "status": "ok",
-                    "message": "Logged out via Claude Code",
-                }))?
-            );
-        }
-    }
-    Ok(())
-}
-
-fn find_claude_cli() -> Result<PathBuf, Box<dyn std::error::Error>> {
-    // Check CLAUDE_BIN env override first, then search PATH.
-    if let Some(bin) = env::var_os("CLAUDE_BIN") {
-        let path = PathBuf::from(bin);
-        if path.is_file() {
-            return Ok(path);
-        }
-    }
-    which_command("claude").ok_or_else(|| {
-        "Claude Code CLI (`claude`) not found. Install it first: https://docs.anthropic.com/en/docs/claude-code".into()
-    })
-}
-
-fn which_command(name: &str) -> Option<PathBuf> {
-    let path_var = env::var_os("PATH")?;
-    env::split_paths(&path_var)
-        .map(|dir| dir.join(name))
-        .find(|candidate| candidate.is_file())
-}
-
 fn run_doctor(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
     let report = render_doctor_report()?;
     let message = report.render();
@@ -2270,7 +2178,7 @@ fn check_auth_health() -> DiagnosticCheck {
                     token_set.scopes.join(",")
                 }
             ),
-            "Suggested action  set ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or SCODE_TOKEN; or run `scode login`"
+            "Suggested action  set ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN"
                 .to_string(),
         ])
         .with_data(Map::from_iter([
@@ -3584,8 +3492,6 @@ fn run_resume_command(
         | SlashCommand::Permissions { .. }
         | SlashCommand::Session { .. }
         | SlashCommand::Plugins { .. }
-        | SlashCommand::Login
-        | SlashCommand::Logout
         | SlashCommand::Vim
         | SlashCommand::Upgrade
         | SlashCommand::Share
@@ -4842,14 +4748,6 @@ impl LiveCli {
             SlashCommand::Stats => {
                 let usage = UsageTracker::from_session(self.runtime.session()).cumulative_usage();
                 println!("{}", format_cost_report(usage));
-                false
-            }
-            SlashCommand::Login => {
-                run_login(CliOutputFormat::Text)?;
-                false
-            }
-            SlashCommand::Logout => {
-                run_logout(CliOutputFormat::Text)?;
                 false
             }
             SlashCommand::Vim
@@ -8292,8 +8190,6 @@ fn collect_prompt_cache_events(summary: &runtime::TurnSummary) -> Vec<serde_json
 /// in this build. Used to filter both REPL completions and help output so the
 /// discovery surface only shows commands that actually work (ROADMAP #39).
 const STUB_COMMANDS: &[&str] = &[
-    "login",
-    "logout",
     "vim",
     "upgrade",
     "share",
@@ -10219,19 +10115,7 @@ mod tests {
     }
 
     #[test]
-    fn login_and_logout_subcommands_parse_successfully() {
-        assert_eq!(
-            parse_args(&["login".to_string()]).expect("login should parse"),
-            CliAction::Login {
-                output_format: CliOutputFormat::Text,
-            }
-        );
-        assert_eq!(
-            parse_args(&["logout".to_string()]).expect("logout should parse"),
-            CliAction::Logout {
-                output_format: CliOutputFormat::Text,
-            }
-        );
+    fn diagnostic_subcommands_parse_successfully() {
         assert_eq!(
             parse_args(&["doctor".to_string()]).expect("doctor should parse"),
             CliAction::Doctor {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -30,11 +30,10 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    detect_provider_kind, resolve_startup_auth_source, AnthropicClient, AnthropicRequestProfile,
-    AuthSource, ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest,
-    MessageResponse, OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient,
-    ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
-    ToolResultContentBlock,
+    detect_provider_kind, resolve_startup_auth_source, AnthropicClient, AuthSource,
+    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
+    OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient, ProviderKind,
+    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
 
 use commands::{
@@ -1655,7 +1654,12 @@ fn provider_label(kind: ProviderKind) -> &'static str {
 
 fn format_connected_line(model: &str) -> String {
     let provider = provider_label(detect_provider_kind(model));
-    format!("Connected: {model} via {provider}")
+    let auth_hint = if api::is_claude_code_oauth_token() {
+        " (subscription)"
+    } else {
+        ""
+    };
+    format!("Connected: {model} via {provider}{auth_hint}")
 }
 
 fn filter_tool_specs(
@@ -7819,13 +7823,17 @@ impl AnthropicRuntimeClient {
                     .with_base_url(api::read_base_url())
                     .with_prompt_cache(PromptCache::new(session_id));
                 if api::is_claude_code_oauth_token() {
-                    // Replace the default betas with only the OAuth beta.
-                    // The default claude-code-20250219 beta routes to a
-                    // backend that rejects raw OAuth tokens.
-                    inner = inner.with_request_profile(
-                        AnthropicRequestProfile::default()
-                            .with_betas(vec!["oauth-2025-04-20".to_string()]),
-                    );
+                    // OAuth tokens require:
+                    // 1. Direct Anthropic API (not proxies)
+                    // 2. The oauth-2025-04-20 beta header
+                    // 3. System prompt split into array blocks where the
+                    //    first block is the exact magic prefix string
+                    inner = inner
+                        .with_base_url("https://api.anthropic.com".to_string())
+                        .with_beta("oauth-2025-04-20")
+                        .with_oauth_system_prefix(
+                            "You are Claude Code, Anthropic's official CLI for Claude.",
+                        );
                 }
                 ApiProviderClient::Anthropic(inner)
             }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1656,6 +1656,12 @@ fn format_connected_line(model: &str) -> String {
     let provider = provider_label(detect_provider_kind(model));
     let auth_hint = if api::is_claude_code_oauth_token() {
         " (subscription)"
+    } else if std::env::var("ANTHROPIC_AUTH_TOKEN")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .is_some()
+    {
+        " (proxy)"
     } else {
         ""
     };

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7814,9 +7814,12 @@ impl AnthropicRuntimeClient {
         let client = match detect_provider_kind(&resolved_model) {
             ProviderKind::Anthropic => {
                 let auth = resolve_cli_auth_source()?;
-                let inner = AnthropicClient::from_auth(auth)
+                let mut inner = AnthropicClient::from_auth(auth)
                     .with_base_url(api::read_base_url())
                     .with_prompt_cache(PromptCache::new(session_id));
+                if api::is_claude_code_oauth_token() {
+                    inner = inner.with_beta("oauth-2025-04-20");
+                }
                 ApiProviderClient::Anthropic(inner)
             }
             ProviderKind::Xai | ProviderKind::OpenAi => {
@@ -7871,7 +7874,18 @@ impl ApiClient for AnthropicRuntimeClient {
             model: self.model.clone(),
             max_tokens: max_tokens_for_model(&self.model),
             messages: convert_messages(&request.messages),
-            system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n")),
+            system: if api::is_claude_code_oauth_token() {
+                let joined = request.system_prompt.join("\n\n");
+                if joined.is_empty() {
+                    Some("You are Claude Code, Anthropic's official CLI for Claude.".to_string())
+                } else {
+                    Some(format!(
+                        "You are Claude Code, Anthropic's official CLI for Claude.\n\n{joined}"
+                    ))
+                }
+            } else {
+                (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n"))
+            },
             tools: self
                 .enable_tools
                 .then(|| filter_tool_specs(&self.tool_registry, self.allowed_tools.as_ref())),

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7738,11 +7738,8 @@ impl AnthropicRuntimeClient {
                     .with_base_url(api::read_base_url())
                     .with_prompt_cache(PromptCache::new(session_id));
                 if api::is_claude_code_oauth_token() {
-                    // OAuth tokens require:
-                    // 1. Direct Anthropic API (not proxies)
-                    // 2. The oauth-2025-04-20 beta header
-                    // 3. System prompt split into array blocks where the
-                    //    first block is the exact magic prefix string
+                    // OAuth tokens require the direct Anthropic API,
+                    // the oauth beta header, and a magic system prefix.
                     inner = inner
                         .with_base_url("https://api.anthropic.com".to_string())
                         .with_beta("oauth-2025-04-20")
@@ -7804,18 +7801,7 @@ impl ApiClient for AnthropicRuntimeClient {
             model: self.model.clone(),
             max_tokens: max_tokens_for_model(&self.model),
             messages: convert_messages(&request.messages),
-            system: if api::is_claude_code_oauth_token() {
-                let joined = request.system_prompt.join("\n\n");
-                if joined.is_empty() {
-                    Some("You are Claude Code, Anthropic's official CLI for Claude.".to_string())
-                } else {
-                    Some(format!(
-                        "You are Claude Code, Anthropic's official CLI for Claude.\n\n{joined}"
-                    ))
-                }
-            } else {
-                (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n"))
-            },
+            system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n")),
             tools: self
                 .enable_tools
                 .then(|| filter_tool_specs(&self.tool_registry, self.allowed_tools.as_ref())),

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -973,6 +973,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             permission_mode_override,
             reasoning_effort,
         ),
+        "login" | "logout" => Err(removed_auth_surface_error(rest[0].as_str())),
         "init" => Ok(CliAction::Init { output_format }),
         "export" => parse_export_args(&rest[1..], output_format),
         "prompt" => {
@@ -1167,6 +1168,12 @@ fn bare_slash_command_guidance(command_name: &str) -> Option<String> {
         )
     };
     Some(guidance)
+}
+
+fn removed_auth_surface_error(command_name: &str) -> String {
+    format!(
+        "`scode {command_name}` has been removed. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN instead."
+    )
 }
 
 fn parse_acp_args(
@@ -3492,6 +3499,8 @@ fn run_resume_command(
         | SlashCommand::Permissions { .. }
         | SlashCommand::Session { .. }
         | SlashCommand::Plugins { .. }
+        | SlashCommand::Login
+        | SlashCommand::Logout
         | SlashCommand::Vim
         | SlashCommand::Upgrade
         | SlashCommand::Share
@@ -4750,7 +4759,9 @@ impl LiveCli {
                 println!("{}", format_cost_report(usage));
                 false
             }
-            SlashCommand::Vim
+            SlashCommand::Login
+            | SlashCommand::Logout
+            | SlashCommand::Vim
             | SlashCommand::Upgrade
             | SlashCommand::Share
             | SlashCommand::Feedback
@@ -8190,6 +8201,8 @@ fn collect_prompt_cache_events(summary: &runtime::TurnSummary) -> Vec<serde_json
 /// in this build. Used to filter both REPL completions and help output so the
 /// discovery surface only shows commands that actually work (ROADMAP #39).
 const STUB_COMMANDS: &[&str] = &[
+    "login",
+    "logout",
     "vim",
     "upgrade",
     "share",
@@ -10115,7 +10128,11 @@ mod tests {
     }
 
     #[test]
-    fn diagnostic_subcommands_parse_successfully() {
+    fn removed_login_and_logout_subcommands_error_helpfully() {
+        let login = parse_args(&["login".to_string()]).expect_err("login should be removed");
+        assert!(login.contains("ANTHROPIC_API_KEY"));
+        let logout = parse_args(&["logout".to_string()]).expect_err("logout should be removed");
+        assert!(logout.contains("ANTHROPIC_AUTH_TOKEN"));
         assert_eq!(
             parse_args(&["doctor".to_string()]).expect("doctor should parse"),
             CliAction::Doctor {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1650,11 +1650,7 @@ fn format_connected_line(model: &str) -> String {
     let provider = provider_label(detect_provider_kind(model));
     let auth_hint = if api::is_claude_code_oauth_token() {
         " (subscription)"
-    } else if std::env::var("ANTHROPIC_AUTH_TOKEN")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .is_some()
-    {
+    } else if api::is_anthropic_auth_token() {
         " (proxy)"
     } else {
         ""

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -699,9 +699,9 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 index += 1;
             }
             "--auth" => {
-                let value = args
-                    .get(index + 1)
-                    .ok_or_else(|| "missing value for --auth; must be subscription, proxy, or api-key".to_string())?;
+                let value = args.get(index + 1).ok_or_else(|| {
+                    "missing value for --auth; must be subscription, proxy, or api-key".to_string()
+                })?;
                 auth_mode = Some(AuthMode::parse(value)?);
                 index += 2;
             }
@@ -9251,6 +9251,10 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(
         out,
         "  --model MODEL              Override the active model"
+    )?;
+    writeln!(
+        out,
+        "  --auth MODE                Auth mode: subscription, proxy, or api-key"
     )?;
     writeln!(
         out,

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7798,19 +7798,23 @@ impl AnthropicRuntimeClient {
         auth_mode: Option<AuthMode>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let resolved_model = api::resolve_model_alias(&model);
-        let client = if let Some(mode) = auth_mode {
-            // Explicit --auth mode: validate required env vars, resolve
-            // auth source for the mode, then build via from_model_and_mode
-            // which handles proxy/subscription/api-key routing.
-            validate_auth_env(mode)?;
+        // Resolve the effective auth mode: use the explicit --auth flag if
+        // provided, otherwise auto-detect from env vars.  Once we have
+        // a mode, the same from_model_and_mode path handles all routing.
+        let effective_mode = match auth_mode {
+            Some(mode) => {
+                validate_auth_env(mode)?;
+                Some(mode)
+            }
+            None => resolve_auth_mode(None).ok(),
+        };
+        let client = if let Some(mode) = effective_mode {
             let auth = AuthSource::for_mode(mode)?;
             ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
                 .with_prompt_cache(PromptCache::new(session_id))
         } else {
-            // Auto-detect: legacy path. For Anthropic we build the client
-            // directly to apply `api::read_base_url()` (needed for the
-            // mock-server test harness) and attach a session-scoped prompt
-            // cache. Non-Anthropic variants route via detect_provider_kind.
+            // No recognised auth env vars at all — fall back to the
+            // legacy provider-detection path for non-Anthropic models.
             match detect_provider_kind(&resolved_model) {
                 ProviderKind::Anthropic => {
                     let auth = resolve_cli_auth_source()?;

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -2225,7 +2225,7 @@ fn check_auth_health() -> DiagnosticCheck {
                     token_set.scopes.join(",")
                 }
             ),
-            "Suggested action  set ANTHROPIC_API_KEY, PROXY_AUTH_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN"
+            "Suggested action  set ANTHROPIC_API_KEY or use --auth; `scode login` is removed"
                 .to_string(),
         ])
         .with_data(Map::from_iter([

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -30,10 +30,11 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    detect_provider_kind, resolve_startup_auth_source, AnthropicClient, AuthSource,
-    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient, ProviderKind,
-    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
+    detect_provider_kind, resolve_startup_auth_source, AnthropicClient, AnthropicRequestProfile,
+    AuthSource, ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient,
+    ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
+    ToolResultContentBlock,
 };
 
 use commands::{
@@ -7818,7 +7819,13 @@ impl AnthropicRuntimeClient {
                     .with_base_url(api::read_base_url())
                     .with_prompt_cache(PromptCache::new(session_id));
                 if api::is_claude_code_oauth_token() {
-                    inner = inner.with_beta("oauth-2025-04-20");
+                    // Replace the default betas with only the OAuth beta.
+                    // The default claude-code-20250219 beta routes to a
+                    // backend that rejects raw OAuth tokens.
+                    inner = inner.with_request_profile(
+                        AnthropicRequestProfile::default()
+                            .with_betas(vec!["oauth-2025-04-20".to_string()]),
+                    );
                 }
                 ApiProviderClient::Anthropic(inner)
             }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1657,7 +1657,13 @@ fn format_connected_line(model: &str) -> String {
     } else {
         ""
     };
-    format!("Connected: {model} via {provider}{auth_hint}")
+    let base_url = api::read_base_url();
+    let endpoint_hint = if base_url != api::DEFAULT_BASE_URL {
+        format!("\nEndpoint:  {base_url}")
+    } else {
+        String::new()
+    };
+    format!("Connected: {model} via {provider}{auth_hint}{endpoint_hint}")
 }
 
 fn filter_tool_specs(

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -30,10 +30,11 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    detect_provider_kind, resolve_startup_auth_source, AnthropicClient, AuthSource,
-    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient, ProviderKind,
-    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
+    base_url_for_mode, detect_provider_kind, resolve_auth_mode, resolve_startup_auth_source,
+    validate_auth_env, AnthropicClient, AuthMode, AuthSource, ContentBlockDelta, InputContentBlock,
+    InputMessage, MessageRequest, MessageResponse, OutputContentBlock, PromptCache,
+    ProviderClient as ApiProviderClient, ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice,
+    ToolDefinition, ToolResultContentBlock,
 };
 
 use commands::{
@@ -185,6 +186,7 @@ const CLI_OPTION_SUGGESTIONS: &[&str] = &[
     "--version",
     "-V",
     "--model",
+    "--auth",
     "--output-format",
     "--permission-mode",
     "--dangerously-skip-permissions",
@@ -397,6 +399,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             base_commit,
             reasoning_effort,
             allow_broad_cwd,
+            auth_mode,
         } => {
             enforce_broad_cwd_policy(allow_broad_cwd, output_format)?;
             run_stale_base_preflight(base_commit.as_deref());
@@ -411,7 +414,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 None
             };
             let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
-            let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode)?;
+            let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode, auth_mode)?;
             cli.set_reasoning_effort(reasoning_effort);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
         }
@@ -422,12 +425,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
+            auth_mode,
         } => run_acp_server(
             model,
             model_flag_raw,
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
+            auth_mode,
         )?,
         CliAction::State { output_format } => run_worker_state(output_format)?,
         CliAction::Init { output_format } => run_init(output_format)?,
@@ -472,6 +477,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             base_commit,
             reasoning_effort,
             allow_broad_cwd,
+            auth_mode,
         } => run_repl(
             model,
             allowed_tools,
@@ -479,6 +485,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             base_commit,
             reasoning_effort,
             allow_broad_cwd,
+            auth_mode,
         )?,
         CliAction::HelpTopic(topic) => print_help_topic(topic),
         CliAction::Help { output_format } => print_help(output_format)?,
@@ -547,6 +554,7 @@ enum CliAction {
         base_commit: Option<String>,
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
+        auth_mode: Option<AuthMode>,
     },
     Doctor {
         output_format: CliOutputFormat,
@@ -557,6 +565,7 @@ enum CliAction {
         allowed_tools: Option<AllowedToolSet>,
         permission_mode_override: Option<PermissionMode>,
         reasoning_effort: Option<String>,
+        auth_mode: Option<AuthMode>,
     },
     State {
         output_format: CliOutputFormat,
@@ -585,6 +594,7 @@ enum CliAction {
         base_commit: Option<String>,
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
+        auth_mode: Option<AuthMode>,
     },
     HelpTopic(LocalHelpTopic),
     // prompt-mode formatting is only supported for non-interactive runs
@@ -634,6 +644,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
     // #148: when user passes --model/--model=, capture the raw input so we
     // can attribute source: "flag" later. None means no flag was supplied.
     let mut model_flag_raw: Option<String> = None;
+    let mut auth_mode: Option<AuthMode> = None;
     let mut output_format = CliOutputFormat::Text;
     let mut permission_mode_override = None;
     let mut wants_help = false;
@@ -685,6 +696,17 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 validate_model_syntax(value)?;
                 model = resolve_model_alias_with_config(value);
                 model_flag_raw = Some(value.to_string()); // #148
+                index += 1;
+            }
+            "--auth" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| "missing value for --auth; must be subscription, proxy, or api-key".to_string())?;
+                auth_mode = Some(AuthMode::parse(value)?);
+                index += 2;
+            }
+            flag if flag.starts_with("--auth=") => {
+                auth_mode = Some(AuthMode::parse(&flag[7..])?);
                 index += 1;
             }
             "--output-format" => {
@@ -771,6 +793,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                     base_commit: base_commit.clone(),
                     reasoning_effort: reasoning_effort.clone(),
                     allow_broad_cwd,
+                    auth_mode,
                 });
             }
             "--print" => {
@@ -847,6 +870,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                     base_commit,
                     reasoning_effort,
                     allow_broad_cwd,
+                    auth_mode,
                 });
             }
         }
@@ -857,6 +881,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             base_commit,
             reasoning_effort: reasoning_effort.clone(),
             allow_broad_cwd,
+            auth_mode,
         });
     }
     if rest.first().map(String::as_str) == Some("--resume") {
@@ -957,6 +982,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                     base_commit,
                     reasoning_effort: reasoning_effort.clone(),
                     allow_broad_cwd,
+                    auth_mode,
                 }),
                 SkillSlashDispatch::Local => Ok(CliAction::Skills {
                     args,
@@ -972,6 +998,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
+            auth_mode,
         ),
         "login" | "logout" => Err(removed_auth_surface_error(rest[0].as_str())),
         "init" => Ok(CliAction::Init { output_format }),
@@ -991,6 +1018,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 base_commit: base_commit.clone(),
                 reasoning_effort: reasoning_effort.clone(),
                 allow_broad_cwd,
+                auth_mode,
             })
         }
         other if other.starts_with('/') => parse_direct_slash_cli_action(
@@ -1003,6 +1031,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             base_commit,
             reasoning_effort,
             allow_broad_cwd,
+            auth_mode,
         ),
         other => {
             if rest.len() == 1 && looks_like_subcommand_typo(other) {
@@ -1041,6 +1070,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 base_commit,
                 reasoning_effort: reasoning_effort.clone(),
                 allow_broad_cwd,
+                auth_mode,
             })
         }
     }
@@ -1171,9 +1201,7 @@ fn bare_slash_command_guidance(command_name: &str) -> Option<String> {
 }
 
 fn removed_auth_surface_error(command_name: &str) -> String {
-    format!(
-        "`scode {command_name}` has been removed. Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN instead."
-    )
+    format!("`scode {command_name}` has been removed. Set ANTHROPIC_API_KEY or use --auth instead.")
 }
 
 fn parse_acp_args(
@@ -1183,6 +1211,7 @@ fn parse_acp_args(
     allowed_tools: Option<AllowedToolSet>,
     permission_mode_override: Option<PermissionMode>,
     reasoning_effort: Option<String>,
+    auth_mode: Option<AuthMode>,
 ) -> Result<CliAction, String> {
     match args {
         [] => Ok(CliAction::Acp {
@@ -1191,6 +1220,7 @@ fn parse_acp_args(
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
+            auth_mode,
         }),
         [subcommand] if subcommand == "serve" => Ok(CliAction::Acp {
             model,
@@ -1198,6 +1228,7 @@ fn parse_acp_args(
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
+            auth_mode,
         }),
         _ => Err(String::from(
             "unsupported ACP invocation. Use `scode acp`, `scode acp serve`, `scode --acp`, or `scode -acp`.",
@@ -1238,6 +1269,7 @@ fn parse_direct_slash_cli_action(
     base_commit: Option<String>,
     reasoning_effort: Option<String>,
     allow_broad_cwd: bool,
+    auth_mode: Option<AuthMode>,
 ) -> Result<CliAction, String> {
     let raw = rest.join(" ");
     match SlashCommand::parse(&raw) {
@@ -1267,6 +1299,7 @@ fn parse_direct_slash_cli_action(
                     base_commit,
                     reasoning_effort: reasoning_effort.clone(),
                     allow_broad_cwd,
+                    auth_mode,
                 }),
                 SkillSlashDispatch::Local => Ok(CliAction::Skills {
                     args,
@@ -1647,17 +1680,20 @@ fn provider_label(kind: ProviderKind) -> &'static str {
 }
 
 fn format_connected_line(model: &str) -> String {
+    format_connected_line_with_mode(model, None)
+}
+
+fn format_connected_line_with_mode(model: &str, mode: Option<AuthMode>) -> String {
     let provider = provider_label(detect_provider_kind(model));
-    let auth_hint = if api::is_claude_code_oauth_token() {
-        " (subscription)"
-    } else if api::is_anthropic_auth_token() {
-        " (proxy)"
-    } else if api::is_anthropic_api_key() {
-        " (api key)"
-    } else {
-        ""
+    let resolved_mode = mode.or_else(|| resolve_auth_mode(None).ok());
+    let auth_hint = match resolved_mode {
+        Some(m) => format!(" ({})", m.label()),
+        None => String::new(),
     };
-    let base_url = api::read_base_url();
+    let base_url = match mode {
+        Some(m) => api::base_url_for_mode(m),
+        None => api::read_base_url(),
+    };
     let endpoint_hint = if base_url != api::DEFAULT_BASE_URL {
         format!("\nEndpoint:  {base_url}")
     } else {
@@ -2144,13 +2180,13 @@ fn check_auth_health() -> DiagnosticCheck {
     let api_key_present = env::var("ANTHROPIC_API_KEY")
         .ok()
         .is_some_and(|value| !value.trim().is_empty());
-    let auth_token_present = env::var("ANTHROPIC_AUTH_TOKEN")
+    let proxy_token_present = env::var("PROXY_AUTH_TOKEN")
         .ok()
         .is_some_and(|value| !value.trim().is_empty());
     let env_details = format!(
-        "Environment       api_key={} auth_token={}",
+        "Environment       api_key={} proxy_token={}",
         if api_key_present { "present" } else { "absent" },
-        if auth_token_present {
+        if proxy_token_present {
             "present"
         } else {
             "absent"
@@ -2160,12 +2196,12 @@ fn check_auth_health() -> DiagnosticCheck {
     match load_oauth_credentials() {
         Ok(Some(token_set)) => DiagnosticCheck::new(
             "Auth",
-            if api_key_present || auth_token_present {
+            if api_key_present || proxy_token_present {
                 DiagnosticLevel::Ok
             } else {
                 DiagnosticLevel::Warn
             },
-            if api_key_present || auth_token_present {
+            if api_key_present || proxy_token_present {
                 "supported auth env vars are configured; legacy saved OAuth is ignored"
             } else {
                 "legacy saved OAuth credentials are present but unsupported"
@@ -2189,12 +2225,15 @@ fn check_auth_health() -> DiagnosticCheck {
                     token_set.scopes.join(",")
                 }
             ),
-            "Suggested action  set ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN"
+            "Suggested action  set ANTHROPIC_API_KEY, PROXY_AUTH_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN"
                 .to_string(),
         ])
         .with_data(Map::from_iter([
             ("api_key_present".to_string(), json!(api_key_present)),
-            ("auth_token_present".to_string(), json!(auth_token_present)),
+            (
+                "proxy_token_present".to_string(),
+                json!(proxy_token_present),
+            ),
             ("legacy_saved_oauth_present".to_string(), json!(true)),
             (
                 "legacy_saved_oauth_expires_at".to_string(),
@@ -2208,12 +2247,12 @@ fn check_auth_health() -> DiagnosticCheck {
         ])),
         Ok(None) => DiagnosticCheck::new(
             "Auth",
-            if api_key_present || auth_token_present {
+            if api_key_present || proxy_token_present {
                 DiagnosticLevel::Ok
             } else {
                 DiagnosticLevel::Warn
             },
-            if api_key_present || auth_token_present {
+            if api_key_present || proxy_token_present {
                 "supported auth env vars are configured"
             } else {
                 "no supported auth env vars were found"
@@ -2222,7 +2261,10 @@ fn check_auth_health() -> DiagnosticCheck {
         .with_details(vec![env_details])
         .with_data(Map::from_iter([
             ("api_key_present".to_string(), json!(api_key_present)),
-            ("auth_token_present".to_string(), json!(auth_token_present)),
+            (
+                "proxy_token_present".to_string(),
+                json!(proxy_token_present),
+            ),
             ("legacy_saved_oauth_present".to_string(), json!(false)),
             ("legacy_saved_oauth_expires_at".to_string(), Value::Null),
             ("legacy_refresh_token_present".to_string(), json!(false)),
@@ -2235,12 +2277,18 @@ fn check_auth_health() -> DiagnosticCheck {
         )
         .with_data(Map::from_iter([
             ("api_key_present".to_string(), json!(api_key_present)),
-            ("auth_token_present".to_string(), json!(auth_token_present)),
+            (
+                "proxy_token_present".to_string(),
+                json!(proxy_token_present),
+            ),
             ("legacy_saved_oauth_present".to_string(), Value::Null),
             ("legacy_saved_oauth_expires_at".to_string(), Value::Null),
             ("legacy_refresh_token_present".to_string(), Value::Null),
             ("legacy_scopes".to_string(), Value::Null),
-            ("legacy_saved_oauth_error".to_string(), json!(error.to_string())),
+            (
+                "legacy_saved_oauth_error".to_string(),
+                json!(error.to_string()),
+            ),
         ])),
     }
 }
@@ -3642,16 +3690,23 @@ fn run_repl(
     base_commit: Option<String>,
     reasoning_effort: Option<String>,
     allow_broad_cwd: bool,
+    auth_mode: Option<AuthMode>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     enforce_broad_cwd_policy(allow_broad_cwd, CliOutputFormat::Text)?;
     run_stale_base_preflight(base_commit.as_deref());
     let resolved_model = resolve_repl_model(model);
-    let mut cli = LiveCli::new(resolved_model, true, allowed_tools, permission_mode)?;
+    let mut cli = LiveCli::new(
+        resolved_model,
+        true,
+        allowed_tools,
+        permission_mode,
+        auth_mode,
+    )?;
     cli.set_reasoning_effort(reasoning_effort);
     let mut editor =
         input::LineEditor::new("> ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
-    println!("{}", format_connected_line(&cli.model));
+    println!("{}", format_connected_line_with_mode(&cli.model, auth_mode));
 
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
@@ -3728,6 +3783,7 @@ struct LiveCli {
     runtime: BuiltRuntime,
     session: SessionHandle,
     prompt_history: Vec<PromptHistoryEntry>,
+    auth_mode: Option<AuthMode>,
 }
 
 #[derive(Debug, Clone)]
@@ -3841,6 +3897,7 @@ struct AcpCliAgent {
     allowed_tools: Option<AllowedToolSet>,
     permission_mode_override: Option<PermissionMode>,
     reasoning_effort: Option<String>,
+    auth_mode: Option<AuthMode>,
     sessions: HashMap<String, AcpCliSession>,
 }
 
@@ -3851,6 +3908,7 @@ impl AcpCliAgent {
         allowed_tools: Option<AllowedToolSet>,
         permission_mode_override: Option<PermissionMode>,
         reasoning_effort: Option<String>,
+        auth_mode: Option<AuthMode>,
     ) -> Self {
         Self {
             model,
@@ -3858,6 +3916,7 @@ impl AcpCliAgent {
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
+            auth_mode,
             sessions: HashMap::new(),
         }
     }
@@ -3885,6 +3944,7 @@ impl AcpCliAgent {
             self.allowed_tools.clone(),
             permission_mode,
             None,
+            self.auth_mode,
         )
         .map_err(|error| AcpError::internal(format!("failed to build runtime: {error}")))?;
         if let Some(runtime) = runtime.runtime.as_mut() {
@@ -3994,6 +4054,7 @@ fn run_acp_server(
     allowed_tools: Option<AllowedToolSet>,
     permission_mode_override: Option<PermissionMode>,
     reasoning_effort: Option<String>,
+    auth_mode: Option<AuthMode>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let agent = AcpCliAgent::new(
         model,
@@ -4001,6 +4062,7 @@ fn run_acp_server(
         allowed_tools,
         permission_mode_override,
         reasoning_effort,
+        auth_mode,
     );
     runtime::run_acp_stdio_server(agent, runtime::AcpServerOptions::new(VERSION))?;
     Ok(())
@@ -4390,6 +4452,7 @@ impl LiveCli {
         enable_tools: bool,
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
+        auth_mode: Option<AuthMode>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let system_prompt = build_system_prompt()?;
         let session_state = new_cli_session()?;
@@ -4404,6 +4467,7 @@ impl LiveCli {
             allowed_tools.clone(),
             permission_mode,
             None,
+            auth_mode,
         )?;
         let cli = Self {
             model,
@@ -4413,6 +4477,7 @@ impl LiveCli {
             runtime,
             session,
             prompt_history: Vec::new(),
+            auth_mode,
         };
         cli.persist_session()?;
         Ok(cli)
@@ -4494,6 +4559,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?
         .with_hook_abort_signal(hook_abort_signal.clone());
         let hook_abort_monitor = HookAbortMonitor::spawn(hook_abort_signal);
@@ -4940,6 +5006,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?;
         self.replace_runtime(runtime)?;
         self.model.clone_from(&model);
@@ -4986,6 +5053,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?;
         self.replace_runtime(runtime)?;
         println!(
@@ -5016,6 +5084,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?;
         self.replace_runtime(runtime)?;
         println!(
@@ -5057,6 +5126,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?;
         self.replace_runtime(runtime)?;
         self.session = SessionHandle {
@@ -5213,6 +5283,7 @@ impl LiveCli {
                     self.allowed_tools.clone(),
                     self.permission_mode,
                     None,
+                    self.auth_mode,
                 )?;
                 self.replace_runtime(runtime)?;
                 self.session = SessionHandle {
@@ -5248,6 +5319,7 @@ impl LiveCli {
                     self.allowed_tools.clone(),
                     self.permission_mode,
                     None,
+                    self.auth_mode,
                 )?;
                 self.replace_runtime(runtime)?;
                 self.session = handle;
@@ -5344,6 +5416,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?;
         self.replace_runtime(runtime)?;
         self.persist_session()
@@ -5364,6 +5437,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             None,
+            self.auth_mode,
         )?;
         self.replace_runtime(runtime)?;
         self.persist_session()?;
@@ -5388,6 +5462,7 @@ impl LiveCli {
             self.allowed_tools.clone(),
             self.permission_mode,
             progress,
+            self.auth_mode,
         )?;
         let mut permission_prompter = CliPermissionPrompter::new(self.permission_mode);
         let summary = runtime.run_turn(prompt, Some(&mut permission_prompter), None)?;
@@ -7502,6 +7577,7 @@ fn build_runtime(
     allowed_tools: Option<AllowedToolSet>,
     permission_mode: PermissionMode,
     progress_reporter: Option<InternalPromptProgressReporter>,
+    auth_mode: Option<AuthMode>,
 ) -> Result<BuiltRuntime, Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
     build_runtime_for_cwd(
@@ -7515,6 +7591,7 @@ fn build_runtime(
         allowed_tools,
         permission_mode,
         progress_reporter,
+        auth_mode,
     )
 }
 
@@ -7531,6 +7608,7 @@ fn build_runtime_for_cwd(
     allowed_tools: Option<AllowedToolSet>,
     permission_mode: PermissionMode,
     progress_reporter: Option<InternalPromptProgressReporter>,
+    auth_mode: Option<AuthMode>,
 ) -> Result<BuiltRuntime, Box<dyn std::error::Error>> {
     let loader = ConfigLoader::default_for(cwd);
     let runtime_config = loader.load()?;
@@ -7547,6 +7625,7 @@ fn build_runtime_for_cwd(
         permission_mode,
         progress_reporter,
         runtime_plugin_state,
+        auth_mode,
     )
 }
 
@@ -7563,6 +7642,7 @@ fn build_runtime_with_plugin_state(
     permission_mode: PermissionMode,
     progress_reporter: Option<InternalPromptProgressReporter>,
     runtime_plugin_state: RuntimePluginState,
+    auth_mode: Option<AuthMode>,
 ) -> Result<BuiltRuntime, Box<dyn std::error::Error>> {
     // Persist the model in session metadata so resumed sessions can report it.
     if session.model.is_none() {
@@ -7587,6 +7667,7 @@ fn build_runtime_with_plugin_state(
             allowed_tools.clone(),
             tool_registry.clone(),
             progress_reporter,
+            auth_mode,
         )?,
         CliToolExecutor::new(
             allowed_tools.clone(),
@@ -7714,47 +7795,33 @@ impl AnthropicRuntimeClient {
         allowed_tools: Option<AllowedToolSet>,
         tool_registry: GlobalToolRegistry,
         progress_reporter: Option<InternalPromptProgressReporter>,
+        auth_mode: Option<AuthMode>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Dispatch to the correct provider at construction time.
-        // `ApiProviderClient` (exposed by the api crate as
-        // `ProviderClient`) is an enum over Anthropic / xAI / OpenAI
-        // variants, where xAI and OpenAI both use the OpenAI-compat
-        // wire format under the hood. We consult
-        // `detect_provider_kind(&resolved_model)` so model-name prefix
-        // routing (`openai/`, `gpt-`, `grok`, `qwen/`) wins over
-        // env-var presence.
-        //
-        // For Anthropic we build the client directly instead of going
-        // through `ApiProviderClient::from_model_with_anthropic_auth`
-        // so we can explicitly apply `api::read_base_url()` — that
-        // reads `ANTHROPIC_BASE_URL` and is required for the local
-        // mock-server test harness
-        // (`crates/rusty-claude-cli/tests/compact_output.rs`) to point
-        // scode at its fake Anthropic endpoint. We also attach a
-        // session-scoped prompt cache on the Anthropic path; the
-        // prompt cache is Anthropic-only so non-Anthropic variants
-        // skip it.
         let resolved_model = api::resolve_model_alias(&model);
-        let client = match detect_provider_kind(&resolved_model) {
-            ProviderKind::Anthropic => {
-                let auth = resolve_cli_auth_source()?;
-                let inner = AnthropicClient::from_auth(auth)
-                    .with_base_url(api::read_base_url())
-                    .with_prompt_cache(PromptCache::new(session_id));
-                ApiProviderClient::Anthropic(inner)
-            }
-            ProviderKind::Xai | ProviderKind::OpenAi => {
-                // The api crate's `ProviderClient::from_model_with_anthropic_auth`
-                // with `None` for the anthropic auth routes via
-                // `detect_provider_kind` and builds an
-                // `OpenAiCompatClient::from_env` with the matching
-                // `OpenAiCompatConfig` (openai / xai / dashscope).
-                // That reads the correct API-key env var and BASE_URL
-                // override internally, so this one call covers OpenAI,
-                // OpenRouter, xAI, DashScope, Ollama, and any other
-                // OpenAI-compat endpoint users configure via
-                // `OPENAI_BASE_URL` / `XAI_BASE_URL` / `DASHSCOPE_BASE_URL`.
-                ApiProviderClient::from_model_with_anthropic_auth(&resolved_model, None)?
+        let client = if let Some(mode) = auth_mode {
+            // Explicit --auth mode: validate required env vars, resolve
+            // auth source for the mode, then build via from_model_and_mode
+            // which handles proxy/subscription/api-key routing.
+            validate_auth_env(mode)?;
+            let auth = AuthSource::for_mode(mode)?;
+            ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
+                .with_prompt_cache(PromptCache::new(session_id))
+        } else {
+            // Auto-detect: legacy path. For Anthropic we build the client
+            // directly to apply `api::read_base_url()` (needed for the
+            // mock-server test harness) and attach a session-scoped prompt
+            // cache. Non-Anthropic variants route via detect_provider_kind.
+            match detect_provider_kind(&resolved_model) {
+                ProviderKind::Anthropic => {
+                    let auth = resolve_cli_auth_source()?;
+                    let inner = AnthropicClient::from_auth(auth)
+                        .with_base_url(api::read_base_url())
+                        .with_prompt_cache(PromptCache::new(session_id));
+                    ApiProviderClient::Anthropic(inner)
+                }
+                ProviderKind::Xai | ProviderKind::OpenAi => {
+                    ApiProviderClient::from_model_with_anthropic_auth(&resolved_model, None)?
+                }
             }
         };
         Ok(Self {
@@ -9617,6 +9684,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -9699,10 +9767,10 @@ mod tests {
 
         let original_config_home = std::env::var("SUDO_CODE_CONFIG_HOME").ok();
         let original_api_key = std::env::var("ANTHROPIC_API_KEY").ok();
-        let original_auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
+        let original_auth_token = std::env::var("PROXY_AUTH_TOKEN").ok();
         std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
         std::env::remove_var("ANTHROPIC_API_KEY");
-        std::env::remove_var("ANTHROPIC_AUTH_TOKEN");
+        std::env::remove_var("PROXY_AUTH_TOKEN");
 
         save_oauth_credentials(&runtime::OAuthTokenSet {
             access_token: "expired-access-token".to_string(),
@@ -9724,8 +9792,8 @@ mod tests {
             None => std::env::remove_var("ANTHROPIC_API_KEY"),
         }
         match original_auth_token {
-            Some(value) => std::env::set_var("ANTHROPIC_AUTH_TOKEN", value),
-            None => std::env::remove_var("ANTHROPIC_AUTH_TOKEN"),
+            Some(value) => std::env::set_var("PROXY_AUTH_TOKEN", value),
+            None => std::env::remove_var("PROXY_AUTH_TOKEN"),
         }
         std::fs::remove_dir_all(config_home).expect("temp config home should clean up");
 
@@ -9753,6 +9821,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -9844,6 +9913,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -9875,6 +9945,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -9918,6 +9989,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -9998,6 +10070,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -10019,6 +10092,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -10049,6 +10123,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -10076,6 +10151,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -10112,7 +10188,7 @@ mod tests {
         let login = parse_args(&["login".to_string()]).expect_err("login should be removed");
         assert!(login.contains("ANTHROPIC_API_KEY"));
         let logout = parse_args(&["logout".to_string()]).expect_err("logout should be removed");
-        assert!(logout.contains("ANTHROPIC_AUTH_TOKEN"));
+        assert!(logout.contains("--auth"));
         assert_eq!(
             parse_args(&["doctor".to_string()]).expect("doctor should parse"),
             CliAction::Doctor {
@@ -10180,6 +10256,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
         assert_eq!(
@@ -10394,6 +10471,7 @@ mod tests {
             allowed_tools: None,
             permission_mode_override: None,
             reasoning_effort: None,
+            auth_mode: None,
         };
         assert_eq!(
             parse_args(&["acp".to_string()]).expect("acp should parse"),
@@ -10435,6 +10513,7 @@ mod tests {
                 allowed_tools,
                 permission_mode_override,
                 reasoning_effort,
+                auth_mode: _,
             } => {
                 assert_eq!(model, resolve_model_alias_with_config("sonnet"));
                 assert_eq!(model_flag_raw.as_deref(), Some("sonnet"));
@@ -11147,6 +11226,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -11215,6 +11295,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
         assert_eq!(
@@ -11242,6 +11323,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
         let error = parse_args(&["/status".to_string()])
@@ -11334,6 +11416,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -11353,6 +11436,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -11382,6 +11466,7 @@ mod tests {
                 base_commit: None,
                 reasoning_effort: None,
                 allow_broad_cwd: false,
+                auth_mode: None,
             }
         );
     }
@@ -11649,6 +11734,7 @@ mod tests {
                 true,
                 None,
                 PermissionMode::DangerFullAccess,
+                None,
             )
             .expect("cli should initialize")
             .startup_banner()
@@ -13161,6 +13247,7 @@ UU conflicted.rs",
             PermissionMode::DangerFullAccess,
             None,
             runtime_plugin_state,
+            None,
         )
         .expect("runtime should build");
 

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -84,6 +84,12 @@ impl AnthropicRequestProfile {
     }
 
     #[must_use]
+    pub fn with_betas(mut self, betas: Vec<String>) -> Self {
+        self.betas = betas;
+        self
+    }
+
+    #[must_use]
     pub fn with_extra_body(mut self, key: impl Into<String>, value: Value) -> Self {
         self.extra_body.insert(key.into(), value);
         self


### PR DESCRIPTION
## Summary

- Add `--auth <mode>` CLI flag with three modes: `subscription`, `proxy`, `api-key`
- Rename proxy env vars from `ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_BASE_URL` to `PROXY_AUTH_TOKEN`/`PROXY_BASE_URL` (clean break)
- Each session/agent stores its own `auth_mode` for per-session provider selection
- Auto-detection preserved when `--auth` is omitted (subscription -> proxy -> api-key)
- Mode-specific validation with clear error messages (e.g. `--auth proxy requires PROXY_AUTH_TOKEN to be set`)

### Auth modes

| Mode | Env vars | Endpoint |
|------|----------|----------|
| `subscription` | `CLAUDE_CODE_OAUTH_TOKEN` | api.anthropic.com (default) |
| `proxy` | `PROXY_AUTH_TOKEN` + `PROXY_BASE_URL` | `PROXY_BASE_URL` |
| `api-key` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc. | Provider default |

### Files changed

- `api/providers/mod.rs` — `AuthMode` enum, `resolve_auth_mode()`, `validate_auth_env()`
- `api/providers/anthropic.rs` — `AuthSource::for_mode()`, `from_auth_with_mode()`, `base_url_for_mode()`, proxy env rename
- `api/client.rs` — `ProviderClient::from_model_and_mode()`
- `api/lib.rs` — Updated exports
- `api/error.rs` — Updated test env var lists
- `commands/lib.rs` — Updated login/logout error message
- `rusty-claude-cli/main.rs` — `--auth` flag parsing, threaded through full call chain

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo check -p api -p commands -p rusty-claude-cli` — clean
- [x] `cargo test -p api -p commands -p rusty-claude-cli` — all pass
- [x] Manual: `--auth api-key` with `ANTHROPIC_API_KEY` — works
- [x] Manual: `--auth proxy` with `PROXY_AUTH_TOKEN` + `PROXY_BASE_URL` — works
- [x] Manual: `--auth subscription` with `CLAUDE_CODE_OAUTH_TOKEN` — works
- [x] Manual: `--auth` without value — clear error with valid options
- [x] Manual: `--auth foo` — clear error with valid options
- [x] Manual: `--auth proxy` without env vars — mode-specific error

Generated with [Claude Code](https://claude.com/claude-code)