### PR TITLE
feat: config-driven provider & model registry (auth-mode-centric)

### DIFF
--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -2,6 +2,7 @@ use crate::error::ApiError;
 use crate::prompt_cache::{PromptCache, PromptCacheRecord, PromptCacheStats};
 use crate::providers::anthropic::{self, AnthropicClient, AuthSource};
 use crate::providers::openai_compat::{self, OpenAiCompatClient, OpenAiCompatConfig};
+use crate::providers::registry::{ProviderProtocol, ProviderRegistry};
 use crate::providers::{self, AuthMode, ProviderKind};
 use crate::types::{MessageRequest, MessageResponse, StreamEvent};
 
@@ -87,6 +88,97 @@ impl ProviderClient {
                         Ok(Self::OpenAi(OpenAiCompatClient::from_env(config)?))
                     }
                 }
+            }
+        }
+    }
+
+    /// Build a `ProviderClient` using the config-driven registry.
+    ///
+    /// Resolution order:
+    /// 1. Look up the model in the registry's config models.
+    /// 2. If found, resolve the provider from config and build accordingly.
+    /// 3. If not found, fall back to the standard `from_model_and_mode` /
+    ///    `from_model` path.
+    pub fn from_model_with_registry(
+        model: &str,
+        registry: &ProviderRegistry,
+        mode: Option<AuthMode>,
+        auth: Option<AuthSource>,
+    ) -> Result<Self, ApiError> {
+        let resolved_alias = registry.resolve_model_alias(model);
+
+        // Try config-driven resolution first.
+        if let Some(config_model) = registry.config_model(model) {
+            if let Some(provider) = registry.config_provider(&config_model.provider) {
+                return Self::from_config_provider(&config_model.model_id, provider, mode, auth);
+            }
+        }
+
+        // Fall back to standard path.
+        match (mode, auth) {
+            (Some(m), Some(a)) => Self::from_model_and_mode(&resolved_alias, m, a),
+            (_, Some(a)) => Self::from_model_with_anthropic_auth(&resolved_alias, Some(a)),
+            _ => Self::from_model(&resolved_alias),
+        }
+    }
+
+    /// Build a `ProviderClient` from an explicit config provider entry.
+    fn from_config_provider(
+        _model_id: &str,
+        provider: &crate::providers::registry::ConfigProvider,
+        mode: Option<AuthMode>,
+        auth: Option<AuthSource>,
+    ) -> Result<Self, ApiError> {
+        match provider.protocol {
+            ProviderProtocol::Anthropic => {
+                // Anthropic protocol: use AnthropicClient.
+                let client = match (mode, auth) {
+                    (Some(m), Some(a)) => {
+                        let base_url = provider
+                            .base_url
+                            .clone()
+                            .unwrap_or_else(|| anthropic::base_url_for_mode(m));
+                        AnthropicClient::from_auth_with_mode(a, Some(m)).with_base_url(base_url)
+                    }
+                    (_, Some(a)) => {
+                        let mut client = AnthropicClient::from_auth(a);
+                        if let Some(url) = &provider.base_url {
+                            client = client.with_base_url(url.clone());
+                        } else {
+                            client = client.with_base_url(anthropic::read_base_url());
+                        }
+                        client
+                    }
+                    _ => {
+                        let mut client = AnthropicClient::from_env()?;
+                        if let Some(url) = &provider.base_url {
+                            client = client.with_base_url(url.clone());
+                        }
+                        client
+                    }
+                };
+                Ok(Self::Anthropic(client))
+            }
+            ProviderProtocol::OpenAiCompat => {
+                // OpenAI-compat protocol: build OpenAiCompatConfig from the
+                // config provider entry.
+                let config = ProviderRegistry::openai_compat_config_for(provider)
+                    .unwrap_or_else(OpenAiCompatConfig::openai);
+                let mut client = OpenAiCompatClient::from_env(config)?;
+                // If the provider specifies a fixed base_url that differs
+                // from what from_env resolved (which reads the env var),
+                // override it.  The env var takes precedence only when set.
+                if let Some(url) = &provider.base_url {
+                    let env_key = provider.base_url_env.as_deref().unwrap_or("");
+                    let env_set = !env_key.is_empty()
+                        && std::env::var(env_key)
+                            .ok()
+                            .is_some_and(|v| !v.trim().is_empty());
+                    if !env_set {
+                        client = client.with_base_url(url.clone());
+                    }
+                }
+                Ok(Self::OpenAi(client))
             }
         }
     }

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -97,23 +97,22 @@ impl ProviderClient {
     /// This is the primary entry point for config-driven provider construction.
     /// The caller is responsible for calling `resolve_provider_from_config()`
     /// first to obtain the `ResolvedProvider`.
-    pub fn from_resolved(resolved: &ResolvedProvider) -> Result<Self, ApiError> {
+    pub fn from_resolved(
+        resolved: &ResolvedProvider,
+        mode: Option<AuthMode>,
+    ) -> Result<Self, ApiError> {
         match resolved.api_format {
             ApiFormat::AnthropicMessages => {
-                // Build AnthropicClient with the resolved credential + base URL.
                 let auth = match &resolved.credential {
                     Credential::ApiKey(key) => AuthSource::ApiKey(key.clone()),
                     Credential::Token(token) => AuthSource::BearerToken(token.clone()),
                     Credential::AuthFile(path) => {
-                        // Load token from auth file (e.g. ~/.claude/credentials.json).
                         let content = std::fs::read_to_string(path).map_err(|e| {
                             ApiError::Configuration(format!(
                                 "failed to read auth file {}: {e}",
                                 path.display()
                             ))
                         })?;
-                        // Try to parse as JSON and extract an accessToken field,
-                        // falling back to the raw file content as a token.
                         let token = serde_json::from_str::<serde_json::Value>(&content)
                             .ok()
                             .and_then(|v| {
@@ -130,8 +129,8 @@ impl ProviderClient {
                         ));
                     }
                 };
-                let client =
-                    AnthropicClient::from_auth(auth).with_base_url(resolved.base_url.clone());
+                let client = AnthropicClient::from_auth_with_mode(auth, mode)
+                    .with_base_url(resolved.base_url.clone());
                 Ok(Self::Anthropic(client))
             }
             ApiFormat::OpenAiCompletions | ApiFormat::OpenAiResponses => {

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -2,7 +2,7 @@ use crate::error::ApiError;
 use crate::prompt_cache::{PromptCache, PromptCacheRecord, PromptCacheStats};
 use crate::providers::anthropic::{self, AnthropicClient, AuthSource};
 use crate::providers::openai_compat::{self, OpenAiCompatClient, OpenAiCompatConfig};
-use crate::providers::registry::{ProviderProtocol, ProviderRegistry};
+use crate::providers::registry::{ApiFormat, Credential, ResolvedProvider};
 use crate::providers::{self, AuthMode, ProviderKind};
 use crate::types::{MessageRequest, MessageResponse, StreamEvent};
 
@@ -92,93 +92,68 @@ impl ProviderClient {
         }
     }
 
-    /// Build a `ProviderClient` using the config-driven registry.
+    /// Build a `ProviderClient` from a fully resolved provider config.
     ///
-    /// Resolution order:
-    /// 1. Look up the model in the registry's config models.
-    /// 2. If found, resolve the provider from config and build accordingly.
-    /// 3. If not found, fall back to the standard `from_model_and_mode` /
-    ///    `from_model` path.
-    pub fn from_model_with_registry(
-        model: &str,
-        registry: &ProviderRegistry,
-        mode: Option<AuthMode>,
-        auth: Option<AuthSource>,
-    ) -> Result<Self, ApiError> {
-        let resolved_alias = registry.resolve_model_alias(model);
-
-        // Try config-driven resolution first.
-        if let Some(config_model) = registry.config_model(model) {
-            if let Some(provider) = registry.config_provider(&config_model.provider) {
-                return Self::from_config_provider(&config_model.model_id, provider, mode, auth);
-            }
-        }
-
-        // Fall back to standard path.
-        match (mode, auth) {
-            (Some(m), Some(a)) => Self::from_model_and_mode(&resolved_alias, m, a),
-            (_, Some(a)) => Self::from_model_with_anthropic_auth(&resolved_alias, Some(a)),
-            _ => Self::from_model(&resolved_alias),
-        }
-    }
-
-    /// Build a `ProviderClient` from an explicit config provider entry.
-    fn from_config_provider(
-        _model_id: &str,
-        provider: &crate::providers::registry::ConfigProvider,
-        mode: Option<AuthMode>,
-        auth: Option<AuthSource>,
-    ) -> Result<Self, ApiError> {
-        match provider.protocol {
-            ProviderProtocol::Anthropic => {
-                // Anthropic protocol: use AnthropicClient.
-                let client = match (mode, auth) {
-                    (Some(m), Some(a)) => {
-                        let base_url = provider
-                            .base_url
-                            .clone()
-                            .unwrap_or_else(|| anthropic::base_url_for_mode(m));
-                        AnthropicClient::from_auth_with_mode(a, Some(m)).with_base_url(base_url)
+    /// This is the primary entry point for config-driven provider construction.
+    /// The caller is responsible for calling `resolve_provider_from_config()`
+    /// first to obtain the `ResolvedProvider`.
+    pub fn from_resolved(resolved: &ResolvedProvider) -> Result<Self, ApiError> {
+        match resolved.api_format {
+            ApiFormat::AnthropicMessages => {
+                // Build AnthropicClient with the resolved credential + base URL.
+                let auth = match &resolved.credential {
+                    Credential::ApiKey(key) => AuthSource::ApiKey(key.clone()),
+                    Credential::Token(token) => AuthSource::BearerToken(token.clone()),
+                    Credential::AuthFile(path) => {
+                        // Load token from auth file (e.g. ~/.claude/credentials.json).
+                        let content = std::fs::read_to_string(path).map_err(|e| {
+                            ApiError::Configuration(format!(
+                                "failed to read auth file {}: {e}",
+                                path.display()
+                            ))
+                        })?;
+                        // Try to parse as JSON and extract an accessToken field,
+                        // falling back to the raw file content as a token.
+                        let token = serde_json::from_str::<serde_json::Value>(&content)
+                            .ok()
+                            .and_then(|v| {
+                                v.get("accessToken")
+                                    .or_else(|| v.get("token"))
+                                    .and_then(|t| t.as_str().map(String::from))
+                            })
+                            .unwrap_or_else(|| content.trim().to_string());
+                        AuthSource::BearerToken(token)
                     }
-                    (_, Some(a)) => {
-                        let mut client = AnthropicClient::from_auth(a);
-                        if let Some(url) = &provider.base_url {
-                            client = client.with_base_url(url.clone());
-                        } else {
-                            client = client.with_base_url(anthropic::read_base_url());
-                        }
-                        client
-                    }
-                    _ => {
-                        let mut client = AnthropicClient::from_env()?;
-                        if let Some(url) = &provider.base_url {
-                            client = client.with_base_url(url.clone());
-                        }
-                        client
+                    Credential::None => {
+                        return Err(ApiError::Configuration(
+                            "no credential available for Anthropic provider".to_string(),
+                        ));
                     }
                 };
+                let client =
+                    AnthropicClient::from_auth(auth).with_base_url(resolved.base_url.clone());
                 Ok(Self::Anthropic(client))
             }
-            ProviderProtocol::OpenAiCompat => {
-                // OpenAI-compat protocol: build OpenAiCompatConfig from the
-                // config provider entry.
-                let config = ProviderRegistry::openai_compat_config_for(provider)
-                    .unwrap_or_else(OpenAiCompatConfig::openai);
-                let mut client = OpenAiCompatClient::from_env(config)?;
-                // If the provider specifies a fixed base_url that differs
-                // from what from_env resolved (which reads the env var),
-                // override it.  The env var takes precedence only when set.
-                if let Some(url) = &provider.base_url {
-                    let env_key = provider.base_url_env.as_deref().unwrap_or("");
-                    let env_set = !env_key.is_empty()
-                        && std::env::var(env_key)
-                            .ok()
-                            .is_some_and(|v| !v.trim().is_empty());
-                    if !env_set {
-                        client = client.with_base_url(url.clone());
+            ApiFormat::OpenAiCompletions | ApiFormat::OpenAiResponses => {
+                // Build OpenAiCompatClient with the resolved credential + base URL.
+                let api_key = match &resolved.credential {
+                    Credential::ApiKey(key) => key.clone(),
+                    Credential::Token(token) => token.clone(),
+                    Credential::None => String::new(),
+                    Credential::AuthFile(_) => {
+                        return Err(ApiError::Configuration(
+                            "auth file credential not supported for OpenAI-compat providers"
+                                .to_string(),
+                        ));
                     }
+                };
+                let config = OpenAiCompatConfig::openai();
+                let client = OpenAiCompatClient::new(api_key, config)
+                    .with_base_url(resolved.base_url.clone());
+                match resolved.kind {
+                    ProviderKind::Xai => Ok(Self::Xai(client)),
+                    _ => Ok(Self::OpenAi(client)),
                 }
-                Ok(Self::OpenAi(client))
             }
         }
     }

--- a/rust/crates/api/src/error.rs
+++ b/rust/crates/api/src/error.rs
@@ -70,6 +70,9 @@ pub enum ApiError {
         max_bytes: usize,
         provider: &'static str,
     },
+    /// Config-driven provider resolution error (e.g. missing model alias,
+    /// unavailable auth mode, missing credential in sudocode.json).
+    Configuration(String),
 }
 
 impl ApiError {
@@ -137,7 +140,8 @@ impl ApiError {
             | Self::Json { .. }
             | Self::InvalidSseFrame(_)
             | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. } => false,
+            | Self::RequestBodySizeExceeded { .. }
+            | Self::Configuration(_) => false,
         }
     }
 
@@ -156,7 +160,8 @@ impl ApiError {
             | Self::Json { .. }
             | Self::InvalidSseFrame(_)
             | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. } => None,
+            | Self::RequestBodySizeExceeded { .. }
+            | Self::Configuration(_) => None,
         }
     }
 
@@ -168,9 +173,10 @@ impl ApiError {
                 "provider_retry_exhausted"
             }
             Self::RetriesExhausted { last_error, .. } => last_error.safe_failure_class(),
-            Self::MissingCredentials { .. } | Self::ExpiredOAuthToken | Self::Auth(_) => {
-                "provider_auth"
-            }
+            Self::MissingCredentials { .. }
+            | Self::ExpiredOAuthToken
+            | Self::Auth(_)
+            | Self::Configuration(_) => "provider_auth",
             Self::Api { status, .. } if matches!(status.as_u16(), 401 | 403) => "provider_auth",
             Self::ContextWindowExceeded { .. } => "context_window",
             Self::Api { .. } if self.is_context_window_failure() => "context_window",
@@ -205,7 +211,8 @@ impl ApiError {
             | Self::Json { .. }
             | Self::InvalidSseFrame(_)
             | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. } => false,
+            | Self::RequestBodySizeExceeded { .. }
+            | Self::Configuration(_) => false,
         }
     }
 
@@ -235,7 +242,8 @@ impl ApiError {
             | Self::Json { .. }
             | Self::InvalidSseFrame(_)
             | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. } => false,
+            | Self::RequestBodySizeExceeded { .. }
+            | Self::Configuration(_) => false,
         }
     }
 }
@@ -345,6 +353,7 @@ impl Display for ApiError {
                 f,
                 "request body size ({estimated_bytes} bytes) exceeds {provider} limit ({max_bytes} bytes); reduce prompt length or context before retrying"
             ),
+            Self::Configuration(msg) => write!(f, "provider configuration error: {msg}"),
         }
     }
 }

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -28,7 +28,9 @@ pub use providers::openai_compat::{
     model_rejects_is_error_field, translate_message, OpenAiCompatClient, OpenAiCompatConfig,
 };
 pub use providers::registry::{
-    ConfigModel, ConfigProvider, ProviderProtocol, ProviderRegistry, ResolvedProviderMeta,
+    available_auth_modes, resolve_model, resolve_provider_from_config, ApiFormat, Credential,
+    ModelConfigEntry, ModelProviderMapping, ProviderConnectionConfig, ResolvedProvider,
+    SudoCodeConfig,
 };
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -28,9 +28,8 @@ pub use providers::openai_compat::{
     model_rejects_is_error_field, translate_message, OpenAiCompatClient, OpenAiCompatConfig,
 };
 pub use providers::registry::{
-    available_auth_modes, resolve_model, resolve_provider_from_config, ApiFormat, Credential,
-    ModelConfigEntry, ModelProviderMapping, ProviderConnectionConfig, ResolvedProvider,
-    SudoCodeConfig,
+    resolve_model, resolve_provider_from_config, ApiFormat, Credential, ModelConfigEntry,
+    ModelProviderMapping, ProviderConnectionConfig, ResolvedProvider, SudoCodeConfig,
 };
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -27,6 +27,9 @@ pub use providers::openai_compat::{
     build_chat_completion_request, flatten_tool_result_content, is_reasoning_model,
     model_rejects_is_error_field, translate_message, OpenAiCompatClient, OpenAiCompatConfig,
 };
+pub use providers::registry::{
+    ConfigModel, ConfigProvider, ProviderProtocol, ProviderRegistry, ResolvedProviderMeta,
+};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     resolve_model_alias, AuthMode, ProviderKind,

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -9,6 +9,7 @@ use crate::types::{MessageRequest, MessageResponse};
 
 pub mod anthropic;
 pub mod openai_compat;
+pub mod registry;
 
 /// Explicit auth mode selected via `--auth` CLI flag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -1,299 +1,321 @@
 //! Config-driven provider & model registry.
 //!
-//! Layers user-defined `"providers"` and `"models"` entries from the JSON
-//! config on top of the built-in hardcoded registry so that:
-//!
-//! - Config entries take precedence for matching aliases.
-//! - Hardcoded entries remain available when no config is present.
-//! - Unknown models still fall through to prefix-based detection.
+//! Resolves model alias → auth mode → provider → connection details using the
+//! `sudocode.json` config file.  Falls back to hardcoded registry when config
+//! is absent.
 
-use std::collections::BTreeMap;
+use std::path::PathBuf;
 
-use super::openai_compat::{self, OpenAiCompatConfig};
-use super::{ModelTokenLimit, ProviderKind, ProviderMetadata};
+use super::{AuthMode, ProviderKind};
+use crate::error::ApiError;
+
+// Re-export the config types from the runtime crate so consumers can use them
+// via `api::providers::registry::*` without depending on runtime directly.
+pub use runtime::config::{
+    ModelConfigEntry, ModelProviderMapping, ProviderConnectionConfig, SudoCodeConfig,
+};
 
 // ---------------------------------------------------------------------------
-// Types
+// Types (API-layer only)
 // ---------------------------------------------------------------------------
 
-/// Wire protocol family for a configured provider.
+/// Wire protocol / API format for talking to a provider.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProviderProtocol {
+pub enum ApiFormat {
     /// Native Anthropic Messages API (`/v1/messages`).
-    Anthropic,
+    AnthropicMessages,
     /// OpenAI-compatible chat completions API (`/v1/chat/completions`).
-    OpenAiCompat,
+    OpenAiCompletions,
+    /// OpenAI Responses API (`/v1/responses`).
+    OpenAiResponses,
 }
 
-/// A provider endpoint defined in the config file.
+/// Resolved credential for authenticating with a provider.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConfigProvider {
-    /// Protocol used to talk to this provider.
-    pub protocol: ProviderProtocol,
-    /// Env-var name whose value is the API key (e.g. `"MY_KEY"`).
-    pub api_key_env: Option<String>,
-    /// Fixed base URL.  Takes precedence over `base_url_env`.
-    pub base_url: Option<String>,
-    /// Env-var name whose value overrides the base URL at runtime.
-    pub base_url_env: Option<String>,
-    /// Human-friendly label shown in the connection banner.
-    pub display_name: Option<String>,
+pub enum Credential {
+    /// Direct API key string.
+    ApiKey(String),
+    /// Bearer / OAuth token string.
+    Token(String),
+    /// Path to a credentials file (e.g. `~/.claude/credentials.json`).
+    AuthFile(PathBuf),
+    /// No credential available — provider may not require one.
+    None,
 }
 
-/// A model binding defined in the config file.
+/// Fully resolved provider information — everything needed to build a client.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConfigModel {
-    /// Key into the `providers` map.
-    pub provider: String,
-    /// Model identifier sent over the wire (e.g. `"claude-opus-4-6"`).
-    pub model_id: String,
-    /// Optional max output tokens override.
-    pub max_output_tokens: Option<u32>,
-    /// Optional context window override.
-    pub context_window: Option<u32>,
-}
-
-/// Combined config-driven + hardcoded provider/model registry.
-///
-/// The zero-value (`Default`) contains no config entries, making every
-/// resolution fall through to the hardcoded registry.
-#[derive(Debug, Clone, Default)]
-pub struct ProviderRegistry {
-    providers: BTreeMap<String, ConfigProvider>,
-    models: BTreeMap<String, ConfigModel>,
-}
-
-/// Metadata resolved through the registry for a given model.
-#[derive(Debug, Clone)]
-pub struct ResolvedProviderMeta {
+pub struct ResolvedProvider {
     pub kind: ProviderKind,
-    pub api_key_env: Option<String>,
-    pub base_url: Option<String>,
-    pub base_url_env: Option<String>,
-    /// Provider display name for UI banners.  `None` means use the default
-    /// label derived from `ProviderKind`.
+    pub api_format: ApiFormat,
+    pub base_url: String,
+    pub credential: Credential,
+    /// The wire model ID to send to the provider.
+    pub model_id: String,
+    /// Human-friendly display name for UI banners.
     pub display_name: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
-// ProviderRegistry
+// SudoCodeConfig helpers
 // ---------------------------------------------------------------------------
 
-impl ProviderRegistry {
-    /// Build a registry from parsed config sections.
-    #[must_use]
-    pub fn new(
-        providers: BTreeMap<String, ConfigProvider>,
-        models: BTreeMap<String, ConfigModel>,
-    ) -> Self {
-        Self { providers, models }
-    }
+/// Look up a model by alias (case-insensitive).
+#[must_use]
+pub fn resolve_model<'a>(config: &'a SudoCodeConfig, alias: &str) -> Option<&'a ModelConfigEntry> {
+    config.models.get(&alias.trim().to_ascii_lowercase())
+}
 
-    /// Whether the config contributed any providers or models.
-    #[must_use]
-    pub fn is_config_empty(&self) -> bool {
-        self.providers.is_empty() && self.models.is_empty()
-    }
+/// List available auth modes for a model alias, in config order.
+#[must_use]
+pub fn available_auth_modes<'a>(config: &'a SudoCodeConfig, alias: &str) -> Vec<&'a str> {
+    resolve_model(config, alias)
+        .map(|m| m.providers.keys().map(String::as_str).collect())
+        .unwrap_or_default()
+}
 
