### PR TITLE
feat(acp): return token usage in PromptResponse

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2360,7 +2360,6 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
- "sha2",
  "syntect",
  "tokio",
  "tokio-tungstenite",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 publish = false
 
 [workspace.dependencies]
-agent-client-protocol = { version = "0.11", features = ["unstable_session_model", "unstable_session_close"] }
-agent-client-protocol-schema = { version = "0.12", features = ["unstable_session_model", "unstable_session_close"] }
+agent-client-protocol = { version = "0.11", features = ["unstable_session_model", "unstable_session_close", "unstable_session_usage"] }
+agent-client-protocol-schema = { version = "0.12", features = ["unstable_session_model", "unstable_session_close", "unstable_session_usage"] }
 agent-client-protocol-tokio = "0.11"
 axum = { version = "0.8", features = ["ws"] }
 serde_json = "1"

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -28,7 +28,7 @@ use agent_client_protocol_schema::{
     RequestPermissionRequest, RequestPermissionResponse, SessionCapabilities,
     SessionCloseCapabilities, SessionInfo, SessionNotification, SessionUpdate,
     SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, ToolCall,
-    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage,
 };
 
 /// Error type returned by ACP agent implementations.
@@ -102,7 +102,7 @@ pub trait SdkAcpDelegate: Send + 'static {
         session_id: &str,
         prompt: String,
         observer: &mut SdkSessionObserver,
-    ) -> Result<StopReason, AcpError>;
+    ) -> Result<(StopReason, Option<PromptUsage>), AcpError>;
 
     /// Run a prompt with permission prompting bridged to the ACP client.
     fn run_prompt_with_prompter(
@@ -111,7 +111,7 @@ pub trait SdkAcpDelegate: Send + 'static {
         prompt: String,
         observer: &mut SdkSessionObserver,
         prompter: &mut dyn PermissionPrompter,
-    ) -> Result<StopReason, AcpError>;
+    ) -> Result<(StopReason, Option<PromptUsage>), AcpError>;
 
     /// Handle a slash command, returning text output.
     fn handle_slash_command(
@@ -288,6 +288,16 @@ pub(crate) fn extract_content_from_blocks(
 /// Re-export `StopReason` so the CLI crate doesn't need a direct dep on
 /// the schema crate.
 pub use agent_client_protocol_schema::StopReason as AcpStopReason;
+
+/// Token usage data returned by a prompt turn.
+#[derive(Debug, Clone, Default)]
+pub struct PromptUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub cache_read_tokens: Option<u64>,
+    pub cache_write_tokens: Option<u64>,
+}
 
 /// Thread-safe handle to a delegate, shared across async handlers.
 pub type SharedDelegate = Arc<Mutex<Box<dyn SdkAcpDelegate>>>;
@@ -518,7 +528,7 @@ pub(crate) async fn run_acp_on_transport(
                                         &prompt_text,
                                         &mut observer,
                                     )
-                                    .map(|()| StopReason::EndTurn)
+                                    .map(|()| (StopReason::EndTurn, None))
                             } else {
                                 delegate.run_prompt_with_prompter(
                                     &sid_for_blocking,
@@ -528,8 +538,8 @@ pub(crate) async fn run_acp_on_transport(
                                 )
                             };
                             let notifications = observer.drain();
-                            let reason = stop.unwrap_or(StopReason::EndTurn);
-                            (reason, notifications)
+                            let (reason, usage) = stop.unwrap_or((StopReason::EndTurn, None));
+                            (reason, usage, notifications)
                         });
 
                         // Concurrently serve permission requests from the
@@ -562,21 +572,29 @@ pub(crate) async fn run_acp_on_transport(
                                         // Await the result directly to avoid a busy loop
                                         // (biased select would keep picking this branch).
                                         break blocking_handle.await
-                                            .unwrap_or((StopReason::EndTurn, Vec::new()));
+                                            .unwrap_or((StopReason::EndTurn, None, Vec::new()));
                                     }
                                 }
                                 done = &mut blocking_handle => {
-                                    break done.unwrap_or((StopReason::EndTurn, Vec::new()));
+                                    break done.unwrap_or((StopReason::EndTurn, None, Vec::new()));
                                 }
                             }
                         };
 
-                        let (stop_reason, notifications) = result;
+                        let (stop_reason, prompt_usage, notifications) = result;
                         for notif in notifications {
                             cx_inner.send_notification(notif)?;
                         }
 
