### PR TITLE
feat(api): HTTP request debug capture + unified HttpTransport layer

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2359,8 +2359,8 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
- "sha2",
  "syntect",
+ "telemetry",
  "tokio",
  "tools",
 ]

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -1,3 +1,5 @@
+use telemetry::SessionTracer;
+
 use crate::error::ApiError;
 use crate::prompt_cache::{PromptCache, PromptCacheRecord, PromptCacheStats};
 use crate::providers::anthropic::{self, AnthropicClient, AuthSource};
@@ -148,6 +150,14 @@ impl ProviderClient {
             Self::OpenAi(_) => ProviderKind::OpenAi,
             Self::Codex(_) => ProviderKind::Codex,
             Self::Gemini(_) => ProviderKind::Gemini,
+        }
+    }
+
+    #[must_use]
+    pub fn with_session_tracer(self, session_tracer: SessionTracer) -> Self {
+        match self {
+            Self::Anthropic(client) => Self::Anthropic(client.with_session_tracer(session_tracer)),
+            other => other,
         }
     }
 

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -157,7 +157,10 @@ impl ProviderClient {
     pub fn with_session_tracer(self, session_tracer: SessionTracer) -> Self {
         match self {
             Self::Anthropic(client) => Self::Anthropic(client.with_session_tracer(session_tracer)),
-            other => other,
+            Self::Xai(client) => Self::Xai(client.with_session_tracer(session_tracer)),
+            Self::OpenAi(client) => Self::OpenAi(client.with_session_tracer(session_tracer)),
+            Self::Codex(client) => Self::Codex(client.with_session_tracer(session_tracer)),
+            Self::Gemini(client) => Self::Gemini(client.with_session_tracer(session_tracer)),
         }
     }
 

--- a/rust/crates/api/src/http_transport.rs
+++ b/rust/crates/api/src/http_transport.rs
@@ -1,0 +1,356 @@
+//! Unified HTTP transport layer — owns retry loop, observability, and lifecycle logging.
+//!
+//! All providers prepare `(url, headers, body)` and hand them to `HttpTransport::send_json`.
+//! Provider-specific error parsing is injected via the `check_response` callback.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::{Map, Value};
+use telemetry::{AnalyticsEvent, SessionTracer};
+
+use crate::error::ApiError;
+use crate::http_client::build_http_client_or_default;
+
+const REQUEST_ID_HEADER: &str = "request-id";
+const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+
+// ---------------------------------------------------------------------------
+// RetryPolicy
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_retries: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+impl RetryPolicy {
+    pub const DEFAULT: Self = Self {
+        max_retries: 8,
+        initial_backoff: Duration::from_secs(1),
+        max_backoff: Duration::from_secs(128),
+    };
+
+    fn backoff_for_attempt(&self, attempt: u32) -> Result<Duration, ApiError> {
+        let Some(multiplier) = 1_u32.checked_shl(attempt.saturating_sub(1)) else {
+            return Err(ApiError::BackoffOverflow {
+                attempt,
+                base_delay: self.initial_backoff,
+            });
+        };
+        Ok(self
+            .initial_backoff
+            .checked_mul(multiplier)
+            .map_or(self.max_backoff, |delay| delay.min(self.max_backoff)))
+    }
+
+    fn jittered_backoff_for_attempt(&self, attempt: u32) -> Result<Duration, ApiError> {
+        let base = self.backoff_for_attempt(attempt)?;
+        Ok(base + jitter_for_base(base))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HttpTransport
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct HttpTransport {
+    inner: reqwest::Client,
+    session_tracer: Option<SessionTracer>,
+}
+
+impl Default for HttpTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpTransport {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: build_http_client_or_default(),
+            session_tracer: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_session_tracer(mut self, session_tracer: SessionTracer) -> Self {
+        self.session_tracer = Some(session_tracer);
+        self
+    }
+
+    pub fn set_session_tracer(&mut self, session_tracer: SessionTracer) {
+        self.session_tracer = Some(session_tracer);
+    }
+
+    #[must_use]
+    pub fn session_tracer(&self) -> Option<&SessionTracer> {
+        self.session_tracer.as_ref()
+    }
+
+    /// Direct access to the inner `reqwest::Client` for OAuth token refresh
+    /// and other operations that don't go through the standard retry path.
+    #[must_use]
+    pub fn raw(&self) -> &reqwest::Client {
+        &self.inner
+    }
+
+    pub fn record_analytics(&self, event: AnalyticsEvent) {
+        if let Some(tracer) = &self.session_tracer {
+            tracer.record_analytics(event);
+        }
+    }
+
+    /// Send a JSON request with retry + full lifecycle logging.
+    ///
+    /// `check_response` is provider-specific error parsing (non-2xx → `ApiError`).
+    /// The transport uses `error.is_retryable()` to decide whether to retry.
+    pub async fn send_json<F, Fut>(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+        body: &Value,
+        retry_policy: &RetryPolicy,
+        check_response: F,
+    ) -> Result<reqwest::Response, ApiError>
+    where
+        F: Fn(reqwest::Response) -> Fut,
+        Fut: Future<Output = Result<reqwest::Response, ApiError>>,
+    {
+        let path = extract_path(url);
+        let mut attempts = 0u32;
+        let mut last_error: Option<ApiError>;
+
+        loop {
+            attempts += 1;
+
+            // Log started.
+            if let Some(tracer) = &self.session_tracer {
+                tracer.record_http_request_started(attempts, "POST", &path, Map::new());
+            }
+
+            // Log debug (every attempt — matches existing Anthropic behavior).
+            if let Some(tracer) = &self.session_tracer {
+                let masked = telemetry::mask_sensitive_headers(headers);
+                tracer.record_http_request_debug(url, "POST", masked, body.clone());
+            }
+
+            // Build and send request.
+            let send_result = {
+                let mut builder = self.inner.post(url);
+                for (name, value) in headers {
+                    builder = builder.header(name.as_str(), value.as_str());
+                }
+                builder.json(body).send().await.map_err(ApiError::from)
+            };
+
+            match send_result {
+                Ok(response) => match check_response(response).await {
+                    Ok(response) => {
+                        if let Some(tracer) = &self.session_tracer {
+                            tracer.record_http_request_succeeded(
+                                attempts,
+                                "POST",
+                                &path,
+                                response.status().as_u16(),
+                                request_id_from_headers(response.headers()),
+                                Map::new(),
+                            );
+                        }
+                        return Ok(response);
+                    }
+                    Err(error)
+                        if error.is_retryable() && attempts <= retry_policy.max_retries + 1 =>
+                    {
+                        self.record_failure(attempts, &path, &error);
+                        last_error = Some(error);
+                    }
+                    Err(error) => {
+                        self.record_failure(attempts, &path, &error);
+                        return Err(error);
+                    }
+                },
+                Err(error) if error.is_retryable() && attempts <= retry_policy.max_retries + 1 => {
+                    self.record_failure(attempts, &path, &error);
+                    last_error = Some(error);
+                }
+                Err(error) => {
+                    self.record_failure(attempts, &path, &error);
+                    return Err(error);
+                }
+            }
+
+            if attempts > retry_policy.max_retries {
+                break;
+            }
+
+            tokio::time::sleep(retry_policy.jittered_backoff_for_attempt(attempts)?).await;
+        }
+
+        Err(ApiError::RetriesExhausted {
+            attempts,
+            last_error: Box::new(last_error.expect("retry loop must capture an error")),
+        })
+    }
+
+    fn record_failure(&self, attempt: u32, path: &str, error: &ApiError) {
+        if let Some(tracer) = &self.session_tracer {
+            tracer.record_http_request_failed(
+                attempt,
+                "POST",
+                path,
+                error.to_string(),
+                error.is_retryable(),
+                Map::new(),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the URL path for logging
+/// (e.g., `"https://api.anthropic.com/v1/messages"` → `"/v1/messages"`).
+fn extract_path(url: &str) -> String {
+    if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        if let Some(slash_pos) = rest.find('/') {
+            return rest[slash_pos..].to_string();
+        }
+    }
+    url.to_string()
+}
+
+/// Extract request ID from response headers (`request-id` or `x-request-id`).
+pub fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+// ---------------------------------------------------------------------------
+// Jitter — extracted from duplicated code in anthropic.rs & openai_compat.rs
+// ---------------------------------------------------------------------------
+
+/// Process-wide counter that guarantees distinct jitter samples even when
+/// the system clock resolution is coarser than consecutive retry sleeps.
+static JITTER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Returns a random additive jitter in `[0, base]` to decorrelate retries
+/// from multiple concurrent clients. Entropy is drawn from the nanosecond
+/// wall clock mixed with a monotonic counter and run through a splitmix64
+/// finalizer; adequate for retry jitter (no cryptographic requirement).
+fn jitter_for_base(base: Duration) -> Duration {
+    let base_nanos = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+    if base_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let raw_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let tick = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut mixed = raw_nanos
+        .wrapping_add(tick)
+        .wrapping_add(0x9E37_79B9_7F4A_7C15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    mixed ^= mixed >> 31;
+    let jitter_nanos = mixed % base_nanos.saturating_add(1);
+    Duration::from_nanos(jitter_nanos)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_policy_default_has_expected_values() {
+        let policy = RetryPolicy::DEFAULT;
+        assert_eq!(policy.max_retries, 8);
+        assert_eq!(policy.initial_backoff, Duration::from_secs(1));
+        assert_eq!(policy.max_backoff, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn backoff_doubles_each_attempt_up_to_max() {
+        let policy = RetryPolicy {
+            max_retries: 10,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(128),
+        };
+        assert_eq!(
+            policy.backoff_for_attempt(1).unwrap(),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(2).unwrap(),
+            Duration::from_secs(2)
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(3).unwrap(),
+            Duration::from_secs(4)
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(8).unwrap(),
+            Duration::from_secs(128)
+        );
+        // Attempt 9 would be 256s but is clamped to max.
+        assert_eq!(
+            policy.backoff_for_attempt(9).unwrap(),
+            Duration::from_secs(128)
+        );
+    }
+
+    #[test]
+    fn jittered_backoff_is_bounded() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_secs(10),
+        };
+        for attempt in 1..=3 {
+            let base = policy.backoff_for_attempt(attempt).unwrap();
+            let jittered = policy.jittered_backoff_for_attempt(attempt).unwrap();
+            // jitter in [0, base], so jittered in [base, 2*base].
+            assert!(jittered >= base, "jittered must be >= base");
+            assert!(jittered <= base * 2, "jittered must be <= 2*base");
+        }
+    }
+
+    #[test]
+    fn extract_path_from_https_url() {
+        assert_eq!(
+            extract_path("https://api.anthropic.com/v1/messages"),
+            "/v1/messages"
+        );
+    }
+
+    #[test]
+    fn extract_path_from_http_url() {
+        assert_eq!(
+            extract_path("http://127.0.0.1:8080/v1/chat/completions"),
+            "/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn extract_path_without_scheme_returns_input() {
+        assert_eq!(extract_path("/v1/messages"), "/v1/messages");
+    }
+}

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -1,6 +1,7 @@
 mod client;
 mod error;
 mod http_client;
+mod http_transport;
 mod prompt_cache;
 mod providers;
 mod sse;
@@ -15,6 +16,7 @@ pub use error::ApiError;
 pub use http_client::{
     build_http_client, build_http_client_or_default, build_http_client_with, ProxyConfig,
 };
+pub use http_transport::{request_id_from_headers, HttpTransport, RetryPolicy};
 pub use prompt_cache::{
     CacheBreakEvent, PromptCache, PromptCacheConfig, PromptCachePaths, PromptCacheRecord,
     PromptCacheStats,

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -500,6 +500,26 @@ impl AnthropicClient {
         let mut request_body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut request_body);
         self.prepend_oauth_system_prefix(&mut request_body);
+
+        if let Some(session_tracer) = &self.session_tracer {
+            let mut headers: Vec<(String, String)> =
+                vec![("content-type".to_string(), "application/json".to_string())];
+            if let Some(api_key) = self.auth.api_key() {
+                headers.push(("x-api-key".to_string(), api_key.to_string()));
+            }
+            if let Some(token) = self.auth.bearer_token() {
+                headers.push(("authorization".to_string(), format!("Bearer {token}")));
+            }
+            headers.extend(self.request_profile.header_pairs());
+            let masked = telemetry::mask_sensitive_headers(&headers);
+            session_tracer.record_http_request_debug(
+                &request_url,
+                "POST",
+                masked,
+                request_body.clone(),
+            );
+        }
+
         let request_builder = self.build_request(&request_url).json(&request_body);
         request_builder.send().await.map_err(ApiError::from)
     }

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use runtime::format_usd;
 use runtime::{
@@ -13,7 +12,7 @@ use serde_json::{Map, Value};
 use telemetry::{AnalyticsEvent, AnthropicRequestProfile, ClientIdentity, SessionTracer};
 
 use crate::error::ApiError;
-use crate::http_client::build_http_client_or_default;
+use crate::http_transport::{request_id_from_headers, HttpTransport, RetryPolicy};
 use crate::prompt_cache::{PromptCache, PromptCacheRecord, PromptCacheStats};
 
 use super::registry::{self, model_token_limit};
@@ -22,11 +21,6 @@ use crate::sse::SseParser;
 use crate::types::{MessageDeltaEvent, MessageRequest, MessageResponse, StreamEvent, Usage};
 
 pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
-const REQUEST_ID_HEADER: &str = "request-id";
-const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
-const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(128);
-const DEFAULT_MAX_RETRIES: u32 = 8;
 const OAUTH_SYSTEM_PREFIX: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,14 +105,11 @@ impl From<OAuthTokenSet> for AuthSource {
 
 #[derive(Debug, Clone)]
 pub struct AnthropicClient {
-    http: reqwest::Client,
+    http: HttpTransport,
     auth: AuthSource,
     base_url: String,
-    max_retries: u32,
-    initial_backoff: Duration,
-    max_backoff: Duration,
+    retry_policy: RetryPolicy,
     request_profile: AnthropicRequestProfile,
-    session_tracer: Option<SessionTracer>,
     prompt_cache: Option<PromptCache>,
     last_prompt_cache_record: Arc<Mutex<Option<PromptCacheRecord>>>,
     /// When true, prepend `OAUTH_SYSTEM_PREFIX` as the first system content
@@ -131,14 +122,11 @@ impl AnthropicClient {
     #[must_use]
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            http: build_http_client_or_default(),
+            http: HttpTransport::new(),
             auth: AuthSource::ApiKey(api_key.into()),
             base_url: DEFAULT_BASE_URL.to_string(),
-            max_retries: DEFAULT_MAX_RETRIES,
-            initial_backoff: DEFAULT_INITIAL_BACKOFF,
-            max_backoff: DEFAULT_MAX_BACKOFF,
+            retry_policy: RetryPolicy::DEFAULT,
             request_profile: AnthropicRequestProfile::default(),
-            session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
             oauth_system_prefix: false,
@@ -162,14 +150,11 @@ impl AnthropicClient {
             None => is_claude_code_oauth_token(),
         };
         let mut client = Self {
-            http: build_http_client_or_default(),
+            http: HttpTransport::new(),
             auth,
             base_url: DEFAULT_BASE_URL.to_string(),
-            max_retries: DEFAULT_MAX_RETRIES,
-            initial_backoff: DEFAULT_INITIAL_BACKOFF,
-            max_backoff: DEFAULT_MAX_BACKOFF,
+            retry_policy: RetryPolicy::DEFAULT,
             request_profile: AnthropicRequestProfile::default(),
-            session_tracer: None,
             prompt_cache: None,
             last_prompt_cache_record: Arc::new(Mutex::new(None)),
             oauth_system_prefix: is_subscription,
@@ -234,15 +219,17 @@ impl AnthropicClient {
         initial_backoff: Duration,
         max_backoff: Duration,
     ) -> Self {
-        self.max_retries = max_retries;
-        self.initial_backoff = initial_backoff;
-        self.max_backoff = max_backoff;
+        self.retry_policy = RetryPolicy {
+            max_retries,
+            initial_backoff,
+            max_backoff,
+        };
         self
     }
 
     #[must_use]
     pub fn with_session_tracer(mut self, session_tracer: SessionTracer) -> Self {
-        self.session_tracer = Some(session_tracer);
+        self.http.set_session_tracer(session_tracer);
         self
     }
 
@@ -282,7 +269,7 @@ impl AnthropicClient {
 
     #[must_use]
     pub fn session_tracer(&self) -> Option<&SessionTracer> {
-        self.session_tracer.as_ref()
+        self.http.session_tracer()
     }
 
     #[must_use]
@@ -326,7 +313,7 @@ impl AnthropicClient {
 
         self.preflight_message_request(&request).await?;
 
-        let http_response = self.send_with_retry(&request).await?;
+        let http_response = self.send_request(&request).await?;
         let request_id = request_id_from_headers(http_response.headers());
         let body = http_response.text().await.map_err(ApiError::from)?;
         let mut response = serde_json::from_str::<MessageResponse>(&body).map_err(|error| {
@@ -340,28 +327,26 @@ impl AnthropicClient {
             let record = prompt_cache.record_response(&request, &response);
             self.store_last_prompt_cache_record(record);
         }
-        if let Some(session_tracer) = &self.session_tracer {
-            session_tracer.record_analytics(
-                AnalyticsEvent::new("api", "message_usage")
-                    .with_property(
-                        "request_id",
+        self.http.record_analytics(
+            AnalyticsEvent::new("api", "message_usage")
+                .with_property(
+                    "request_id",
+                    response
+                        .request_id
+                        .clone()
+                        .map_or(Value::Null, Value::String),
+                )
+                .with_property("total_tokens", Value::from(response.total_tokens()))
+                .with_property(
+                    "estimated_cost_usd",
+                    Value::String(format_usd(
                         response
-                            .request_id
-                            .clone()
-                            .map_or(Value::Null, Value::String),
-                    )
-                    .with_property("total_tokens", Value::from(response.total_tokens()))
-                    .with_property(
-                        "estimated_cost_usd",
-                        Value::String(format_usd(
-                            response
-                                .usage
-                                .estimated_cost_usd(&response.model)
-                                .total_cost_usd(),
-                        )),
-                    ),
-            );
-        }
+                            .usage
+                            .estimated_cost_usd(&response.model)
+                            .total_cost_usd(),
+                    )),
+                ),
+        );
         Ok(response)
     }
 
@@ -370,9 +355,7 @@ impl AnthropicClient {
         request: &MessageRequest,
     ) -> Result<MessageStream, ApiError> {
         self.preflight_message_request(request).await?;
-        let response = self
-            .send_with_retry(&request.clone().with_streaming())
-            .await?;
+        let response = self.send_request(&request.clone().with_streaming()).await?;
         Ok(MessageStream {
             request_id: request_id_from_headers(response.headers()),
             response,
@@ -394,6 +377,7 @@ impl AnthropicClient {
     ) -> Result<OAuthTokenSet, ApiError> {
         let response = self
             .http
+            .raw()
             .post(&config.token_url)
             .header("content-type", "application/x-www-form-urlencoded")
             .form(&request.form_params())
@@ -414,6 +398,7 @@ impl AnthropicClient {
     ) -> Result<OAuthTokenSet, ApiError> {
         let response = self
             .http
+            .raw()
             .post(&config.token_url)
             .header("content-type", "application/x-www-form-urlencoded")
             .form(&request.form_params())
@@ -427,113 +412,27 @@ impl AnthropicClient {
         })
     }
 
-    async fn send_with_retry(
-        &self,
-        request: &MessageRequest,
-    ) -> Result<reqwest::Response, ApiError> {
-        let mut attempts = 0;
-        let mut last_error: Option<ApiError>;
+    /// Build URL, headers, body and send through `HttpTransport` with retries.
+    async fn send_request(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
+        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let mut body = self.request_profile.render_json_body(request)?;
+        strip_unsupported_beta_body_fields(&mut body);
+        self.prepend_oauth_system_prefix(&mut body);
 
-        loop {
-            attempts += 1;
-            if let Some(session_tracer) = &self.session_tracer {
-                session_tracer.record_http_request_started(
-                    attempts,
-                    "POST",
-                    "/v1/messages",
-                    Map::new(),
-                );
-            }
-            match self.send_raw_request(request).await {
-                Ok(response) => match expect_success(response).await {
-                    Ok(response) => {
-                        if let Some(session_tracer) = &self.session_tracer {
-                            session_tracer.record_http_request_succeeded(
-                                attempts,
-                                "POST",
-                                "/v1/messages",
-                                response.status().as_u16(),
-                                request_id_from_headers(response.headers()),
-                                Map::new(),
-                            );
-                        }
-                        return Ok(response);
-                    }
-                    Err(error) if error.is_retryable() && attempts <= self.max_retries + 1 => {
-                        self.record_request_failure(attempts, &error);
-                        last_error = Some(error);
-                    }
-                    Err(error) => {
-                        let error = enrich_bearer_auth_error(error, &self.auth);
-                        self.record_request_failure(attempts, &error);
-                        return Err(error);
-                    }
-                },
-                Err(error) if error.is_retryable() && attempts <= self.max_retries + 1 => {
-                    self.record_request_failure(attempts, &error);
-                    last_error = Some(error);
-                }
-                Err(error) => {
-                    self.record_request_failure(attempts, &error);
-                    return Err(error);
-                }
-            }
-
-            if attempts > self.max_retries {
-                break;
-            }
-
-            tokio::time::sleep(self.jittered_backoff_for_attempt(attempts)?).await;
+        let mut headers: Vec<(String, String)> =
+            vec![("content-type".to_string(), "application/json".to_string())];
+        if let Some(api_key) = self.auth.api_key() {
+            headers.push(("x-api-key".to_string(), api_key.to_string()));
         }
-
-        Err(ApiError::RetriesExhausted {
-            attempts,
-            last_error: Box::new(last_error.expect("retry loop must capture an error")),
-        })
-    }
-
-    async fn send_raw_request(
-        &self,
-        request: &MessageRequest,
-    ) -> Result<reqwest::Response, ApiError> {
-        let request_url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
-        let mut request_body = self.request_profile.render_json_body(request)?;
-        strip_unsupported_beta_body_fields(&mut request_body);
-        self.prepend_oauth_system_prefix(&mut request_body);
-
-        if let Some(session_tracer) = &self.session_tracer {
-            let mut headers: Vec<(String, String)> =
-                vec![("content-type".to_string(), "application/json".to_string())];
-            if let Some(api_key) = self.auth.api_key() {
-                headers.push(("x-api-key".to_string(), api_key.to_string()));
-            }
-            if let Some(token) = self.auth.bearer_token() {
-                headers.push(("authorization".to_string(), format!("Bearer {token}")));
-            }
-            headers.extend(self.request_profile.header_pairs());
-            let masked = telemetry::mask_sensitive_headers(&headers);
-            session_tracer.record_http_request_debug(
-                &request_url,
-                "POST",
-                masked,
-                request_body.clone(),
-            );
+        if let Some(token) = self.auth.bearer_token() {
+            headers.push(("authorization".to_string(), format!("Bearer {token}")));
         }
+        headers.extend(self.request_profile.header_pairs());
 
-        let request_builder = self.build_request(&request_url).json(&request_body);
-        request_builder.send().await.map_err(ApiError::from)
-    }
-
-    fn build_request(&self, request_url: &str) -> reqwest::RequestBuilder {
-        let request_builder = self
-            .http
-            .post(request_url)
-            .header("content-type", "application/json");
-        let mut request_builder = self.auth.apply(request_builder);
-        for (header_name, header_value) in self.request_profile.header_pairs() {
-            request_builder = request_builder.header(header_name, header_value);
-        }
-        request_builder
+        self.http
+            .send_json(&url, &headers, &body, &self.retry_policy, expect_success)
+            .await
+            .map_err(|e| enrich_bearer_auth_error(e, &self.auth))
     }
 
     /// When `oauth_system_prefix` is set, transform the `system` field into
@@ -609,8 +508,21 @@ impl AnthropicClient {
         let mut request_body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut request_body);
         self.prepend_oauth_system_prefix(&mut request_body);
-        let response = self
-            .build_request(&request_url)
+        let mut builder = self
+            .http
+            .raw()
+            .post(&request_url)
+            .header("content-type", "application/json");
+        if let Some(api_key) = self.auth.api_key() {
+            builder = builder.header("x-api-key", api_key);
+        }
+        if let Some(token) = self.auth.bearer_token() {
+            builder = builder.bearer_auth(token);
+        }
+        for (header_name, header_value) in self.request_profile.header_pairs() {
+            builder = builder.header(header_name, header_value);
+        }
+        let response = builder
             .json(&request_body)
             .send()
             .await
@@ -624,74 +536,12 @@ impl AnthropicClient {
         Ok(parsed.input_tokens)
     }
 
-    fn record_request_failure(&self, attempt: u32, error: &ApiError) {
-        if let Some(session_tracer) = &self.session_tracer {
-            session_tracer.record_http_request_failed(
-                attempt,
-                "POST",
-                "/v1/messages",
-                error.to_string(),
-                error.is_retryable(),
-                Map::new(),
-            );
-        }
-    }
-
     fn store_last_prompt_cache_record(&self, record: PromptCacheRecord) {
         *self
             .last_prompt_cache_record
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(record);
     }
-
-    fn backoff_for_attempt(&self, attempt: u32) -> Result<Duration, ApiError> {
-        let Some(multiplier) = 1_u32.checked_shl(attempt.saturating_sub(1)) else {
-            return Err(ApiError::BackoffOverflow {
-                attempt,
-                base_delay: self.initial_backoff,
-            });
-        };
-        Ok(self
-            .initial_backoff
-            .checked_mul(multiplier)
-            .map_or(self.max_backoff, |delay| delay.min(self.max_backoff)))
-    }
-
-    fn jittered_backoff_for_attempt(&self, attempt: u32) -> Result<Duration, ApiError> {
-        let base = self.backoff_for_attempt(attempt)?;
-        Ok(base + jitter_for_base(base))
-    }
-}
-
-/// Process-wide counter that guarantees distinct jitter samples even when
-/// the system clock resolution is coarser than consecutive retry sleeps.
-static JITTER_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Returns a random additive jitter in `[0, base]` to decorrelate retries
-/// from multiple concurrent clients. Entropy is drawn from the nanosecond
-/// wall clock mixed with a monotonic counter and run through a splitmix64
-/// finalizer; adequate for retry jitter (no cryptographic requirement).
-fn jitter_for_base(base: Duration) -> Duration {
-    let base_nanos = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
-    if base_nanos == 0 {
-        return Duration::ZERO;
-    }
-    let raw_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
-        .unwrap_or(0);
-    let tick = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
-    // splitmix64 finalizer — mixes the low bits so large bases still see
-    // jitter across their full range instead of being clamped to subsec nanos.
-    let mut mixed = raw_nanos
-        .wrapping_add(tick)
-        .wrapping_add(0x9E37_79B9_7F4A_7C15);
-    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    mixed ^= mixed >> 31;
-    // Inclusive upper bound: jitter may equal `base`, matching "up to base".
-    let jitter_nanos = mixed % base_nanos.saturating_add(1);
-    Duration::from_nanos(jitter_nanos)
 }
 
 impl AuthSource {
@@ -882,9 +732,9 @@ fn load_saved_oauth_token() -> Result<Option<OAuthTokenSet>, ApiError> {
 }
 
 fn now_unix_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_secs())
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
 }
 
 fn read_env_non_empty(key: &str) -> Result<Option<String>, ApiError> {
@@ -929,14 +779,6 @@ pub fn base_url_for_mode(mode: super::AuthMode) -> String {
         super::AuthMode::Subscription => DEFAULT_BASE_URL.to_string(),
         super::AuthMode::ApiKey => read_base_url(),
     }
-}
-
-fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {
-    headers
-        .get(REQUEST_ID_HEADER)
-        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
-        .and_then(|value| value.to_str().ok())
-        .map(ToOwned::to_owned)
 }
 
 impl Provider for AnthropicClient {
@@ -1195,7 +1037,7 @@ struct AnthropicErrorBody {
 
 #[cfg(test)]
 mod tests {
-    use super::{ALT_REQUEST_ID_HEADER, REQUEST_ID_HEADER};
+    use crate::http_transport::{request_id_from_headers, RetryPolicy};
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::{Mutex, OnceLock};
@@ -1484,75 +1326,23 @@ mod tests {
 
     #[test]
     fn backoff_doubles_until_maximum() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(25),
+        };
+        // Verify with_retry_policy wires through correctly.
         let client = AnthropicClient::new("test-key").with_retry_policy(
-            3,
-            Duration::from_millis(10),
-            Duration::from_millis(25),
+            policy.max_retries,
+            policy.initial_backoff,
+            policy.max_backoff,
         );
+        assert_eq!(client.retry_policy.max_retries, 3);
         assert_eq!(
-            client.backoff_for_attempt(1).expect("attempt 1"),
+            client.retry_policy.initial_backoff,
             Duration::from_millis(10)
         );
-        assert_eq!(
-            client.backoff_for_attempt(2).expect("attempt 2"),
-            Duration::from_millis(20)
-        );
-        assert_eq!(
-            client.backoff_for_attempt(3).expect("attempt 3"),
-            Duration::from_millis(25)
-        );
-    }
-
-    #[test]
-    fn jittered_backoff_stays_within_additive_bounds_and_varies() {
-        let client = AnthropicClient::new("test-key").with_retry_policy(
-            8,
-            Duration::from_secs(1),
-            Duration::from_secs(128),
-        );
-        let mut samples = Vec::with_capacity(64);
-        for _ in 0..64 {
-            let base = client.backoff_for_attempt(3).expect("base attempt 3");
-            let jittered = client
-                .jittered_backoff_for_attempt(3)
-                .expect("jittered attempt 3");
-            assert!(
-                jittered >= base,
-                "jittered delay {jittered:?} must be at least the base {base:?}"
-            );
-            assert!(
-                jittered <= base * 2,
-                "jittered delay {jittered:?} must not exceed base*2 {:?}",
-                base * 2
-            );
-            samples.push(jittered);
-        }
-        let distinct: std::collections::HashSet<_> = samples.iter().collect();
-        assert!(
-            distinct.len() > 1,
-            "jitter should produce varied delays across samples, got {samples:?}"
-        );
-    }
-
-    #[test]
-    fn default_retry_policy_matches_exponential_schedule() {
-        let client = AnthropicClient::new("test-key");
-        assert_eq!(
-            client.backoff_for_attempt(1).expect("attempt 1"),
-            Duration::from_secs(1)
-        );
-        assert_eq!(
-            client.backoff_for_attempt(2).expect("attempt 2"),
-            Duration::from_secs(2)
-        );
-        assert_eq!(
-            client.backoff_for_attempt(3).expect("attempt 3"),
-            Duration::from_secs(4)
-        );
-        assert_eq!(
-            client.backoff_for_attempt(8).expect("attempt 8"),
-            Duration::from_secs(128)
-        );
+        assert_eq!(client.retry_policy.max_backoff, Duration::from_millis(25));
     }
 
     #[test]
@@ -1582,19 +1372,16 @@ mod tests {
     #[test]
     fn request_id_uses_primary_or_fallback_header() {
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(REQUEST_ID_HEADER, "req_primary".parse().expect("header"));
+        headers.insert("request-id", "req_primary".parse().expect("header"));
         assert_eq!(
-            super::request_id_from_headers(&headers).as_deref(),
+            request_id_from_headers(&headers).as_deref(),
             Some("req_primary")
         );
 
         headers.clear();
-        headers.insert(
-            ALT_REQUEST_ID_HEADER,
-            "req_fallback".parse().expect("header"),
-        );
+        headers.insert("x-request-id", "req_fallback".parse().expect("header"));
         assert_eq!(
-            super::request_id_from_headers(&headers).as_deref(),
+            request_id_from_headers(&headers).as_deref(),
             Some("req_fallback")
         );
     }

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::error::ApiError;
-use crate::http_client::build_http_client_or_default;
+use crate::http_transport::{HttpTransport, RetryPolicy};
 use crate::types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
     InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,
@@ -85,10 +85,11 @@ fn read_auth_file() -> Result<(String, String), ApiError> {
 
 #[derive(Debug, Clone)]
 pub struct CodexClient {
-    http: reqwest::Client,
+    http: HttpTransport,
     base_url: String,
     access_token: String,
     account_id: String,
+    retry_policy: RetryPolicy,
 }
 
 impl CodexClient {
@@ -96,24 +97,31 @@ impl CodexClient {
     #[must_use]
     pub fn new(base_url: String, access_token: String, account_id: String) -> Self {
         Self {
-            http: build_http_client_or_default(),
+            http: HttpTransport::new(),
             base_url,
             access_token,
             account_id,
+            retry_policy: RetryPolicy::DEFAULT,
         }
+    }
+
+    #[must_use]
+    pub fn with_session_tracer(mut self, session_tracer: telemetry::SessionTracer) -> Self {
+        self.http.set_session_tracer(session_tracer);
+        self
     }
 
     /// Build from `~/.codex/auth.json`.
     pub fn from_auth_file() -> Result<Self, ApiError> {
         let (access_token, account_id) = read_auth_file()?;
-        let http = build_http_client_or_default();
         let base_url =
             std::env::var("CODEX_BASE_URL").unwrap_or_else(|_| DEFAULT_CODEX_BASE_URL.to_string());
         Ok(Self {
-            http,
+            http: HttpTransport::new(),
             base_url,
             access_token,
             account_id,
+            retry_policy: RetryPolicy::DEFAULT,
         })
     }
 
@@ -141,22 +149,26 @@ impl CodexClient {
         let payload = build_codex_request(request);
         let url = format!("{}/responses", self.base_url);
 
+        let headers = vec![
+            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "authorization".to_string(),
+                format!("Bearer {}", self.access_token),
+            ),
+            ("chatgpt-account-id".to_string(), self.account_id.clone()),
+            (
+                "openai-beta".to_string(),
+                "responses=experimental".to_string(),
+            ),
+            ("originator".to_string(), "codex_cli_rs".to_string()),
+        ];
+
         let response = self
             .http
-            .post(&url)
-            .header("content-type", "application/json")
-            .header("authorization", format!("Bearer {}", self.access_token))
-            .header("chatgpt-account-id", &self.account_id)
-            .header("openai-beta", "responses=experimental")
-            .header("originator", "codex_cli_rs")
-            .json(&payload)
-            .send()
+            .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
+                check_codex_response(response)
+            })
             .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            return Err(error_from_response(status, response).await);
-        }
 
         Ok(MessageStream {
             response,
@@ -168,7 +180,11 @@ impl CodexClient {
     }
 }
 
-async fn error_from_response(status: reqwest::StatusCode, response: reqwest::Response) -> ApiError {
+async fn check_codex_response(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
     let body = response.text().await.unwrap_or_default();
     let (error_type, message) = serde_json::from_str::<Value>(&body)
         .ok()
@@ -180,7 +196,7 @@ async fn error_from_response(status: reqwest::StatusCode, response: reqwest::Res
             ))
         })
         .unwrap_or((None, None));
-    ApiError::Api {
+    Err(ApiError::Api {
         status,
         error_type,
         message,
@@ -188,7 +204,7 @@ async fn error_from_response(status: reqwest::StatusCode, response: reqwest::Res
         body,
         retryable: matches!(status.as_u16(), 429 | 500 | 502 | 503),
         suggested_action: None,
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::error::ApiError;
-use crate::http_client::build_http_client_or_default;
+use crate::http_transport::{HttpTransport, RetryPolicy};
 use crate::providers::registry::Credential;
 use crate::types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
@@ -77,7 +77,7 @@ struct RefreshTokenResponse {
 
 #[derive(Debug)]
 pub struct GeminiClient {
-    http: reqwest::Client,
+    http: HttpTransport,
     base_url: String,
     credential: Credential,
     is_subscription: bool,
@@ -85,6 +85,7 @@ pub struct GeminiClient {
     project_id: tokio::sync::Mutex<Option<String>>,
     /// Cached access token + expiry (epoch ms) after refresh.
     token_cache: tokio::sync::Mutex<Option<(String, u64)>>,
+    retry_policy: RetryPolicy,
 }
 
 impl Clone for GeminiClient {
@@ -96,6 +97,7 @@ impl Clone for GeminiClient {
             is_subscription: self.is_subscription,
             project_id: tokio::sync::Mutex::new(None),
             token_cache: tokio::sync::Mutex::new(None),
+            retry_policy: self.retry_policy.clone(),
         }
     }
 }
@@ -108,13 +110,20 @@ impl GeminiClient {
             Credential::AuthFile(_) | Credential::Token(_)
         );
         Ok(Self {
-            http: build_http_client_or_default(),
+            http: HttpTransport::new(),
             base_url: resolved.base_url.clone(),
             credential: resolved.credential.clone(),
             is_subscription,
             project_id: tokio::sync::Mutex::new(None),
             token_cache: tokio::sync::Mutex::new(None),
+            retry_policy: RetryPolicy::DEFAULT,
         })
+    }
+
+    #[must_use]
+    pub fn with_session_tracer(mut self, session_tracer: telemetry::SessionTracer) -> Self {
+        self.http.set_session_tracer(session_tracer);
+        self
     }
 
     // -----------------------------------------------------------------------
@@ -184,6 +193,7 @@ impl GeminiClient {
 
                 let resp = self
                     .http
+                    .raw()
                     .post("https://oauth2.googleapis.com/token")
                     .form(&[
                         ("grant_type", "refresh_token"),
@@ -230,6 +240,7 @@ impl GeminiClient {
         let url = format!("{}/v1internal:loadCodeAssist", self.base_url);
         let resp = self
             .http
+            .raw()
             .post(&url)
             .header("authorization", format!("Bearer {token}"))
             .header("content-type", "application/json")
@@ -308,22 +319,23 @@ impl GeminiClient {
             (url, payload)
         };
 
-        let mut req_builder = self
-            .http
-            .post(&url)
-            .header("content-type", "application/json")
-            .header("user-agent", gemini_cli_user_agent(&request.model));
-
+        let mut headers = vec![
+            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "user-agent".to_string(),
+                gemini_cli_user_agent(&request.model),
+            ),
+        ];
         if self.is_subscription {
-            req_builder = req_builder.header("authorization", format!("Bearer {token}"));
+            headers.push(("authorization".to_string(), format!("Bearer {token}")));
         }
 
-        let response = req_builder.json(&payload).send().await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            return Err(error_from_response(status, response).await);
-        }
+        let response = self
+            .http
+            .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
+                check_gemini_response(response)
+            })
+            .await?;
 
         Ok(MessageStream {
             response,
@@ -351,7 +363,11 @@ fn now_epoch_ms() -> u64 {
         .map_or(0, |d| d.as_millis() as u64)
 }
 
-async fn error_from_response(status: reqwest::StatusCode, response: reqwest::Response) -> ApiError {
+async fn check_gemini_response(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
     let body = response.text().await.unwrap_or_default();
     let (error_type, message) = serde_json::from_str::<Value>(&body)
         .ok()
@@ -363,7 +379,7 @@ async fn error_from_response(status: reqwest::StatusCode, response: reqwest::Res
             ))
         })
         .unwrap_or((None, None));
-    ApiError::Api {
+    Err(ApiError::Api {
         status,
         error_type,
         message,
@@ -371,7 +387,7 @@ async fn error_from_response(status: reqwest::StatusCode, response: reqwest::Res
         body,
         retryable: matches!(status.as_u16(), 429 | 500 | 502 | 503),
         suggested_action: None,
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -1,12 +1,11 @@
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::error::ApiError;
-use crate::http_client::build_http_client_or_default;
+use crate::http_transport::{request_id_from_headers, HttpTransport, RetryPolicy};
 use crate::types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
     InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,
@@ -20,11 +19,6 @@ use super::{Provider, ProviderFuture};
 pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
 pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 pub const DEFAULT_DASHSCOPE_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
-const REQUEST_ID_HEADER: &str = "request-id";
-const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
-const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
-const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(128);
-const DEFAULT_MAX_RETRIES: u32 = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OpenAiCompatConfig {
@@ -99,13 +93,11 @@ impl OpenAiCompatConfig {
 
 #[derive(Debug, Clone)]
 pub struct OpenAiCompatClient {
-    http: reqwest::Client,
+    http: HttpTransport,
     api_key: String,
     config: OpenAiCompatConfig,
     base_url: String,
-    max_retries: u32,
-    initial_backoff: Duration,
-    max_backoff: Duration,
+    retry_policy: RetryPolicy,
 }
 
 impl OpenAiCompatClient {
@@ -120,13 +112,11 @@ impl OpenAiCompatClient {
     #[must_use]
     pub fn new(api_key: impl Into<String>, config: OpenAiCompatConfig) -> Self {
         Self {
-            http: build_http_client_or_default(),
+            http: HttpTransport::new(),
             api_key: api_key.into(),
             config,
             base_url: read_base_url(config),
-            max_retries: DEFAULT_MAX_RETRIES,
-            initial_backoff: DEFAULT_INITIAL_BACKOFF,
-            max_backoff: DEFAULT_MAX_BACKOFF,
+            retry_policy: RetryPolicy::DEFAULT,
         }
     }
 
@@ -147,15 +137,23 @@ impl OpenAiCompatClient {
     }
 
     #[must_use]
+    pub fn with_session_tracer(mut self, session_tracer: telemetry::SessionTracer) -> Self {
+        self.http.set_session_tracer(session_tracer);
+        self
+    }
+
+    #[must_use]
     pub fn with_retry_policy(
         mut self,
         max_retries: u32,
         initial_backoff: Duration,
         max_backoff: Duration,
     ) -> Self {
-        self.max_retries = max_retries;
-        self.initial_backoff = initial_backoff;
-        self.max_backoff = max_backoff;
+        self.retry_policy = RetryPolicy {
+            max_retries,
+            initial_backoff,
+            max_backoff,
+        };
         self
     }
 
@@ -168,7 +166,7 @@ impl OpenAiCompatClient {
             ..request.clone()
         };
         preflight_message_request(&request)?;
-        let response = self.send_with_retry(&request).await?;
+        let response = self.send_request(&request).await?;
         let request_id = request_id_from_headers(response.headers());
         let body = response.text().await.map_err(ApiError::from)?;
         // Some backends return {"error":{"message":"...","type":"...","code":...}}
@@ -219,9 +217,7 @@ impl OpenAiCompatClient {
         request: &MessageRequest,
     ) -> Result<MessageStream, ApiError> {
         preflight_message_request(request)?;
-        let response = self
-            .send_with_retry(&request.clone().with_streaming())
-            .await?;
+        let response = self.send_request(&request.clone().with_streaming()).await?;
         Ok(MessageStream {
             request_id: request_id_from_headers(response.headers()),
             response,
@@ -232,79 +228,27 @@ impl OpenAiCompatClient {
         })
     }
 
-    async fn send_with_retry(
-        &self,
-        request: &MessageRequest,
-    ) -> Result<reqwest::Response, ApiError> {
-        let mut attempts = 0;
-
-        let last_error = loop {
-            attempts += 1;
-            let retryable_error = match self.send_raw_request(request).await {
-                Ok(response) => match expect_success(response).await {
-                    Ok(response) => return Ok(response),
-                    Err(error) if error.is_retryable() && attempts <= self.max_retries + 1 => error,
-                    Err(error) => return Err(error),
-                },
-                Err(error) if error.is_retryable() && attempts <= self.max_retries + 1 => error,
-                Err(error) => return Err(error),
-            };
-
-            if attempts > self.max_retries {
-                break retryable_error;
-            }
-
-            tokio::time::sleep(self.jittered_backoff_for_attempt(attempts)?).await;
-        };
-
-        Err(ApiError::RetriesExhausted {
-            attempts,
-            last_error: Box::new(last_error),
-        })
-    }
-
-    async fn send_raw_request(
-        &self,
-        request: &MessageRequest,
-    ) -> Result<reqwest::Response, ApiError> {
-        // Pre-flight check: verify request body size against provider limits
+    /// Build URL, headers, body and send through `HttpTransport` with retries.
+    async fn send_request(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
         check_request_body_size(request, self.config())?;
 
-        let request_url = chat_completions_endpoint(&self.base_url);
+        let url = chat_completions_endpoint(&self.base_url);
+        let body = build_chat_completion_request(request, self.config());
+
+        let headers = vec![
+            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "authorization".to_string(),
+                format!("Bearer {}", self.api_key),
+            ),
+        ];
+
         self.http
-            .post(&request_url)
-            .header("content-type", "application/json")
-            .bearer_auth(&self.api_key)
-            .json(&build_chat_completion_request(request, self.config()))
-            .send()
+            .send_json(&url, &headers, &body, &self.retry_policy, expect_success)
             .await
-            .map_err(ApiError::from)
-    }
-
-    fn backoff_for_attempt(&self, attempt: u32) -> Result<Duration, ApiError> {
-        let Some(multiplier) = 1_u32.checked_shl(attempt.saturating_sub(1)) else {
-            return Err(ApiError::BackoffOverflow {
-                attempt,
-                base_delay: self.initial_backoff,
-            });
-        };
-        Ok(self
-            .initial_backoff
-            .checked_mul(multiplier)
-            .map_or(self.max_backoff, |delay| delay.min(self.max_backoff)))
-    }
-
-    fn jittered_backoff_for_attempt(&self, attempt: u32) -> Result<Duration, ApiError> {
-        let base = self.backoff_for_attempt(attempt)?;
-        Ok(base + jitter_for_base(base))
     }
 }
 
-/// Process-wide counter that guarantees distinct jitter samples even when
-/// the system clock resolution is coarser than consecutive retry sleeps.
-static JITTER_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Returns a random additive jitter in `[0, base]` to decorrelate retries
 /// Deserialize a JSON field as a `Vec<T>`, treating an explicit `null` value
 /// the same as a missing field (i.e. as an empty vector).
 /// Some OpenAI-compatible providers emit `"tool_calls": null` instead of
@@ -316,29 +260,6 @@ where
     T: serde::Deserialize<'de>,
 {
     Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
-}
-
-/// from multiple concurrent clients. Entropy is drawn from the nanosecond
-/// wall clock mixed with a monotonic counter and run through a splitmix64
-/// finalizer; adequate for retry jitter (no cryptographic requirement).
-fn jitter_for_base(base: Duration) -> Duration {
-    let base_nanos = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
-    if base_nanos == 0 {
-        return Duration::ZERO;
-    }
-    let raw_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
-        .unwrap_or(0);
-    let tick = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let mut mixed = raw_nanos
-        .wrapping_add(tick)
-        .wrapping_add(0x9E37_79B9_7F4A_7C15);
-    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-    mixed ^= mixed >> 31;
-    let jitter_nanos = mixed % base_nanos.saturating_add(1);
-    Duration::from_nanos(jitter_nanos)
 }
 
 impl Provider for OpenAiCompatClient {
@@ -1360,14 +1281,6 @@ fn chat_completions_endpoint(base_url: &str) -> String {
     } else {
         format!("{trimmed}/chat/completions")
     }
-}
-
-fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {
-    headers
-        .get(REQUEST_ID_HEADER)
-        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
-        .and_then(|value| value.to_str().ok())
-        .map(ToOwned::to_owned)
 }
 
 async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -198,7 +198,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
     );
 
     let events = sink.events();
-    assert_eq!(events.len(), 6);
+    assert_eq!(events.len(), 7);
     assert!(matches!(
         &events[0],
         TelemetryEvent::HttpRequestStarted {
@@ -215,6 +215,14 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
     ));
     assert!(matches!(
         &events[2],
+        TelemetryEvent::HttpRequestDebug {
+            method,
+            url,
+            ..
+        } if method == "POST" && url.contains("/v1/messages")
+    ));
+    assert!(matches!(
+        &events[3],
         TelemetryEvent::HttpRequestSucceeded {
             request_id,
             status: 200,
@@ -222,11 +230,11 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
         } if request_id.as_deref() == Some("req_profile_123")
     ));
     assert!(matches!(
-        &events[3],
+        &events[4],
         TelemetryEvent::SessionTrace(trace) if trace.name == "http_request_succeeded"
     ));
     assert!(matches!(
-        &events[4],
+        &events[5],
         TelemetryEvent::Analytics(event)
             if event.namespace == "api"
                 && event.action == "message_usage"
@@ -235,7 +243,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
                 && event.properties.get("estimated_cost_usd") == Some(&json!("$0.0001"))
     ));
     assert!(matches!(
-        &events[5],
+        &events[6],
         TelemetryEvent::SessionTrace(trace) if trace.name == "analytics"
     ));
 }

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -22,6 +22,7 @@ pulldown-cmark = "0.13"
 rustyline = "15"
 runtime = { path = "../runtime" }
 plugins = { path = "../plugins" }
+telemetry = { path = "../telemetry" }
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
 syntect = "5"

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -61,8 +61,8 @@ impl AnthropicRuntimeClient {
         let mut client = ApiProviderClient::from_resolved(&resolved, Some(effective_mode))?
             .with_prompt_cache(PromptCache::new(session_id));
 
-        if let Some(capture_path) = &config.debug_request_capture {
-            let sink = Arc::new(JsonlTelemetrySink::new(capture_path)?);
+        if let Ok(capture_path) = std::env::var("SCODE_HTTP_DEBUG") {
+            let sink = Arc::new(JsonlTelemetrySink::new(&capture_path)?);
             let tracer = SessionTracer::new(session_id, sink);
             client = client.with_session_tracer(tracer);
         }

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -10,6 +10,7 @@ use runtime::{
     ApiClient, ApiRequest, AssistantEvent, ContentBlock, ConversationMessage, MessageRole,
     PromptCacheEvent, RuntimeError, TokenUsage,
 };
+use telemetry::{JsonlTelemetrySink, SessionTracer};
 use tools::GlobalToolRegistry;
 
 use super::format::{format_tool_call_start, format_user_visible_api_error};
@@ -57,8 +58,15 @@ impl AnthropicRuntimeClient {
             Some(effective_mode),
             sudocode_config,
         )?;
-        let client = ApiProviderClient::from_resolved(&resolved, Some(effective_mode))?
+        let mut client = ApiProviderClient::from_resolved(&resolved, Some(effective_mode))?
             .with_prompt_cache(PromptCache::new(session_id));
+
+        if let Some(capture_path) = &config.debug_request_capture {
+            let sink = Arc::new(JsonlTelemetrySink::new(capture_path)?);
+            let tracer = SessionTracer::new(session_id, sink);
+            client = client.with_session_tracer(tracer);
+        }
+
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
             client,

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -74,6 +74,10 @@ struct Cli {
     #[arg(long, global = true)]
     allow_broad_cwd: bool,
 
+    /// Capture full HTTP request debug data (URL, headers, body) to a JSONL file
+    #[arg(long, global = true)]
+    debug_request_capture: Option<PathBuf>,
+
     /// Non-interactive print mode
     #[arg(long, global = true)]
     print: bool,
@@ -272,6 +276,7 @@ pub(crate) enum CliAction {
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
         auth_mode: Option<AuthMode>,
+        debug_request_capture: Option<PathBuf>,
     },
     Doctor {
         output_format: CliOutputFormat,
@@ -311,6 +316,7 @@ pub(crate) enum CliAction {
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
         auth_mode: Option<AuthMode>,
+        debug_request_capture: Option<PathBuf>,
     },
     HelpTopic(LocalHelpTopic),
     Help {
@@ -423,6 +429,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
     };
     let allowed_tools = normalize_allowed_tools(&cli.allowed_tools)?;
     let permission_mode = permission_mode_override.unwrap_or_else(default_permission_mode);
+    let debug_request_capture = cli.debug_request_capture.clone();
 
     // --resume takes priority over subcommands
     if let Some(resume_value) = cli.resume {
@@ -483,6 +490,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                         reasoning_effort: cli.reasoning_effort,
                         allow_broad_cwd: cli.allow_broad_cwd,
                         auth_mode,
+                        debug_request_capture,
                     }),
                     SkillSlashDispatch::Local => Ok(CliAction::Skills {
                         args: joined,
@@ -529,6 +537,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                     reasoning_effort: cli.reasoning_effort,
                     allow_broad_cwd: cli.allow_broad_cwd,
                     auth_mode,
+                    debug_request_capture,
                 })
             }
         };
@@ -554,6 +563,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
             reasoning_effort: cli.reasoning_effort,
             allow_broad_cwd: cli.allow_broad_cwd,
             auth_mode,
+            debug_request_capture: debug_request_capture.clone(),
         });
     }
 
@@ -574,6 +584,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                 reasoning_effort: cli.reasoning_effort,
                 allow_broad_cwd: cli.allow_broad_cwd,
                 auth_mode,
+                debug_request_capture: debug_request_capture.clone(),
             });
         }
     }
@@ -586,6 +597,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
         reasoning_effort: cli.reasoning_effort,
         allow_broad_cwd: cli.allow_broad_cwd,
         auth_mode,
+        debug_request_capture,
     })
 }
 
@@ -625,6 +637,7 @@ fn parse_slash_command_invocation(args: &[String]) -> Result<CliAction, String> 
                     reasoning_effort: None,
                     allow_broad_cwd: false,
                     auth_mode: None,
+                    debug_request_capture: None,
                 }),
                 SkillSlashDispatch::Local => Ok(CliAction::Skills {
                     args,

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -74,10 +74,6 @@ struct Cli {
     #[arg(long, global = true)]
     allow_broad_cwd: bool,
 
-    /// Capture full HTTP request debug data (URL, headers, body) to a JSONL file
-    #[arg(long, global = true)]
-    debug_request_capture: Option<PathBuf>,
-
     /// Non-interactive print mode
     #[arg(long, global = true)]
     print: bool,
@@ -276,7 +272,6 @@ pub(crate) enum CliAction {
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
         auth_mode: Option<AuthMode>,
-        debug_request_capture: Option<PathBuf>,
     },
     Doctor {
         output_format: CliOutputFormat,
@@ -316,7 +311,6 @@ pub(crate) enum CliAction {
         reasoning_effort: Option<String>,
         allow_broad_cwd: bool,
         auth_mode: Option<AuthMode>,
-        debug_request_capture: Option<PathBuf>,
     },
     HelpTopic(LocalHelpTopic),
     Help {
@@ -429,7 +423,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
     };
     let allowed_tools = normalize_allowed_tools(&cli.allowed_tools)?;
     let permission_mode = permission_mode_override.unwrap_or_else(default_permission_mode);
-    let debug_request_capture = cli.debug_request_capture.clone();
 
     // --resume takes priority over subcommands
     if let Some(resume_value) = cli.resume {
@@ -490,7 +483,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                         reasoning_effort: cli.reasoning_effort,
                         allow_broad_cwd: cli.allow_broad_cwd,
                         auth_mode,
-                        debug_request_capture,
                     }),
                     SkillSlashDispatch::Local => Ok(CliAction::Skills {
                         args: joined,
@@ -537,7 +529,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                     reasoning_effort: cli.reasoning_effort,
                     allow_broad_cwd: cli.allow_broad_cwd,
                     auth_mode,
-                    debug_request_capture,
                 })
             }
         };
@@ -563,7 +554,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
             reasoning_effort: cli.reasoning_effort,
             allow_broad_cwd: cli.allow_broad_cwd,
             auth_mode,
-            debug_request_capture: debug_request_capture.clone(),
         });
     }
 
@@ -584,7 +574,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                 reasoning_effort: cli.reasoning_effort,
                 allow_broad_cwd: cli.allow_broad_cwd,
                 auth_mode,
-                debug_request_capture: debug_request_capture.clone(),
             });
         }
     }
@@ -597,7 +586,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
         reasoning_effort: cli.reasoning_effort,
         allow_broad_cwd: cli.allow_broad_cwd,
         auth_mode,
-        debug_request_capture,
     })
 }
 
@@ -637,7 +625,6 @@ fn parse_slash_command_invocation(args: &[String]) -> Result<CliAction, String> 
                     reasoning_effort: None,
                     allow_broad_cwd: false,
                     auth_mode: None,
-                    debug_request_capture: None,
                 }),
                 SkillSlashDispatch::Local => Ok(CliAction::Skills {
                     args,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -36,7 +36,6 @@ use api::{
     OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient, ProviderKind,
     StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
-use base64::Engine;
 
 use cli::api_client::{
     collect_prompt_cache_events, collect_tool_results, collect_tool_uses, final_assistant_text,
@@ -420,6 +419,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
             auth_mode,
+            debug_request_capture,
         } => {
             enforce_broad_cwd_policy(allow_broad_cwd, output_format)?;
             run_stale_base_preflight(base_commit.as_deref());
@@ -434,7 +434,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 None
             };
             let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
-            let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode, auth_mode)?;
+            let mut cli = LiveCli::new(
+                model,
+                true,
+                allowed_tools,
+                permission_mode,
+                auth_mode,
+                debug_request_capture,
+            )?;
             cli.set_reasoning_effort(reasoning_effort);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
         }
@@ -502,6 +509,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
             auth_mode,
+            debug_request_capture,
         } => run_repl(
             model,
             allowed_tools,
@@ -510,6 +518,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
             auth_mode,
+            debug_request_capture,
         )?,
         CliAction::HelpTopic(topic) => print_help_topic(topic),
         CliAction::Help { output_format } => print_help(output_format)?,
@@ -1260,7 +1269,7 @@ fn run_stale_base_preflight(flag_value: Option<&str>) {
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 fn run_repl(
     model: String,
     allowed_tools: Option<AllowedToolSet>,
@@ -1269,6 +1278,7 @@ fn run_repl(
     reasoning_effort: Option<String>,
     allow_broad_cwd: bool,
     auth_mode: Option<AuthMode>,
+    debug_request_capture: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     enforce_broad_cwd_policy(allow_broad_cwd, CliOutputFormat::Text)?;
     run_stale_base_preflight(base_commit.as_deref());
@@ -1279,6 +1289,7 @@ fn run_repl(
         allowed_tools,
         permission_mode,
         auth_mode,
+        debug_request_capture,
     )?;
     cli.set_reasoning_effort(reasoning_effort);
     let mut editor =
@@ -1292,10 +1303,9 @@ fn run_repl(
             .unwrap_or(80);
         let separator = format!("\x1b[2m{}\x1b[0m", "─".repeat(term_width));
         let footer = "  \x1b[2m/help · /status · Tab for /commands\x1b[0m";
-        // Print the entire input chrome block: image indicator placeholder,
-        // top sep, prompt placeholder, bottom sep, footer.  Then move the
-        // cursor back to the prompt line so read_line() renders there.
-        println!(); // image indicator (initially blank)
+        // Print the entire input chrome block: top sep, prompt placeholder,
+        // bottom sep, footer.  Then move the cursor back to the prompt line
+        // so read_line() renders there — the user sees all four elements at once.
         println!("{separator}");
         println!();
         println!("{separator}");
@@ -1304,24 +1314,18 @@ fn run_repl(
         std::io::Write::flush(&mut std::io::stdout())?;
         match editor.read_line()? {
             input::ReadOutcome::Submit(input) => {
-                // Clear pre-printed chrome (indicator + sep + prompt + sep + footer).
+                // Clear pre-printed bottom sep + footer
                 print!("\x1b[J");
+                // Replace prompt line with gray-background echo of user input
                 let trimmed = input.trim().to_string();
-                let echo_display = format!("❯ {}", trimmed.replace('\n', " "));
+                let echo_display = format!(" › {}", trimmed.replace('\n', " "));
                 let pad = term_width.saturating_sub(echo_display.chars().count());
-                print!("\x1b[3F\x1b[J"); // up 3 to indicator line, clear all below
-
-                // Print echo of user input, then any image-attach lines,
-                // then separator — all in one block.
+                print!(
+                    "\x1b[1F\x1b[2K\x1b[48;5;236m{echo_display}{}\x1b[0m",
+                    " ".repeat(pad)
+                );
                 println!();
-                print!("\x1b[48;5;236m{echo_display}{}\x1b[0m", " ".repeat(pad));
-                println!();
-                let pasted_images = editor.take_images();
-                for hash in pasted_images.keys() {
-                    println!("  \x1b[2m📎 [Image #{}] attached\x1b[0m", &hash[..12]);
-                }
-                println!();
-
+                println!("{separator}");
                 if matches!(trimmed.as_str(), "/exit" | "/quit") {
                     cli.persist_session()?;
                     break;
@@ -1361,24 +1365,8 @@ fn run_repl(
                 }
                 editor.push_history(input);
                 cli.record_prompt_history(&trimmed);
-
-                if pasted_images.is_empty() {
-                    if let Err(e) = cli.run_turn(&trimmed) {
-                        eprintln!("\x1b[31m{e}\x1b[0m");
-                    }
-                } else {
-                    let mut blocks = vec![ContentBlock::Text {
-                        text: trimmed.clone(),
-                    }];
-                    for (b64, mime) in pasted_images.values() {
-                        blocks.push(ContentBlock::Image {
-                            data: b64.clone(),
-                            mime_type: mime.clone(),
-                        });
-                    }
-                    if let Err(e) = cli.run_turn_with_blocks(blocks) {
-                        eprintln!("\x1b[31m{e}\x1b[0m");
-                    }
+                if let Err(e) = cli.run_turn(&trimmed) {
+                    eprintln!("\x1b[31m{e}\x1b[0m");
                 }
             }
             input::ReadOutcome::Exit => {
@@ -1419,6 +1407,7 @@ struct RuntimeConfig {
     progress_reporter: Option<InternalPromptProgressReporter>,
     auth_mode: AuthMode,
     sudocode_config: api::SudoCodeConfig,
+    debug_request_capture: Option<PathBuf>,
 }
 
 struct BuiltRuntime {
@@ -1568,6 +1557,7 @@ impl AcpCliAgent {
                     progress_reporter: None,
                     auth_mode,
                     sudocode_config,
+                    debug_request_capture: None,
                 }
             },
         )
@@ -1666,6 +1656,7 @@ impl AcpCliAgent {
                 progress_reporter: None,
                 auth_mode,
                 sudocode_config,
+                debug_request_capture: None,
             },
         )
         .map_err(|e| AcpError::internal(e.to_string()))?;
@@ -1963,23 +1954,12 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
             runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
         })?;
-        let registry = runtime::ImageRegistry::default_cache()
-            .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
         for (data, mime_type) in images {
-            let raw_bytes = base64::engine::general_purpose::STANDARD
-                .decode(data)
-                .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
-            let registered = registry
-                .register_bytes(&raw_bytes, mime_type)
-                .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
-            let (b64, final_mime) = registry
-                .load(&registered.hash)
-                .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
             let msg = runtime::ConversationMessage {
                 role: runtime::MessageRole::User,
                 blocks: vec![runtime::ContentBlock::Image {
-                    data: b64,
-                    mime_type: final_mime,
+                    data: data.clone(),
+                    mime_type: mime_type.clone(),
                 }],
                 usage: None,
             };
@@ -2030,6 +2010,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 progress_reporter: None,
                 auth_mode,
                 sudocode_config,
+                debug_request_capture: None,
             },
         )
         .map_err(|e| runtime::AcpError::internal(format!("failed to build runtime: {e}")))?;
@@ -2164,6 +2145,7 @@ impl LiveCli {
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
         auth_mode: Option<AuthMode>,
+        debug_request_capture: Option<PathBuf>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let system_prompt = build_system_prompt()?;
         let session_state = new_cli_session()?;
@@ -2182,6 +2164,7 @@ impl LiveCli {
             progress_reporter: None,
             auth_mode,
             sudocode_config,
+            debug_request_capture,
         };
         let runtime = build_runtime(
             session_state.with_persistence_path(session.path.clone()),
@@ -2333,15 +2316,6 @@ impl LiveCli {
     }
 
     fn run_turn(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
-        self.run_turn_with_blocks(vec![ContentBlock::Text {
-            text: input.to_string(),
-        }])
-    }
-
-    fn run_turn_with_blocks(
-        &mut self,
-        blocks: Vec<ContentBlock>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
         let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
         let mut spinner = Spinner::new();
@@ -2357,7 +2331,7 @@ impl LiveCli {
             .set_spinner_pause(pause_flag.clone());
         runtime.tool_executor_mut().set_spinner_pause(pause_flag);
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
-        let result = runtime.run_turn_with_blocks(blocks, Some(&mut permission_prompter), None);
+        let result = runtime.run_turn(input, Some(&mut permission_prompter), None);
         hook_abort_monitor.stop();
         match result {
             Ok(summary) => {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -419,7 +419,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
             auth_mode,
-            debug_request_capture,
         } => {
             enforce_broad_cwd_policy(allow_broad_cwd, output_format)?;
             run_stale_base_preflight(base_commit.as_deref());
@@ -434,14 +433,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 None
             };
             let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
-            let mut cli = LiveCli::new(
-                model,
-                true,
-                allowed_tools,
-                permission_mode,
-                auth_mode,
-                debug_request_capture,
-            )?;
+            let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode, auth_mode)?;
             cli.set_reasoning_effort(reasoning_effort);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
         }
@@ -509,7 +501,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
             auth_mode,
-            debug_request_capture,
         } => run_repl(
             model,
             allowed_tools,
@@ -518,7 +509,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             allow_broad_cwd,
             auth_mode,
-            debug_request_capture,
         )?,
         CliAction::HelpTopic(topic) => print_help_topic(topic),
         CliAction::Help { output_format } => print_help(output_format)?,
@@ -1278,7 +1268,6 @@ fn run_repl(
     reasoning_effort: Option<String>,
     allow_broad_cwd: bool,
     auth_mode: Option<AuthMode>,
-    debug_request_capture: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     enforce_broad_cwd_policy(allow_broad_cwd, CliOutputFormat::Text)?;
     run_stale_base_preflight(base_commit.as_deref());
@@ -1289,7 +1278,6 @@ fn run_repl(
         allowed_tools,
         permission_mode,
         auth_mode,
-        debug_request_capture,
     )?;
     cli.set_reasoning_effort(reasoning_effort);
     let mut editor =
@@ -1407,7 +1395,6 @@ struct RuntimeConfig {
     progress_reporter: Option<InternalPromptProgressReporter>,
     auth_mode: AuthMode,
     sudocode_config: api::SudoCodeConfig,
-    debug_request_capture: Option<PathBuf>,
 }
 
 struct BuiltRuntime {
@@ -1557,7 +1544,6 @@ impl AcpCliAgent {
                     progress_reporter: None,
                     auth_mode,
                     sudocode_config,
-                    debug_request_capture: None,
                 }
             },
         )
@@ -1656,7 +1642,6 @@ impl AcpCliAgent {
                 progress_reporter: None,
                 auth_mode,
                 sudocode_config,
-                debug_request_capture: None,
             },
         )
         .map_err(|e| AcpError::internal(e.to_string()))?;
@@ -2010,7 +1995,6 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 progress_reporter: None,
                 auth_mode,
                 sudocode_config,
-                debug_request_capture: None,
             },
         )
         .map_err(|e| runtime::AcpError::internal(format!("failed to build runtime: {e}")))?;
@@ -2145,7 +2129,6 @@ impl LiveCli {
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
         auth_mode: Option<AuthMode>,
-        debug_request_capture: Option<PathBuf>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let system_prompt = build_system_prompt()?;
         let session_state = new_cli_session()?;
@@ -2164,7 +2147,6 @@ impl LiveCli {
             progress_reporter: None,
             auth_mode,
             sudocode_config,
-            debug_request_capture,
         };
         let runtime = build_runtime(
             session_state.with_persistence_path(session.path.clone()),

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -204,6 +204,15 @@ pub enum TelemetryEvent {
         #[serde(default, skip_serializing_if = "Map::is_empty")]
         attributes: Map<String, Value>,
     },
+    HttpRequestDebug {
+        session_id: String,
+        timestamp_ms: u64,
+        url: String,
+        method: String,
+        #[serde(default, skip_serializing_if = "Map::is_empty")]
+        headers: Map<String, Value>,
+        body: Value,
+    },
     Analytics(AnalyticsEvent),
     SessionTrace(SessionTraceRecord),
 }
@@ -400,6 +409,23 @@ impl SessionTracer {
         self.record("http_request_failed", trace_attributes);
     }
 
+    pub fn record_http_request_debug(
+        &self,
+        url: impl Into<String>,
+        method: impl Into<String>,
+        headers: Map<String, Value>,
+        body: Value,
+    ) {
+        self.sink.record(TelemetryEvent::HttpRequestDebug {
+            session_id: self.session_id.clone(),
+            timestamp_ms: current_timestamp_ms(),
+            url: url.into(),
+            method: method.into(),
+            headers,
+            body,
+        });
+    }
+
     pub fn record_analytics(&self, event: AnalyticsEvent) {
         let mut attributes = event.properties.clone();
         attributes.insert(
@@ -410,6 +436,33 @@ impl SessionTracer {
         self.sink.record(TelemetryEvent::Analytics(event));
         self.record("analytics", attributes);
     }
+}
+
+/// Mask sensitive header values for debug capture logs.
+/// Authorization and x-api-key headers are redacted.
+#[must_use]
+pub fn mask_sensitive_headers(headers: &[(String, String)]) -> Map<String, Value> {
+    let mut map = Map::new();
+    for (key, value) in headers {
+        let lower = key.to_ascii_lowercase();
+        let masked = if lower == "authorization" || lower == "x-api-key" {
+            mask_credential_value(value)
+        } else {
+            value.clone()
+        };
+        map.insert(key.clone(), Value::String(masked));
+    }
+    map
+}
+
+fn mask_credential_value(value: &str) -> String {
+    let trimmed = value.trim();
+    if let Some(token) = trimmed.strip_prefix("Bearer ") {
+        let visible = &token[..token.len().min(10)];
+        return format!("Bearer {visible}... (hidden)");
+    }
+    let visible = &trimmed[..trimmed.len().min(10)];
+    format!("{visible}... (hidden)")
 }
 
 fn merge_trace_fields(


### PR DESCRIPTION
## Summary
- **`SCODE_HTTP_DEBUG` env var** — set to a file path to capture full HTTP request debug data (URL, headers, body) as JSONL. Auth headers are automatically masked.
- **Unified `HttpTransport` layer** — consolidates duplicated retry logic, backoff/jitter, and session tracer plumbing from 4 providers into a single transport that owns the full request lifecycle.
- Codex and Gemini providers now gain automatic retry with exponential backoff (previously had no retry support).

```bash
SCODE_HTTP_DEBUG=/tmp/out.jsonl scode prompt "hello"
```

Closes #53

## Test plan
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass
- [x] E2E verified with Claude, Codex (GPT), and Gemini — all produce valid JSONL with masked auth headers and lifecycle events (started → debug → succeeded)
- [x] Existing retry/backoff integration tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)