-    #[must_use]
-    pub fn providers(&self) -> &BTreeMap<String, ConfigProvider> {
-        &self.providers
-    }
-
-    #[must_use]
-    pub fn models(&self) -> &BTreeMap<String, ConfigModel> {
-        &self.models
-    }
-
-    // -- Resolution helpers ------------------------------------------------
-
-    /// Look up a config model entry by alias (case-insensitive).
-    #[must_use]
-    pub fn config_model(&self, alias: &str) -> Option<&ConfigModel> {
-        let key = alias.trim().to_ascii_lowercase();
-        self.models.get(&key)
-    }
-
-    /// Look up a config provider entry by name.
-    #[must_use]
-    pub fn config_provider(&self, name: &str) -> Option<&ConfigProvider> {
-        self.providers.get(name)
-    }
-
-    /// Resolve a model alias.  Config models take precedence; falls back to
-    /// the built-in hardcoded alias table.
-    #[must_use]
-    pub fn resolve_model_alias(&self, alias: &str) -> String {
-        if let Some(entry) = self.config_model(alias) {
-            return entry.model_id.clone();
-        }
-        super::resolve_model_alias(alias)
-    }
-
-    /// Resolve full provider metadata for a model.  Checks config first
-    /// (by alias *and* by canonical model ID), then falls back to the
-    /// hardcoded `metadata_for_model`.
-    #[must_use]
-    pub fn metadata_for_model(&self, model: &str) -> Option<ResolvedProviderMeta> {
-        // 1. Direct alias match in config models.
-        if let Some(meta) = self.resolve_config_meta_by_alias(model) {
-            return Some(meta);
-        }
-        // 2. Resolve via hardcoded alias, then check if the canonical ID
-        //    matches a config model entry's model_id.
-        let canonical = super::resolve_model_alias(model);
-        if canonical != model {
-            if let Some(meta) = self.resolve_config_meta_by_model_id(&canonical) {
-                return Some(meta);
-            }
-        }
-        // 3. Check config models by model_id directly.
-        if let Some(meta) = self.resolve_config_meta_by_model_id(model) {
-            return Some(meta);
-        }
-        // 4. Fall back to hardcoded.
-        super::metadata_for_model(model).map(hardcoded_to_resolved)
-    }
-
-    /// Detect provider kind for a model.
-    #[must_use]
-    pub fn detect_provider_kind(&self, model: &str) -> ProviderKind {
-        if let Some(meta) = self.metadata_for_model(model) {
-            return meta.kind;
-        }
-        super::detect_provider_kind(model)
-    }
-
-    /// Token limits for a model.
-    #[must_use]
-    pub fn model_token_limit(&self, model: &str) -> Option<ModelTokenLimit> {
-        if let Some(entry) = self.config_model(model) {
-            if entry.max_output_tokens.is_some() || entry.context_window.is_some() {
-                return Some(ModelTokenLimit {
-                    max_output_tokens: entry.max_output_tokens.unwrap_or(64_000),
-                    context_window_tokens: entry.context_window.unwrap_or(200_000),
-                });
-            }
-            // Config model without explicit limits → try hardcoded for the
-            // wire model_id.
-            return super::model_token_limit(&entry.model_id);
-        }
-        super::model_token_limit(model)
-    }
-
-    /// Max output tokens for a model.
-    #[must_use]
-    pub fn max_tokens_for_model(&self, model: &str) -> u32 {
-        self.model_token_limit(model).map_or_else(
-            || {
-                let canonical = self.resolve_model_alias(model);
-                if canonical.contains("opus") {
-                    32_000
-                } else {
-                    64_000
-                }
-            },
-            |limit| limit.max_output_tokens,
-        )
-    }
-
-    /// Build an [`OpenAiCompatConfig`] from a [`ConfigProvider`].
-    ///
-    /// Returns `None` if the provider uses the Anthropic protocol.
-    #[must_use]
-    pub fn openai_compat_config_for(provider: &ConfigProvider) -> Option<OpenAiCompatConfig> {
-        if provider.protocol != ProviderProtocol::OpenAiCompat {
-            return None;
-        }
-        // We construct a config with the provider's settings.  The
-        // `api_key_env` and `base_url_env` are leaked into 'static
-        // references via `Box::leak` because `OpenAiCompatConfig` requires
-        // `&'static str` fields.  This is acceptable because provider
-        // configs are loaded once at startup and live for the process
-        // lifetime.
-        let api_key_env: &'static str = provider
-            .api_key_env
-            .as_deref()
-            .map_or("OPENAI_API_KEY", |s| leak_string(s));
-        let base_url_env: &'static str = provider
-            .base_url_env
-            .as_deref()
-            .map_or("OPENAI_BASE_URL", |s| leak_string(s));
-        let default_base_url: &'static str = provider
-            .base_url
-            .as_deref()
-            .map_or(openai_compat::DEFAULT_OPENAI_BASE_URL, |s| leak_string(s));
-        let provider_name: &'static str = provider
-            .display_name
-            .as_deref()
-            .map_or("OpenAI-compat", |s| leak_string(s));
-
-        Some(OpenAiCompatConfig {
-            provider_name,
-            api_key_env,
-            base_url_env,
-            default_base_url,
-            // Use a reasonable default; custom providers rarely have tight
-            // body limits.
-            max_request_body_bytes: 104_857_600, // 100 MB
-        })
-    }
-
-    // -- Private helpers ---------------------------------------------------
-
-    fn resolve_config_meta_by_alias(&self, alias: &str) -> Option<ResolvedProviderMeta> {
-        let model_entry = self.config_model(alias)?;
-        let provider_entry = self.providers.get(&model_entry.provider)?;
-        Some(config_to_resolved(model_entry, provider_entry))
-    }
-
-    fn resolve_config_meta_by_model_id(&self, model_id: &str) -> Option<ResolvedProviderMeta> {
-        for model_entry in self.models.values() {
-            if model_entry.model_id == model_id {
-                if let Some(provider_entry) = self.providers.get(&model_entry.provider) {
-                    return Some(config_to_resolved(model_entry, provider_entry));
-                }
-            }
-        }
-        None
-    }
+/// Look up connection config for a provider under a given auth mode.
+#[must_use]
+pub fn connection_for<'a>(
+    config: &'a SudoCodeConfig,
+    auth_mode: &str,
+    provider_name: &str,
+) -> Option<&'a ProviderConnectionConfig> {
+    config.auth_modes.get(auth_mode)?.get(provider_name)
 }
 
 // ---------------------------------------------------------------------------
-// Conversion helpers
+// Resolution
 // ---------------------------------------------------------------------------
 