-                        responder.respond(PromptResponse::new(stop_reason))?;
+                        let mut response = PromptResponse::new(stop_reason);
+                        if let Some(u) = prompt_usage {
+                            response = response.usage(
+                                Usage::new(u.total_tokens, u.input_tokens, u.output_tokens)
+                                    .cached_read_tokens(u.cache_read_tokens)
+                                    .cached_write_tokens(u.cache_write_tokens),
+                            );
+                        }
+                        responder.respond(response)?;
                         Ok(())
                     })?;
                     Ok(())

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1788,7 +1788,13 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         session_id: &str,
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
-    ) -> Result<runtime::acp_sdk_server::AcpStopReason, runtime::AcpError> {
+    ) -> Result<
+        (
+            runtime::acp_sdk_server::AcpStopReason,
+            Option<runtime::acp_sdk_server::PromptUsage>,
+        ),
+        runtime::AcpError,
+    > {
         self.run_prompt_impl(session_id, prompt, observer, None)
     }
 
@@ -1798,7 +1804,13 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
         prompter: &mut dyn runtime::PermissionPrompter,
-    ) -> Result<runtime::acp_sdk_server::AcpStopReason, runtime::AcpError> {
+    ) -> Result<
+        (
+            runtime::acp_sdk_server::AcpStopReason,
+            Option<runtime::acp_sdk_server::PromptUsage>,
+        ),
+        runtime::AcpError,
+    > {
         self.run_prompt_impl(session_id, prompt, observer, Some(prompter))
     }
 
@@ -2062,7 +2074,13 @@ impl AcpSdkDelegate {
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
         prompter: Option<&mut dyn runtime::PermissionPrompter>,
-    ) -> Result<runtime::acp_sdk_server::AcpStopReason, runtime::AcpError> {
+    ) -> Result<
+        (
+            runtime::acp_sdk_server::AcpStopReason,
+            Option<runtime::acp_sdk_server::PromptUsage>,
+        ),
+        runtime::AcpError,
+    > {
         let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
             runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
         })?;
@@ -2075,12 +2093,23 @@ impl AcpSdkDelegate {
             .runtime
             .run_turn(prompt, prompter, Some(observer))
             .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
+        let usage = UsageTracker::from_session(session.runtime.session()).cumulative_usage();
+        let prompt_usage = runtime::acp_sdk_server::PromptUsage {
+            input_tokens: u64::from(usage.input_tokens),
+            output_tokens: u64::from(usage.output_tokens),
+            total_tokens: u64::from(usage.total_tokens()),
+            cache_read_tokens: Some(u64::from(usage.cache_read_input_tokens)),
+            cache_write_tokens: Some(u64::from(usage.cache_creation_input_tokens)),
+        };
         session
             .runtime
             .session()
             .save_to_path(&session.handle.path)
             .map_err(|e| runtime::AcpError::internal(format!("failed to persist session: {e}")))?;
-        Ok(runtime::acp_sdk_server::AcpStopReason::EndTurn)
+        Ok((
+            runtime::acp_sdk_server::AcpStopReason::EndTurn,
+            Some(prompt_usage),
+        ))
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -396,6 +396,30 @@ async fn scenario_session_prompt_streaming(client: &mut AcpTestClient, session_i
         result.get("stopReason").is_some(),
         "prompt response should include stopReason"
     );
+
+    // The response should include token usage data.
+    let usage = result.get("usage");
+    assert!(
+        usage.is_some(),
+        "prompt response should include usage (got result: {result})"
+    );
+    let usage = usage.unwrap();
+    assert!(
+        usage.get("totalTokens").is_some(),
+        "usage should include totalTokens"
+    );
+    assert!(
+        usage["totalTokens"].as_u64().unwrap_or(0) > 0,
+        "totalTokens should be > 0"
+    );
+    assert!(
+        usage.get("inputTokens").is_some(),
+        "usage should include inputTokens"
+    );
+    assert!(
+        usage.get("outputTokens").is_some(),
+        "usage should include outputTokens"
+    );
 }
 
 async fn scenario_session_list(client: &mut AcpTestClient, expected_session_id: &str) {


### PR DESCRIPTION
## Summary
- Enable `unstable_session_usage` feature in ACP SDK dependencies
- Add `PromptUsage` struct to `SdkAcpDelegate` trait, returning cumulative token counts (input, output, total, cached read/write) after each prompt turn
- Populate `PromptResponse.usage` field so ACP clients (e.g. Sudowork) can display per-turn token consumption

## Test plan
- [x] `cargo fmt` / `cargo clippy` pass with zero warnings
- [x] `cargo test --workspace` all 30 test suites pass
- [x] ACP integration tests (`acp_stdio_integration`, `acp_ws_integration`) verify `usage` field is present with `totalTokens > 0`, `inputTokens`, `outputTokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)