### PR TITLE
Prepare v0.1.1 cross-platform release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,24 @@ jobs:
         include:
           - name: linux-x64
             os: ubuntu-latest
-            bin: claw
-            artifact_name: claw-linux-x64
+            bin: scode
+            package_dir: scode-linux-x64
+            archive_name: scode-linux-x64.tar.gz
           - name: macos-arm64
             os: macos-14
-            bin: claw
-            artifact_name: claw-macos-arm64
+            bin: scode
+            package_dir: scode-macos-arm64
+            archive_name: scode-macos-arm64.tar.gz
+          - name: macos-x64
+            os: macos-13
+            bin: scode
+            package_dir: scode-macos-x64
+            archive_name: scode-macos-x64.tar.gz
+          - name: windows-x64
+            os: windows-2022
+            bin: scode.exe
+            package_dir: scode-windows-x64
+            archive_name: scode-windows-x64.zip
     defaults:
       run:
         working-directory: rust
@@ -45,24 +57,44 @@ jobs:
           workspaces: rust -> target
 
       - name: Build release binary
-        run: cargo build --release -p rusty-claude-cli
+        run: cargo build --locked --release -p rusty-sudocode-cli --bin scode
 
-      - name: Package artifact
+      - name: Stage release payload
         shell: bash
         run: |
-          mkdir -p dist
-          cp "target/release/${{ matrix.bin }}" "dist/${{ matrix.artifact_name }}"
-          chmod +x "dist/${{ matrix.artifact_name }}"
+          set -euo pipefail
+          mkdir -p "dist/${{ matrix.package_dir }}"
+          cp "target/release/${{ matrix.bin }}" "dist/${{ matrix.package_dir }}/${{ matrix.bin }}"
+          cp "../README.md" "dist/${{ matrix.package_dir }}/README.md"
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            chmod +x "dist/${{ matrix.package_dir }}/${{ matrix.bin }}"
+          fi
+
+      - name: Archive release payload (tar.gz)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -C dist -czf "dist/${{ matrix.archive_name }}" "${{ matrix.package_dir }}"
+
+      - name: Archive release payload (zip)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path "dist/${{ matrix.package_dir }}" `
+            -DestinationPath "dist/${{ matrix.archive_name }}" `
+            -Force
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}
-          path: rust/dist/${{ matrix.artifact_name }}
+          name: ${{ matrix.package_dir }}
+          path: rust/dist/${{ matrix.archive_name }}
 
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: rust/dist/${{ matrix.artifact_name }}
+          files: rust/dist/${{ matrix.archive_name }}
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,18 @@ jobs:
             bin: scode
             package_dir: scode-linux-x64
             archive_name: scode-linux-x64.tar.gz
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            bin: scode
+            package_dir: scode-linux-arm64
+            archive_name: scode-linux-arm64.tar.gz
           - name: macos-arm64
             os: macos-14
             bin: scode
             package_dir: scode-macos-arm64
             archive_name: scode-macos-arm64.tar.gz
           - name: macos-x64
-            os: macos-13
+            os: macos-15-intel
             bin: scode
             package_dir: scode-macos-x64
             archive_name: scode-macos-x64.tar.gz
@@ -44,6 +49,11 @@ jobs:
             bin: scode.exe
             package_dir: scode-windows-x64
             archive_name: scode-windows-x64.zip
+          - name: windows-arm64
+            os: windows-11-arm
+            bin: scode.exe
+            package_dir: scode-windows-arm64
+            archive_name: scode-windows-arm64.zip
     defaults:
       run:
         working-directory: rust
@@ -92,9 +102,29 @@ jobs:
           name: ${{ matrix.package_dir }}
           path: rust/dist/${{ matrix.archive_name }}
 
-      - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/')
+  publish-release:
+    name: publish-release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum scode-* > SHA256SUMS.txt
+
+      - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          files: rust/dist/${{ matrix.archive_name }}
+          files: |
+            dist/scode-*
+            dist/SHA256SUMS.txt
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'omx-issue-*'
     paths:
       - .github/workflows/rust-ci.yml
+      - .github/workflows/release.yml
       - .github/scripts/check_doc_source_of_truth.py
       - .github/FUNDING.yml
       - README.md
@@ -22,6 +23,7 @@ on:
       - main
     paths:
       - .github/workflows/rust-ci.yml
+      - .github/workflows/release.yml
       - .github/scripts/check_doc_source_of_truth.py
       - .github/FUNDING.yml
       - README.md

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "criterion",
@@ -414,7 +414,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "commands"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "plugins",
  "runtime",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "commands",
  "runtime",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "serde_json",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -2149,7 +2149,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "clap",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "commands",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -82,7 +82,7 @@ async fn send_message_posts_json_and_parses_response() {
     );
     assert_eq!(
         request.headers.get("user-agent").map(String::as_str),
-        Some("claude-code/0.1.0")
+        Some(concat!("claude-code/", env!("CARGO_PKG_VERSION")))
     );
     assert_eq!(
         request.headers.get("anthropic-beta").map(String::as_str),


### PR DESCRIPTION
## Summary
- fix the release workflow to build and publish real `scode` archives for Linux/macOS/Windows across x64 and arm64
- make Rust CI rerun when the release workflow changes and cancel stale branch release runs
- bump the workspace version to `0.1.1` and make the API user-agent test follow `CARGO_PKG_VERSION`

## Validation
- `cargo test --workspace`
- verified the release workflow on GitHub Actions for all 6 os-arch targets and confirmed a tag-triggered release upload path end to end