### PR TITLE
refactor(acp): migrate ACP server to SDK path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,12 +9,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "anyhow",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
+]
+
+[[package]]
+name = "agent-client-protocol-tokio"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1572b219f22c4b3be0f20f934c8b6f1d1457126ce72923c4f6608f96153b65"
+dependencies = [
+ "agent-client-protocol",
+ "futures",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -30,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "api"
 version = "0.1.0"
 dependencies = [
@@ -41,6 +122,17 @@ dependencies = [
  "serde_json",
  "telemetry",
  "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -124,6 +216,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -216,6 +322,21 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -338,12 +459,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -380,6 +559,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -445,6 +630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,12 +652,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -480,16 +692,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -509,8 +769,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -568,9 +830,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -592,15 +867,42 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -711,6 +1013,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +1118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,12 +1152,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -877,6 +1228,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +1246,12 @@ dependencies = [
  "log",
  "zeroize",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1045,6 +1412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,10 +1441,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1092,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.13.0",
  "quick-xml",
  "serde",
  "time",
@@ -1156,6 +1555,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1266,6 +1675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1746,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1417,9 +1852,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "runtime"
 version = "0.1.0"
 dependencies = [
+ "agent-client-protocol",
+ "agent-client-protocol-schema",
+ "agent-client-protocol-tokio",
  "glob",
  "keyring",
  "plugins",
@@ -1437,6 +1910,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1564,10 +2046,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1600,6 +2126,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +2159,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1711,6 +2279,33 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1915,6 +2510,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1940,6 +2536,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2010,7 +2620,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2059,6 +2681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2715,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2124,6 +2763,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2181,6 +2829,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -2244,10 +2926,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2419,6 +3154,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+agent-client-protocol = { version = "0.11.1" }
+agent-client-protocol-schema = { version = "0.12.0" }
+agent-client-protocol-tokio = { version = "0.11.1" }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/acp_server.rs
+++ b/rust/crates/runtime/src/acp_server.rs
@@ -1,33 +1,33 @@
-//! Minimal Agent Client Protocol (ACP) JSON-RPC server support.
+//! Agent Client Protocol (ACP) server support built on the official Rust SDK.
 //!
-//! This module owns the ACP wire protocol and stdio framing. The actual agent
-//! runtime is supplied by the CLI crate so it can reuse the normal provider,
-//! tool, plugin, config, and MCP construction path without adding those
-//! dependencies to `runtime`.
+//! This module keeps the existing CLI-facing ACP adapter types (`AcpAgent`,
+//! `AcpError`, `AcpSessionUpdateObserver`) while delegating the wire protocol
+//! and stdio transport to `agent-client-protocol`.
 
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex, PoisonError};
 
-use serde_json::{json, Value};
-use tokio::io::{AsyncBufRead, AsyncWrite, BufReader};
+use agent_client_protocol::role::acp::Agent;
+use agent_client_protocol::{Client, ConnectionTo, Dispatch, Responder};
+use agent_client_protocol_schema::{
+    AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, Implementation,
+    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    McpCapabilities, NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest,
+    PromptResponse, ProtocolVersion, SessionCapabilities, SessionId, SessionInfo,
+    SessionListCapabilities, SessionNotification, SessionUpdate, StopReason, TextContent, ToolCall,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+};
+use agent_client_protocol_tokio::Stdio;
+use serde_json::Value;
 
 use crate::conversation::RuntimeObserver;
-use crate::jsonrpc_transport::{read_msg, write_msg};
 
-const JSONRPC_VERSION: &str = "2.0";
-const DEFAULT_PROTOCOL_VERSION: i64 = 1;
-const PARSE_ERROR: i64 = -32700;
-const INVALID_REQUEST: i64 = -32600;
-const METHOD_NOT_FOUND: i64 = -32601;
-const INVALID_PARAMS: i64 = -32602;
-const INTERNAL_ERROR: i64 = -32603;
-
-/// Configuration for the ACP JSON-RPC server.
+/// Configuration for the ACP server.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcpServerOptions {
     agent_version: String,
-    default_protocol_version: i64,
 }
 
 impl AcpServerOptions {
@@ -35,27 +35,43 @@ impl AcpServerOptions {
     pub fn new(agent_version: impl Into<String>) -> Self {
         Self {
             agent_version: agent_version.into(),
-            default_protocol_version: DEFAULT_PROTOCOL_VERSION,
         }
     }
 
-    #[must_use]
-    pub fn with_default_protocol_version(mut self, version: i64) -> Self {
-        self.default_protocol_version = version;
-        self
+    pub(crate) fn agent_version(&self) -> &str {
+        &self.agent_version
     }
 }
 
-/// Agent-side operations invoked by the protocol server.
+/// Agent-side operations invoked by the ACP server.
 pub trait AcpAgent {
     fn new_session(&mut self, cwd: Option<PathBuf>) -> Result<String, AcpError>;
+
+    fn list_sessions(&self, cwd: Option<PathBuf>) -> Result<Vec<AcpSessionInfo>, AcpError>;
 
     fn run_prompt(
         &mut self,
         session_id: &str,
         prompt: String,
-        observer: &mut AcpSessionUpdateObserver<'_>,
+        observer: &mut AcpSessionUpdateObserver,
     ) -> Result<(), AcpError>;
+}
+
+/// Minimal ACP session metadata exposed to `session/list`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpSessionInfo {
+    pub session_id: String,
+    pub cwd: PathBuf,
+}
+
+impl AcpSessionInfo {
+    #[must_use]
+    pub fn new(session_id: impl Into<String>, cwd: impl Into<PathBuf>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            cwd: cwd.into(),
+        }
+    }
 }
 
 /// Error type returned by ACP agent implementations.
@@ -74,13 +90,6 @@ impl AcpError {
     #[must_use]
     pub fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
-    }
-
-    fn code(&self) -> i64 {
-        match self {
-            Self::InvalidParams(_) => INVALID_PARAMS,
-            Self::Internal(_) => INTERNAL_ERROR,
-        }
     }
 
     fn message(&self) -> &str {
@@ -102,14 +111,14 @@ impl std::error::Error for AcpError {}
 #[derive(Debug)]
 pub enum AcpServerError {
     Io(io::Error),
-    Json(serde_json::Error),
+    Protocol(agent_client_protocol::Error),
 }
 
 impl Display for AcpServerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(error) => write!(f, "{error}"),
-            Self::Json(error) => write!(f, "{error}"),
+            Self::Protocol(error) => write!(f, "{error}"),
         }
     }
 }