-fn config_to_resolved(model: &ConfigModel, provider: &ConfigProvider) -> ResolvedProviderMeta {
-    ResolvedProviderMeta {
-        kind: match provider.protocol {
-            ProviderProtocol::Anthropic => ProviderKind::Anthropic,
-            ProviderProtocol::OpenAiCompat => ProviderKind::OpenAi,
+/// Resolve a model alias + optional auth mode through the config into a fully
+/// resolved provider specification.
+///
+/// Resolution flow:
+/// 1. Look up `models.<alias>` → get available auth modes
+/// 2. If `explicit_auth` specified, use it; otherwise pick first available
+/// 3. From `models.<alias>.providers.<mode>` get `{ provider, model, api? }`
+/// 4. From `auth_modes.<mode>.<provider>` get connection details
+/// 5. Resolve wire format: non-proxy → infer from provider type; proxy → use `api` field
+/// 6. Resolve credentials from connection config
+pub fn resolve_provider_from_config(
+    model_alias: &str,
+    explicit_auth: Option<AuthMode>,
+    config: &SudoCodeConfig,
+) -> Result<ResolvedProvider, ApiError> {
+    let alias_lower = model_alias.trim().to_ascii_lowercase();
+
+    // 1. Look up the model in config.
+    let model_config = resolve_model(config, &alias_lower).ok_or_else(|| {
+        ApiError::Configuration(format!(
+            "model alias '{model_alias}' not found in sudocode.json"
+        ))
+    })?;
+
+    // 2. Determine the auth mode to use.
+    let auth_mode_str = match explicit_auth {
+        Some(mode) => {
+            let s = mode.as_str();
+            if !model_config.providers.contains_key(s) {
+                return Err(ApiError::Configuration(format!(
+                    "auth mode '{}' is not available for model '{}'. Available: {}",
+                    s,
+                    model_alias,
+                    model_config
+                        .providers
+                        .keys()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
+            }
+            s.to_string()
+        }
+        None => {
+            // Pick first available (BTreeMap is ordered, config order = priority).
+            model_config
+                .providers
+                .keys()
+                .next()
+                .cloned()
+                .ok_or_else(|| {
+                    ApiError::Configuration(format!(
+                        "model '{}' has no provider mappings in sudocode.json",
+                        model_alias
+                    ))
+                })?
+        }
+    };
+
+    // 3. Get the provider mapping for this auth mode.
+    let mapping = model_config.providers.get(&auth_mode_str).ok_or_else(|| {
+        ApiError::Configuration(format!(
+            "no provider mapping for auth mode '{auth_mode_str}' on model '{model_alias}'"
+        ))
+    })?;
+
+    // 4. Get connection config.
+    let connection =
+        connection_for(config, &auth_mode_str, &mapping.provider).ok_or_else(|| {
+            ApiError::Configuration(format!(
+                "provider '{}' not found under auth_modes.{} in sudocode.json",
+                mapping.provider, auth_mode_str
+            ))
+        })?;
+
+    // 5. Determine API format.
+    let api_format = resolve_api_format(&auth_mode_str, &mapping.provider, mapping.api.as_deref())?;
+
+    // 6. Resolve credential.
+    let credential = resolve_credential(&auth_mode_str, connection)?;
+
+    // 7. Determine provider kind from the provider name / api format.
+    let kind = infer_provider_kind(&mapping.provider, api_format);
+
+    Ok(ResolvedProvider {
+        kind,
+        api_format,
+        base_url: connection.base_url.clone(),
+        credential,
+        model_id: mapping.model.clone(),
+        display_name: Some(model_config.name.clone()),
+    })
+}
+
+/// Resolve the wire API format.
+///
+/// - Proxy providers: must have an `api` field (`"openai-completions"` or `"openai-responses"`).
+/// - Non-proxy providers: inferred from the provider name.
+fn resolve_api_format(
+    auth_mode: &str,
+    provider_name: &str,
+    api_override: Option<&str>,
+) -> Result<ApiFormat, ApiError> {
+    // If there's an explicit `api` field, use it.
+    if let Some(api) = api_override {
+        return match api {
+            "openai-completions" => Ok(ApiFormat::OpenAiCompletions),
+            "openai-responses" => Ok(ApiFormat::OpenAiResponses),
+            "anthropic-messages" => Ok(ApiFormat::AnthropicMessages),
+            other => Err(ApiError::Configuration(format!(
+                "unknown api format '{other}' for provider '{provider_name}' under mode '{auth_mode}'"
+            ))),
+        };
+    }
+
+    // For proxy mode without an explicit `api`, default to OpenAI completions.
+    if auth_mode == "proxy" {
+        return Ok(ApiFormat::OpenAiCompletions);
+    }
+
+    // Infer from provider name.
+    match provider_name {
+        "anthropic" | "claude" => Ok(ApiFormat::AnthropicMessages),
+        "openai" | "xai" | "dashscope" | "google" | "codex" | "gemini" => {
+            Ok(ApiFormat::OpenAiCompletions)
+        }
+        // Unknown providers under api-key mode: default to OpenAI-compatible.
+        _ => Ok(ApiFormat::OpenAiCompletions),
+    }
+}
+
+/// Resolve credentials from the connection config.
+///
+/// - `api-key` mode: inline `apiKey` → `apiKeyEnv` from env
+/// - `subscription` mode: inline `token` → `tokenEnv` from env → `authFile`
+/// - `proxy` mode: inline `apiKey` → `apiKeyEnv` from env
+fn resolve_credential(
+    auth_mode: &str,
+    connection: &ProviderConnectionConfig,
+) -> Result<Credential, ApiError> {
+    match auth_mode {
+        "api-key" | "proxy" => {
+            // Inline API key takes priority.
+            if let Some(key) = &connection.api_key {
+                if !key.is_empty() {
+                    return Ok(Credential::ApiKey(key.clone()));
+                }
+            }
+            // Then env var.
+            if let Some(env_name) = &connection.api_key_env {
+                if let Ok(val) = std::env::var(env_name) {
+                    if !val.trim().is_empty() {
+                        return Ok(Credential::ApiKey(val));
+                    }
+                }
+            }
+            // For proxy mode, allow no credential (some proxies don't need auth).
+            if auth_mode == "proxy" {
+                return Ok(Credential::None);
+            }
+            Err(ApiError::Configuration(format!(
+                "no API key available for provider under auth mode '{auth_mode}'. \
+                 Set apiKey or apiKeyEnv in sudocode.json, or set the appropriate env var."
+            )))
+        }
+        "subscription" => {
+            // 1. Inline token.
+            if let Some(token) = &connection.token {
+                if !token.is_empty() {
+                    return Ok(Credential::Token(token.clone()));
+                }
+            }
+            // 2. Token env var.
+            if let Some(env_name) = &connection.token_env {
+                if let Ok(val) = std::env::var(env_name) {
+                    if !val.trim().is_empty() {
+                        return Ok(Credential::Token(val));
+                    }
+                }
+            }
+            // 3. Auth file.
+            if let Some(path) = &connection.auth_file {
+                let expanded = expand_tilde(path);
+                if expanded.exists() {
+                    return Ok(Credential::AuthFile(expanded));
+                }
+            }
+            Err(ApiError::Configuration(format!(
+                "no token available for subscription provider. \
+                 Set token, tokenEnv, or authFile in sudocode.json."
+            )))
+        }
+        _ => {
+            // Unknown auth mode — try apiKey then token.
+            if let Some(key) = &connection.api_key {
+                if !key.is_empty() {
+                    return Ok(Credential::ApiKey(key.clone()));
+                }
+            }
+            if let Some(token) = &connection.token {
+                if !token.is_empty() {
+                    return Ok(Credential::Token(token.clone()));
+                }
+            }
+            Ok(Credential::None)
+        }
+    }
+}
+
+/// Infer `ProviderKind` from the provider name and API format.
+fn infer_provider_kind(provider_name: &str, api_format: ApiFormat) -> ProviderKind {
+    match api_format {
+        ApiFormat::AnthropicMessages => ProviderKind::Anthropic,
+        ApiFormat::OpenAiCompletions | ApiFormat::OpenAiResponses => match provider_name {
+            "xai" => ProviderKind::Xai,
+            _ => ProviderKind::OpenAi,
         },
-        api_key_env: provider.api_key_env.clone(),
-        base_url: provider.base_url.clone(),
-        base_url_env: provider.base_url_env.clone(),
-        display_name: provider
-            .display_name
-            .clone()
-            .or_else(|| Some(model.provider.clone())),
     }
 }
 
-fn hardcoded_to_resolved(meta: ProviderMetadata) -> ResolvedProviderMeta {
-    ResolvedProviderMeta {
-        kind: meta.provider,
-        api_key_env: Some(meta.auth_env.to_string()),
-        base_url: None,
-        base_url_env: Some(meta.base_url_env.to_string()),
-        display_name: None,
+/// Expand `~` prefix to the user's home directory.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
     }
-}
-
-/// Leak a string so it lives for `'static`.  Used to bridge config values
-/// into the `OpenAiCompatConfig` type which requires `&'static str` fields.
-/// Safe because provider configs are loaded once at process start.
-fn leak_string(s: &str) -> &'static str {
-    Box::leak(s.to_string().into_boxed_str())
+    PathBuf::from(path)
 }
 
 // ---------------------------------------------------------------------------
@@ -302,142 +324,249 @@ fn leak_string(s: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
-    fn sample_registry() -> ProviderRegistry {
-        let mut providers = BTreeMap::new();
-        providers.insert(
-            "my-ollama".to_string(),
-            ConfigProvider {
-                protocol: ProviderProtocol::OpenAiCompat,
+    fn sample_config() -> SudoCodeConfig {
+        let mut auth_modes = BTreeMap::new();
+
+        // subscription mode
+        let mut subscription = BTreeMap::new();
+        subscription.insert(
+            "claude".to_string(),
+            ProviderConnectionConfig {
+                base_url: "https://api.anthropic.com/v1/messages".to_string(),
+                api_key: None,
                 api_key_env: None,
-                base_url: Some("http://localhost:11434/v1".to_string()),
-                base_url_env: None,
-                display_name: Some("Ollama".to_string()),
+                token: None,
+                token_env: Some("CLAUDE_CODE_OAUTH_TOKEN".to_string()),
+                auth_file: Some("~/.claude/credentials.json".to_string()),
             },
         );
-        providers.insert(
+        auth_modes.insert("subscription".to_string(), subscription);
+
+        // proxy mode
+        let mut proxy = BTreeMap::new();
+        proxy.insert(
+            "sudorouter".to_string(),
+            ProviderConnectionConfig {
+                base_url: "https://hk.sudorouter.ai/v1".to_string(),
+                api_key: Some("sk-test-key".to_string()),
+                api_key_env: None,
+                token: None,
+                token_env: None,
+                auth_file: None,
+            },
+        );
+        auth_modes.insert("proxy".to_string(), proxy);
+
+        // api-key mode
+        let mut api_key = BTreeMap::new();
+        api_key.insert(
             "anthropic".to_string(),
-            ConfigProvider {
-                protocol: ProviderProtocol::Anthropic,
+            ProviderConnectionConfig {
+                base_url: "https://api.anthropic.com".to_string(),
+                api_key: None,
                 api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
-                base_url: None,
-                base_url_env: Some("ANTHROPIC_BASE_URL".to_string()),
-                display_name: None,
+                token: None,
+                token_env: None,
+                auth_file: None,
             },
         );
+        api_key.insert(
+            "xai".to_string(),
+            ProviderConnectionConfig {
+                base_url: "https://api.x.ai/v1".to_string(),
+                api_key: None,
+                api_key_env: Some("XAI_API_KEY".to_string()),
+                token: None,
+                token_env: None,
+                auth_file: None,
+            },
+        );
+        auth_modes.insert("api-key".to_string(), api_key);
 
+        // models
         let mut models = BTreeMap::new();
-        models.insert(
-            "local".to_string(),
-            ConfigModel {
-                provider: "my-ollama".to_string(),
-                model_id: "llama3.2:8b".to_string(),
-                max_output_tokens: Some(16_384),
-                context_window: Some(128_000),
+        let mut opus_providers = BTreeMap::new();
+        opus_providers.insert(
+            "subscription".to_string(),
+            ModelProviderMapping {
+                provider: "claude".to_string(),
+                model: "claude-opus-4-6".to_string(),
+                api: None,
             },
         );
-        models.insert(
-            "fast".to_string(),
-            ConfigModel {
+        opus_providers.insert(
+            "proxy".to_string(),
+            ModelProviderMapping {
+                provider: "sudorouter".to_string(),
+                model: "claude-opus-4-6".to_string(),
+                api: Some("openai-completions".to_string()),
+            },
+        );
+        opus_providers.insert(
+            "api-key".to_string(),
+            ModelProviderMapping {
                 provider: "anthropic".to_string(),
-                model_id: "claude-sonnet-4-6".to_string(),
-                max_output_tokens: None,
-                context_window: None,
+                model: "claude-opus-4-6".to_string(),
+                api: None,
+            },
+        );
+        models.insert(
+            "opus".to_string(),
+            ModelConfigEntry {
+                alias: "opus".to_string(),
+                name: "Claude Opus 4.6".to_string(),
+                input: vec!["text".to_string()],
+                providers: opus_providers,
             },
         );
 
-        ProviderRegistry::new(providers, models)
+        let mut grok_providers = BTreeMap::new();
+        grok_providers.insert(
+            "api-key".to_string(),
+            ModelProviderMapping {
+                provider: "xai".to_string(),
+                model: "grok-3".to_string(),
+                api: None,
+            },
+        );
+        models.insert(
+            "grok".to_string(),
+            ModelConfigEntry {
+                alias: "grok".to_string(),
+                name: "Grok 3".to_string(),
+                input: vec!["text".to_string()],
+                providers: grok_providers,
+            },
+        );
+
+        SudoCodeConfig { auth_modes, models }
     }
 
     #[test]
-    fn config_model_alias_resolves() {
-        let reg = sample_registry();
-        assert_eq!(reg.resolve_model_alias("local"), "llama3.2:8b");
-        assert_eq!(reg.resolve_model_alias("fast"), "claude-sonnet-4-6");
+    fn resolve_model_finds_alias() {
+        let config = sample_config();
+        assert!(resolve_model(&config, "opus").is_some());
+        assert!(resolve_model(&config, "OPUS").is_some()); // case insensitive
+        assert!(resolve_model(&config, "unknown").is_none());
     }
 
     #[test]
-    fn falls_back_to_hardcoded_alias() {
-        let reg = sample_registry();
-        assert_eq!(reg.resolve_model_alias("opus"), "claude-opus-4-6");
-        assert_eq!(reg.resolve_model_alias("grok"), "grok-3");
+    fn available_auth_modes_lists_keys() {
+        let config = sample_config();
+        let modes = available_auth_modes(&config, "opus");
+        assert!(modes.contains(&"subscription"));
+        assert!(modes.contains(&"proxy"));
+        assert!(modes.contains(&"api-key"));
+
+        let grok_modes = available_auth_modes(&config, "grok");
+        assert_eq!(grok_modes, vec!["api-key"]);
     }
 
     #[test]
-    fn config_metadata_resolves_with_display_name() {
-        let reg = sample_registry();
-        let meta = reg
-            .metadata_for_model("local")
-            .expect("config model should resolve");
-        assert_eq!(meta.kind, ProviderKind::OpenAi);
-        assert_eq!(meta.base_url.as_deref(), Some("http://localhost:11434/v1"));
-        assert_eq!(meta.display_name.as_deref(), Some("Ollama"));
+    fn connection_for_resolves() {
+        let config = sample_config();
+        let conn =
+            connection_for(&config, "proxy", "sudorouter").expect("should find proxy sudorouter");
+        assert_eq!(conn.base_url, "https://hk.sudorouter.ai/v1");
+        assert_eq!(conn.api_key.as_deref(), Some("sk-test-key"));
     }
 
     #[test]
-    fn config_token_limits() {
-        let reg = sample_registry();
-        let limit = reg
-            .model_token_limit("local")
-            .expect("config model should have limits");
-        assert_eq!(limit.max_output_tokens, 16_384);
-        assert_eq!(limit.context_window_tokens, 128_000);
+    fn resolve_provider_proxy_with_inline_key() {
+        let config = sample_config();
+        let resolved = resolve_provider_from_config("opus", Some(AuthMode::Proxy), &config)
+            .expect("should resolve");
+        assert_eq!(resolved.kind, ProviderKind::OpenAi);
+        assert_eq!(resolved.api_format, ApiFormat::OpenAiCompletions);
+        assert_eq!(resolved.base_url, "https://hk.sudorouter.ai/v1");
+        assert_eq!(
+            resolved.credential,
+            Credential::ApiKey("sk-test-key".to_string())
+        );
+        assert_eq!(resolved.model_id, "claude-opus-4-6");
     }
 
     #[test]
-    fn config_model_without_limits_falls_back_to_hardcoded() {
-        let reg = sample_registry();
-        // "fast" maps to claude-sonnet-4-6 which has hardcoded limits
-        let limit = reg
-            .model_token_limit("fast")
-            .expect("should fall back to hardcoded limits");
-        assert_eq!(limit.max_output_tokens, 64_000);
-        assert_eq!(limit.context_window_tokens, 200_000);
+    fn resolve_provider_picks_first_mode_by_default() {
+        let config = sample_config();
+        // First mode in BTreeMap for "grok" is "api-key" (only one).
+        let resolved = resolve_provider_from_config("grok", None, &config);
+        // This will fail credential resolution since XAI_API_KEY is not set in
+        // test env, but the error should mention the right auth mode.
+        match resolved {
+            Err(ApiError::Configuration(msg)) => {
+                assert!(msg.contains("API key"), "unexpected error: {msg}");
+            }
+            Ok(r) => {
+                // If XAI_API_KEY happens to be set in the env, that's fine too.
+                assert_eq!(r.kind, ProviderKind::Xai);
+            }
+            Err(other) => panic!("unexpected error: {other}"),
+        }
     }
 
     #[test]
-    fn empty_registry_falls_back_entirely() {
-        let reg = ProviderRegistry::default();
-        assert_eq!(reg.resolve_model_alias("opus"), "claude-opus-4-6");
-        assert!(reg.metadata_for_model("claude-opus-4-6").is_some());
-        assert!(reg.is_config_empty());
+    fn resolve_provider_rejects_unavailable_mode() {
+        let config = sample_config();
+        let result = resolve_provider_from_config("grok", Some(AuthMode::Subscription), &config);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("not available"), "unexpected error: {msg}");
     }
 
     #[test]
-    fn detect_provider_kind_uses_config() {
-        let reg = sample_registry();
-        assert_eq!(reg.detect_provider_kind("local"), ProviderKind::OpenAi);
-        assert_eq!(reg.detect_provider_kind("fast"), ProviderKind::Anthropic);
-        // Hardcoded fallback
-        assert_eq!(reg.detect_provider_kind("grok-3"), ProviderKind::Xai);
+    fn resolve_api_format_infers_correctly() {
+        assert_eq!(
+            resolve_api_format("api-key", "anthropic", None).unwrap(),
+            ApiFormat::AnthropicMessages
+        );
+        assert_eq!(
+            resolve_api_format("api-key", "openai", None).unwrap(),
+            ApiFormat::OpenAiCompletions
+        );
+        assert_eq!(
+            resolve_api_format("proxy", "any", Some("openai-responses")).unwrap(),
+            ApiFormat::OpenAiResponses
+        );
+        assert_eq!(
+            resolve_api_format("proxy", "any", None).unwrap(),
+            ApiFormat::OpenAiCompletions
+        );
     }
 
     #[test]
-    fn openai_compat_config_for_builds_correctly() {
-        let provider = ConfigProvider {
-            protocol: ProviderProtocol::OpenAiCompat,
-            api_key_env: Some("MY_KEY".to_string()),
-            base_url: Some("http://localhost:8080/v1".to_string()),
-            base_url_env: None,
-            display_name: Some("LocalLLM".to_string()),
-        };
-        let config =
-            ProviderRegistry::openai_compat_config_for(&provider).expect("should build config");
-        assert_eq!(config.api_key_env, "MY_KEY");
-        assert_eq!(config.default_base_url, "http://localhost:8080/v1");
-        assert_eq!(config.provider_name, "LocalLLM");
+    fn infer_provider_kind_maps_correctly() {
+        assert_eq!(
+            infer_provider_kind("anthropic", ApiFormat::AnthropicMessages),
+            ProviderKind::Anthropic
+        );
+        assert_eq!(
+            infer_provider_kind("xai", ApiFormat::OpenAiCompletions),
+            ProviderKind::Xai
+        );
+        assert_eq!(
+            infer_provider_kind("openai", ApiFormat::OpenAiCompletions),
+            ProviderKind::OpenAi
+        );
     }
 
     #[test]
-    fn openai_compat_config_returns_none_for_anthropic() {
-        let provider = ConfigProvider {
-            protocol: ProviderProtocol::Anthropic,
-            api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
-            base_url: None,
-            base_url_env: None,
-            display_name: None,
-        };
-        assert!(ProviderRegistry::openai_compat_config_for(&provider).is_none());
+    fn empty_config_is_empty() {
+        let config = SudoCodeConfig::default();
+        assert!(config.auth_modes.is_empty());
+        assert!(config.models.is_empty());
+    }
+
+    #[test]
+    fn expand_tilde_works() {
+        let path = expand_tilde("~/.claude/credentials.json");
+        if let Some(home) = std::env::var_os("HOME") {
+            let expected = std::path::PathBuf::from(home).join(".claude/credentials.json");
+            assert_eq!(path, expected);
+        }
     }
 }

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -196,7 +196,6 @@ fn resolve_api_format(
         return match api {
             "openai-completions" => Ok(ApiFormat::OpenAiCompletions),
             "openai-responses" => Ok(ApiFormat::OpenAiResponses),
-            "anthropic-messages" => Ok(ApiFormat::AnthropicMessages),
             other => Err(ApiError::Configuration(format!(
                 "unknown api format '{other}' for provider '{provider_name}' under mode '{auth_mode}'"
             ))),

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -52,8 +52,6 @@ pub struct ResolvedProvider {
     pub credential: Credential,
     /// The wire model ID to send to the provider.
     pub model_id: String,
-    /// Human-friendly display name for UI banners.
-    pub display_name: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -77,17 +75,9 @@ pub fn resolve_model<'a>(config: &'a SudoCodeConfig, alias: &str) -> Option<&'a 
     })
 }
 
-/// List available auth modes for a model alias, in config order.
-#[must_use]
-pub fn available_auth_modes<'a>(config: &'a SudoCodeConfig, alias: &str) -> Vec<&'a str> {
-    resolve_model(config, alias)
-        .map(|m| m.providers.keys().map(String::as_str).collect())
-        .unwrap_or_default()
-}
-
 /// Look up connection config for a provider under a given auth mode.
 #[must_use]
-pub fn connection_for<'a>(
+fn connection_for<'a>(
     config: &'a SudoCodeConfig,
     auth_mode: &str,
     provider_name: &str,
@@ -143,7 +133,7 @@ pub fn resolve_provider_from_config(
             s.to_string()
         }
         None => {
-            // Pick first available (BTreeMap is ordered, config order = priority).
+            // Pick first available (BTreeMap is lexicographically sorted).
             model_config
                 .providers
                 .keys()
@@ -189,7 +179,6 @@ pub fn resolve_provider_from_config(
         base_url: connection.base_url.clone(),
         credential,
         model_id: mapping.model.clone(),
-        display_name: Some(model_config.name.clone()),
     })
 }
 
@@ -338,6 +327,13 @@ mod tests {
 
     use super::*;
 
+    /// List available auth modes for a model alias, in lexicographic order.
+    fn available_auth_modes<'a>(config: &'a SudoCodeConfig, alias: &str) -> Vec<&'a str> {
+        resolve_model(config, alias)
+            .map(|m| m.providers.keys().map(String::as_str).collect())
+            .unwrap_or_default()
+    }
+
     fn sample_config() -> SudoCodeConfig {
         let mut auth_modes = BTreeMap::new();
 
@@ -346,7 +342,7 @@ mod tests {
         subscription.insert(
             "claude".to_string(),
             ProviderConnectionConfig {
-                base_url: "https://api.anthropic.com/v1/messages".to_string(),
+                base_url: "https://api.anthropic.com".to_string(),
                 api_key: None,
                 api_key_env: None,
                 token: None,
@@ -596,7 +592,7 @@ mod tests {
             .expect("should resolve with inline token");
         assert_eq!(resolved.kind, ProviderKind::Anthropic);
         assert_eq!(resolved.api_format, ApiFormat::AnthropicMessages);
-        assert_eq!(resolved.base_url, "https://api.anthropic.com/v1/messages");
+        assert_eq!(resolved.base_url, "https://api.anthropic.com");
         assert_eq!(
             resolved.credential,
             Credential::Token("sk-inline-oauth-token".to_string())

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -63,7 +63,18 @@ pub struct ResolvedProvider {
 /// Look up a model by alias (case-insensitive).
 #[must_use]
 pub fn resolve_model<'a>(config: &'a SudoCodeConfig, alias: &str) -> Option<&'a ModelConfigEntry> {
-    config.models.get(&alias.trim().to_ascii_lowercase())
+    let key = alias.trim().to_ascii_lowercase();
+    // Direct alias lookup first.
+    if let Some(entry) = config.models.get(&key) {
+        return Some(entry);
+    }
+    // Fall back: match by wire model ID in any provider mapping.
+    config.models.values().find(|entry| {
+        entry
+            .providers
+            .values()
+            .any(|m| m.model.eq_ignore_ascii_case(&key))
+    })
 }
 
 /// List available auth modes for a model alias, in config order.
@@ -567,5 +578,53 @@ mod tests {
             let expected = std::path::PathBuf::from(home).join(".claude/credentials.json");
             assert_eq!(path, expected);
         }
+    }
+
+    #[test]
+    fn resolve_provider_with_inline_token_subscription() {
+        let mut config = sample_config();
+        // Set an inline token on the subscription claude provider.
+        config
+            .auth_modes
+            .get_mut("subscription")
+            .unwrap()
+            .get_mut("claude")
+            .unwrap()
+            .token = Some("sk-inline-oauth-token".to_string());
+
+        let resolved = resolve_provider_from_config("opus", Some(AuthMode::Subscription), &config)
+            .expect("should resolve with inline token");
+        assert_eq!(resolved.kind, ProviderKind::Anthropic);
+        assert_eq!(resolved.api_format, ApiFormat::AnthropicMessages);
+        assert_eq!(resolved.base_url, "https://api.anthropic.com/v1/messages");
+        assert_eq!(
+            resolved.credential,
+            Credential::Token("sk-inline-oauth-token".to_string())
+        );
+        assert_eq!(resolved.model_id, "claude-opus-4-6");
+    }
+
+    #[test]
+    fn resolve_provider_with_inline_apikey() {
+        let mut config = sample_config();
+        // Set an inline API key on the api-key anthropic provider.
+        config
+            .auth_modes
+            .get_mut("api-key")
+            .unwrap()
+            .get_mut("anthropic")
+            .unwrap()
+            .api_key = Some("sk-inline-api-key".to_string());
+
+        let resolved = resolve_provider_from_config("opus", Some(AuthMode::ApiKey), &config)
+            .expect("should resolve with inline api key");
+        assert_eq!(resolved.kind, ProviderKind::Anthropic);
+        assert_eq!(resolved.api_format, ApiFormat::AnthropicMessages);
+        assert_eq!(resolved.base_url, "https://api.anthropic.com");
+        assert_eq!(
+            resolved.credential,
+            Credential::ApiKey("sk-inline-api-key".to_string())
+        );
+        assert_eq!(resolved.model_id, "claude-opus-4-6");
     }
 }

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -1,0 +1,443 @@
+//! Config-driven provider & model registry.
+//!
+//! Layers user-defined `"providers"` and `"models"` entries from the JSON
+//! config on top of the built-in hardcoded registry so that:
+//!
+//! - Config entries take precedence for matching aliases.
+//! - Hardcoded entries remain available when no config is present.
+//! - Unknown models still fall through to prefix-based detection.
+
+use std::collections::BTreeMap;
+
+use super::openai_compat::{self, OpenAiCompatConfig};
+use super::{ModelTokenLimit, ProviderKind, ProviderMetadata};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Wire protocol family for a configured provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderProtocol {
+    /// Native Anthropic Messages API (`/v1/messages`).
+    Anthropic,
+    /// OpenAI-compatible chat completions API (`/v1/chat/completions`).
+    OpenAiCompat,
+}
+
+/// A provider endpoint defined in the config file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigProvider {
+    /// Protocol used to talk to this provider.
+    pub protocol: ProviderProtocol,
+    /// Env-var name whose value is the API key (e.g. `"MY_KEY"`).
+    pub api_key_env: Option<String>,
+    /// Fixed base URL.  Takes precedence over `base_url_env`.
+    pub base_url: Option<String>,
+    /// Env-var name whose value overrides the base URL at runtime.
+    pub base_url_env: Option<String>,
+    /// Human-friendly label shown in the connection banner.
+    pub display_name: Option<String>,
+}
+
+/// A model binding defined in the config file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigModel {
+    /// Key into the `providers` map.
+    pub provider: String,
+    /// Model identifier sent over the wire (e.g. `"claude-opus-4-6"`).
+    pub model_id: String,
+    /// Optional max output tokens override.
+    pub max_output_tokens: Option<u32>,
+    /// Optional context window override.
+    pub context_window: Option<u32>,
+}
+
+/// Combined config-driven + hardcoded provider/model registry.
+///
+/// The zero-value (`Default`) contains no config entries, making every
+/// resolution fall through to the hardcoded registry.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderRegistry {
+    providers: BTreeMap<String, ConfigProvider>,
+    models: BTreeMap<String, ConfigModel>,
+}
+
+/// Metadata resolved through the registry for a given model.
+#[derive(Debug, Clone)]
+pub struct ResolvedProviderMeta {
+    pub kind: ProviderKind,
+    pub api_key_env: Option<String>,
+    pub base_url: Option<String>,
+    pub base_url_env: Option<String>,
+    /// Provider display name for UI banners.  `None` means use the default
+    /// label derived from `ProviderKind`.
+    pub display_name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ProviderRegistry
+// ---------------------------------------------------------------------------
+
+impl ProviderRegistry {
+    /// Build a registry from parsed config sections.
+    #[must_use]
+    pub fn new(
+        providers: BTreeMap<String, ConfigProvider>,
+        models: BTreeMap<String, ConfigModel>,
+    ) -> Self {
+        Self { providers, models }
+    }
+
+    /// Whether the config contributed any providers or models.
+    #[must_use]
+    pub fn is_config_empty(&self) -> bool {
+        self.providers.is_empty() && self.models.is_empty()
+    }
+
+    #[must_use]
+    pub fn providers(&self) -> &BTreeMap<String, ConfigProvider> {
+        &self.providers
+    }
+
+    #[must_use]
+    pub fn models(&self) -> &BTreeMap<String, ConfigModel> {
+        &self.models
+    }
+
+    // -- Resolution helpers ------------------------------------------------
+
+    /// Look up a config model entry by alias (case-insensitive).
+    #[must_use]
+    pub fn config_model(&self, alias: &str) -> Option<&ConfigModel> {
+        let key = alias.trim().to_ascii_lowercase();
+        self.models.get(&key)
+    }
+
+    /// Look up a config provider entry by name.
+    #[must_use]
+    pub fn config_provider(&self, name: &str) -> Option<&ConfigProvider> {
+        self.providers.get(name)
+    }
+
+    /// Resolve a model alias.  Config models take precedence; falls back to
+    /// the built-in hardcoded alias table.
+    #[must_use]
+    pub fn resolve_model_alias(&self, alias: &str) -> String {
+        if let Some(entry) = self.config_model(alias) {
+            return entry.model_id.clone();
+        }
+        super::resolve_model_alias(alias)
+    }
+
+    /// Resolve full provider metadata for a model.  Checks config first
+    /// (by alias *and* by canonical model ID), then falls back to the
+    /// hardcoded `metadata_for_model`.
+    #[must_use]
+    pub fn metadata_for_model(&self, model: &str) -> Option<ResolvedProviderMeta> {
+        // 1. Direct alias match in config models.
+        if let Some(meta) = self.resolve_config_meta_by_alias(model) {
+            return Some(meta);
+        }
+        // 2. Resolve via hardcoded alias, then check if the canonical ID
+        //    matches a config model entry's model_id.
+        let canonical = super::resolve_model_alias(model);
+        if canonical != model {
+            if let Some(meta) = self.resolve_config_meta_by_model_id(&canonical) {
+                return Some(meta);
+            }
+        }
+        // 3. Check config models by model_id directly.
+        if let Some(meta) = self.resolve_config_meta_by_model_id(model) {
+            return Some(meta);
+        }
+        // 4. Fall back to hardcoded.
+        super::metadata_for_model(model).map(hardcoded_to_resolved)
+    }
+
+    /// Detect provider kind for a model.
+    #[must_use]
+    pub fn detect_provider_kind(&self, model: &str) -> ProviderKind {
+        if let Some(meta) = self.metadata_for_model(model) {
+            return meta.kind;
+        }
+        super::detect_provider_kind(model)
+    }
+
+    /// Token limits for a model.
+    #[must_use]
+    pub fn model_token_limit(&self, model: &str) -> Option<ModelTokenLimit> {
+        if let Some(entry) = self.config_model(model) {
+            if entry.max_output_tokens.is_some() || entry.context_window.is_some() {
+                return Some(ModelTokenLimit {
+                    max_output_tokens: entry.max_output_tokens.unwrap_or(64_000),
+                    context_window_tokens: entry.context_window.unwrap_or(200_000),
+                });
+            }
+            // Config model without explicit limits → try hardcoded for the
+            // wire model_id.
+            return super::model_token_limit(&entry.model_id);
+        }
+        super::model_token_limit(model)
+    }
+
+    /// Max output tokens for a model.
+    #[must_use]
+    pub fn max_tokens_for_model(&self, model: &str) -> u32 {
+        self.model_token_limit(model).map_or_else(
+            || {
+                let canonical = self.resolve_model_alias(model);
+                if canonical.contains("opus") {
+                    32_000
+                } else {
+                    64_000
+                }
+            },
+            |limit| limit.max_output_tokens,
+        )
+    }
+
+    /// Build an [`OpenAiCompatConfig`] from a [`ConfigProvider`].
+    ///
+    /// Returns `None` if the provider uses the Anthropic protocol.
+    #[must_use]
+    pub fn openai_compat_config_for(provider: &ConfigProvider) -> Option<OpenAiCompatConfig> {
+        if provider.protocol != ProviderProtocol::OpenAiCompat {
+            return None;
+        }
+        // We construct a config with the provider's settings.  The
+        // `api_key_env` and `base_url_env` are leaked into 'static
+        // references via `Box::leak` because `OpenAiCompatConfig` requires
+        // `&'static str` fields.  This is acceptable because provider
+        // configs are loaded once at startup and live for the process
+        // lifetime.
+        let api_key_env: &'static str = provider
+            .api_key_env
+            .as_deref()
+            .map_or("OPENAI_API_KEY", |s| leak_string(s));
+        let base_url_env: &'static str = provider
+            .base_url_env
+            .as_deref()
+            .map_or("OPENAI_BASE_URL", |s| leak_string(s));
+        let default_base_url: &'static str = provider
+            .base_url
+            .as_deref()
+            .map_or(openai_compat::DEFAULT_OPENAI_BASE_URL, |s| leak_string(s));
+        let provider_name: &'static str = provider
+            .display_name
+            .as_deref()
+            .map_or("OpenAI-compat", |s| leak_string(s));
+
+        Some(OpenAiCompatConfig {
+            provider_name,
+            api_key_env,
+            base_url_env,
+            default_base_url,
+            // Use a reasonable default; custom providers rarely have tight
+            // body limits.
+            max_request_body_bytes: 104_857_600, // 100 MB
+        })
+    }
+
+    // -- Private helpers ---------------------------------------------------
+
+    fn resolve_config_meta_by_alias(&self, alias: &str) -> Option<ResolvedProviderMeta> {
+        let model_entry = self.config_model(alias)?;
+        let provider_entry = self.providers.get(&model_entry.provider)?;
+        Some(config_to_resolved(model_entry, provider_entry))
+    }
+
+    fn resolve_config_meta_by_model_id(&self, model_id: &str) -> Option<ResolvedProviderMeta> {
+        for model_entry in self.models.values() {
+            if model_entry.model_id == model_id {
+                if let Some(provider_entry) = self.providers.get(&model_entry.provider) {
+                    return Some(config_to_resolved(model_entry, provider_entry));
+                }
+            }
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+fn config_to_resolved(model: &ConfigModel, provider: &ConfigProvider) -> ResolvedProviderMeta {
+    ResolvedProviderMeta {
+        kind: match provider.protocol {
+            ProviderProtocol::Anthropic => ProviderKind::Anthropic,
+            ProviderProtocol::OpenAiCompat => ProviderKind::OpenAi,
+        },
+        api_key_env: provider.api_key_env.clone(),
+        base_url: provider.base_url.clone(),
+        base_url_env: provider.base_url_env.clone(),
+        display_name: provider
+            .display_name
+            .clone()
+            .or_else(|| Some(model.provider.clone())),
+    }
+}
+
+fn hardcoded_to_resolved(meta: ProviderMetadata) -> ResolvedProviderMeta {
+    ResolvedProviderMeta {
+        kind: meta.provider,
+        api_key_env: Some(meta.auth_env.to_string()),
+        base_url: None,
+        base_url_env: Some(meta.base_url_env.to_string()),
+        display_name: None,
+    }
+}
+
+/// Leak a string so it lives for `'static`.  Used to bridge config values
+/// into the `OpenAiCompatConfig` type which requires `&'static str` fields.
+/// Safe because provider configs are loaded once at process start.
+fn leak_string(s: &str) -> &'static str {
+    Box::leak(s.to_string().into_boxed_str())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_registry() -> ProviderRegistry {
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "my-ollama".to_string(),
+            ConfigProvider {
+                protocol: ProviderProtocol::OpenAiCompat,
+                api_key_env: None,
+                base_url: Some("http://localhost:11434/v1".to_string()),
+                base_url_env: None,
+                display_name: Some("Ollama".to_string()),
+            },
+        );
+        providers.insert(
+            "anthropic".to_string(),
+            ConfigProvider {
+                protocol: ProviderProtocol::Anthropic,
+                api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+                base_url: None,
+                base_url_env: Some("ANTHROPIC_BASE_URL".to_string()),
+                display_name: None,
+            },
+        );
+
+        let mut models = BTreeMap::new();
+        models.insert(
+            "local".to_string(),
+            ConfigModel {
+                provider: "my-ollama".to_string(),
+                model_id: "llama3.2:8b".to_string(),
+                max_output_tokens: Some(16_384),
+                context_window: Some(128_000),
+            },
+        );
+        models.insert(
+            "fast".to_string(),
+            ConfigModel {
+                provider: "anthropic".to_string(),
+                model_id: "claude-sonnet-4-6".to_string(),
+                max_output_tokens: None,
+                context_window: None,
+            },
+        );
+
+        ProviderRegistry::new(providers, models)
+    }
+
+    #[test]
+    fn config_model_alias_resolves() {
+        let reg = sample_registry();
+        assert_eq!(reg.resolve_model_alias("local"), "llama3.2:8b");
+        assert_eq!(reg.resolve_model_alias("fast"), "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn falls_back_to_hardcoded_alias() {
+        let reg = sample_registry();
+        assert_eq!(reg.resolve_model_alias("opus"), "claude-opus-4-6");
+        assert_eq!(reg.resolve_model_alias("grok"), "grok-3");
+    }
+
+    #[test]
+    fn config_metadata_resolves_with_display_name() {
+        let reg = sample_registry();
+        let meta = reg
+            .metadata_for_model("local")
+            .expect("config model should resolve");
+        assert_eq!(meta.kind, ProviderKind::OpenAi);
+        assert_eq!(meta.base_url.as_deref(), Some("http://localhost:11434/v1"));
+        assert_eq!(meta.display_name.as_deref(), Some("Ollama"));
+    }
+
+    #[test]
+    fn config_token_limits() {
+        let reg = sample_registry();
+        let limit = reg
+            .model_token_limit("local")
+            .expect("config model should have limits");
+        assert_eq!(limit.max_output_tokens, 16_384);
+        assert_eq!(limit.context_window_tokens, 128_000);
+    }
+
+    #[test]
+    fn config_model_without_limits_falls_back_to_hardcoded() {
+        let reg = sample_registry();
+        // "fast" maps to claude-sonnet-4-6 which has hardcoded limits
+        let limit = reg
+            .model_token_limit("fast")
+            .expect("should fall back to hardcoded limits");
+        assert_eq!(limit.max_output_tokens, 64_000);
+        assert_eq!(limit.context_window_tokens, 200_000);
+    }
+
+    #[test]
+    fn empty_registry_falls_back_entirely() {
+        let reg = ProviderRegistry::default();
+        assert_eq!(reg.resolve_model_alias("opus"), "claude-opus-4-6");
+        assert!(reg.metadata_for_model("claude-opus-4-6").is_some());
+        assert!(reg.is_config_empty());
+    }
+
+    #[test]
+    fn detect_provider_kind_uses_config() {
+        let reg = sample_registry();
+        assert_eq!(reg.detect_provider_kind("local"), ProviderKind::OpenAi);
+        assert_eq!(reg.detect_provider_kind("fast"), ProviderKind::Anthropic);
+        // Hardcoded fallback
+        assert_eq!(reg.detect_provider_kind("grok-3"), ProviderKind::Xai);
+    }
+
+    #[test]
+    fn openai_compat_config_for_builds_correctly() {
+        let provider = ConfigProvider {
+            protocol: ProviderProtocol::OpenAiCompat,
+            api_key_env: Some("MY_KEY".to_string()),
+            base_url: Some("http://localhost:8080/v1".to_string()),
+            base_url_env: None,
+            display_name: Some("LocalLLM".to_string()),
+        };
+        let config =
+            ProviderRegistry::openai_compat_config_for(&provider).expect("should build config");
+        assert_eq!(config.api_key_env, "MY_KEY");
+        assert_eq!(config.default_base_url, "http://localhost:8080/v1");
+        assert_eq!(config.provider_name, "LocalLLM");
+    }
+
+    #[test]
+    fn openai_compat_config_returns_none_for_anthropic() {
+        let provider = ConfigProvider {
+            protocol: ProviderProtocol::Anthropic,
+            api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+            base_url: None,
+            base_url_env: None,
+            display_name: None,
+        };
+        assert!(ProviderRegistry::openai_compat_config_for(&provider).is_none());
+    }
+}

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -2333,7 +2333,7 @@ mod tests {
           "auth_modes": {
             "subscription": {
               "claude": {
-                "baseUrl": "https://api.anthropic.com/v1/messages",
+                "baseUrl": "https://api.anthropic.com",
                 "token": "sk-test-oauth-token"
               }
             },
@@ -2382,7 +2382,7 @@ mod tests {
         // auth_modes
         assert_eq!(config.auth_modes.len(), 3);
         let sub_claude = &config.auth_modes["subscription"]["claude"];
-        assert_eq!(sub_claude.base_url, "https://api.anthropic.com/v1/messages");
+        assert_eq!(sub_claude.base_url, "https://api.anthropic.com");
         assert_eq!(sub_claude.token.as_deref(), Some("sk-test-oauth-token"));
         assert!(sub_claude.token_env.is_none());
 

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -9,6 +9,10 @@ use crate::sandbox::{FilesystemIsolationMode, SandboxConfig};
 /// Schema name advertised by generated settings files.
 pub const SUDOCODE_SETTINGS_SCHEMA_NAME: &str = "SettingsSchema";
 
+/// The sample `sudocode.json` shipped with the repo, embedded at compile time.
+/// Tests can write this to a temp config home instead of hardcoding config JSON.
+pub const SAMPLE_SUDOCODE_JSON: &str = include_str!("sudocode.sample.json");
+
 /// Origin of a loaded settings file in the configuration precedence chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ConfigSource {

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -51,38 +51,59 @@ pub struct RuntimePluginConfig {
     max_output_tokens: Option<u32>,
 }
 
-/// A provider endpoint defined in the `"providers"` config section.
+/// Connection details for a provider under a specific auth mode.
+///
+/// Parsed from `auth_modes.<mode>.<provider>` in `sudocode.json`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProviderConfigEntry {
-    /// Protocol kind: `"anthropic"` or `"openai-compat"`.
-    pub kind: String,
-    /// Env-var name whose value is the API key.
+pub struct ProviderConnectionConfig {
+    /// Base URL for API requests.
+    pub base_url: String,
+    /// Inline API key (api-key / proxy mode).
+    pub api_key: Option<String>,
+    /// Env var name for API key.
     pub api_key_env: Option<String>,
-    /// Fixed base URL for this provider.
-    pub base_url: Option<String>,
-    /// Env-var name that overrides the base URL at runtime.
-    pub base_url_env: Option<String>,
-    /// Human-friendly display name for banners.
-    pub display_name: Option<String>,
+    /// Inline token (subscription mode).
+    pub token: Option<String>,
+    /// Env var name for token.
+    pub token_env: Option<String>,
+    /// Path to auth/credentials file (subscription mode).
+    pub auth_file: Option<String>,
 }
 
-/// A model binding defined in the `"models"` config section.
+/// Which provider + wire model ID to use for a model under a given auth mode.
+///
+/// Parsed from `models.<alias>.providers.<mode>` in `sudocode.json`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelProviderMapping {
+    /// Key into `auth_modes.<mode>`.
+    pub provider: String,
+    /// Provider-specific wire model ID.
+    pub model: String,
+    /// Wire format override (only needed for proxy providers).
+    pub api: Option<String>,
+}
+
+/// Model entry in the config registry.
+///
+/// Parsed from `models.<alias>` in `sudocode.json`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelConfigEntry {
-    /// Key into the `"providers"` map.
-    pub provider: String,
-    /// The model identifier sent over the wire.
-    pub model_id: String,
-    /// Optional max output tokens.
-    pub max_output_tokens: Option<u32>,
-    /// Optional context window size.
-    pub context_window: Option<u32>,
+    /// Short alias (also the map key), e.g. `"opus"`.
+    pub alias: String,
+    /// Display name, e.g. `"Claude Opus 4.6"`.
+    pub name: String,
+    /// Input modalities (informational).
+    pub input: Vec<String>,
+    /// Auth mode → provider mapping.
+    pub providers: BTreeMap<String, ModelProviderMapping>,
 }
 
-/// Parsed `"providers"` + `"models"` sections from config.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct ProvidersConfig {
-    pub providers: BTreeMap<String, ProviderConfigEntry>,
+/// Top-level config from `sudocode.json`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SudoCodeConfig {
+    /// `auth_modes.<mode>.<provider_name>` → connection details.
+    pub auth_modes: BTreeMap<String, BTreeMap<String, ProviderConnectionConfig>>,
+    /// `models.<alias>` → model config.
     pub models: BTreeMap<String, ModelConfigEntry>,
 }
 
@@ -100,7 +121,6 @@ pub struct RuntimeFeatureConfig {
     sandbox: SandboxConfig,
     provider_fallbacks: ProviderFallbackConfig,
     trusted_roots: Vec<String>,
-    providers_config: ProvidersConfig,
 }
 
 /// Ordered chain of fallback model identifiers used when the primary
@@ -355,7 +375,6 @@ impl ConfigLoader {
             sandbox: parse_optional_sandbox_config(&merged_value)?,
             provider_fallbacks: parse_optional_provider_fallbacks(&merged_value)?,
             trusted_roots: parse_optional_trusted_roots(&merged_value)?,
-            providers_config: parse_optional_providers_config(&merged_value)?,
         };
 
         Ok(RuntimeConfig {
@@ -363,6 +382,17 @@ impl ConfigLoader {
             loaded_entries,
             feature_config,
         })
+    }
+
+    /// Load `sudocode.json` from the config home directory.
+    ///
+    /// Returns `SudoCodeConfig::default()` if the file does not exist.
+    pub fn load_sudocode_config(&self) -> Result<SudoCodeConfig, ConfigError> {
+        let path = self.config_home.join("sudocode.json");
+        if !path.exists() {
+            return Ok(SudoCodeConfig::default());
+        }
+        parse_sudocode_json(&path)
     }
 }
 
@@ -455,11 +485,6 @@ impl RuntimeConfig {
     pub fn trusted_roots(&self) -> &[String] {
         &self.feature_config.trusted_roots
     }
-
-    #[must_use]
-    pub fn providers_config(&self) -> &ProvidersConfig {
-        &self.feature_config.providers_config
-    }
 }
 
 impl RuntimeFeatureConfig {
@@ -528,11 +553,6 @@ impl RuntimeFeatureConfig {
     #[must_use]
     pub fn trusted_roots(&self) -> &[String] {
         &self.trusted_roots
-    }
-
-    #[must_use]
-    pub fn providers_config(&self) -> &ProvidersConfig {
-        &self.providers_config
     }
 }
 
@@ -962,77 +982,132 @@ fn parse_optional_trusted_roots(root: &JsonValue) -> Result<Vec<String>, ConfigE
     )
 }
 
-fn parse_optional_providers_config(root: &JsonValue) -> Result<ProvidersConfig, ConfigError> {
-    let Some(object) = root.as_object() else {
-        return Ok(ProvidersConfig::default());
+// ---------------------------------------------------------------------------
+// sudocode.json parsing
+// ---------------------------------------------------------------------------
+
+/// Parse `sudocode.json` into `SudoCodeConfig`.
+fn parse_sudocode_json(path: &Path) -> Result<SudoCodeConfig, ConfigError> {
+    let content = fs::read_to_string(path).map_err(ConfigError::Io)?;
+    let root: JsonValue = JsonValue::parse(&content)
+        .map_err(|e| ConfigError::Parse(format!("{}: {e}", path.display())))?;
+    let Some(root_obj) = root.as_object() else {
+        return Err(ConfigError::Parse(format!(
+            "{}: expected JSON object at top level",
+            path.display()
+        )));
     };
 
-    let providers = parse_providers_section(object)?;
-    let models = parse_models_section(object)?;
-    Ok(ProvidersConfig { providers, models })
+    let auth_modes = parse_auth_modes_section(root_obj, path)?;
+    let models = parse_sudocode_models_section(root_obj, path)?;
+
+    Ok(SudoCodeConfig { auth_modes, models })
 }
 
-fn parse_providers_section(
+fn parse_auth_modes_section(
     root: &BTreeMap<String, JsonValue>,
-) -> Result<BTreeMap<String, ProviderConfigEntry>, ConfigError> {
-    let Some(value) = root.get("providers") else {
+    path: &Path,
+) -> Result<BTreeMap<String, BTreeMap<String, ProviderConnectionConfig>>, ConfigError> {
+    let Some(value) = root.get("auth_modes") else {
         return Ok(BTreeMap::new());
     };
-    let providers_obj = expect_object(value, "merged settings.providers")?;
+    let modes_obj = expect_object(value, &format!("{}.auth_modes", path.display()))?;
     let mut result = BTreeMap::new();
-    for (name, entry_value) in providers_obj {
-        let entry = expect_object(entry_value, &format!("merged settings.providers.{name}"))?;
-        let context = format!("merged settings.providers.{name}");
-        let kind = expect_string(entry, "kind", &context)?.to_string();
-        if kind != "anthropic" && kind != "openai-compat" {
-            return Err(ConfigError::Parse(format!(
-                "{context}: field kind must be \"anthropic\" or \"openai-compat\", got \"{kind}\""
-            )));
+    for (mode_name, mode_value) in modes_obj {
+        let providers_obj = expect_object(
+            mode_value,
+            &format!("{}.auth_modes.{mode_name}", path.display()),
+        )?;
+        let mut providers = BTreeMap::new();
+        for (provider_name, provider_value) in providers_obj {
+            let ctx = format!("{}.auth_modes.{mode_name}.{provider_name}", path.display());
+            let entry = expect_object(provider_value, &ctx)?;
+            let base_url = expect_string(entry, "baseUrl", &ctx)?.to_string();
+            let api_key = optional_string(entry, "apiKey", &ctx)?.map(str::to_string);
+            let api_key_env = optional_string(entry, "apiKeyEnv", &ctx)?.map(str::to_string);
+            let token = optional_json_string_or_null(entry, "token");
+            let token_env = optional_string(entry, "tokenEnv", &ctx)?.map(str::to_string);
+            let auth_file = optional_string(entry, "authFile", &ctx)?.map(str::to_string);
+            providers.insert(
+                provider_name.clone(),
+                ProviderConnectionConfig {
+                    base_url,
+                    api_key,
+                    api_key_env,
+                    token,
+                    token_env,
+                    auth_file,
+                },
+            );
         }
-        let api_key_env = optional_string(entry, "apiKeyEnv", &context)?.map(str::to_string);
-        let base_url = optional_string(entry, "baseUrl", &context)?.map(str::to_string);
-        let base_url_env = optional_string(entry, "baseUrlEnv", &context)?.map(str::to_string);
-        let display_name = optional_string(entry, "displayName", &context)?.map(str::to_string);
-        result.insert(
-            name.clone(),
-            ProviderConfigEntry {
-                kind,
-                api_key_env,
-                base_url,
-                base_url_env,
-                display_name,
-            },
-        );
+        result.insert(mode_name.clone(), providers);
     }
     Ok(result)
 }
 
-fn parse_models_section(
+fn parse_sudocode_models_section(
     root: &BTreeMap<String, JsonValue>,
+    path: &Path,
 ) -> Result<BTreeMap<String, ModelConfigEntry>, ConfigError> {
     let Some(value) = root.get("models") else {
         return Ok(BTreeMap::new());
     };
-    let models_obj = expect_object(value, "merged settings.models")?;
+    let models_obj = expect_object(value, &format!("{}.models", path.display()))?;
     let mut result = BTreeMap::new();
-    for (name, entry_value) in models_obj {
-        let entry = expect_object(entry_value, &format!("merged settings.models.{name}"))?;
-        let context = format!("merged settings.models.{name}");
-        let provider = expect_string(entry, "provider", &context)?.to_string();
-        let model_id = expect_string(entry, "modelId", &context)?.to_string();
-        let max_output_tokens = optional_u32(entry, "maxOutputTokens", &context)?;
-        let context_window = optional_u32(entry, "contextWindow", &context)?;
+    for (alias, model_value) in models_obj {
+        let ctx = format!("{}.models.{alias}", path.display());
+        let entry = expect_object(model_value, &ctx)?;
+        let name = optional_string(entry, "name", &ctx)?
+            .map(str::to_string)
+            .unwrap_or_else(|| alias.clone());
+        let input = optional_string_array(entry, "input", &ctx)?.unwrap_or_default();
+        let alias_field = optional_string(entry, "alias", &ctx)?
+            .map(str::to_string)
+            .unwrap_or_else(|| alias.clone());
+
+        // Parse the providers sub-object.
+        let providers = if let Some(providers_value) = entry.get("providers") {
+            let providers_obj = expect_object(providers_value, &format!("{ctx}.providers"))?;
+            let mut mappings = BTreeMap::new();
+            for (mode_name, mapping_value) in providers_obj {
+                let m_ctx = format!("{ctx}.providers.{mode_name}");
+                let m_entry = expect_object(mapping_value, &m_ctx)?;
+                let provider = expect_string(m_entry, "provider", &m_ctx)?.to_string();
+                let model = expect_string(m_entry, "model", &m_ctx)?.to_string();
+                let api = optional_string(m_entry, "api", &m_ctx)?.map(str::to_string);
+                mappings.insert(
+                    mode_name.clone(),
+                    ModelProviderMapping {
+                        provider,
+                        model,
+                        api,
+                    },
+                );
+            }
+            mappings
+        } else {
+            BTreeMap::new()
+        };
+
         result.insert(
-            name.to_ascii_lowercase(),
+            alias.to_ascii_lowercase(),
             ModelConfigEntry {
-                provider,
-                model_id,
-                max_output_tokens,
-                context_window,
+                alias: alias_field,
+                name,
+                input,
+                providers,
             },
         );
     }
     Ok(result)
+}
+
+/// Read a JSON string field that might be `null` (treat as `None`).
+fn optional_json_string_or_null(object: &BTreeMap<String, JsonValue>, key: &str) -> Option<String> {
+    match object.get(key) {
+        Some(JsonValue::String(s)) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
 }
 
 fn parse_filesystem_mode_label(value: &str) -> Result<FilesystemIsolationMode, ConfigError> {

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -51,6 +51,41 @@ pub struct RuntimePluginConfig {
     max_output_tokens: Option<u32>,
 }
 
+/// A provider endpoint defined in the `"providers"` config section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderConfigEntry {
+    /// Protocol kind: `"anthropic"` or `"openai-compat"`.
+    pub kind: String,
+    /// Env-var name whose value is the API key.
+    pub api_key_env: Option<String>,
+    /// Fixed base URL for this provider.
+    pub base_url: Option<String>,
+    /// Env-var name that overrides the base URL at runtime.
+    pub base_url_env: Option<String>,
+    /// Human-friendly display name for banners.
+    pub display_name: Option<String>,
+}
+
+/// A model binding defined in the `"models"` config section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelConfigEntry {
+    /// Key into the `"providers"` map.
+    pub provider: String,
+    /// The model identifier sent over the wire.
+    pub model_id: String,
+    /// Optional max output tokens.
+    pub max_output_tokens: Option<u32>,
+    /// Optional context window size.
+    pub context_window: Option<u32>,
+}
+
+/// Parsed `"providers"` + `"models"` sections from config.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProvidersConfig {
+    pub providers: BTreeMap<String, ProviderConfigEntry>,
+    pub models: BTreeMap<String, ModelConfigEntry>,
+}
+
 /// Structured feature configuration consumed by runtime subsystems.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RuntimeFeatureConfig {
@@ -65,6 +100,7 @@ pub struct RuntimeFeatureConfig {
     sandbox: SandboxConfig,
     provider_fallbacks: ProviderFallbackConfig,
     trusted_roots: Vec<String>,
+    providers_config: ProvidersConfig,
 }
 
 /// Ordered chain of fallback model identifiers used when the primary
@@ -319,6 +355,7 @@ impl ConfigLoader {
             sandbox: parse_optional_sandbox_config(&merged_value)?,
             provider_fallbacks: parse_optional_provider_fallbacks(&merged_value)?,
             trusted_roots: parse_optional_trusted_roots(&merged_value)?,
+            providers_config: parse_optional_providers_config(&merged_value)?,
         };
 
         Ok(RuntimeConfig {
@@ -418,6 +455,11 @@ impl RuntimeConfig {
     pub fn trusted_roots(&self) -> &[String] {
         &self.feature_config.trusted_roots
     }
+
+    #[must_use]
+    pub fn providers_config(&self) -> &ProvidersConfig {
+        &self.feature_config.providers_config
+    }
 }
 
 impl RuntimeFeatureConfig {
@@ -486,6 +528,11 @@ impl RuntimeFeatureConfig {
     #[must_use]
     pub fn trusted_roots(&self) -> &[String] {
         &self.trusted_roots
+    }
+
+    #[must_use]
+    pub fn providers_config(&self) -> &ProvidersConfig {
+        &self.providers_config
     }
 }
 
@@ -913,6 +960,79 @@ fn parse_optional_trusted_roots(root: &JsonValue) -> Result<Vec<String>, ConfigE
         optional_string_array(object, "trustedRoots", "merged settings.trustedRoots")?
             .unwrap_or_default(),
     )
+}
+
+fn parse_optional_providers_config(root: &JsonValue) -> Result<ProvidersConfig, ConfigError> {
+    let Some(object) = root.as_object() else {
+        return Ok(ProvidersConfig::default());
+    };
+
+    let providers = parse_providers_section(object)?;
+    let models = parse_models_section(object)?;
+    Ok(ProvidersConfig { providers, models })
+}
+
+fn parse_providers_section(
+    root: &BTreeMap<String, JsonValue>,
+) -> Result<BTreeMap<String, ProviderConfigEntry>, ConfigError> {
+    let Some(value) = root.get("providers") else {
+        return Ok(BTreeMap::new());
+    };
+    let providers_obj = expect_object(value, "merged settings.providers")?;
+    let mut result = BTreeMap::new();
+    for (name, entry_value) in providers_obj {
+        let entry = expect_object(entry_value, &format!("merged settings.providers.{name}"))?;
+        let context = format!("merged settings.providers.{name}");
+        let kind = expect_string(entry, "kind", &context)?.to_string();
+        if kind != "anthropic" && kind != "openai-compat" {
+            return Err(ConfigError::Parse(format!(
+                "{context}: field kind must be \"anthropic\" or \"openai-compat\", got \"{kind}\""
+            )));
+        }
+        let api_key_env = optional_string(entry, "apiKeyEnv", &context)?.map(str::to_string);
+        let base_url = optional_string(entry, "baseUrl", &context)?.map(str::to_string);
+        let base_url_env = optional_string(entry, "baseUrlEnv", &context)?.map(str::to_string);
+        let display_name = optional_string(entry, "displayName", &context)?.map(str::to_string);
+        result.insert(
+            name.clone(),
+            ProviderConfigEntry {
+                kind,
+                api_key_env,
+                base_url,
+                base_url_env,
+                display_name,
+            },
+        );
+    }
+    Ok(result)
+}
+
+fn parse_models_section(
+    root: &BTreeMap<String, JsonValue>,
+) -> Result<BTreeMap<String, ModelConfigEntry>, ConfigError> {
+    let Some(value) = root.get("models") else {
+        return Ok(BTreeMap::new());
+    };
+    let models_obj = expect_object(value, "merged settings.models")?;
+    let mut result = BTreeMap::new();
+    for (name, entry_value) in models_obj {
+        let entry = expect_object(entry_value, &format!("merged settings.models.{name}"))?;
+        let context = format!("merged settings.models.{name}");
+        let provider = expect_string(entry, "provider", &context)?.to_string();
+        let model_id = expect_string(entry, "modelId", &context)?.to_string();
+        let max_output_tokens = optional_u32(entry, "maxOutputTokens", &context)?;
+        let context_window = optional_u32(entry, "contextWindow", &context)?;
+        result.insert(
+            name.to_ascii_lowercase(),
+            ModelConfigEntry {
+                provider,
+                model_id,
+                max_output_tokens,
+                context_window,
+            },
+        );
+    }
+    Ok(result)
 }
 
 fn parse_filesystem_mode_label(value: &str) -> Result<FilesystemIsolationMode, ConfigError> {

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -2322,4 +2322,97 @@ mod tests {
 
         fs::remove_dir_all(root).expect("cleanup temp dir");
     }
+
+    #[test]
+    fn parses_sudocode_json_with_inline_credentials() {
+        let root = temp_dir();
+        let home = root.join("home").join(".nexus").join("sudocode");
+        fs::create_dir_all(&home).expect("config dir");
+
+        let json = r#"{
+          "auth_modes": {
+            "subscription": {
+              "claude": {
+                "baseUrl": "https://api.anthropic.com/v1/messages",
+                "token": "sk-test-oauth-token"
+              }
+            },
+            "proxy": {
+              "sudorouter": {
+                "baseUrl": "https://hk.sudorouter.ai/v1",
+                "apiKey": "sk-test-proxy-key"
+              }
+            },
+            "api-key": {
+              "anthropic": {
+                "baseUrl": "https://api.anthropic.com",
+                "apiKey": "sk-test-anthropic-key"
+              }
+            }
+          },
+          "models": {
+            "opus": {
+              "alias": "opus",
+              "name": "Claude Opus 4.6",
+              "input": ["text"],
+              "providers": {
+                "subscription": { "provider": "claude", "model": "claude-opus-4-6" },
+                "proxy":        { "provider": "sudorouter", "model": "claude-opus-4-6", "api": "openai-completions" },
+                "api-key":      { "provider": "anthropic", "model": "claude-opus-4-6" }
+              }
+            },
+            "deepseek": {
+              "alias": "deepseek",
+              "name": "DeepSeek V3",
+              "input": ["text"],
+              "providers": {
+                "proxy": { "provider": "sudorouter", "model": "deepseek-chat", "api": "openai-completions" }
+              }
+            }
+          }
+        }"#;
+
+        fs::write(home.join("sudocode.json"), json).expect("write sudocode.json");
+
+        let cwd = root.join("project");
+        fs::create_dir_all(&cwd).expect("project dir");
+        let loader = ConfigLoader::new(&cwd, &home);
+        let config = loader.load_sudocode_config().expect("should parse");
+
+        // auth_modes
+        assert_eq!(config.auth_modes.len(), 3);
+        let sub_claude = &config.auth_modes["subscription"]["claude"];
+        assert_eq!(sub_claude.base_url, "https://api.anthropic.com/v1/messages");
+        assert_eq!(sub_claude.token.as_deref(), Some("sk-test-oauth-token"));
+        assert!(sub_claude.token_env.is_none());
+
+        let proxy = &config.auth_modes["proxy"]["sudorouter"];
+        assert_eq!(proxy.base_url, "https://hk.sudorouter.ai/v1");
+        assert_eq!(proxy.api_key.as_deref(), Some("sk-test-proxy-key"));
+
+        let apikey = &config.auth_modes["api-key"]["anthropic"];
+        assert_eq!(apikey.base_url, "https://api.anthropic.com");
+        assert_eq!(apikey.api_key.as_deref(), Some("sk-test-anthropic-key"));
+
+        // models
+        assert_eq!(config.models.len(), 2);
+        let opus = &config.models["opus"];
+        assert_eq!(opus.name, "Claude Opus 4.6");
+        assert_eq!(opus.providers.len(), 3);
+        assert_eq!(opus.providers["subscription"].provider, "claude");
+        assert_eq!(opus.providers["subscription"].model, "claude-opus-4-6");
+        assert!(opus.providers["subscription"].api.is_none());
+        assert_eq!(opus.providers["proxy"].provider, "sudorouter");
+        assert_eq!(
+            opus.providers["proxy"].api.as_deref(),
+            Some("openai-completions")
+        );
+        assert_eq!(opus.providers["api-key"].provider, "anthropic");
+
+        let deepseek = &config.models["deepseek"];
+        assert_eq!(deepseek.providers.len(), 1);
+        assert_eq!(deepseek.providers["proxy"].model, "deepseek-chat");
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
 }

--- a/rust/crates/runtime/src/config_validate.rs
+++ b/rust/crates/runtime/src/config_validate.rs
@@ -197,6 +197,14 @@ const TOP_LEVEL_FIELDS: &[FieldSpec] = &[
         name: "trustedRoots",
         expected: FieldType::StringArray,
     },
+    FieldSpec {
+        name: "providers",
+        expected: FieldType::Object,
+    },
+    FieldSpec {
+        name: "models",
+        expected: FieldType::Object,
+    },
 ];
 
 const HOOKS_FIELDS: &[FieldSpec] = &[

--- a/rust/crates/runtime/src/config_validate.rs
+++ b/rust/crates/runtime/src/config_validate.rs
@@ -197,14 +197,6 @@ const TOP_LEVEL_FIELDS: &[FieldSpec] = &[
         name: "trustedRoots",
         expected: FieldType::StringArray,
     },
-    FieldSpec {
-        name: "providers",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "models",
-        expected: FieldType::Object,
-    },
 ];
 
 const HOOKS_FIELDS: &[FieldSpec] = &[

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -10,7 +10,7 @@ pub mod bash_validation;
 mod bootstrap;
 pub mod branch_lock;
 mod compact;
-mod config;
+pub mod config;
 pub mod config_validate;
 mod conversation;
 mod file_ops;
@@ -65,9 +65,10 @@ pub use compact::{
 pub use config::{
     ConfigEntry, ConfigError, ConfigLoader, ConfigSource, McpConfigCollection,
     McpManagedProxyServerConfig, McpOAuthConfig, McpRemoteServerConfig, McpSdkServerConfig,
-    McpServerConfig, McpStdioServerConfig, McpTransport, McpWebSocketServerConfig, OAuthConfig,
-    ProviderFallbackConfig, ResolvedPermissionMode, RuntimeConfig, RuntimeFeatureConfig,
-    RuntimeHookConfig, RuntimePermissionRuleConfig, RuntimePluginConfig, ScopedMcpServerConfig,
+    McpServerConfig, McpStdioServerConfig, McpTransport, McpWebSocketServerConfig,
+    ModelConfigEntry, OAuthConfig, ProviderConfigEntry, ProviderFallbackConfig, ProvidersConfig,
+    ResolvedPermissionMode, RuntimeConfig, RuntimeFeatureConfig, RuntimeHookConfig,
+    RuntimePermissionRuleConfig, RuntimePluginConfig, ScopedMcpServerConfig,
     SUDOCODE_SETTINGS_SCHEMA_NAME,
 };
 pub use config_validate::{

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -66,10 +66,10 @@ pub use config::{
     ConfigEntry, ConfigError, ConfigLoader, ConfigSource, McpConfigCollection,
     McpManagedProxyServerConfig, McpOAuthConfig, McpRemoteServerConfig, McpSdkServerConfig,
     McpServerConfig, McpStdioServerConfig, McpTransport, McpWebSocketServerConfig,
-    ModelConfigEntry, OAuthConfig, ProviderConfigEntry, ProviderFallbackConfig, ProvidersConfig,
-    ResolvedPermissionMode, RuntimeConfig, RuntimeFeatureConfig, RuntimeHookConfig,
-    RuntimePermissionRuleConfig, RuntimePluginConfig, ScopedMcpServerConfig,
-    SUDOCODE_SETTINGS_SCHEMA_NAME,
+    ModelConfigEntry, ModelProviderMapping, OAuthConfig, ProviderConnectionConfig,
+    ProviderFallbackConfig, ResolvedPermissionMode, RuntimeConfig, RuntimeFeatureConfig,
+    RuntimeHookConfig, RuntimePermissionRuleConfig, RuntimePluginConfig, ScopedMcpServerConfig,
+    SudoCodeConfig, SUDOCODE_SETTINGS_SCHEMA_NAME,
 };
 pub use config_validate::{
     check_unsupported_format, format_diagnostics, validate_config_file, ConfigDiagnostic,

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -69,7 +69,7 @@ pub use config::{
     ModelConfigEntry, ModelProviderMapping, OAuthConfig, ProviderConnectionConfig,
     ProviderFallbackConfig, ResolvedPermissionMode, RuntimeConfig, RuntimeFeatureConfig,
     RuntimeHookConfig, RuntimePermissionRuleConfig, RuntimePluginConfig, ScopedMcpServerConfig,
-    SudoCodeConfig, SUDOCODE_SETTINGS_SCHEMA_NAME,
+    SudoCodeConfig, SAMPLE_SUDOCODE_JSON, SUDOCODE_SETTINGS_SCHEMA_NAME,
 };
 pub use config_validate::{
     check_unsupported_format, format_diagnostics, validate_config_file, ConfigDiagnostic,

--- a/rust/crates/runtime/src/sudocode.sample.json
+++ b/rust/crates/runtime/src/sudocode.sample.json
@@ -2,7 +2,7 @@
   "auth_modes": {
     "subscription": {
       "claude": {
-        "baseUrl": "https://api.anthropic.com/v1/messages",
+        "baseUrl": "https://api.anthropic.com",
         "token": "<YOUR_CLAUDE_OAUTH_TOKEN>"
       }
     },
@@ -52,7 +52,7 @@
         "api-key":      { "provider": "anthropic", "model": "claude-sonnet-4-6" }
       }
     },
-"gemini-3-pro": {
+    "gemini-3-pro": {
       "alias": "gemini-3-pro",
       "name": "Gemini 3.1 Pro",
       "input": ["text"],
@@ -74,14 +74,6 @@
       "input": ["text"],
       "providers": {
         "proxy": { "provider": "sudorouter", "model": "gpt-5.4", "api": "openai-completions" }
-      }
-    },
-    "gpt-5.4-mini": {
-      "alias": "gpt-5.4-mini",
-      "name": "GPT 5.4 Mini",
-      "input": ["text"],
-      "providers": {
-        "proxy": { "provider": "sudorouter", "model": "gpt-5.4-mini", "api": "openai-completions" }
       }
     },
     "gpt-5.4-mini": {

--- a/rust/crates/runtime/src/sudocode.sample.json
+++ b/rust/crates/runtime/src/sudocode.sample.json
@@ -1,0 +1,96 @@
+{
+  "auth_modes": {
+    "subscription": {
+      "claude": {
+        "baseUrl": "https://api.anthropic.com/v1/messages",
+        "token": "<YOUR_CLAUDE_OAUTH_TOKEN>"
+      }
+    },
+    "proxy": {
+      "sudorouter": {
+        "baseUrl": "https://hk.sudorouter.ai/v1",
+        "apiKey": "<YOUR_SUDOROUTER_API_KEY>"
+      }
+    },
+    "api-key": {
+      "anthropic": {
+        "baseUrl": "https://api.anthropic.com",
+        "apiKey": "<YOUR_ANTHROPIC_API_KEY>"
+      },
+      "openai": {
+        "baseUrl": "https://api.openai.com/v1",
+        "apiKey": "<YOUR_OPENAI_API_KEY>"
+      },
+      "xai": {
+        "baseUrl": "https://api.x.ai/v1",
+        "apiKey": "<YOUR_XAI_API_KEY>"
+      },
+      "dashscope": {
+        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "apiKey": "<YOUR_DASHSCOPE_API_KEY>"
+      }
+    }
+  },
+  "models": {
+    "opus": {
+      "alias": "opus",
+      "name": "Claude Opus 4.6",
+      "input": ["text"],
+      "providers": {
+        "subscription": { "provider": "claude", "model": "claude-opus-4-6" },
+        "proxy":        { "provider": "sudorouter", "model": "claude-opus-4-6", "api": "openai-completions" },
+        "api-key":      { "provider": "anthropic", "model": "claude-opus-4-6" }
+      }
+    },
+    "sonnet": {
+      "alias": "sonnet",
+      "name": "Claude Sonnet 4.6",
+      "input": ["text"],
+      "providers": {
+        "subscription": { "provider": "claude", "model": "claude-sonnet-4-6" },
+        "proxy":        { "provider": "sudorouter", "model": "claude-sonnet-4-6", "api": "openai-completions" },
+        "api-key":      { "provider": "anthropic", "model": "claude-sonnet-4-6" }
+      }
+    },
+"gemini-3-pro": {
+      "alias": "gemini-3-pro",
+      "name": "Gemini 3.1 Pro",
+      "input": ["text"],
+      "providers": {
+        "proxy": { "provider": "sudorouter", "model": "gemini-3.1-pro-preview", "api": "openai-completions" }
+      }
+    },
+    "gemini-3-flash": {
+      "alias": "gemini-3-flash",
+      "name": "Gemini 3 Flash",
+      "input": ["text"],
+      "providers": {
+        "proxy": { "provider": "sudorouter", "model": "gemini-3-flash-preview", "api": "openai-completions" }
+      }
+    },
+    "gpt-5.4": {
+      "alias": "gpt-5.4",
+      "name": "GPT 5.4",
+      "input": ["text"],
+      "providers": {
+        "proxy": { "provider": "sudorouter", "model": "gpt-5.4", "api": "openai-completions" }
+      }
+    },
+    "gpt-5.4-mini": {
+      "alias": "gpt-5.4-mini",
+      "name": "GPT 5.4 Mini",
+      "input": ["text"],
+      "providers": {
+        "proxy": { "provider": "sudorouter", "model": "gpt-5.4-mini", "api": "openai-completions" }
+      }
+    },
+    "gpt-5.4-mini": {
+      "alias": "gpt-5.4-mini",
+      "name": "GPT 5.4 Mini",
+      "input": ["text"],
+      "providers": {
+        "proxy": { "provider": "sudorouter", "model": "gpt-5.4-mini", "api": "openai-completions" }
+      }
+    }
+  }
+}

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1515,11 +1515,12 @@ fn resolve_model_alias(model: &str) -> &str {
 /// user-supplied model string is about to be dispatched to a provider.
 fn resolve_model_alias_with_config(model: &str) -> String {
     let trimmed = model.trim();
-    // Check config-driven model registry first.
-    let registry = load_provider_registry_for_current_dir();
-    if !registry.is_config_empty() {
-        if let Some(entry) = registry.config_model(trimmed) {
-            return entry.model_id.clone();
+    // Check sudocode.json model registry first.
+    let config = load_sudocode_config_for_current_dir();
+    if let Some(entry) = config.models.get(&trimmed.to_ascii_lowercase()) {
+        // Return the wire model ID from the first available provider mapping.
+        if let Some(mapping) = entry.providers.values().next() {
+            return mapping.model.clone();
         }
     }
     // Then check config aliases.
@@ -1585,67 +1586,21 @@ fn config_alias_for_current_dir(alias: &str) -> Option<String> {
     config.aliases().get(alias).cloned()
 }
 
-/// Build a [`ProviderRegistry`] from the config for the current directory.
-fn load_provider_registry_for_current_dir() -> api::ProviderRegistry {
+/// Load `SudoCodeConfig` from the config home for the current directory.
+fn load_sudocode_config_for_current_dir() -> api::SudoCodeConfig {
     let Ok(cwd) = env::current_dir() else {
-        return api::ProviderRegistry::default();
+        return api::SudoCodeConfig::default();
     };
-    load_provider_registry_for_cwd(&cwd)
+    load_sudocode_config_for_cwd(&cwd)
 }
 
-/// Build a [`ProviderRegistry`] from the config for the given directory.
-fn load_provider_registry_for_cwd(cwd: &Path) -> api::ProviderRegistry {
+/// Load `SudoCodeConfig` from the config home for a given directory.
+fn load_sudocode_config_for_cwd(cwd: &Path) -> api::SudoCodeConfig {
     let loader = ConfigLoader::default_for(cwd);
-    let Ok(config) = loader.load() else {
-        return api::ProviderRegistry::default();
-    };
-    build_provider_registry(config.providers_config())
-}
-
-/// Convert the parsed config types into the API-layer [`ProviderRegistry`].
-fn build_provider_registry(config: &runtime::config::ProvidersConfig) -> api::ProviderRegistry {
-    if config.providers.is_empty() && config.models.is_empty() {
-        return api::ProviderRegistry::default();
-    }
-
-    let providers = config
-        .providers
-        .iter()
-        .map(|(name, entry)| {
-            let protocol = match entry.kind.as_str() {
-                "anthropic" => api::ProviderProtocol::Anthropic,
-                _ => api::ProviderProtocol::OpenAiCompat,
-            };
-            (
-                name.clone(),
-                api::ConfigProvider {
-                    protocol,
-                    api_key_env: entry.api_key_env.clone(),
-                    base_url: entry.base_url.clone(),
-                    base_url_env: entry.base_url_env.clone(),
-                    display_name: entry.display_name.clone(),
-                },
-            )
-        })
-        .collect();
-
-    let models = config
-        .models
-        .iter()
-        .map(|(name, entry)| {
-            (
-                name.clone(),
-                api::ConfigModel {
-                    provider: entry.provider.clone(),
-                    model_id: entry.model_id.clone(),
-                    max_output_tokens: entry.max_output_tokens,
-                    context_window: entry.context_window,
-                },
-            )
-        })
-        .collect();
-
-    api::ProviderRegistry::new(providers, models)
+    loader.load_sudocode_config().unwrap_or_else(|e| {
+        eprintln!("warning: failed to load sudocode.json: {e}");
+        api::SudoCodeConfig::default()
+    })
 }
 
 fn normalize_allowed_tools(values: &[String]) -> Result<Option<AllowedToolSet>, String> {
@@ -1755,19 +1710,22 @@ fn format_connected_line(model: &str) -> String {
 }
 
 fn format_connected_line_with_mode(model: &str, mode: Option<AuthMode>) -> String {
-    format_connected_line_with_registry(model, mode, &api::ProviderRegistry::default())
+    format_connected_line_with_config(model, mode, &api::SudoCodeConfig::default())
 }
 
-fn format_connected_line_with_registry(
+fn format_connected_line_with_config(
     model: &str,
     mode: Option<AuthMode>,
-    registry: &api::ProviderRegistry,
+    sudocode_config: &api::SudoCodeConfig,
 ) -> String {
-    // Use registry display name if available, otherwise fall back to provider kind label.
-    let provider = registry
-        .metadata_for_model(model)
-        .and_then(|meta| meta.display_name)
-        .unwrap_or_else(|| provider_label(registry.detect_provider_kind(model)).to_string());
+    // Try to get display name from sudocode.json config first.
+    let config_display = sudocode_config
+        .models
+        .get(&model.to_ascii_lowercase())
+        .map(|m| m.name.as_str());
+    let provider = config_display
+        .map(String::from)
+        .unwrap_or_else(|| provider_label(detect_provider_kind(model)).to_string());
     let resolved_mode = mode.or_else(|| resolve_auth_mode(None).ok());
     let auth_hint = match resolved_mode {
         Some(m) => format!(" ({})", m.label()),
@@ -3842,10 +3800,10 @@ fn run_repl(
     println!("{}", cli.startup_banner());
     println!(
         "{}",
-        format_connected_line_with_registry(
+        format_connected_line_with_config(
             &cli.config.model,
             auth_mode,
-            &cli.config.provider_registry
+            &cli.config.sudocode_config
         )
     );
 
@@ -3949,7 +3907,7 @@ struct RuntimeConfig {
     permission_mode: PermissionMode,
     progress_reporter: Option<InternalPromptProgressReporter>,
     auth_mode: Option<AuthMode>,
-    provider_registry: api::ProviderRegistry,
+    sudocode_config: api::SudoCodeConfig,
 }
 
 struct RuntimeMcpState {
@@ -4099,7 +4057,7 @@ impl AcpCliAgent {
                 permission_mode,
                 progress_reporter: None,
                 auth_mode: self.auth_mode,
-                provider_registry: load_provider_registry_for_cwd(&cwd),
+                sudocode_config: load_sudocode_config_for_cwd(&cwd),
             },
         )
         .map_err(|error| AcpError::internal(format!("failed to build runtime: {error}")))?;
@@ -4622,7 +4580,7 @@ impl LiveCli {
             permission_mode,
             progress_reporter: None,
             auth_mode,
-            provider_registry: load_provider_registry_for_current_dir(),
+            sudocode_config: load_sudocode_config_for_current_dir(),
         };
         let runtime = build_runtime(
             session_state.with_persistence_path(session.path.clone()),
@@ -7844,11 +7802,11 @@ impl AnthropicRuntimeClient {
         config: &RuntimeConfig,
         tool_registry: GlobalToolRegistry,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let registry = &config.provider_registry;
-        let resolved_model = registry.resolve_model_alias(&config.model);
+        let sudocode_config = &config.sudocode_config;
+        let resolved_model = resolve_model_alias(&config.model);
+
         // Resolve the effective auth mode: use the explicit --auth flag if
-        // provided, otherwise auto-detect from env vars.  Once we have
-        // a mode, the same from_model_and_mode path handles all routing.
+        // provided, otherwise auto-detect from env vars.
         let effective_mode = match config.auth_mode {
             Some(mode) => {
                 validate_auth_env(mode)?;
@@ -7857,16 +7815,19 @@ impl AnthropicRuntimeClient {
             None => resolve_auth_mode(None).ok(),
         };
 
-        // Try config-driven resolution first.
-        let client = if !registry.is_config_empty() {
-            let auth = effective_mode.map(AuthSource::for_mode).transpose()?;
-            ApiProviderClient::from_model_with_registry(
+        // Try config-driven resolution first (sudocode.json).
+        let client = if !sudocode_config.auth_modes.is_empty()
+            && sudocode_config
+                .models
+                .contains_key(&config.model.to_ascii_lowercase())
+        {
+            let resolved = api::resolve_provider_from_config(
                 &config.model,
-                registry,
-                effective_mode,
-                auth,
-            )?
-            .with_prompt_cache(PromptCache::new(session_id))
+                effective_mode.or(config.auth_mode),
+                sudocode_config,
+            )?;
+            ApiProviderClient::from_resolved(&resolved)?
+                .with_prompt_cache(PromptCache::new(session_id))
         } else if let Some(mode) = effective_mode {
             let auth = AuthSource::for_mode(mode)?;
             ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
@@ -13319,7 +13280,7 @@ UU conflicted.rs",
                 permission_mode: PermissionMode::DangerFullAccess,
                 progress_reporter: None,
                 auth_mode: None,
-                provider_registry: api::ProviderRegistry::default(),
+                sudocode_config: api::SudoCodeConfig::default(),
             },
             runtime_plugin_state,
         )

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1543,6 +1543,11 @@ fn validate_model_syntax(model: &str) -> Result<(), String> {
         "opus" | "sonnet" | "haiku" => return Ok(()),
         _ => {}
     }
+    // Check sudocode.json config for additional model aliases.
+    let config = load_sudocode_config_for_current_dir();
+    if api::resolve_model(&config, trimmed).is_some() {
+        return Ok(());
+    }
     // Check for spaces (malformed)
     if trimmed.contains(' ') {
         return Err(format!(
@@ -7805,22 +7810,25 @@ impl AnthropicRuntimeClient {
         let sudocode_config = &config.sudocode_config;
         let resolved_model = resolve_model_alias(&config.model);
 
+        // Check whether config-driven resolution applies for this model.
+        let has_config_model = !sudocode_config.auth_modes.is_empty()
+            && api::resolve_model(sudocode_config, &config.model).is_some();
+
         // Resolve the effective auth mode: use the explicit --auth flag if
-        // provided, otherwise auto-detect from env vars.
+        // provided, otherwise auto-detect from env vars.  Skip env-var
+        // validation when sudocode.json provides credentials for this model.
         let effective_mode = match config.auth_mode {
             Some(mode) => {
-                validate_auth_env(mode)?;
+                if !has_config_model {
+                    validate_auth_env(mode)?;
+                }
                 Some(mode)
             }
             None => resolve_auth_mode(None).ok(),
         };
 
         // Try config-driven resolution first (sudocode.json).
-        let client = if !sudocode_config.auth_modes.is_empty()
-            && sudocode_config
-                .models
-                .contains_key(&config.model.to_ascii_lowercase())
-        {
+        let client = if has_config_model {
             let resolved = api::resolve_provider_from_config(
                 &config.model,
                 effective_mode.or(config.auth_mode),

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7808,7 +7808,6 @@ impl AnthropicRuntimeClient {
         tool_registry: GlobalToolRegistry,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let sudocode_config = &config.sudocode_config;
-        let resolved_model = resolve_model_alias(&config.model);
 
         // Check whether config-driven resolution applies for this model.
         let has_config_model = !sudocode_config.auth_modes.is_empty()
@@ -7829,30 +7828,30 @@ impl AnthropicRuntimeClient {
 
         // Try config-driven resolution first (sudocode.json).
         let client = if has_config_model {
-            let resolved = api::resolve_provider_from_config(
-                &config.model,
-                effective_mode.or(config.auth_mode),
-                sudocode_config,
-            )?;
-            ApiProviderClient::from_resolved(&resolved)?
-                .with_prompt_cache(PromptCache::new(session_id))
-        } else if let Some(mode) = effective_mode {
-            let auth = AuthSource::for_mode(mode)?;
-            ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
+            let resolved =
+                api::resolve_provider_from_config(&config.model, effective_mode, sudocode_config)?;
+            ApiProviderClient::from_resolved(&resolved, effective_mode)?
                 .with_prompt_cache(PromptCache::new(session_id))
         } else {
-            // No recognised auth env vars at all — fall back to the
-            // legacy provider-detection path for non-Anthropic models.
-            match detect_provider_kind(&resolved_model) {
-                ProviderKind::Anthropic => {
-                    let auth = resolve_cli_auth_source()?;
-                    let inner = AnthropicClient::from_auth(auth)
-                        .with_base_url(api::read_base_url())
-                        .with_prompt_cache(PromptCache::new(session_id));
-                    ApiProviderClient::Anthropic(inner)
-                }
-                ProviderKind::Xai | ProviderKind::OpenAi => {
-                    ApiProviderClient::from_model_with_anthropic_auth(&resolved_model, None)?
+            let resolved_model = resolve_model_alias(&config.model);
+            if let Some(mode) = effective_mode {
+                let auth = AuthSource::for_mode(mode)?;
+                ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
+                    .with_prompt_cache(PromptCache::new(session_id))
+            } else {
+                // No recognised auth env vars at all — fall back to the
+                // legacy provider-detection path for non-Anthropic models.
+                match detect_provider_kind(&resolved_model) {
+                    ProviderKind::Anthropic => {
+                        let auth = resolve_cli_auth_source()?;
+                        let inner = AnthropicClient::from_auth(auth)
+                            .with_base_url(api::read_base_url())
+                            .with_prompt_cache(PromptCache::new(session_id));
+                        ApiProviderClient::Anthropic(inner)
+                    }
+                    ProviderKind::Xai | ProviderKind::OpenAi => {
+                        ApiProviderClient::from_model_with_anthropic_auth(&resolved_model, None)?
+                    }
                 }
             }
         };

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -4657,14 +4657,11 @@ impl LiveCli {
 
         // Endpoint from config-driven resolution.
         let config = &self.config.sudocode_config;
-        let endpoint = api::resolve_provider_from_config(
-            &self.config.model,
-            self.config.auth_mode,
-            config,
-        )
-        .ok()
-        .map(|r| r.base_url)
-        .unwrap_or_default();
+        let endpoint =
+            api::resolve_provider_from_config(&self.config.model, self.config.auth_mode, config)
+                .ok()
+                .map(|r| r.base_url)
+                .unwrap_or_default();
 
         format!(
             "\x1b[38;5;117m\
@@ -11770,10 +11767,15 @@ mod tests {
     #[test]
     fn startup_banner_mentions_workflow_completions() {
         let _guard = env_lock();
-        // Inject dummy credentials so LiveCli can construct without real Anthropic key
-        std::env::set_var("ANTHROPIC_API_KEY", "test-dummy-key-for-banner-test");
         let root = temp_dir();
-        fs::create_dir_all(&root).expect("root dir");
+        let config_home = root.join("config-home");
+        fs::create_dir_all(&config_home).expect("config home");
+        // Write sample sudocode.json with a dummy API key.
+        let sample =
+            runtime::SAMPLE_SUDOCODE_JSON.replace("<YOUR_ANTHROPIC_API_KEY>", "test-dummy-key");
+        fs::write(config_home.join("sudocode.json"), &sample).expect("write sudocode.json");
+        let original_config_home = std::env::var("SUDO_CODE_CONFIG_HOME").ok();
+        std::env::set_var("SUDO_CODE_CONFIG_HOME", &config_home);
 
         let banner = with_current_dir(&root, || {
             LiveCli::new(
@@ -11781,7 +11783,7 @@ mod tests {
                 true,
                 None,
                 PermissionMode::DangerFullAccess,
-                None,
+                Some(api::AuthMode::ApiKey),
             )
             .expect("cli should initialize")
             .startup_banner()
@@ -11790,8 +11792,11 @@ mod tests {
         assert!(banner.contains("Tab"));
         assert!(banner.contains("workflow completions"));
 
+        match original_config_home {
+            Some(v) => std::env::set_var("SUDO_CODE_CONFIG_HOME", v),
+            None => std::env::remove_var("SUDO_CODE_CONFIG_HOME"),
+        }
         fs::remove_dir_all(root).expect("cleanup temp dir");
-        std::env::remove_var("ANTHROPIC_API_KEY");
     }
 
     #[test]
@@ -13263,14 +13268,16 @@ UU conflicted.rs",
         // set/remove ANTHROPIC_API_KEY do not race with this test.
         let _guard = env_lock();
         let config_home = temp_dir();
-        // Inject a dummy API key so runtime construction succeeds without real credentials.
-        // This test only exercises plugin lifecycle (init/shutdown), never calls the API.
-        std::env::set_var("ANTHROPIC_API_KEY", "test-dummy-key-for-plugin-lifecycle");
         let workspace = temp_dir();
         let source_root = temp_dir();
         fs::create_dir_all(&config_home).expect("config home");
         fs::create_dir_all(&workspace).expect("workspace");
         fs::create_dir_all(&source_root).expect("source root");
+        // Write the sample sudocode.json with a dummy API key so runtime
+        // construction succeeds. This test only exercises plugin lifecycle.
+        let sample =
+            runtime::SAMPLE_SUDOCODE_JSON.replace("<YOUR_ANTHROPIC_API_KEY>", "test-dummy-key");
+        fs::write(config_home.join("sudocode.json"), sample).expect("write sudocode.json");
         write_plugin_fixture(&source_root, "lifecycle-runtime-demo", false, true);
 
         let mut manager = PluginManager::new(PluginManagerConfig::new(&config_home));
@@ -13294,8 +13301,10 @@ UU conflicted.rs",
                 allowed_tools: None,
                 permission_mode: PermissionMode::DangerFullAccess,
                 progress_reporter: None,
-                auth_mode: None,
-                sudocode_config: api::SudoCodeConfig::default(),
+                auth_mode: Some(api::AuthMode::ApiKey),
+                sudocode_config: loader
+                    .load_sudocode_config()
+                    .expect("sudocode config should load"),
             },
             runtime_plugin_state,
         )

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1515,6 +1515,14 @@ fn resolve_model_alias(model: &str) -> &str {
 /// user-supplied model string is about to be dispatched to a provider.
 fn resolve_model_alias_with_config(model: &str) -> String {
     let trimmed = model.trim();
+    // Check config-driven model registry first.
+    let registry = load_provider_registry_for_current_dir();
+    if !registry.is_config_empty() {
+        if let Some(entry) = registry.config_model(trimmed) {
+            return entry.model_id.clone();
+        }
+    }
+    // Then check config aliases.
     if let Some(resolved) = config_alias_for_current_dir(trimmed) {
         return resolve_model_alias(&resolved).to_string();
     }
@@ -1575,6 +1583,69 @@ fn config_alias_for_current_dir(alias: &str) -> Option<String> {
     let loader = ConfigLoader::default_for(&cwd);
     let config = loader.load().ok()?;
     config.aliases().get(alias).cloned()
+}
+
+/// Build a [`ProviderRegistry`] from the config for the current directory.
+fn load_provider_registry_for_current_dir() -> api::ProviderRegistry {
+    let Ok(cwd) = env::current_dir() else {
+        return api::ProviderRegistry::default();
+    };
+    load_provider_registry_for_cwd(&cwd)
+}
+
+/// Build a [`ProviderRegistry`] from the config for the given directory.
+fn load_provider_registry_for_cwd(cwd: &Path) -> api::ProviderRegistry {
+    let loader = ConfigLoader::default_for(cwd);
+    let Ok(config) = loader.load() else {
+        return api::ProviderRegistry::default();
+    };
+    build_provider_registry(config.providers_config())
+}
+
+/// Convert the parsed config types into the API-layer [`ProviderRegistry`].
+fn build_provider_registry(config: &runtime::config::ProvidersConfig) -> api::ProviderRegistry {
+    if config.providers.is_empty() && config.models.is_empty() {
+        return api::ProviderRegistry::default();
+    }
+
+    let providers = config
+        .providers
+        .iter()
+        .map(|(name, entry)| {
+            let protocol = match entry.kind.as_str() {
+                "anthropic" => api::ProviderProtocol::Anthropic,
+                _ => api::ProviderProtocol::OpenAiCompat,
+            };
+            (
+                name.clone(),
+                api::ConfigProvider {
+                    protocol,
+                    api_key_env: entry.api_key_env.clone(),
+                    base_url: entry.base_url.clone(),
+                    base_url_env: entry.base_url_env.clone(),
+                    display_name: entry.display_name.clone(),
+                },
+            )
+        })
+        .collect();
+
+    let models = config
+        .models
+        .iter()
+        .map(|(name, entry)| {
+            (
+                name.clone(),
+                api::ConfigModel {
+                    provider: entry.provider.clone(),
+                    model_id: entry.model_id.clone(),
+                    max_output_tokens: entry.max_output_tokens,
+                    context_window: entry.context_window,
+                },
+            )
+        })
+        .collect();
+
+    api::ProviderRegistry::new(providers, models)
 }
 
 fn normalize_allowed_tools(values: &[String]) -> Result<Option<AllowedToolSet>, String> {
@@ -1684,7 +1755,19 @@ fn format_connected_line(model: &str) -> String {
 }
 
 fn format_connected_line_with_mode(model: &str, mode: Option<AuthMode>) -> String {
-    let provider = provider_label(detect_provider_kind(model));
+    format_connected_line_with_registry(model, mode, &api::ProviderRegistry::default())
+}
+
+fn format_connected_line_with_registry(
+    model: &str,
+    mode: Option<AuthMode>,
+    registry: &api::ProviderRegistry,
+) -> String {
+    // Use registry display name if available, otherwise fall back to provider kind label.
+    let provider = registry
+        .metadata_for_model(model)
+        .and_then(|meta| meta.display_name)
+        .unwrap_or_else(|| provider_label(registry.detect_provider_kind(model)).to_string());
     let resolved_mode = mode.or_else(|| resolve_auth_mode(None).ok());
     let auth_hint = match resolved_mode {
         Some(m) => format!(" ({})", m.label()),
@@ -3759,7 +3842,11 @@ fn run_repl(
     println!("{}", cli.startup_banner());
     println!(
         "{}",
-        format_connected_line_with_mode(&cli.config.model, auth_mode)
+        format_connected_line_with_registry(
+            &cli.config.model,
+            auth_mode,
+            &cli.config.provider_registry
+        )
     );
 
     loop {
@@ -3862,6 +3949,7 @@ struct RuntimeConfig {
     permission_mode: PermissionMode,
     progress_reporter: Option<InternalPromptProgressReporter>,
     auth_mode: Option<AuthMode>,
+    provider_registry: api::ProviderRegistry,
 }
 
 struct RuntimeMcpState {
@@ -4011,6 +4099,7 @@ impl AcpCliAgent {
                 permission_mode,
                 progress_reporter: None,
                 auth_mode: self.auth_mode,
+                provider_registry: load_provider_registry_for_cwd(&cwd),
             },
         )
         .map_err(|error| AcpError::internal(format!("failed to build runtime: {error}")))?;
@@ -4533,6 +4622,7 @@ impl LiveCli {
             permission_mode,
             progress_reporter: None,
             auth_mode,
+            provider_registry: load_provider_registry_for_current_dir(),
         };
         let runtime = build_runtime(
             session_state.with_persistence_path(session.path.clone()),
@@ -7754,7 +7844,8 @@ impl AnthropicRuntimeClient {
         config: &RuntimeConfig,
         tool_registry: GlobalToolRegistry,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let resolved_model = api::resolve_model_alias(&config.model);
+        let registry = &config.provider_registry;
+        let resolved_model = registry.resolve_model_alias(&config.model);
         // Resolve the effective auth mode: use the explicit --auth flag if
         // provided, otherwise auto-detect from env vars.  Once we have
         // a mode, the same from_model_and_mode path handles all routing.
@@ -7765,7 +7856,18 @@ impl AnthropicRuntimeClient {
             }
             None => resolve_auth_mode(None).ok(),
         };
-        let client = if let Some(mode) = effective_mode {
+
+        // Try config-driven resolution first.
+        let client = if !registry.is_config_empty() {
+            let auth = effective_mode.map(AuthSource::for_mode).transpose()?;
+            ApiProviderClient::from_model_with_registry(
+                &config.model,
+                registry,
+                effective_mode,
+                auth,
+            )?
+            .with_prompt_cache(PromptCache::new(session_id))
+        } else if let Some(mode) = effective_mode {
             let auth = AuthSource::for_mode(mode)?;
             ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
                 .with_prompt_cache(PromptCache::new(session_id))
@@ -13217,6 +13319,7 @@ UU conflicted.rs",
                 permission_mode: PermissionMode::DangerFullAccess,
                 progress_reporter: None,
                 auth_mode: None,
+                provider_registry: api::ProviderRegistry::default(),
             },
             runtime_plugin_state,
         )

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3050,14 +3050,35 @@ fn format_unknown_slash_command_message(name: &str) -> String {
 }
 
 fn format_model_report(model: &str, message_count: usize, turns: u32) -> String {
+    let config = load_sudocode_config_for_current_dir();
+    let mut available_lines = String::new();
+    for (alias, entry) in &config.models {
+        let marker = if alias == &model.to_ascii_lowercase() {
+            " *"
+        } else {
+            ""
+        };
+        let modes: Vec<&str> = entry.providers.keys().map(String::as_str).collect();
+        available_lines.push_str(&format!(
+            "\n    {:<16} {} ({}){marker}",
+            alias,
+            entry.name,
+            modes.join(", ")
+        ));
+    }
+    let available = if available_lines.is_empty() {
+        String::from("opus, sonnet, haiku")
+    } else {
+        available_lines
+    };
     format!(
         "Model
   Current model    {model}
+  Available models{available}
   Session messages {message_count}
   Session turns    {turns}
 
 Usage
-  Inspect current model with /model
   Switch models with /model <name>"
     )
 }
@@ -3803,14 +3824,6 @@ fn run_repl(
     let mut editor =
         input::LineEditor::new("> ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
-    println!(
-        "{}",
-        format_connected_line_with_config(
-            &cli.config.model,
-            auth_mode,
-            &cli.config.sudocode_config
-        )
-    );
 
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
@@ -3826,14 +3839,22 @@ fn run_repl(
                 }
                 match SlashCommand::parse(&trimmed) {
                     Ok(Some(command)) => {
-                        if cli.handle_repl_command(command)? {
-                            cli.persist_session()?;
+                        match cli.handle_repl_command(command) {
+                            Ok(true) => {
+                                if let Err(e) = cli.persist_session() {
+                                    eprintln!("\x1b[31m{e}\x1b[0m");
+                                }
+                            }
+                            Ok(false) => {}
+                            Err(e) => {
+                                eprintln!("\x1b[31m{e}\x1b[0m");
+                            }
                         }
                         continue;
                     }
                     Ok(None) => {}
                     Err(error) => {
-                        eprintln!("{error}");
+                        eprintln!("\x1b[31m{error}\x1b[0m");
                         continue;
                     }
                 }
@@ -4626,6 +4647,25 @@ impl LiveCli {
             |_| self.session.path.display().to_string(),
             |path| path.display().to_string(),
         );
+
+        // Auth mode line.
+        let auth_mode_str = self
+            .config
+            .auth_mode
+            .map(|m| m.label().to_string())
+            .unwrap_or_else(|| "auto".to_string());
+
+        // Endpoint from config-driven resolution.
+        let config = &self.config.sudocode_config;
+        let endpoint = api::resolve_provider_from_config(
+            &self.config.model,
+            self.config.auth_mode,
+            config,
+        )
+        .ok()
+        .map(|r| r.base_url)
+        .unwrap_or_default();
+
         format!(
             "\x1b[38;5;117m\
 ███████╗██╗   ██╗██████╗  ██████╗ \n\
@@ -4635,6 +4675,8 @@ impl LiveCli {
 ███████║╚██████╔╝██████╔╝╚██████╔╝\n\
 ╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝\x1b[0m \x1b[38;5;208mCode\x1b[0m\n\n\
   \x1b[2mModel\x1b[0m            {}\n\
+  \x1b[2mAuth mode\x1b[0m        {}\n\
+  \x1b[2mEndpoint\x1b[0m         {}\n\
   \x1b[2mPermissions\x1b[0m      {}\n\
   \x1b[2mBranch\x1b[0m           {}\n\
   \x1b[2mWorkspace\x1b[0m        {}\n\
@@ -4643,6 +4685,8 @@ impl LiveCli {
   \x1b[2mAuto-save\x1b[0m        {}\n\n\
   Type \x1b[1m/help\x1b[0m for commands · \x1b[1m/status\x1b[0m for live context · \x1b[2m/resume latest\x1b[0m jumps back to the newest session · \x1b[1m/diff\x1b[0m then \x1b[1m/commit\x1b[0m to ship · \x1b[2mTab\x1b[0m for workflow completions · \x1b[2mShift+Enter\x1b[0m for newline",
             self.config.model,
+            auth_mode_str,
+            endpoint,
             self.config.permission_mode.as_str(),
             git_branch,
             workspace,
@@ -5165,10 +5209,11 @@ impl LiveCli {
     }
 
     fn set_auth(&mut self, mode: Option<String>) -> Result<bool, Box<dyn std::error::Error>> {
-        let current_str = self.config.auth_mode.map_or_else(
-            || resolve_auth_mode(None).map(|m| m.as_str().to_string()),
-            |m| Ok(m.as_str().to_string()),
-        )?;
+        let current_str = self
+            .config
+            .auth_mode
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_else(|| "auto".to_string());
 
         let Some(mode) = mode else {
             println!("{}", format_auth_report(&current_str));
@@ -5181,8 +5226,6 @@ impl LiveCli {
             println!("{}", format_auth_report(&current_str));
             return Ok(false);
         }
-
-        validate_auth_env(parsed)?;
 
         let previous = current_str;
         let session = self.runtime.session().clone();
@@ -7808,53 +7851,12 @@ impl AnthropicRuntimeClient {
         tool_registry: GlobalToolRegistry,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let sudocode_config = &config.sudocode_config;
+        let effective_mode = config.auth_mode;
 
-        // Check whether config-driven resolution applies for this model.
-        let has_config_model = !sudocode_config.auth_modes.is_empty()
-            && api::resolve_model(sudocode_config, &config.model).is_some();
-
-        // Resolve the effective auth mode: use the explicit --auth flag if
-        // provided, otherwise auto-detect from env vars.  Skip env-var
-        // validation when sudocode.json provides credentials for this model.
-        let effective_mode = match config.auth_mode {
-            Some(mode) => {
-                if !has_config_model {
-                    validate_auth_env(mode)?;
-                }
-                Some(mode)
-            }
-            None => resolve_auth_mode(None).ok(),
-        };
-
-        // Try config-driven resolution first (sudocode.json).
-        let client = if has_config_model {
-            let resolved =
-                api::resolve_provider_from_config(&config.model, effective_mode, sudocode_config)?;
-            ApiProviderClient::from_resolved(&resolved, effective_mode)?
-                .with_prompt_cache(PromptCache::new(session_id))
-        } else {
-            let resolved_model = resolve_model_alias(&config.model);
-            if let Some(mode) = effective_mode {
-                let auth = AuthSource::for_mode(mode)?;
-                ApiProviderClient::from_model_and_mode(&resolved_model, mode, auth)?
-                    .with_prompt_cache(PromptCache::new(session_id))
-            } else {
-                // No recognised auth env vars at all — fall back to the
-                // legacy provider-detection path for non-Anthropic models.
-                match detect_provider_kind(&resolved_model) {
-                    ProviderKind::Anthropic => {
-                        let auth = resolve_cli_auth_source()?;
-                        let inner = AnthropicClient::from_auth(auth)
-                            .with_base_url(api::read_base_url())
-                            .with_prompt_cache(PromptCache::new(session_id));
-                        ApiProviderClient::Anthropic(inner)
-                    }
-                    ProviderKind::Xai | ProviderKind::OpenAi => {
-                        ApiProviderClient::from_model_with_anthropic_auth(&resolved_model, None)?
-                    }
-                }
-            }
-        };
+        let resolved =
+            api::resolve_provider_from_config(&config.model, effective_mode, sudocode_config)?;
+        let client = ApiProviderClient::from_resolved(&resolved, effective_mode)?
+            .with_prompt_cache(PromptCache::new(session_id));
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
             client,
@@ -8454,6 +8456,12 @@ fn slash_command_completion_candidates_with_sessions(
         "/skills help",
     ] {
         completions.insert(candidate.to_string());
+    }
+
+    // Add config-driven model aliases to /model completions.
+    let sudocode_config = load_sudocode_config_for_current_dir();
+    for alias in sudocode_config.models.keys() {
+        completions.insert(format!("/model {alias}"));
     }
 
     if !model.trim().is_empty() {

--- a/rust/crates/rusty-claude-cli/tests/compact_output.rs
+++ b/rust/crates/rusty-claude-cli/tests/compact_output.rs
@@ -190,17 +190,25 @@ fn run_scode(
     base_url: &str,
     args: &[&str],
 ) -> Output {
+    // Write the sample sudocode.json with the mock server's base URL
+    // substituted for the real Anthropic endpoint.
+    let sample = runtime::SAMPLE_SUDOCODE_JSON
+        .replace("https://api.anthropic.com", base_url)
+        .replace("<YOUR_ANTHROPIC_API_KEY>", "test-compact-key");
+    fs::write(config_home.join("sudocode.json"), sample).expect("sudocode.json should be written");
+
+    let mut full_args = vec!["--auth", "api-key"];
+    full_args.extend_from_slice(args);
+
     let mut command = Command::new(env!("CARGO_BIN_EXE_scode"));
     command
         .current_dir(cwd)
         .env_clear()
-        .env("ANTHROPIC_API_KEY", "test-compact-key")
-        .env("ANTHROPIC_BASE_URL", base_url)
         .env("SUDO_CODE_CONFIG_HOME", config_home)
         .env("HOME", home)
         .env("NO_COLOR", "1")
         .env("PATH", "/usr/bin:/bin")
-        .args(args);
+        .args(&full_args);
     command.output().expect("scode should launch")
 }
 

--- a/rust/crates/rusty-claude-cli/tests/mock_parity_harness.rs
+++ b/rust/crates/rusty-claude-cli/tests/mock_parity_harness.rs
@@ -279,6 +279,16 @@ impl HarnessWorkspace {
         fs::create_dir_all(&self.home)?;
         Ok(())
     }
+
+    /// Write the sample sudocode.json with the mock server's base URL
+    /// substituted for the real Anthropic endpoint.
+    fn write_sudocode_json(&self, base_url: &str) {
+        let sample = runtime::SAMPLE_SUDOCODE_JSON
+            .replace("https://api.anthropic.com", base_url)
+            .replace("<YOUR_ANTHROPIC_API_KEY>", "test-parity-key");
+        fs::write(self.config_home.join("sudocode.json"), sample)
+            .expect("test sudocode.json should be written");
+    }
 }
 
 struct ScenarioRun {
@@ -308,17 +318,20 @@ struct ScenarioReport {
 }
 
 fn run_case(case: ScenarioCase, workspace: &HarnessWorkspace, base_url: &str) -> ScenarioRun {
+    // Write a test sudocode.json pointing at the mock server.
+    workspace.write_sudocode_json(base_url);
+
     let mut command = Command::new(env!("CARGO_BIN_EXE_scode"));
     command
         .current_dir(&workspace.root)
         .env_clear()
-        .env("ANTHROPIC_API_KEY", "test-parity-key")
-        .env("ANTHROPIC_BASE_URL", base_url)
         .env("SUDO_CODE_CONFIG_HOME", &workspace.config_home)
         .env("HOME", &workspace.home)
         .env("NO_COLOR", "1")
         .env("PATH", "/usr/bin:/bin")
         .args([
+            "--auth",
+            "api-key",
             "--model",
             "sonnet",
             "--permission-mode",


### PR DESCRIPTION
## Summary

Replaces fragile env-var sniffing with a full provider registry config at `~/.nexus/sudocode/sudocode.json`. Auth modes are first-class citizens — the config groups providers by auth mode (`subscription`, `proxy`, `api-key`) and models list which auth modes are available.

**Resolution flow**: User picks model → look up available auth modes → pick/auto-select mode → get provider + wire model ID → get connection details → build client.

### Key changes
- **New config file**: `sudocode.json` with `auth_modes` and `models` sections
- **New types**: `SudoCodeConfig`, `ProviderConnectionConfig`, `ModelConfigEntry`, `ModelProviderMapping`, `ResolvedProvider`, `ApiFormat`, `Credential`
- **Resolution**: `resolve_provider_from_config()` handles model → auth mode → provider → connection flow
- **Client**: `ProviderClient::from_resolved()` builds clients from fully resolved config
- **Backward compat**: Falls back to env-var detection when `sudocode.json` is absent

### Config schema example

```json
{
  "auth_modes": {
    "subscription": {
      "claude": { "baseUrl": "https://api.anthropic.com/v1/messages", "tokenEnv": "CLAUDE_CODE_OAUTH_TOKEN", "authFile": "~/.claude/credentials.json" }
    },
    "proxy": {
      "sudorouter": { "baseUrl": "https://hk.sudorouter.ai/v1", "apiKey": "sk-..." }
    },
    "api-key": {
      "anthropic": { "baseUrl": "https://api.anthropic.com", "apiKeyEnv": "ANTHROPIC_API_KEY" },
      "xai": { "baseUrl": "https://api.x.ai/v1", "apiKeyEnv": "XAI_API_KEY" }
    }
  },
  "models": {
    "opus": {
      "alias": "opus", "name": "Claude Opus 4.6",
      "providers": {
        "subscription": { "provider": "claude", "model": "claude-opus-4-6" },
        "proxy": { "provider": "sudorouter", "model": "claude-opus-4-6", "api": "openai-completions" },
        "api-key": { "provider": "anthropic", "model": "claude-opus-4-6" }
      }
    }
  }
}
```

### Files changed
1. `rust/crates/api/src/providers/registry.rs` — `ResolvedProvider`, `ApiFormat`, `Credential`, `resolve_provider_from_config()`
2. `rust/crates/runtime/src/config.rs` — `SudoCodeConfig` types, `load_sudocode_config()` parser
3. `rust/crates/api/src/client.rs` — `ProviderClient::from_resolved()`
4. `rust/crates/api/src/error.rs` — `ApiError::Configuration` variant
5. `rust/crates/rusty-claude-cli/src/main.rs` — load config, thread through, update banner

## Plan reference

See `~/.claude/plans/wobbly-skipping-lagoon.md` for the full design document.

## Test plan

- [x] All 1048 existing tests pass
- [x] New registry tests: model resolution, auth mode selection, credential resolution, API format inference
- [ ] Manual: Create `sudocode.json`, run `scode --model opus` → resolves via config
- [ ] Manual: `scode --model opus --auth api-key` → picks api-key provider
- [ ] Manual: No config file → falls back to env-var detection
- [ ] Manual: `/auth` shows available modes for current model

🤖 Generated with [Claude Code](https://claude.com/claude-code)