### PR TITLE
feat(tui): batch 2 — compact output, turn status, bordered banner, completion descriptions

### DIFF
--- a/rust/crates/rusty-claude-cli/src/cli/format.rs
+++ b/rust/crates/rusty-claude-cli/src/cli/format.rs
@@ -997,6 +997,22 @@ pub(crate) fn truncate_for_summary(value: &str, limit: usize) -> String {
     }
 }
 
+pub(crate) fn format_turn_status_line(
+    model: &str,
+    turn: u32,
+    usage: &TokenUsage,
+    elapsed: Duration,
+) -> String {
+    let total = usage.total_tokens();
+    let tokens_display = if total >= 1000 {
+        format!("{:.1}k", f64::from(total) / 1000.0)
+    } else {
+        total.to_string()
+    };
+    let secs = elapsed.as_secs_f64();
+    format!("\x1b[2m[{model}] · turn {turn} · {tokens_display} tokens · {secs:.1}s\x1b[0m")
+}
+
 pub(crate) fn truncate_output_for_display(
     content: &str,
     max_lines: usize,

--- a/rust/crates/rusty-claude-cli/src/cli/format.rs
+++ b/rust/crates/rusty-claude-cli/src/cli/format.rs
@@ -14,10 +14,10 @@ use crate::{
 
 pub(crate) const DISPLAY_TRUNCATION_NOTICE: &str =
     "\x1b[2m… output truncated for display; full result preserved in session.\x1b[0m";
-pub(crate) const READ_DISPLAY_MAX_LINES: usize = 80;
-pub(crate) const READ_DISPLAY_MAX_CHARS: usize = 6_000;
-pub(crate) const TOOL_OUTPUT_DISPLAY_MAX_LINES: usize = 60;
-pub(crate) const TOOL_OUTPUT_DISPLAY_MAX_CHARS: usize = 4_000;
+pub(crate) const READ_DISPLAY_MAX_LINES: usize = 10;
+pub(crate) const READ_DISPLAY_MAX_CHARS: usize = 2_000;
+pub(crate) const TOOL_OUTPUT_DISPLAY_MAX_LINES: usize = 8;
+pub(crate) const TOOL_OUTPUT_DISPLAY_MAX_CHARS: usize = 1_500;
 
 pub(crate) fn provider_label(kind: ProviderKind) -> &'static str {
     match kind {
@@ -763,26 +763,36 @@ pub(crate) fn format_bash_result(icon: &str, parsed: &serde_json::Value) -> Stri
         write!(&mut lines[0], " {status}").expect("write to string");
     }
 
-    if let Some(stdout) = parsed.get("stdout").and_then(|value| value.as_str()) {
-        if !stdout.trim().is_empty() {
-            lines.push(truncate_output_for_display(
-                stdout,
+    // Count total output lines for the summary suffix.
+    let stdout_text = parsed
+        .get("stdout")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let stderr_text = parsed
+        .get("stderr")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let total_lines = stdout_text.lines().count() + stderr_text.lines().count();
+    if total_lines > 0 {
+        write!(&mut lines[0], " \x1b[2m— {total_lines} lines\x1b[0m").expect("write to string");
+    }
+
+    if !stdout_text.trim().is_empty() {
+        lines.push(truncate_output_for_display(
+            stdout_text,
+            TOOL_OUTPUT_DISPLAY_MAX_LINES,
+            TOOL_OUTPUT_DISPLAY_MAX_CHARS,
+        ));
+    }
+    if !stderr_text.trim().is_empty() {
+        lines.push(format!(
+            "\x1b[38;5;203m{}\x1b[0m",
+            truncate_output_for_display(
+                stderr_text,
                 TOOL_OUTPUT_DISPLAY_MAX_LINES,
                 TOOL_OUTPUT_DISPLAY_MAX_CHARS,
-            ));
-        }
-    }
-    if let Some(stderr) = parsed.get("stderr").and_then(|value| value.as_str()) {
-        if !stderr.trim().is_empty() {
-            lines.push(format!(
-                "\x1b[38;5;203m{}\x1b[0m",
-                truncate_output_for_display(
-                    stderr,
-                    TOOL_OUTPUT_DISPLAY_MAX_LINES,
-                    TOOL_OUTPUT_DISPLAY_MAX_CHARS,
-                )
-            ));
-        }
+            )
+        ));
     }
 
     lines.join("\n\n")

--- a/rust/crates/rusty-claude-cli/src/input.rs
+++ b/rust/crates/rusty-claude-cli/src/input.rs
@@ -21,12 +21,13 @@ pub enum ReadOutcome {
 }
 
 struct SlashCommandHelper {
-    completions: Vec<String>,
+    /// Each entry is (command, description). Description may be empty.
+    completions: Vec<(String, String)>,
     current_line: RefCell<String>,
 }
 
 impl SlashCommandHelper {
-    fn new(completions: Vec<String>) -> Self {
+    fn new(completions: Vec<(String, String)>) -> Self {
         Self {
             completions: normalize_completions(completions),
             current_line: RefCell::new(String::new()),
@@ -47,7 +48,7 @@ impl SlashCommandHelper {
         current.push_str(line);
     }
 
-    fn set_completions(&mut self, completions: Vec<String>) {
+    fn set_completions(&mut self, completions: Vec<(String, String)>) {
         self.completions = normalize_completions(completions);
     }
 }
@@ -68,10 +69,14 @@ impl Completer for SlashCommandHelper {
         let matches = self
             .completions
             .iter()
-            .filter(|candidate| candidate.starts_with(prefix))
-            .map(|candidate| Pair {
-                display: candidate.clone(),
-                replacement: candidate.clone(),
+            .filter(|(cmd, _)| cmd.starts_with(prefix))
+            .map(|(cmd, desc)| Pair {
+                display: if desc.is_empty() {
+                    cmd.clone()
+                } else {
+                    format!("{cmd:<24} — {desc}")
+                },
+                replacement: cmd.clone(),
             })
             .collect();
 
@@ -105,7 +110,7 @@ pub struct LineEditor {
 
 impl LineEditor {
     #[must_use]
-    pub fn new(prompt: impl Into<String>, completions: Vec<String>) -> Self {
+    pub fn new(prompt: impl Into<String>, completions: Vec<(String, String)>) -> Self {
         let config = Config::builder()
             .completion_type(CompletionType::List)
             .edit_mode(EditMode::Emacs)
@@ -131,7 +136,7 @@ impl LineEditor {
         let _ = self.editor.add_history_entry(entry);
     }
 
-    pub fn set_completions(&mut self, completions: Vec<String>) {
+    pub fn set_completions(&mut self, completions: Vec<(String, String)>) {
         if let Some(helper) = self.editor.helper_mut() {
             helper.set_completions(completions);
         }
@@ -210,11 +215,11 @@ fn slash_command_prefix(line: &str, pos: usize) -> Option<&str> {
     Some(prefix)
 }
 
-fn normalize_completions(completions: Vec<String>) -> Vec<String> {
+fn normalize_completions(completions: Vec<(String, String)>) -> Vec<(String, String)> {
     let mut seen = BTreeSet::new();
     completions
         .into_iter()
-        .filter(|candidate| candidate.starts_with('/'))
-        .filter(|candidate| seen.insert(candidate.clone()))
+        .filter(|(cmd, _)| cmd.starts_with('/'))
+        .filter(|(cmd, _)| seen.insert(cmd.clone()))
         .collect()
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -59,8 +59,8 @@ use cli::format::{
     format_commit_skipped_report, format_compact_report, format_cost_report,
     format_internal_prompt_progress_line, format_issue_report, format_model_report,
     format_model_switch_report, format_permissions_report, format_permissions_switch_report,
-    format_pr_report, format_resume_report, format_sandbox_report, format_ultraplan_report,
-    render_resume_usage, render_version_report, truncate_for_summary,
+    format_pr_report, format_resume_report, format_sandbox_report, format_turn_status_line,
+    format_ultraplan_report, render_resume_usage, render_version_report, truncate_for_summary,
 };
 use cli::git::{
     enforce_broad_cwd_policy, git_output, parse_git_status_branch, parse_git_status_metadata,
@@ -1834,6 +1834,7 @@ impl LiveCli {
     }
 
     fn run_turn(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
         let mut spinner = Spinner::new();
         let mut stdout = io::stdout();
@@ -1860,6 +1861,13 @@ impl LiveCli {
                         format_auto_compaction_notice(event.removed_message_count)
                     );
                 }
+                let elapsed = turn_start.elapsed();
+                let usage = self.runtime.usage().current_turn_usage();
+                let turns = self.runtime.usage().turns();
+                println!(
+                    "{}",
+                    format_turn_status_line(&self.config.model, turns, &usage, elapsed)
+                );
                 self.persist_session()?;
                 Ok(())
             }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1689,6 +1689,24 @@ impl HookAbortMonitor {
     }
 }
 
+/// Measure visible string width by stripping ANSI escape sequences.
+fn strip_ansi_width(s: &str) -> usize {
+    let mut width = 0;
+    let mut in_escape = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+        } else if in_escape {
+            if c == 'm' {
+                in_escape = false;
+            }
+        } else {
+            width += 1;
+        }
+    }
+    width
+}
+
 impl LiveCli {
     fn new(
         model: String,
@@ -1767,33 +1785,60 @@ impl LiveCli {
         .map(|r| r.base_url)
         .unwrap_or_default();
 
-        format!(
-            "\x1b[38;5;117m\
+        let logo = "\x1b[38;5;117m\
 ███████╗██╗   ██╗██████╗  ██████╗ \n\
 ██╔════╝██║   ██║██╔══██╗██╔═══██╗\n\
 ███████╗██║   ██║██║  ██║██║   ██║\n\
 ╚════██║██║   ██║██║  ██║██║   ██║\n\
 ███████║╚██████╔╝██████╔╝╚██████╔╝\n\
-╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝\x1b[0m \x1b[38;5;208mCode\x1b[0m\n\n\
-  \x1b[2mModel\x1b[0m            {}\n\
-  \x1b[2mAuth mode\x1b[0m        {}\n\
-  \x1b[2mEndpoint\x1b[0m         {}\n\
-  \x1b[2mPermissions\x1b[0m      {}\n\
-  \x1b[2mBranch\x1b[0m           {}\n\
-  \x1b[2mWorkspace\x1b[0m        {}\n\
-  \x1b[2mDirectory\x1b[0m        {}\n\
-  \x1b[2mSession\x1b[0m          {}\n\
-  \x1b[2mAuto-save\x1b[0m        {}\n\n\
-  Type \x1b[1m/help\x1b[0m for commands · \x1b[1m/status\x1b[0m for live context · \x1b[2m/resume latest\x1b[0m jumps back to the newest session · \x1b[1m/diff\x1b[0m then \x1b[1m/commit\x1b[0m to ship · \x1b[2mTab\x1b[0m for workflow completions · \x1b[2mShift+Enter\x1b[0m for newline",
-            self.config.model,
-            auth_mode_str,
-            endpoint,
-            self.config.permission_mode.as_str(),
-            git_branch,
-            workspace,
-            cwd,
-            self.session.id,
-            session_path,
+╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝\x1b[0m \x1b[38;5;208mCode\x1b[0m";
+
+        let lines = [
+            format!("  \x1b[2mModel\x1b[0m            {}", self.config.model),
+            format!("  \x1b[2mAuth mode\x1b[0m        {}", auth_mode_str),
+            format!("  \x1b[2mEndpoint\x1b[0m         {}", endpoint),
+            format!(
+                "  \x1b[2mPermissions\x1b[0m      {}",
+                self.config.permission_mode.as_str()
+            ),
+            format!("  \x1b[2mBranch\x1b[0m           {}", git_branch),
+            format!("  \x1b[2mWorkspace\x1b[0m        {}", workspace),
+            format!("  \x1b[2mDirectory\x1b[0m        {}", cwd),
+            format!("  \x1b[2mSession\x1b[0m          {}", self.session.id),
+            format!("  \x1b[2mAuto-save\x1b[0m        {}", session_path),
+        ];
+
+        let max_width = lines.iter().map(|l| strip_ansi_width(l)).max().unwrap_or(0);
+        let box_width = max_width + 2; // 1 space padding on each side
+
+        let grey = "\x1b[38;5;245m";
+        let reset = "\x1b[0m";
+
+        let top = format!("{grey}╭{}╮{reset}", "─".repeat(box_width));
+        let bottom = format!("{grey}╰{}╯{reset}", "─".repeat(box_width));
+
+        let boxed_lines: Vec<String> = lines
+            .iter()
+            .map(|line| {
+                let visible_width = strip_ansi_width(line);
+                let padding = max_width - visible_width;
+                format!(
+                    "{grey}│{reset} {}{} {grey}│{reset}",
+                    line,
+                    " ".repeat(padding)
+                )
+            })
+            .collect();
+
+        let hint = "  Type \x1b[1m/help\x1b[0m for commands · \x1b[1m/status\x1b[0m for live context · \x1b[2m/resume latest\x1b[0m jumps back to the newest session · \x1b[1m/diff\x1b[0m then \x1b[1m/commit\x1b[0m to ship · \x1b[2mTab\x1b[0m for workflow completions · \x1b[2mShift+Enter\x1b[0m for newline";
+
+        format!(
+            "{}\n\n{}\n{}\n{}\n\n{}",
+            logo,
+            top,
+            boxed_lines.join("\n"),
+            bottom,
+            hint,
         )
     }
 

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -17,7 +17,7 @@ mod init;
 mod input;
 mod render;
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;
 use std::fs;
 use std::io::{self, IsTerminal, Read, Write};
@@ -1797,7 +1797,9 @@ impl LiveCli {
         )
     }
 
-    fn repl_completion_candidates(&self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    fn repl_completion_candidates(
+        &self,
+    ) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
         Ok(slash_command_completion_candidates_with_sessions(
             &self.config.model,
             Some(&self.session.id),
@@ -3358,17 +3360,17 @@ fn slash_command_completion_candidates_with_sessions(
     model: &str,
     active_session_id: Option<&str>,
     recent_session_ids: Vec<String>,
-) -> Vec<String> {
-    let mut completions = BTreeSet::new();
+) -> Vec<(String, String)> {
+    let mut completions = BTreeMap::new();
 
     for spec in slash_command_specs() {
         if STUB_COMMANDS.contains(&spec.name) {
             continue;
         }
-        completions.insert(format!("/{}", spec.name));
+        completions.insert(format!("/{}", spec.name), spec.summary.to_string());
         for alias in spec.aliases {
             if !STUB_COMMANDS.contains(alias) {
-                completions.insert(format!("/{alias}"));
+                completions.insert(format!("/{alias}"), spec.summary.to_string());
             }
         }
     }
@@ -3416,23 +3418,35 @@ fn slash_command_completion_candidates_with_sessions(
         "/mcp help",
         "/skills help",
     ] {
-        completions.insert(candidate.to_string());
+        completions
+            .entry(candidate.to_string())
+            .or_insert_with(String::new);
     }
 
     // Add config-driven model aliases to /model completions.
     let sudocode_config = load_sudocode_config_for_current_dir();
     for alias in sudocode_config.models.keys() {
-        completions.insert(format!("/model {alias}"));
+        completions
+            .entry(format!("/model {alias}"))
+            .or_insert_with(String::new);
     }
 
     if !model.trim().is_empty() {
-        completions.insert(format!("/model {}", resolve_model_alias_with_config(model)));
-        completions.insert(format!("/model {model}"));
+        completions
+            .entry(format!("/model {}", resolve_model_alias_with_config(model)))
+            .or_insert_with(String::new);
+        completions
+            .entry(format!("/model {model}"))
+            .or_insert_with(String::new);
     }
 
     if let Some(active_session_id) = active_session_id.filter(|value| !value.trim().is_empty()) {
-        completions.insert(format!("/resume {active_session_id}"));
-        completions.insert(format!("/session switch {active_session_id}"));
+        completions
+            .entry(format!("/resume {active_session_id}"))
+            .or_insert_with(String::new);
+        completions
+            .entry(format!("/session switch {active_session_id}"))
+            .or_insert_with(String::new);
     }
 
     for session_id in recent_session_ids
@@ -3440,8 +3454,12 @@ fn slash_command_completion_candidates_with_sessions(
         .filter(|value| !value.trim().is_empty())
         .take(10)
     {
-        completions.insert(format!("/resume {session_id}"));
-        completions.insert(format!("/session switch {session_id}"));
+        completions
+            .entry(format!("/resume {session_id}"))
+            .or_insert_with(String::new);
+        completions
+            .entry(format!("/session switch {session_id}"))
+            .or_insert_with(String::new);
     }
 
     completions.into_iter().collect()


### PR DESCRIPTION
## Summary
- **Gap #1 — Compact tool output**: Reduce display limits (60→8 lines, 4k→1.5k chars for tool output; 80→10 lines, 6k→2k chars for read). Add `— N lines` suffix to bash result headers.
- **Gap #5 — Turn status line**: Print dim status after each REPL turn: `[model] · turn 3 · 1.2k tokens · 0.8s`
- **Gap #8 — Bordered banner**: Wrap startup banner key-value section in Unicode box-drawing border (`╭─╮`/`│ │`/`╰─╯`), grey colored.
- **Gap #9 — Completion descriptions**: Show `SlashCommandSpec.summary` alongside slash command completions (`/help                    — Show available commands`).

## Test plan
- [ ] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` (CI)
- [ ] `cargo run --bin scode` — verify compact tool output with truncation suffix
- [ ] Verify dim turn status line appears after each assistant turn in REPL
- [ ] Verify bordered banner on startup
- [ ] Verify slash command completions show descriptions
- [ ] Verify non-interactive / compact / JSON modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)