@@ -122,73 +131,61 @@ impl From<io::Error> for AcpServerError {
     }
 }
 
-impl From<serde_json::Error> for AcpServerError {
-    fn from(value: serde_json::Error) -> Self {
-        Self::Json(value)
+impl From<agent_client_protocol::Error> for AcpServerError {
+    fn from(value: agent_client_protocol::Error) -> Self {
+        Self::Protocol(value)
     }
 }
 
 /// Runtime observer that converts model/tool events to ACP session/update notifications.
-pub struct AcpSessionUpdateObserver<'a> {
-    session_id: String,
-    sink: &'a mut dyn AcpMessageSink,
-    write_error: Option<io::Error>,
+pub struct AcpSessionUpdateObserver {
+    session_id: SessionId,
+    connection: ConnectionTo<Client>,
+    write_error: Option<AcpError>,
 }
 
-impl<'a> AcpSessionUpdateObserver<'a> {
-    fn new(session_id: String, sink: &'a mut dyn AcpMessageSink) -> Self {
+impl AcpSessionUpdateObserver {
+    fn new(session_id: impl Into<SessionId>, connection: ConnectionTo<Client>) -> Self {
         Self {
-            session_id,
-            sink,
+            session_id: session_id.into(),
+            connection,
             write_error: None,
         }
     }
 
-    fn finish(self) -> io::Result<()> {
+    fn finish(self) -> Result<(), AcpError> {
         match self.write_error {
             Some(error) => Err(error),
             None => Ok(()),
         }
     }
 
-    fn notify_update(&mut self, update: &Value) {
+    fn notify_update(&mut self, update: SessionUpdate) {
         if self.write_error.is_some() {
             return;
         }
-        let notification = json!({
-            "jsonrpc": JSONRPC_VERSION,
-            "method": "session/update",
-            "params": {
-                "sessionId": self.session_id,
-                "update": update,
-            },
-        });
-        if let Err(error) = self.sink.send_value(&notification) {
-            self.write_error = Some(error);
+
+        let notification = SessionNotification::new(self.session_id.clone(), update);
+        if let Err(error) = self.connection.send_notification(notification) {
+            self.write_error = Some(AcpError::internal(error.to_string()));
         }
     }
 }
 
-impl RuntimeObserver for AcpSessionUpdateObserver<'_> {
+impl RuntimeObserver for AcpSessionUpdateObserver {
     fn on_text_delta(&mut self, delta: &str) {
-        self.notify_update(&json!({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {
-                "type": "text",
-                "text": delta,
-            },
-        }));
+        self.notify_update(SessionUpdate::AgentMessageChunk(ContentChunk::new(
+            ContentBlock::Text(TextContent::new(delta)),
+        )));
     }
 
     fn on_tool_use(&mut self, id: &str, name: &str, input: &str) {
-        self.notify_update(&json!({
-            "sessionUpdate": "tool_call",
-            "toolCallId": id,
-            "title": name,
-            "kind": "other",
-            "status": "in_progress",
-            "rawInput": parse_json_or_string(input),
-        }));
+        self.notify_update(SessionUpdate::ToolCall(
+            ToolCall::new(id.to_string(), name.to_string())
+                .kind(ToolKind::Other)
+                .status(ToolCallStatus::InProgress)
+                .raw_input(parse_json_or_string(input)),
+        ));
     }
 
     fn on_tool_result(
@@ -198,541 +195,260 @@ impl RuntimeObserver for AcpSessionUpdateObserver<'_> {
         output: &str,
         is_error: bool,
     ) {
-        self.notify_update(&json!({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": tool_use_id,
-            "status": if is_error { "failed" } else { "completed" },
-            "rawOutput": parse_json_or_string(output),
-            "content": [{
-                "type": "content",
-                "content": {
-                    "type": "text",
-                    "text": output,
-                },
-            }],
-        }));
-    }
-}
-
-trait AcpMessageSink {
-    fn send_value(&mut self, value: &Value) -> io::Result<()>;
-}
-
-struct AcpIoSink<'a, W> {
-    runtime: &'a tokio::runtime::Runtime,
-    writer: &'a mut W,
-}
-
-impl<W> AcpMessageSink for AcpIoSink<'_, W>
-where
-    W: AsyncWrite + Unpin,
-{
-    fn send_value(&mut self, value: &Value) -> io::Result<()> {
-        let payload = serde_json::to_vec(value).map_err(io::Error::other)?;
-        self.runtime
-            .block_on(write_msg(&mut *self.writer, &payload))
+        let status = if is_error {
+            ToolCallStatus::Failed
+        } else {
+            ToolCallStatus::Completed
+        };
+        self.notify_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            tool_use_id.to_string(),
+            ToolCallUpdateFields::new()
+                .status(status)
+                .raw_output(parse_json_or_string(output))
+                .content(vec![output.to_string().into()]),
+        )));
     }
 }
 
 /// Run the ACP server on process stdin/stdout.
-///
-/// All stdout writes go through JSON-RPC framing. Diagnostics should be
-/// propagated as errors and rendered by callers on stderr.
+#[allow(clippy::too_many_lines)]
 pub fn run_acp_stdio_server<A>(agent: A, options: &AcpServerOptions) -> Result<(), AcpServerError>
 where
-    A: AcpAgent,
+    A: AcpAgent + Send + 'static,
 {
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
-    run_acp_server_with_io(agent, BufReader::new(stdin), stdout, options)
-}
+    let agent = Arc::new(Mutex::new(agent));
+    let initialize_version = options.agent_version().to_string();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
 
-/// Run the ACP server over supplied framed IO streams.
-pub fn run_acp_server_with_io<A, R, W>(
-    mut agent: A,
-    mut reader: R,
-    mut writer: W,
-    options: &AcpServerOptions,
-) -> Result<(), AcpServerError>
-where
-    A: AcpAgent,
-    R: AsyncBufRead + Unpin,
-    W: AsyncWrite + Unpin,
-{
-    let runtime = tokio::runtime::Runtime::new()?;
-    let mut sink = AcpIoSink {
-        runtime: &runtime,
-        writer: &mut writer,
-    };
+    runtime.block_on(async move {
+        let new_session_agent = Arc::clone(&agent);
+        let list_sessions_agent = Arc::clone(&agent);
+        let prompt_agent = Arc::clone(&agent);
 
-    loop {
-        let Some(payload) = runtime.block_on(read_msg(&mut reader))? else {
-            break;
-        };
-        handle_payload(&mut agent, options, &payload, &mut sink)?;
-    }
+        Agent
+            .builder()
+            .name("scode")
+            .on_receive_request(
+                move |initialize: InitializeRequest,
+                      responder: Responder<InitializeResponse>,
+                      _connection: ConnectionTo<Client>| {
+                    let response =
+                        build_initialize_response(initialize.protocol_version, &initialize_version);
+                    async move { responder.respond(response) }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                move |request: NewSessionRequest,
+                      responder: Responder<NewSessionResponse>,
+                      _connection: ConnectionTo<Client>| {
+                    let agent = Arc::clone(&new_session_agent);
+                    async move {
+                        let session_id = {
+                            let mut agent = agent.lock().unwrap_or_else(PoisonError::into_inner);
+                            agent
+                                .new_session(Some(request.cwd))
+                                .map_err(map_acp_error)?
+                        };
+                        responder.respond(NewSessionResponse::new(session_id))
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                move |request: ListSessionsRequest,
+                      responder: Responder<ListSessionsResponse>,
+                      _connection: ConnectionTo<Client>| {
+                    let agent = Arc::clone(&list_sessions_agent);
+                    async move {
+                        let sessions = {
+                            let agent = agent.lock().unwrap_or_else(PoisonError::into_inner);
+                            agent
+                                .list_sessions(request.cwd)
+                                .map_err(map_acp_error)?
+                                .into_iter()
+                                .map(|session| SessionInfo::new(session.session_id, session.cwd))
+                                .collect::<Vec<_>>()
+                        };
+                        responder.respond(ListSessionsResponse::new(sessions))
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                move |request: PromptRequest,
+                      responder: Responder<PromptResponse>,
+                      connection: ConnectionTo<Client>| {
+                    let agent = Arc::clone(&prompt_agent);
+                    async move {
+                        let prompt = extract_prompt_text(&request.prompt).map_err(map_acp_error)?;
+                        let session_id = request.session_id.clone();
+                        let prompt_result = tokio::task::spawn_blocking(move || {
+                            // Prompt execution is synchronous and may own its own Tokio runtime,
+                            // so run it off the ACP SDK executor to avoid nested `block_on`.
+                            let mut observer =
+                                AcpSessionUpdateObserver::new(session_id.clone(), connection);
+                            {
+                                let mut agent =
+                                    agent.lock().unwrap_or_else(PoisonError::into_inner);
+                                agent.run_prompt(&session_id.to_string(), prompt, &mut observer)?;
+                            }
+                            observer.finish()
+                        })
+                        .await
+                        .map_err(|error| {
+                            map_acp_error(AcpError::internal(format!(
+                                "prompt task failed: {error}"
+                            )))
+                        })?;
+
+                        prompt_result.map_err(map_acp_error)?;
+                        responder.respond(PromptResponse::new(StopReason::EndTurn))
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_notification(
+                async |_cancel: CancelNotification, _connection: ConnectionTo<Client>| Ok(()),
+                agent_client_protocol::on_receive_notification!(),
+            )
+            .on_receive_dispatch(
+                async move |message: Dispatch, _connection: ConnectionTo<Client>| match message {
+                    Dispatch::Request(_, responder) => responder
+                        .respond_with_error(agent_client_protocol::Error::method_not_found()),
+                    Dispatch::Notification(_) | Dispatch::Response(_, _) => Ok(()),
+                },
+                agent_client_protocol::on_receive_dispatch!(),
+            )
+            .connect_to(Stdio::default())
+            .await
+    })?;
+
     Ok(())
 }
 
-fn handle_payload<A>(
-    agent: &mut A,
-    options: &AcpServerOptions,
-    payload: &[u8],
-    sink: &mut dyn AcpMessageSink,
-) -> io::Result<()>
-where
-    A: AcpAgent,
-{
-    match serde_json::from_slice::<Value>(payload) {
-        Ok(value) => handle_value(agent, options, &value, sink),
-        Err(error) => sink.send_value(&error_response(
-            &Value::Null,
-            PARSE_ERROR,
-            format!("parse error: {error}"),
-        )),
-    }
+fn build_initialize_response(
+    protocol_version: ProtocolVersion,
+    agent_version: &str,
+) -> InitializeResponse {
+    InitializeResponse::new(protocol_version)
+        .agent_capabilities(
+            AgentCapabilities::new()
+                .load_session(false)
+                .session_capabilities(
+                    SessionCapabilities::new().list(SessionListCapabilities::new()),
+                )
+                .prompt_capabilities(
+                    PromptCapabilities::new()
+                        .image(false)
+                        .audio(false)
+                        .embedded_context(false),
+                )
+                .mcp_capabilities(McpCapabilities::new().http(false).sse(false)),
+        )
+        .agent_info(Implementation::new("scode", agent_version))
 }
 
-fn handle_value<A>(
-    agent: &mut A,
-    options: &AcpServerOptions,
-    value: &Value,
-    sink: &mut dyn AcpMessageSink,
-) -> io::Result<()>
-where
-    A: AcpAgent,
-{
-    let Some(object) = value.as_object() else {
-        return sink.send_value(&error_response(
-            &Value::Null,
-            INVALID_REQUEST,
-            "JSON-RPC request must be an object",
-        ));
-    };
-    let id = object.get("id").cloned();
-    let is_notification = id.is_none();
-    let response_id = id.unwrap_or(Value::Null);
-
-    let Some(method) = object.get("method").and_then(Value::as_str) else {
-        if is_notification {
-            return Ok(());
-        }
-        return sink.send_value(&error_response(
-            &response_id,
-            INVALID_REQUEST,
-            "JSON-RPC request method must be a string",
-        ));
-    };
-
-    let params = object.get("params");
-    let result = match method {
-        "initialize" => handle_initialize(params, options),
-        "session/new" => handle_session_new(params, agent),
-        "session/prompt" => handle_session_prompt(params, agent, sink),
-        _ => {
-            if is_notification {
-                return Ok(());
-            }
-            Err(AcpError::InvalidParams("__method_not_found__".to_string()))
-        }
-    };
-
-    if is_notification {
-        return Ok(());
-    }
-
-    match result {
-        Ok(result) => sink.send_value(&success_response(&response_id, &result)),
-        Err(AcpError::InvalidParams(message)) if message == "__method_not_found__" => sink
-            .send_value(&error_response(
-                &response_id,
-                METHOD_NOT_FOUND,
-                format!("method not found: {method}"),
-            )),
-        Err(error) => sink.send_value(&error_response(
-            &response_id,
-            error.code(),
-            error.message().to_string(),
-        )),
-    }
-}
-
-fn handle_initialize(
-    params: Option<&Value>,
-    options: &AcpServerOptions,
-) -> Result<Value, AcpError> {
-    if params.is_some_and(|value| !value.is_object()) {
-        return Err(AcpError::invalid_params(
-            "initialize params must be an object",
-        ));
-    }
-    let protocol_version = match params.and_then(|value| value.get("protocolVersion")) {
-        Some(value) => value
-            .as_i64()
-            .ok_or_else(|| AcpError::invalid_params("params.protocolVersion must be numeric"))?,
-        None => options.default_protocol_version,
-    };
-
-    Ok(json!({
-        "protocolVersion": protocol_version,
-        "agentInfo": {
-            "name": "scode",
-            "version": options.agent_version,
-        },
-        "agentCapabilities": {
-            "loadSession": false,
-            "promptCapabilities": {
-                "image": false,
-                "audio": false,
-                "embeddedContext": false,
-            },
-            "mcpCapabilities": {
-                "http": false,
-                "sse": false,
-            },
-            "sessionCapabilities": {},
-        },
-        "authMethods": [],
-    }))
-}
-
-fn handle_session_new<A>(params: Option<&Value>, agent: &mut A) -> Result<Value, AcpError>
-where
-    A: AcpAgent,
-{
-    if params.is_some_and(|value| !value.is_object()) {
-        return Err(AcpError::invalid_params(
-            "session/new params must be an object",
-        ));
-    }
-    let cwd = match params.and_then(|value| value.get("cwd")) {
-        Some(value) => {
-            let raw = value
-                .as_str()
-                .ok_or_else(|| AcpError::invalid_params("params.cwd must be a string"))?;
-            let path = PathBuf::from(raw);
-            if !path.is_absolute() {
-                return Err(AcpError::invalid_params(
-                    "params.cwd must be an absolute path",
-                ));
-            }
-            Some(path)
-        }
-        None => None,
-    };
-
-    let session_id = agent.new_session(cwd)?;
-    Ok(json!({ "sessionId": session_id }))
-}
-
-fn handle_session_prompt<A>(
-    params: Option<&Value>,
-    agent: &mut A,
-    sink: &mut dyn AcpMessageSink,
-) -> Result<Value, AcpError>
-where
-    A: AcpAgent,
-{
-    let params = params
-        .and_then(Value::as_object)
-        .ok_or_else(|| AcpError::invalid_params("session/prompt params must be an object"))?;
-    let session_id = params
-        .get("sessionId")
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| AcpError::invalid_params("params.sessionId must be a non-empty string"))?;
-    let prompt = extract_prompt_text(params.get("prompt"))?;
-
-    let mut observer = AcpSessionUpdateObserver::new(session_id.to_string(), sink);
-    let result = agent.run_prompt(session_id, prompt, &mut observer);
-    observer
-        .finish()
-        .map_err(|error| AcpError::internal(error.to_string()))?;
-    result?;
-
-    Ok(json!({ "stopReason": "end_turn" }))
-}
-
-fn extract_prompt_text(prompt: Option<&Value>) -> Result<String, AcpError> {
-    let prompt = prompt.ok_or_else(|| AcpError::invalid_params("params.prompt is required"))?;
-    let content = prompt
-        .as_object()
-        .and_then(|object| object.get("content"))
-        .or_else(|| prompt.as_array().map(|_| prompt))
-        .ok_or_else(|| AcpError::invalid_params("params.prompt.content must be an array"))?;
-    let blocks = content
-        .as_array()
-        .ok_or_else(|| AcpError::invalid_params("params.prompt.content must be an array"))?;
-
-    let text = blocks
+fn extract_prompt_text(prompt: &[ContentBlock]) -> Result<String, AcpError> {
+    let text = prompt
         .iter()
-        .filter_map(extract_text_block)
+        .filter_map(|block| match block {
+            ContentBlock::Text(content) if !content.text.trim().is_empty() => {
+                Some(content.text.trim().to_string())
+            }
+            _ => None,
+        })
         .collect::<Vec<_>>()
         .join("\n");
+
     if text.trim().is_empty() {
         return Err(AcpError::invalid_params(
             "params.prompt must include at least one text content block",
         ));
     }
+
     Ok(text)
-}
-
-fn extract_text_block(block: &Value) -> Option<String> {
-    let object = block.as_object()?;
-    match object.get("type").and_then(Value::as_str) {
-        Some("text") => object
-            .get("text")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|text| !text.is_empty())
-            .map(ToOwned::to_owned),
-        _ => None,
-    }
-}
-
-fn success_response(id: &Value, result: &Value) -> Value {
-    json!({
-        "jsonrpc": JSONRPC_VERSION,
-        "id": id,
-        "result": result,
-    })
-}
-
-fn error_response(id: &Value, code: i64, message: impl Into<String>) -> Value {
-    json!({
-        "jsonrpc": JSONRPC_VERSION,
-        "id": id,
-        "error": {
-            "code": code,
-            "message": message.into(),
-        },
-    })
 }
 
 fn parse_json_or_string(value: &str) -> Value {
     serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()))
 }
 
+fn map_acp_error(error: AcpError) -> agent_client_protocol::Error {
+    match error {
+        AcpError::InvalidParams(message) => {
+            agent_client_protocol::Error::invalid_params().data(message)
+        }
+        AcpError::Internal(message) => agent_client_protocol::util::internal_error(message),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    struct RecordingSink {
-        messages: Vec<Value>,
-    }
-
-    impl RecordingSink {
-        fn new() -> Self {
-            Self {
-                messages: Vec::new(),
-            }
-        }
-    }
-
-    impl AcpMessageSink for RecordingSink {
-        fn send_value(&mut self, value: &Value) -> io::Result<()> {
-            self.messages.push(value.clone());
-            Ok(())
-        }
-    }
-
-    #[derive(Default)]
-    struct FakeAgent {
-        sessions: Vec<Option<PathBuf>>,
-        prompts: Vec<(String, String)>,
-    }
-
-    impl AcpAgent for FakeAgent {
-        fn new_session(&mut self, cwd: Option<PathBuf>) -> Result<String, AcpError> {
-            self.sessions.push(cwd);
-            Ok(format!("session-{}", self.sessions.len()))
-        }
-
-        fn run_prompt(
-            &mut self,
-            session_id: &str,
-            prompt: String,
-            observer: &mut AcpSessionUpdateObserver<'_>,
-        ) -> Result<(), AcpError> {
-            if session_id != "session-1" {
-                return Err(AcpError::invalid_params("unknown sessionId"));
-            }
-            self.prompts.push((session_id.to_string(), prompt));
-            observer.on_text_delta("hello ");
-            observer.on_tool_use("toolu_1", "read_file", r#"{"file_path":"Cargo.toml"}"#);
-            observer.on_tool_result("toolu_1", "read_file", r#"{"ok":true}"#, false);
-            Ok(())
-        }
-    }
-
-    fn request(id: i64, method: &str, params: &Value) -> Value {
-        json!({
-            "jsonrpc": JSONRPC_VERSION,
-            "id": id,
-            "method": method,
-            "params": params,
-        })
-    }
+    use serde_json::{json, Value};
 
     #[test]
-    fn initialize_echoes_protocol_version_and_capabilities() {
-        let mut agent = FakeAgent::default();
-        let options = AcpServerOptions::new("1.2.3");
-        let mut sink = RecordingSink::new();
+    fn initialize_response_matches_contract() {
+        let protocol_version: ProtocolVersion =
+            serde_json::from_value(json!(9)).expect("protocol version should deserialize");
+        let response = build_initialize_response(protocol_version, "1.2.3");
+        let response_json: Value =
+            serde_json::to_value(response).expect("initialize response should serialize");
 
-        handle_value(
-            &mut agent,
-            &options,
-            &request(1, "initialize", &json!({ "protocolVersion": 42 })),
-            &mut sink,
-        )
-        .expect("initialize should handle");
-
-        let response = sink.messages.pop().expect("response");
-        assert_eq!(response["id"], 1);
-        assert_eq!(response["result"]["protocolVersion"], 42);
-        assert_eq!(response["result"]["agentInfo"]["name"], "scode");
-        assert_eq!(response["result"]["agentInfo"]["version"], "1.2.3");
+        assert_eq!(response_json["protocolVersion"], 9);
+        assert_eq!(response_json["agentInfo"]["name"], "scode");
+        assert_eq!(response_json["agentInfo"]["version"], "1.2.3");
+        assert_eq!(response_json["agentCapabilities"]["loadSession"], false);
         assert_eq!(
-            response["result"]["agentCapabilities"]["loadSession"],
+            response_json["agentCapabilities"]["promptCapabilities"]["image"],
             false
         );
         assert_eq!(
-            response["result"]["agentCapabilities"]["mcpCapabilities"]["http"],
+            response_json["agentCapabilities"]["promptCapabilities"]["audio"],
             false
         );
-        assert_eq!(response["result"]["authMethods"], json!([]));
-    }
-
-    #[test]
-    fn notifications_do_not_receive_responses() {
-        let mut agent = FakeAgent::default();
-        let options = AcpServerOptions::new("1.2.3");
-        let mut sink = RecordingSink::new();
-
-        handle_value(
-            &mut agent,
-            &options,
-            &json!({ "jsonrpc": JSONRPC_VERSION, "method": "unknown/notification" }),
-            &mut sink,
-        )
-        .expect("notification should handle");
-
-        assert!(sink.messages.is_empty());
-    }
-
-    #[test]
-    fn unknown_request_method_returns_method_not_found() {
-        let mut agent = FakeAgent::default();
-        let options = AcpServerOptions::new("1.2.3");
-        let mut sink = RecordingSink::new();
-
-        handle_value(
-            &mut agent,
-            &options,
-            &request(7, "missing/method", &json!({})),
-            &mut sink,
-        )
-        .expect("unknown method should handle");
-
-        let response = sink.messages.pop().expect("response");
-        assert_eq!(response["id"], 7);
-        assert_eq!(response["error"]["code"], METHOD_NOT_FOUND);
-    }
-
-    #[test]
-    fn session_new_rejects_relative_cwd() {
-        let mut agent = FakeAgent::default();
-        let options = AcpServerOptions::new("1.2.3");
-        let mut sink = RecordingSink::new();
-
-        handle_value(
-            &mut agent,
-            &options,
-            &request(2, "session/new", &json!({ "cwd": "relative/path" })),
-            &mut sink,
-        )
-        .expect("session/new should handle");
-
-        let response = sink.messages.pop().expect("response");
-        assert_eq!(response["error"]["code"], INVALID_PARAMS);
-        assert!(agent.sessions.is_empty());
-    }
-
-    #[test]
-    fn session_prompt_extracts_text_and_emits_updates_before_response() {
-        let mut agent = FakeAgent::default();
-        agent.sessions.push(None);
-        let options = AcpServerOptions::new("1.2.3");
-        let mut sink = RecordingSink::new();
-
-        handle_value(
-            &mut agent,
-            &options,
-            &request(
-                3,
-                "session/prompt",
-                &json!({
-                    "sessionId": "session-1",
-                    "prompt": {
-                        "content": [
-                            { "type": "text", "text": "First" },
-                            { "type": "resource_link", "uri": "file:///tmp/a.txt" },
-                            { "type": "text", "text": "Second" }
-                        ]
-                    }
-                }),
-            ),
-            &mut sink,
-        )
-        .expect("session/prompt should handle");
-
         assert_eq!(
-            agent.prompts,
-            vec![("session-1".to_string(), "First\nSecond".to_string())]
-        );
-        assert_eq!(sink.messages.len(), 4);
-        assert_eq!(sink.messages[0]["method"], "session/update");
-        assert_eq!(
-            sink.messages[0]["params"]["update"]["sessionUpdate"],
-            "agent_message_chunk"
+            response_json["agentCapabilities"]["promptCapabilities"]["embeddedContext"],
+            false
         );
         assert_eq!(
-            sink.messages[1]["params"]["update"]["rawInput"],
-            json!({ "file_path": "Cargo.toml" })
+            response_json["agentCapabilities"]["mcpCapabilities"]["http"],
+            false
         );
         assert_eq!(
-            sink.messages[2]["params"]["update"]["rawOutput"],
-            json!({ "ok": true })
+            response_json["agentCapabilities"]["mcpCapabilities"]["sse"],
+            false
         );
-        assert_eq!(sink.messages[3]["result"]["stopReason"], "end_turn");
+        assert_eq!(
+            response_json["agentCapabilities"]["sessionCapabilities"],
+            json!({"list": {}})
+        );
+        assert_eq!(response_json["authMethods"], json!([]));
     }
 
     #[test]
-    fn session_prompt_rejects_prompts_without_text_blocks() {
-        let mut agent = FakeAgent::default();
-        let options = AcpServerOptions::new("1.2.3");
-        let mut sink = RecordingSink::new();
+    fn extract_prompt_text_joins_text_blocks() {
+        let prompt = vec![
+            ContentBlock::Text(TextContent::new("hello")),
+            ContentBlock::Text(TextContent::new("world")),
+        ];
 
-        handle_value(
-            &mut agent,
-            &options,
-            &request(
-                4,
-                "session/prompt",
-                &json!({
-                    "sessionId": "session-1",
-                    "prompt": {
-                        "content": [{ "type": "resource_link", "uri": "file:///tmp/a.txt" }]
-                    }
-                }),
-            ),
-            &mut sink,
-        )
-        .expect("session/prompt should handle");
+        let text = extract_prompt_text(&prompt).expect("prompt text should extract");
+        assert_eq!(text, "hello\nworld");
+    }
 
-        let response = sink.messages.pop().expect("response");
-        assert_eq!(response["error"]["code"], INVALID_PARAMS);
-        assert!(agent.prompts.is_empty());
+    #[test]
+    fn extract_prompt_text_rejects_empty_non_text_prompt() {
+        let prompt = vec![ContentBlock::Text(TextContent::new("   "))];
+
+        let error = extract_prompt_text(&prompt).expect_err("prompt should be rejected");
+        assert_eq!(
+            error,
+            AcpError::invalid_params("params.prompt must include at least one text content block",)
+        );
     }
 }

--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -55,7 +55,7 @@ pub enum HookProgressEvent {
     },
 }
 
-pub trait HookProgressReporter {
+pub trait HookProgressReporter: Send {
     fn on_event(&mut self, event: &HookProgressEvent);
 }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -52,8 +52,8 @@ mod usage;
 pub mod worker_boot;
 
 pub use acp_server::{
-    run_acp_server_with_io, run_acp_stdio_server, AcpAgent, AcpError, AcpServerError,
-    AcpServerOptions, AcpSessionUpdateObserver,
+    run_acp_stdio_server, AcpAgent, AcpError, AcpServerError, AcpServerOptions, AcpSessionInfo,
+    AcpSessionUpdateObserver,
 };
 pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -32,4 +32,3 @@ workspace = true
 mock-anthropic-service = { path = "../mock-anthropic-service" }
 serde_json.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread"] }
-

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -64,7 +64,7 @@ pub(crate) fn render_help_topic(topic: LocalHelpTopic) -> String {
   Usage            scode acp [serve]
   Aliases          scode --acp · scode -acp
   Purpose          run the ACP JSON-RPC agent server over stdio for editor integrations
-  Transport        LSP-style Content-Length framed JSON-RPC on stdin/stdout
+  Transport        line-delimited JSON-RPC on stdin/stdout
   Sessions         session/new creates managed .scode sessions for the requested cwd
   Related          scode --help"
             .to_string(),
@@ -575,7 +575,7 @@ pub(crate) fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "  scode acp [serve]")?;
     writeln!(
         out,
-        "      Run the ACP JSON-RPC stdio server for editor integrations (aliases: --acp, -acp)"
+        "      Run the ACP stdio server for editor integrations (line-delimited JSON-RPC)"
     )?;
     writeln!(out, "      Source of truth: {OFFICIAL_REPO_SLUG}")?;
     writeln!(

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1590,11 +1590,28 @@ impl runtime::AcpAgent for AcpCliAgent {
         Ok(session_id)
     }
 
+    fn list_sessions(
+        &self,
+        cwd: Option<PathBuf>,
+    ) -> Result<Vec<runtime::AcpSessionInfo>, AcpError> {
+        let cwd = cwd.as_deref().map(canonical_session_cwd).transpose()?;
+        let mut sessions = self
+            .sessions
+            .values()
+            .filter(|session| cwd.as_ref().is_none_or(|filter| session.cwd == *filter))
+            .map(|session| {
+                runtime::AcpSessionInfo::new(session.handle.id.clone(), session.cwd.clone())
+            })
+            .collect::<Vec<_>>();
+        sessions.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+        Ok(sessions)
+    }
+
     fn run_prompt(
         &mut self,
         session_id: &str,
         prompt: String,
-        observer: &mut AcpSessionUpdateObserver<'_>,
+        observer: &mut AcpSessionUpdateObserver,
     ) -> Result<(), AcpError> {
         // Intercept slash commands — they should be handled locally, not sent to the LLM.
         if prompt.starts_with('/') {
@@ -1626,17 +1643,14 @@ impl AcpCliAgent {
         &mut self,
         session_id: &str,
         input: &str,
-        observer: &mut AcpSessionUpdateObserver<'_>,
+        observer: &mut AcpSessionUpdateObserver,
     ) -> Result<(), AcpError> {
         use runtime::RuntimeObserver as _;
-        let command = match SlashCommand::parse(input) {
-            Ok(Some(cmd)) => cmd,
-            Ok(None) | Err(_) => {
-                observer.on_text_delta(&format!(
-                    "Unknown slash command: `{input}`. Type `/help` for available commands."
-                ));
-                return Ok(());
-            }
+        let Ok(Some(command)) = SlashCommand::parse(input) else {
+            observer.on_text_delta(&format!(
+                "`{input}` is not supported in ACP mode. Type `/help` for available commands."
+            ));
+            return Ok(());
         };
 
         let response = match &command {

--- a/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::Write;
+use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -48,13 +48,14 @@ fn status_and_sandbox_emit_json_when_requested() {
 }
 
 #[test]
-fn acp_server_responds_to_framed_initialize() {
+fn acp_server_responds_to_line_delimited_initialize() {
     let root = unique_temp_dir("acp-jsonrpc");
     fs::create_dir_all(&root).expect("temp dir should exist");
 
-    let acp = assert_framed_acp_command(
+    let acp = assert_line_delimited_acp_command(
         &root,
         &["--output-format", "json", "acp"],
+        &[],
         &json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -75,6 +76,73 @@ fn acp_server_responds_to_framed_initialize() {
         false
     );
     assert_eq!(acp["result"]["authMethods"], json!([]));
+}
+
+#[test]
+fn acp_server_handles_session_prompt_for_local_slash_command() {
+    let root = unique_temp_dir("acp-slash-prompt");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    let (initialize, new_session, update, prompt_response) = assert_line_delimited_acp_slash_prompt(
+        &root,
+        &["--output-format", "json", "acp"],
+        &[],
+        "/help",
+    );
+
+    assert_eq!(initialize["id"], 1);
+    assert_eq!(new_session["id"], 2);
+    assert!(new_session["result"]["sessionId"].as_str().is_some());
+    assert_eq!(update["method"], "session/update");
+    assert_eq!(
+        update["params"]["update"]["sessionUpdate"],
+        "agent_message_chunk"
+    );
+    assert!(update["params"]["update"]["content"]["text"]
+        .as_str()
+        .expect("slash prompt text")
+        .contains("Slash commands"));
+    assert_eq!(prompt_response["id"], 3);
+    assert_eq!(prompt_response["result"]["stopReason"], "end_turn");
+}
+
+#[test]
+fn acp_server_lists_created_sessions() {
+    let root = unique_temp_dir("acp-session-list");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    let (first_session_id, second_session_id, session_list) =
+        assert_line_delimited_acp_session_list(&root, &["--output-format", "json", "acp"], &[]);
+
+    let listed_ids = session_list["result"]["sessions"]
+        .as_array()
+        .expect("sessions should be an array")
+        .iter()
+        .filter_map(|session| session["sessionId"].as_str())
+        .collect::<Vec<_>>();
+
+    assert!(listed_ids.contains(&first_session_id.as_str()));
+    assert!(listed_ids.contains(&second_session_id.as_str()));
+}
+
+#[test]
+fn acp_server_reports_unknown_slash_commands_as_not_supported() {
+    let root = unique_temp_dir("acp-unknown-slash");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    let (_initialize, _new_session, update, prompt_response) =
+        assert_line_delimited_acp_slash_prompt(
+            &root,
+            &["--output-format", "json", "acp"],
+            &[],
+            "/nonexistent",
+        );
+
+    assert_eq!(prompt_response["result"]["stopReason"], "end_turn");
+    assert!(update["params"]["update"]["content"]["text"]
+        .as_str()
+        .expect("unknown slash text")
+        .contains("not supported"));
 }
 
 #[test]
@@ -421,52 +489,234 @@ fn run_scode(current_dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output
     command.output().expect("scode should launch")
 }
 
-fn assert_framed_acp_command(current_dir: &Path, args: &[&str], request: &Value) -> Value {
-    let request = serde_json::to_vec(request).expect("request should serialize");
-    let frame = format!("Content-Length: {}\r\n\r\n", request.len());
+fn assert_line_delimited_acp_command(
+    current_dir: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    request: &Value,
+) -> Value {
+    let request = serde_json::to_string(request).expect("request should serialize");
     let mut child = Command::new(env!("CARGO_BIN_EXE_scode"))
         .current_dir(current_dir)
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .envs(envs.iter().copied())
         .spawn()
         .expect("scode should launch");
     {
         let stdin = child.stdin.as_mut().expect("stdin should be piped");
         stdin
-            .write_all(frame.as_bytes())
-            .expect("frame header should write");
-        stdin.write_all(&request).expect("frame body should write");
+            .write_all(request.as_bytes())
+            .expect("request line should write");
+        stdin.write_all(b"\n").expect("newline should write");
     }
     drop(child.stdin.take());
-    let output = child.wait_with_output().expect("scode should exit");
-    assert!(
-        output.status.success(),
-        "stdout:\n{}\n\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    parse_framed_json(&output.stdout)
+    let mut stdout = std::io::BufReader::new(child.stdout.take().expect("stdout should be piped"));
+    let mut stderr = child.stderr.take().expect("stderr should be piped");
+    let mut response_line = String::new();
+    stdout
+        .read_line(&mut response_line)
+        .expect("response line should read");
+    if response_line.trim().is_empty() {
+        let _ = child.kill();
+        let _ = child.wait();
+        let mut stderr_output = String::new();
+        let _ = std::io::Read::read_to_string(&mut stderr, &mut stderr_output);
+        panic!("stdout did not contain a JSON-RPC response line\n\nstderr:\n{stderr_output}");
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    serde_json::from_str(&response_line).expect("response line should be valid json")
 }
 
-fn parse_framed_json(stdout: &[u8]) -> Value {
-    let header_end = stdout
-        .windows(4)
-        .position(|window| window == b"\r\n\r\n")
-        .expect("stdout should contain JSON-RPC frame headers");
-    let headers = std::str::from_utf8(&stdout[..header_end]).expect("headers should be utf8");
-    let content_length = headers
-        .lines()
-        .find_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            name.eq_ignore_ascii_case("Content-Length")
-                .then(|| value.trim().parse::<usize>().expect("valid content length"))
-        })
-        .expect("Content-Length header should exist");
-    let body_start = header_end + 4;
-    let body_end = body_start + content_length;
-    serde_json::from_slice(&stdout[body_start..body_end]).expect("body should be valid json")
+fn assert_line_delimited_acp_slash_prompt(
+    current_dir: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    prompt: &str,
+) -> (Value, Value, Value, Value) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_scode"))
+        .current_dir(current_dir)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .envs(envs.iter().copied())
+        .spawn()
+        .expect("scode should launch");
+    let mut stdin = child.stdin.take().expect("stdin should be piped");
+    let mut stdout = std::io::BufReader::new(child.stdout.take().expect("stdout should be piped"));
+    let mut stderr = child.stderr.take().expect("stderr should be piped");
+
+    let read_json_line = |stdout: &mut std::io::BufReader<_>,
+                          stderr: &mut _,
+                          child: &mut std::process::Child|
+     -> Value {
+        let mut line = String::new();
+        stdout
+            .read_line(&mut line)
+            .expect("response line should read");
+        if line.trim().is_empty() {
+            let _ = child.kill();
+            let _ = child.wait();
+            let mut stderr_output = String::new();
+            let _ = std::io::Read::read_to_string(stderr, &mut stderr_output);
+            panic!("stdout did not contain a JSON-RPC response line\n\nstderr:\n{stderr_output}");
+        }
+        serde_json::from_str(&line).expect("response line should be valid json")
+    };
+
+    for request in [
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "protocolVersion": 9 },
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/new",
+            "params": {
+                "cwd": current_dir,
+                "mcpServers": [],
+            },
+        }),
+    ] {
+        let request = serde_json::to_string(&request).expect("request should serialize");
+        stdin
+            .write_all(request.as_bytes())
+            .expect("request line should write");
+        stdin.write_all(b"\n").expect("newline should write");
+    }
+
+    let initialize: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+    let new_session: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+    let session_id = new_session["result"]["sessionId"]
+        .as_str()
+        .expect("session/new should return sessionId");
+    let prompt_request = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "session/prompt",
+        "params": {
+            "sessionId": session_id,
+            "prompt": [{ "type": "text", "text": prompt }],
+        },
+    }))
+    .expect("prompt request should serialize");
+    stdin
+        .write_all(prompt_request.as_bytes())
+        .expect("prompt request should write");
+    stdin.write_all(b"\n").expect("newline should write");
+
+    let update: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+    let prompt_response: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    (initialize, new_session, update, prompt_response)
+}
+
+fn assert_line_delimited_acp_session_list(
+    current_dir: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> (String, String, Value) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_scode"))
+        .current_dir(current_dir)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .envs(envs.iter().copied())
+        .spawn()
+        .expect("scode should launch");
+    let mut stdin = child.stdin.take().expect("stdin should be piped");
+    let mut stdout = std::io::BufReader::new(child.stdout.take().expect("stdout should be piped"));
+    let mut stderr = child.stderr.take().expect("stderr should be piped");
+
+    let read_json_line = |stdout: &mut std::io::BufReader<_>,
+                          stderr: &mut _,
+                          child: &mut std::process::Child|
+     -> Value {
+        let mut line = String::new();
+        stdout
+            .read_line(&mut line)
+            .expect("response line should read");
+        if line.trim().is_empty() {
+            let _ = child.kill();
+            let _ = child.wait();
+            let mut stderr_output = String::new();
+            let _ = std::io::Read::read_to_string(stderr, &mut stderr_output);
+            panic!("stdout did not contain a JSON-RPC response line\n\nstderr:\n{stderr_output}");
+        }
+        serde_json::from_str(&line).expect("response line should be valid json")
+    };
+
+    for request in [
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "protocolVersion": 9 },
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/new",
+            "params": {
+                "cwd": current_dir,
+                "mcpServers": [],
+            },
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/new",
+            "params": {
+                "cwd": current_dir,
+                "mcpServers": [],
+            },
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "session/list",
+            "params": {},
+        }),
+    ] {
+        let request = serde_json::to_string(&request).expect("request should serialize");
+        stdin
+            .write_all(request.as_bytes())
+            .expect("request line should write");
+        stdin.write_all(b"\n").expect("newline should write");
+    }
+
+    let _initialize: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+    let first_session: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+    let second_session: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+    let session_list: Value = read_json_line(&mut stdout, &mut stderr, &mut child);
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    (
+        first_session["result"]["sessionId"]
+            .as_str()
+            .expect("first session id should exist")
+            .to_string(),
+        second_session["result"]["sessionId"]
+            .as_str()
+            .expect("second session id should exist")
+            .to_string(),
+        session_list,
+    )
 }
 
 fn write_upstream_fixture(root: &Path) -> PathBuf {


### PR DESCRIPTION
## Summary

- replace the legacy ACP server split with a single SDK-backed ACP server path
- remove the old ACP feature-gating and keep `scode acp` on the SDK implementation by default
- add ACP session lifecycle coverage and fix the `session/prompt` runtime nesting bug exposed by live smoke testing

## What Changed

- rewrote `runtime/src/acp_server.rs` around `agent-client-protocol` and `agent-client-protocol-tokio`
- removed the old `--acp-sdk` / `SCODE_ACP_SDK` selection flow and kept one ACP codepath in the CLI
- added `session/list` support and advertised it in ACP capabilities
- fixed `session/prompt` so prompt execution runs off the SDK dispatch executor instead of panicking on nested Tokio `block_on`
- updated ACP contract tests to cover initialize, local slash-command prompts, and session listing
- kept the shared `jsonrpc_transport` helper only for MCP, not ACP

## Why

The old ACP path had already been superseded by the SDK migration work, but the cutover still had gaps around live prompt execution and session listing. This consolidates ACP onto one implementation and closes the protocol and runtime regressions found during smoke testing.

## Validation

- `cargo test -p runtime acp_server::tests::`
- `cargo test -p rusty-sudocode-cli --test output_format_contract`
- `cargo clippy -p runtime -p rusty-sudocode-cli --all-targets -- -D warnings`
- `bash /tmp/test_acp.sh`

## Notes

- this PR intentionally excludes the untracked local notes `AGENTS.md` and `acp-sdk-migration-phase1-task.md`
- the shared `jsonrpc_transport` module still exists because MCP continues to use it
