### PR TITLE
chore: update internal references for repository rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ status-help.txt
 .clawd-todos.json
 .omc/
 .sandbox-home/
+.hydra

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,4 +1,4 @@
-# Container-first sudo-code workflows
+# Container-first sudocode workflows
 
 This repo already had **container detection** in the Rust runtime before this document was added:
 
@@ -22,13 +22,13 @@ From the repository root:
 ### Docker
 
 ```bash
-docker build -t sudo-code-dev -f Containerfile .
+docker build -t sudocode-dev -f Containerfile .
 ```
 
 ### Podman
 
 ```bash
-podman build -t sudo-code-dev -f Containerfile .
+podman build -t sudocode-dev -f Containerfile .
 ```
 
 ## Run `cargo test --workspace` in the container
@@ -42,7 +42,7 @@ docker run --rm -it \
   -v "$PWD":/workspace \
   -e CARGO_TARGET_DIR=/tmp/scode-target \
   -w /workspace/rust \
-  sudo-code-dev \
+  sudocode-dev \
   cargo test --workspace
 ```
 
@@ -53,7 +53,7 @@ podman run --rm -it \
   -v "$PWD":/workspace:Z \
   -e CARGO_TARGET_DIR=/tmp/scode-target \
   -w /workspace/rust \
-  sudo-code-dev \
+  sudocode-dev \
   cargo test --workspace
 ```
 
@@ -68,7 +68,7 @@ docker run --rm -it \
   -v "$PWD":/workspace \
   -e CARGO_TARGET_DIR=/tmp/scode-target \
   -w /workspace/rust \
-  sudo-code-dev
+  sudocode-dev
 ```
 
 ### Podman
@@ -78,7 +78,7 @@ podman run --rm -it \
   -v "$PWD":/workspace:Z \
   -e CARGO_TARGET_DIR=/tmp/scode-target \
   -w /workspace/rust \
-  sudo-code-dev
+  sudocode-dev
 ```
 
 Inside the shell:
@@ -94,7 +94,7 @@ The `sandbox` command is a useful sanity check: inside Docker or Podman it shoul
 
 ## Bind-mount this repo and another repo at the same time
 
-If you want to run `scode` against a second checkout while keeping `sudo-code` itself mounted read-write:
+If you want to run `scode` against a second checkout while keeping `sudocode` itself mounted read-write:
 
 ### Docker
 
@@ -104,7 +104,7 @@ docker run --rm -it \
   -v "$HOME/src/other-repo":/repo \
   -e CARGO_TARGET_DIR=/tmp/scode-target \
   -w /workspace/rust \
-  sudo-code-dev
+  sudocode-dev
 ```
 
 ### Podman
@@ -115,7 +115,7 @@ podman run --rm -it \
   -v "$HOME/src/other-repo":/repo:Z \
   -e CARGO_TARGET_DIR=/tmp/scode-target \
   -w /workspace/rust \
-  sudo-code-dev
+  sudocode-dev
 ```
 
 Then, for example:

--- a/rust/PARITY.md
+++ b/rust/PARITY.md
@@ -1,4 +1,4 @@
-# Parity Status — sudo-code Rust Port
+# Parity Status — sudocode Rust Port
 
 Last updated: 2026-04-03
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -155,7 +155,7 @@ Top-level commands:
   init
 ```
 
-`scode acp` is a local discoverability surface for editor-first users: it reports the current ACP/Zed status without starting the runtime. As of April 16, 2026, sudo-code does **not** ship an ACP/Zed daemon entrypoint yet, and `scode acp serve` is only a status alias until the real protocol surface lands.
+`scode acp` is a local discoverability surface for editor-first users: it reports the current ACP/Zed status without starting the runtime. As of April 16, 2026, sudocode does **not** ship an ACP/Zed daemon entrypoint yet, and `scode acp serve` is only a status alias until the real protocol surface lands.
 
 The command surface is moving quickly. For the canonical live help text, run:
 

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -169,7 +169,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
         .with_base_url(server.base_url())
         .with_client_identity(ClientIdentity::new("claude-code", "9.9.9").with_runtime("rust-cli"))
         .with_beta("tools-2026-04-01")
-        .with_extra_body_param("metadata", json!({"source": "sudo-code"}))
+        .with_extra_body_param("metadata", json!({"source": "sudocode"}))
         .with_session_tracer(SessionTracer::new("session-telemetry", sink.clone()));
 
     let response = client
@@ -191,7 +191,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
     );
     let body: serde_json::Value =
         serde_json::from_str(&request.body).expect("request body should be json");
-    assert_eq!(body["metadata"]["source"], json!("sudo-code"));
+    assert_eq!(body["metadata"]["source"], json!("sudocode"));
     assert!(
         body.get("betas").is_none(),
         "betas must travel via the anthropic-beta header, not the request body"

--- a/rust/crates/compat-harness/src/lib.rs
+++ b/rust/crates/compat-harness/src/lib.rs
@@ -76,12 +76,12 @@ fn upstream_repo_candidates(primary_repo_root: &Path) -> Vec<PathBuf> {
     }
 
     for ancestor in primary_repo_root.ancestors().take(4) {
-        candidates.push(ancestor.join("sudo-code"));
-        candidates.push(ancestor.join("sudo-code"));
+        candidates.push(ancestor.join("sudocode"));
+        candidates.push(ancestor.join("sudocode"));
     }
 
-    candidates.push(primary_repo_root.join("reference-source").join("sudo-code"));
-    candidates.push(primary_repo_root.join("vendor").join("sudo-code"));
+    candidates.push(primary_repo_root.join("reference-source").join("sudocode"));
+    candidates.push(primary_repo_root.join("vendor").join("sudocode"));
 
     let mut deduped = Vec::new();
     for candidate in candidates {

--- a/rust/crates/runtime/src/lane_events.rs
+++ b/rust/crates/runtime/src/lane_events.rs
@@ -150,7 +150,7 @@ impl SessionIdentity {
 pub struct LaneOwnership {
     /// Owner/assignee identity
     pub owner: String,
-    /// Workflow scope (e.g., sudo-code-dogfood, external-git-maintenance)
+    /// Workflow scope (e.g., sudocode-dogfood, external-git-maintenance)
     pub workflow_scope: String,
     /// Whether the watcher is expected to act, observe, or ignore
     pub watcher_action: WatcherAction,
@@ -946,12 +946,12 @@ mod tests {
     fn lane_ownership_binding_includes_workflow_scope() {
         let ownership = LaneOwnership {
             owner: "scode-1".to_string(),
-            workflow_scope: "sudo-code-dogfood".to_string(),
+            workflow_scope: "sudocode-dogfood".to_string(),
             watcher_action: WatcherAction::Act,
         };
 
         assert_eq!(ownership.owner, "scode-1");
-        assert_eq!(ownership.workflow_scope, "sudo-code-dogfood");
+        assert_eq!(ownership.workflow_scope, "sudocode-dogfood");
         assert_eq!(ownership.watcher_action, WatcherAction::Act);
     }
 

--- a/rust/crates/runtime/src/worker_boot.rs
+++ b/rust/crates/runtime/src/worker_boot.rs
@@ -1311,7 +1311,7 @@ mod tests {
                 &worker.worker_id,
                 Some("Implement worker handshake"),
                 Some(WorkerTaskReceipt {
-                    repo: "sudo-code".to_string(),
+                    repo: "sudocode".to_string(),
                     task_kind: "repo_code".to_string(),
                     source_surface: "omx_team".to_string(),
                     expected_artifacts: vec!["patch".to_string(), "tests".to_string()],
@@ -1351,7 +1351,7 @@ mod tests {
                     "Explain this KakaoTalk screenshot for a friend".to_string()
                 ),
                 task_receipt: Some(WorkerTaskReceipt {
-                    repo: "sudo-code".to_string(),
+                    repo: "sudocode".to_string(),
                     task_kind: "repo_code".to_string(),
                     source_surface: "omx_team".to_string(),
                     expected_artifacts: vec!["patch".to_string(), "tests".to_string()],

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -216,9 +216,9 @@ const INTERNAL_PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3);
 const POST_TOOL_STALL_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const PRIMARY_SESSION_EXTENSION: &str = "jsonl";
 const LEGACY_SESSION_EXTENSION: &str = "json";
-pub(crate) const OFFICIAL_REPO_URL: &str = "https://github.com/ultraworkers/sudo-code";
-pub(crate) const OFFICIAL_REPO_SLUG: &str = "ultraworkers/sudo-code";
-pub(crate) const DEPRECATED_INSTALL_COMMAND: &str = "cargo install sudo-code";
+pub(crate) const OFFICIAL_REPO_URL: &str = "https://github.com/ultraworkers/sudocode";
+pub(crate) const OFFICIAL_REPO_SLUG: &str = "ultraworkers/sudocode";
+pub(crate) const DEPRECATED_INSTALL_COMMAND: &str = "cargo install sudocode";
 type RuntimePluginStateBuildOutput = (
     Option<Arc<Mutex<RuntimeMcpState>>>,
     Vec<RuntimeToolDefinition>,

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -268,11 +268,11 @@ fn doctor_and_resume_status_emit_json_when_requested() {
         .expect("install source check");
     assert_eq!(
         install_source["official_repo"],
-        "https://github.com/ultraworkers/sudo-code"
+        "https://github.com/ultraworkers/sudocode"
     );
     assert_eq!(
         install_source["deprecated_install"],
-        "cargo install sudo-code"
+        "cargo install sudocode"
     );
 
     let workspace = checks
@@ -470,7 +470,7 @@ fn parse_framed_json(stdout: &[u8]) -> Value {
 }
 
 fn write_upstream_fixture(root: &Path) -> PathBuf {
-    let upstream = root.join("sudo-code");
+    let upstream = root.join("sudocode");
     let src = upstream.join("src");
     let entrypoints = src.join("entrypoints");
     fs::create_dir_all(&entrypoints).expect("upstream entrypoints dir should exist");


### PR DESCRIPTION
Updates documentation, code constants, and test references to match the new repository name 'sudocode'.