### PR TITLE
refactor(runtime): async ApiClient with stream-based cancellation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2241,6 +2241,7 @@ dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "agent-client-protocol-tokio",
+ "async-trait",
  "axum",
  "base64",
  "futures",
@@ -2346,12 +2347,14 @@ version = "0.1.1"
 dependencies = [
  "api",
  "arboard",
+ "async-trait",
  "base64",
  "clap",
  "commands",
  "compat-harness",
  "crossterm",
  "dialoguer",
+ "futures",
  "futures-util",
  "mock-anthropic-service",
  "plugins",
@@ -2965,8 +2968,10 @@ name = "tools"
 version = "0.1.1"
 dependencies = [
  "api",
+ "async-trait",
  "commands",
  "flate2",
+ "futures",
  "plugins",
  "reqwest",
  "runtime",

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 agent-client-protocol = { workspace = true }
 agent-client-protocol-schema = { workspace = true }
 agent-client-protocol-tokio = { workspace = true }
+async-trait = "0.1"
 axum = { workspace = true }
 base64 = "0.22"
 futures = "0.3"

--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -99,8 +99,17 @@ pub fn execute_bash(input: BashCommandInput) -> io::Result<BashCommandOutput> {
         });
     }
 
-    let runtime = Builder::new_current_thread().enable_all().build()?;
-    runtime.block_on(execute_bash_async(input, sandbox_status, cwd))
+    // If we are already inside a tokio runtime (e.g. when run_turn is
+    // driven by an outer block_on), use the current handle instead of
+    // creating a nested runtime which would panic.
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| {
+            handle.block_on(execute_bash_async(input, sandbox_status, cwd))
+        })
+    } else {
+        let runtime = Builder::new_current_thread().enable_all().build()?;
+        runtime.block_on(execute_bash_async(input, sandbox_status, cwd))
+    }
 }
 
 /// Detect git push to main and emit ship provenance event

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -390,10 +390,13 @@ where
         }
 
         self.record_turn_started(&label);
-        let session_len_before_turn = self.session.messages.len();
         self.session
             .push_user_blocks(blocks)
             .map_err(|error| RuntimeError::new(error.to_string()))?;
+        // The user message is now part of the session. On cancellation we
+        // keep it but discard any assistant / tool-result messages that
+        // were added during this turn's iterations.
+        let session_len_after_user = self.session.messages.len();
 
         let mut assistant_messages = Vec::new();
         let mut tool_results = Vec::new();
@@ -402,9 +405,9 @@ where
 
         loop {
             if self.hook_abort_signal.is_aborted() {
-                // Roll back the session to discard the cancelled turn so the
-                // next prompt does not inherit orphaned messages.
-                self.session.messages.truncate(session_len_before_turn);
+                // Keep the user prompt but discard incomplete assistant /
+                // tool-result messages from the cancelled iterations.
+                self.session.messages.truncate(session_len_after_user);
                 return Err(RuntimeError::new("turn cancelled by abort signal"));
             }
 
@@ -441,10 +444,9 @@ where
                             // Drop the stream to close the HTTP connection
                             // and stop token consumption.
                             drop(stream);
-                            // Roll back the session to discard the cancelled
-                            // turn so the next prompt does not inherit
-                            // orphaned messages.
-                            self.session.messages.truncate(session_len_before_turn);
+                            // Keep the user prompt but discard incomplete
+                            // assistant / tool-result messages.
+                            self.session.messages.truncate(session_len_after_user);
                             return Err(RuntimeError::new(
                                 "turn cancelled by abort signal",
                             ));

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -144,7 +144,8 @@ impl Display for RuntimeError {
 
 impl std::error::Error for RuntimeError {}
 
-/// Summary of one completed runtime turn, including tool results and usage.
+/// Summary of one completed (or cancelled) runtime turn, including tool
+/// results and usage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TurnSummary {
     pub assistant_messages: Vec<ConversationMessage>,
@@ -153,6 +154,11 @@ pub struct TurnSummary {
     pub iterations: usize,
     pub usage: TokenUsage,
     pub auto_compaction: Option<AutoCompactionEvent>,
+    /// `true` when the turn was interrupted by the abort signal.  Partial
+    /// progress (user message, streamed assistant text, synthetic tool
+    /// results, interruption marker) has already been committed to the
+    /// session so the model has full context on the next turn.
+    pub cancelled: bool,
 }
 
 /// Details about automatic session compaction applied during a turn.
@@ -484,7 +490,15 @@ where
         loop {
             if self.hook_abort_signal.is_aborted() {
                 self.finalize_cancelled_turn(Vec::new());
-                return Err(RuntimeError::new("turn cancelled by abort signal"));
+                return Ok(TurnSummary {
+                    assistant_messages: Vec::new(),
+                    tool_results: Vec::new(),
+                    prompt_cache_events: Vec::new(),
+                    iterations,
+                    usage: self.usage_tracker.cumulative_usage(),
+                    auto_compaction: None,
+                    cancelled: true,
+                });
             }
 
             iterations += 1;
@@ -521,9 +535,15 @@ where
                             // and stop token consumption.
                             drop(stream);
                             self.finalize_cancelled_turn(collected);
-                            return Err(RuntimeError::new(
-                                "turn cancelled by abort signal",
-                            ));
+                            return Ok(TurnSummary {
+                                assistant_messages: Vec::new(),
+                                tool_results: Vec::new(),
+                                prompt_cache_events: Vec::new(),
+                                iterations,
+                                usage: self.usage_tracker.cumulative_usage(),
+                                auto_compaction: None,
+                                cancelled: true,
+                            });
                         }
                         next = stream.next() => {
                             match next {
@@ -689,6 +709,7 @@ where
             iterations,
             usage: self.usage_tracker.cumulative_usage(),
             auto_compaction,
+            cancelled: false,
         };
         self.record_turn_completed(&summary);
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -23,6 +23,11 @@ use crate::usage::{TokenUsage, UsageTracker};
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 100_000;
 const AUTO_COMPACTION_THRESHOLD_ENV_VAR: &str = "CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS";
 
+/// Message appended to the conversation when a turn is interrupted by the
+/// user.  This tells the model that the previous response was cut short.
+const INTERRUPT_MESSAGE: &str = "User interrupted the response. \
+    You may continue where you left off or start a new approach.";
+
 /// Fully assembled request payload sent to the upstream model client.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiRequest {
@@ -344,6 +349,83 @@ where
         }
     }
 
+    /// Preserve partial progress when a turn is cancelled.
+    ///
+    /// 1. Build an assistant message from whatever events were collected
+    ///    before the abort signal fired and push it to the session.
+    /// 2. For every `tool_use` block in that partial message, generate a
+    ///    synthetic `tool_result` with `is_error: true` so the API contract
+    ///    (every `tool_use` must have a matching `tool_result`) is maintained.
+    /// 3. Append a user interruption message so the model knows the previous
+    ///    response was cut short.
+    fn finalize_cancelled_turn(&mut self, events: Vec<AssistantEvent>) {
+        // Build partial assistant message from whatever events arrived.
+        let mut text = String::new();
+        let mut blocks = Vec::new();
+        for event in events {
+            match event {
+                AssistantEvent::TextDelta(delta) => text.push_str(&delta),
+                AssistantEvent::ToolUse {
+                    id,
+                    name,
+                    input,
+                    thought_signature,
+                } => {
+                    flush_text_block(&mut text, &mut blocks);
+                    blocks.push(ContentBlock::ToolUse {
+                        id,
+                        name,
+                        input,
+                        thought_signature,
+                    });
+                }
+                AssistantEvent::Usage(_)
+                | AssistantEvent::PromptCache(_)
+                | AssistantEvent::MessageStop => {}
+            }
+        }
+        flush_text_block(&mut text, &mut blocks);
+
+        if blocks.is_empty() {
+            // No content was streamed — nothing to preserve except the
+            // interruption marker.
+            let _ = self
+                .session
+                .push_message(ConversationMessage::user_text(INTERRUPT_MESSAGE));
+            return;
+        }
+
+        // Extract tool_use ids before pushing the assistant message.
+        let pending_tool_ids: Vec<(String, String)> = blocks
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::ToolUse { id, name, .. } => Some((id.clone(), name.clone())),
+                _ => None,
+            })
+            .collect();
+
+        // Push the partial assistant message.
+        let _ = self
+            .session
+            .push_message(ConversationMessage::assistant(blocks));
+
+        // Generate synthetic error tool_results for any tool_use blocks
+        // that never got real results.
+        for (tool_use_id, tool_name) in pending_tool_ids {
+            let _ = self.session.push_message(ConversationMessage::tool_result(
+                tool_use_id,
+                tool_name,
+                "Interrupted by user",
+                true,
+            ));
+        }
+
+        // Tell the model the response was interrupted.
+        let _ = self
+            .session
+            .push_message(ConversationMessage::user_text(INTERRUPT_MESSAGE));
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run_turn(
         &mut self,
@@ -393,10 +475,6 @@ where
         self.session
             .push_user_blocks(blocks)
             .map_err(|error| RuntimeError::new(error.to_string()))?;
-        // The user message is now part of the session. On cancellation we
-        // keep it but discard any assistant / tool-result messages that
-        // were added during this turn's iterations.
-        let session_len_after_user = self.session.messages.len();
 
         let mut assistant_messages = Vec::new();
         let mut tool_results = Vec::new();
@@ -405,9 +483,7 @@ where
 
         loop {
             if self.hook_abort_signal.is_aborted() {
-                // Keep the user prompt but discard incomplete assistant /
-                // tool-result messages from the cancelled iterations.
-                self.session.messages.truncate(session_len_after_user);
+                self.finalize_cancelled_turn(Vec::new());
                 return Err(RuntimeError::new("turn cancelled by abort signal"));
             }
 
@@ -444,9 +520,7 @@ where
                             // Drop the stream to close the HTTP connection
                             // and stop token consumption.
                             drop(stream);
-                            // Keep the user prompt but discard incomplete
-                            // assistant / tool-result messages.
-                            self.session.messages.truncate(session_len_after_user);
+                            self.finalize_cancelled_turn(collected);
                             return Err(RuntimeError::new(
                                 "turn cancelled by abort signal",
                             ));

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -390,6 +390,7 @@ where
         }
 
         self.record_turn_started(&label);
+        let session_len_before_turn = self.session.messages.len();
         self.session
             .push_user_blocks(blocks)
             .map_err(|error| RuntimeError::new(error.to_string()))?;
@@ -401,6 +402,9 @@ where
 
         loop {
             if self.hook_abort_signal.is_aborted() {
+                // Roll back the session to discard the cancelled turn so the
+                // next prompt does not inherit orphaned messages.
+                self.session.messages.truncate(session_len_before_turn);
                 return Err(RuntimeError::new("turn cancelled by abort signal"));
             }
 
@@ -437,6 +441,10 @@ where
                             // Drop the stream to close the HTTP connection
                             // and stop token consumption.
                             drop(stream);
+                            // Roll back the session to discard the cancelled
+                            // turn so the next prompt does not inherit
+                            // orphaned messages.
+                            self.session.messages.truncate(session_len_before_turn);
                             return Err(RuntimeError::new(
                                 "turn cancelled by abort signal",
                             ));

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -362,8 +362,13 @@ where
     /// 2. For every `tool_use` block in that partial message, generate a
     ///    synthetic `tool_result` with `is_error: true` so the API contract
     ///    (every `tool_use` must have a matching `tool_result`) is maintained.
-    /// 3. Append a user interruption message so the model knows the previous
-    ///    response was cut short.
+    ///    The error message includes a continuation hint so the model knows
+    ///    the response was cut short.
+    ///
+    /// No separate user interruption message is added — the synthetic tool
+    /// results already convey the cancellation.  Adding an extra user
+    /// message would confuse the model into attributing the interruption to
+    /// the *next* user turn instead of the cancelled one.
     fn finalize_cancelled_turn(&mut self, events: Vec<AssistantEvent>) {
         // Build partial assistant message from whatever events arrived.
         let mut text = String::new();
@@ -393,11 +398,7 @@ where
         flush_text_block(&mut text, &mut blocks);
 
         if blocks.is_empty() {
-            // No content was streamed — nothing to preserve except the
-            // interruption marker.
-            let _ = self
-                .session
-                .push_message(ConversationMessage::user_text(INTERRUPT_MESSAGE));
+            // No content was streamed — nothing to preserve.
             return;
         }
 
@@ -421,15 +422,10 @@ where
             let _ = self.session.push_message(ConversationMessage::tool_result(
                 tool_use_id,
                 tool_name,
-                "Interrupted by user",
+                INTERRUPT_MESSAGE,
                 true,
             ));
         }
-
-        // Tell the model the response was interrupted.
-        let _ = self
-            .session
-            .push_message(ConversationMessage::user_text(INTERRUPT_MESSAGE));
     }
 
     #[allow(clippy::too_many_lines)]

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -395,7 +395,7 @@ where
         // assistant turn (not a separate user message) so attribution is
         // correct.
         blocks.push(ContentBlock::Text {
-            text: "\n\n[Interrupted · What should Sudo Code do instead?]".to_string(),
+            text: format!("\n\n[{INTERRUPT_MESSAGE}]"),
         });
 
         // Extract tool_use ids before pushing the assistant message.

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -23,10 +23,8 @@ use crate::usage::{TokenUsage, UsageTracker};
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 100_000;
 const AUTO_COMPACTION_THRESHOLD_ENV_VAR: &str = "CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS";
 
-/// Message appended to the conversation when a turn is interrupted by the
-/// user.  This tells the model that the previous response was cut short.
-const INTERRUPT_MESSAGE: &str = "User interrupted the response. \
-    You may continue where you left off or start a new approach.";
+/// Message used in synthetic tool results when a turn is interrupted.
+const INTERRUPT_MESSAGE: &str = "Interrupted · What should Sudo Code do instead?";
 
 /// Fully assembled request payload sent to the upstream model client.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -358,17 +356,12 @@ where
     /// Preserve partial progress when a turn is cancelled.
     ///
     /// 1. Build an assistant message from whatever events were collected
-    ///    before the abort signal fired and push it to the session.
-    /// 2. For every `tool_use` block in that partial message, generate a
+    ///    before the abort signal fired.  An `[interrupted]` text block is
+    ///    appended so the model can see which turn was cancelled.
+    /// 2. Push the partial assistant message to the session.
+    /// 3. For every `tool_use` block in that partial message, generate a
     ///    synthetic `tool_result` with `is_error: true` so the API contract
     ///    (every `tool_use` must have a matching `tool_result`) is maintained.
-    ///    The error message includes a continuation hint so the model knows
-    ///    the response was cut short.
-    ///
-    /// No separate user interruption message is added — the synthetic tool
-    /// results already convey the cancellation.  Adding an extra user
-    /// message would confuse the model into attributing the interruption to
-    /// the *next* user turn instead of the cancelled one.
     fn finalize_cancelled_turn(&mut self, events: Vec<AssistantEvent>) {
         // Build partial assistant message from whatever events arrived.
         let mut text = String::new();
@@ -397,10 +390,13 @@ where
         }
         flush_text_block(&mut text, &mut blocks);
 
-        if blocks.is_empty() {
-            // No content was streamed — nothing to preserve.
-            return;
-        }
+        // Append an [interrupted] marker to the assistant message so the
+        // model knows this turn was cancelled.  This stays attached to the
+        // assistant turn (not a separate user message) so attribution is
+        // correct.
+        blocks.push(ContentBlock::Text {
+            text: "\n\n[Interrupted · What should Sudo Code do instead?]".to_string(),
+        });
 
         // Extract tool_use ids before pushing the assistant message.
         let pending_tool_ids: Vec<(String, String)> = blocks

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
+use std::pin::Pin;
 
+use async_trait::async_trait;
+use futures::stream::Stream;
+use futures::StreamExt;
 use serde_json::{Map, Value};
 use telemetry::SessionTracer;
 
@@ -51,9 +55,21 @@ pub struct PromptCacheEvent {
     pub token_drop: u32,
 }
 
+/// A boxed asynchronous stream of assistant events, produced by [`ApiClient::stream`].
+///
+/// Dropping the stream cancels the underlying HTTP request, ensuring unused
+/// tokens are not consumed when a turn is aborted.
+pub type AssistantEventStream =
+    Pin<Box<dyn Stream<Item = Result<AssistantEvent, RuntimeError>> + Send>>;
+
 /// Minimal streaming API contract required by [`ConversationRuntime`].
+///
+/// Implementations return an asynchronous stream of events instead of a
+/// collected `Vec`, enabling the runtime to race each event against an
+/// abort signal for instant cancellation.
+#[async_trait]
 pub trait ApiClient: Send {
-    fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError>;
+    async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError>;
 }
 
 /// Optional observer for runtime events emitted while processing a turn.
@@ -329,7 +345,7 @@ where
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn run_turn(
+    pub async fn run_turn(
         &mut self,
         user_input: impl Into<String>,
         prompter: Option<&mut dyn PermissionPrompter>,
@@ -337,13 +353,19 @@ where
     ) -> Result<TurnSummary, RuntimeError> {
         let text = user_input.into();
         self.run_turn_with_blocks(vec![ContentBlock::Text { text }], prompter, observer)
+            .await
     }
 
     /// Run a conversation turn with pre-built content blocks (e.g. text +
     /// image).  [`run_turn`](Self::run_turn) is a convenience wrapper that
     /// creates a single `Text` block and delegates here.
+    ///
+    /// The stream returned by the API client is consumed event-by-event using
+    /// [`tokio::select!`], racing each event against the hook abort signal.
+    /// When cancellation fires the stream is dropped immediately, which closes
+    /// the underlying HTTP connection and stops token consumption.
     #[allow(clippy::too_many_lines)]
-    pub fn run_turn_with_blocks(
+    pub async fn run_turn_with_blocks(
         &mut self,
         blocks: Vec<ContentBlock>,
         mut prompter: Option<&mut dyn PermissionPrompter>,
@@ -395,13 +417,45 @@ where
                 system_prompt: self.system_prompt.clone(),
                 messages: self.session.messages.clone(),
             };
-            let events = match self.api_client.stream(request) {
-                Ok(events) => events,
+            let mut stream = match self.api_client.stream(request).await {
+                Ok(stream) => stream,
                 Err(error) => {
                     self.record_turn_failed(iterations, &error);
                     return Err(error);
                 }
             };
+
+            // Consume the stream event-by-event, racing against the abort
+            // signal so cancellation drops the HTTP connection immediately.
+            let events = {
+                let abort = &self.hook_abort_signal;
+                let mut collected = Vec::new();
+                loop {
+                    tokio::select! {
+                        biased;
+                        () = abort.cancelled() => {
+                            // Drop the stream to close the HTTP connection
+                            // and stop token consumption.
+                            drop(stream);
+                            return Err(RuntimeError::new(
+                                "turn cancelled by abort signal",
+                            ));
+                        }
+                        next = stream.next() => {
+                            match next {
+                                Some(Ok(event)) => collected.push(event),
+                                Some(Err(error)) => {
+                                    self.record_turn_failed(iterations, &error);
+                                    return Err(error);
+                                }
+                                None => break,
+                            }
+                        }
+                    }
+                }
+                collected
+            };
+
             let (assistant_message, usage, turn_prompt_cache_events) =
                 match build_assistant_message(events, runtime_observer_mut(&mut observer)) {
                     Ok(result) => result,
@@ -927,8 +981,8 @@ impl ToolExecutor for StaticToolExecutor {
 mod tests {
     use super::{
         build_assistant_message, parse_auto_compaction_threshold, ApiClient, ApiRequest,
-        AssistantEvent, AutoCompactionEvent, ConversationRuntime, PromptCacheEvent, RuntimeError,
-        RuntimeObserver, StaticToolExecutor, ToolExecutor,
+        AssistantEvent, AssistantEventStream, AutoCompactionEvent, ConversationRuntime,
+        PromptCacheEvent, RuntimeError, RuntimeObserver, StaticToolExecutor, ToolExecutor,
         DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
     };
     use crate::compact::CompactionConfig;
@@ -941,18 +995,28 @@ mod tests {
     use crate::session::{ContentBlock, MessageRole, Session};
     use crate::usage::TokenUsage;
     use crate::ToolError;
+    use async_trait::async_trait;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
     use telemetry::{MemoryTelemetrySink, SessionTracer, TelemetryEvent};
 
+    /// Helper: convert a `Vec<AssistantEvent>` into an [`AssistantEventStream`].
+    fn events_to_stream(events: Vec<AssistantEvent>) -> AssistantEventStream {
+        Box::pin(futures::stream::iter(events.into_iter().map(Ok)))
+    }
+
     struct ScriptedApiClient {
         call_count: usize,
     }
 
+    #[async_trait]
     impl ApiClient for ScriptedApiClient {
-        fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+        async fn stream(
+            &mut self,
+            request: ApiRequest,
+        ) -> Result<AssistantEventStream, RuntimeError> {
             self.call_count += 1;
             match self.call_count {
                 1 => {
@@ -960,7 +1024,7 @@ mod tests {
                         .messages
                         .iter()
                         .any(|message| message.role == MessageRole::User));
-                    Ok(vec![
+                    Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("Let me calculate that.".to_string()),
                         AssistantEvent::ToolUse {
                             id: "tool-1".to_string(),
@@ -975,7 +1039,7 @@ mod tests {
                             cache_read_input_tokens: 2,
                         }),
                         AssistantEvent::MessageStop,
-                    ])
+                    ]))
                 }
                 2 => {
                     let last_message = request
@@ -983,7 +1047,7 @@ mod tests {
                         .last()
                         .expect("tool result should be present");
                     assert_eq!(last_message.role, MessageRole::Tool);
-                    Ok(vec![
+                    Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("The answer is 4.".to_string()),
                         AssistantEvent::Usage(TokenUsage {
                             input_tokens: 24,
@@ -1001,7 +1065,7 @@ mod tests {
                             token_drop: 5_000,
                         }),
                         AssistantEvent::MessageStop,
-                    ])
+                    ]))
                 }
                 _ => unreachable!("extra API call"),
             }
@@ -1068,8 +1132,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn runs_user_to_tool_to_result_loop_end_to_end_and_tracks_usage() {
+    #[tokio::test]
+    async fn runs_user_to_tool_to_result_loop_end_to_end_and_tracks_usage() {
         let api_client = ScriptedApiClient { call_count: 0 };
         let tool_executor = StaticToolExecutor::new().register("add", |input| {
             let total = input
@@ -1100,6 +1164,7 @@ mod tests {
 
         let summary = runtime
             .run_turn("what is 2 + 2?", Some(&mut PromptAllowOnce), None)
+            .await
             .expect("conversation loop should succeed");
 
         assert_eq!(summary.iterations, 2);
@@ -1122,8 +1187,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn records_runtime_session_trace_events() {
+    #[tokio::test]
+    async fn records_runtime_session_trace_events() {
         let sink = Arc::new(MemoryTelemetrySink::default());
         let tracer = SessionTracer::new("session-runtime", sink.clone());
         let mut runtime = ConversationRuntime::new(
@@ -1137,6 +1202,7 @@ mod tests {
 
         runtime
             .run_turn("what is 2 + 2?", Some(&mut PromptAllowOnce), None)
+            .await
             .expect("conversation loop should succeed");
 
         let events = sink.events();
@@ -1155,8 +1221,8 @@ mod tests {
         assert!(trace_names.contains(&"turn_completed"));
     }
 
-    #[test]
-    fn records_denied_tool_results_when_prompt_rejects() {
+    #[tokio::test]
+    async fn records_denied_tool_results_when_prompt_rejects() {
         struct RejectPrompter;
         impl PermissionPrompter for RejectPrompter {
             fn decide(&mut self, _request: &PermissionRequest) -> PermissionPromptDecision {
@@ -1167,19 +1233,23 @@ mod tests {
         }
 
         struct SingleCallApiClient;
+        #[async_trait]
         impl ApiClient for SingleCallApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 if request
                     .messages
                     .iter()
                     .any(|message| message.role == MessageRole::Tool)
                 {
-                    return Ok(vec![
+                    return Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("I could not use the tool.".to_string()),
                         AssistantEvent::MessageStop,
-                    ]);
+                    ]));
                 }
-                Ok(vec![
+                Ok(events_to_stream(vec![
                     AssistantEvent::ToolUse {
                         id: "tool-1".to_string(),
                         name: "blocked".to_string(),
@@ -1187,7 +1257,7 @@ mod tests {
                         thought_signature: None,
                     },
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1201,6 +1271,7 @@ mod tests {
 
         let summary = runtime
             .run_turn("use the tool", Some(&mut RejectPrompter), None)
+            .await
             .expect("conversation should continue after denied tool");
 
         assert_eq!(summary.tool_results.len(), 1);
@@ -1210,22 +1281,26 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn denies_tool_use_when_pre_tool_hook_blocks() {
+    #[tokio::test]
+    async fn denies_tool_use_when_pre_tool_hook_blocks() {
         struct SingleCallApiClient;
+        #[async_trait]
         impl ApiClient for SingleCallApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 if request
                     .messages
                     .iter()
                     .any(|message| message.role == MessageRole::Tool)
                 {
-                    return Ok(vec![
+                    return Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("blocked".to_string()),
                         AssistantEvent::MessageStop,
-                    ]);
+                    ]));
                 }
-                Ok(vec![
+                Ok(events_to_stream(vec![
                     AssistantEvent::ToolUse {
                         id: "tool-1".to_string(),
                         name: "blocked".to_string(),
@@ -1233,7 +1308,7 @@ mod tests {
                         thought_signature: None,
                     },
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1254,6 +1329,7 @@ mod tests {
 
         let summary = runtime
             .run_turn("use the tool", None, None)
+            .await
             .expect("conversation should continue after hook denial");
 
         assert_eq!(summary.tool_results.len(), 1);
@@ -1273,22 +1349,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn denies_tool_use_when_pre_tool_hook_fails() {
+    #[tokio::test]
+    async fn denies_tool_use_when_pre_tool_hook_fails() {
         struct SingleCallApiClient;
+        #[async_trait]
         impl ApiClient for SingleCallApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 if request
                     .messages
                     .iter()
                     .any(|message| message.role == MessageRole::Tool)
                 {
-                    return Ok(vec![
+                    return Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("failed".to_string()),
                         AssistantEvent::MessageStop,
-                    ]);
+                    ]));
                 }
-                Ok(vec![
+                Ok(events_to_stream(vec![
                     AssistantEvent::ToolUse {
                         id: "tool-1".to_string(),
                         name: "blocked".to_string(),
@@ -1296,7 +1376,7 @@ mod tests {
                         thought_signature: None,
                     },
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1319,6 +1399,7 @@ mod tests {
         // when
         let summary = runtime
             .run_turn("use the tool", None, None)
+            .await
             .expect("conversation should continue after hook failure");
 
         // then
@@ -1339,17 +1420,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn appends_post_tool_hook_feedback_to_tool_result() {
+    #[tokio::test]
+    async fn appends_post_tool_hook_feedback_to_tool_result() {
         struct TwoCallApiClient {
             calls: usize,
         }
 
+        #[async_trait]
         impl ApiClient for TwoCallApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 self.calls += 1;
                 match self.calls {
-                    1 => Ok(vec![
+                    1 => Ok(events_to_stream(vec![
                         AssistantEvent::ToolUse {
                             id: "tool-1".to_string(),
                             name: "add".to_string(),
@@ -1357,16 +1442,16 @@ mod tests {
                             thought_signature: None,
                         },
                         AssistantEvent::MessageStop,
-                    ]),
+                    ])),
                     2 => {
                         assert!(request
                             .messages
                             .iter()
                             .any(|message| message.role == MessageRole::Tool));
-                        Ok(vec![
+                        Ok(events_to_stream(vec![
                             AssistantEvent::TextDelta("done".to_string()),
                             AssistantEvent::MessageStop,
-                        ])
+                        ]))
                     }
                     _ => unreachable!("extra API call"),
                 }
@@ -1388,6 +1473,7 @@ mod tests {
 
         let summary = runtime
             .run_turn("use add", None, None)
+            .await
             .expect("tool loop succeeds");
 
         assert_eq!(summary.tool_results.len(), 1);
@@ -1415,17 +1501,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn appends_post_tool_use_failure_hook_feedback_to_tool_result() {
+    #[tokio::test]
+    async fn appends_post_tool_use_failure_hook_feedback_to_tool_result() {
         struct TwoCallApiClient {
             calls: usize,
         }
 
+        #[async_trait]
         impl ApiClient for TwoCallApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 self.calls += 1;
                 match self.calls {
-                    1 => Ok(vec![
+                    1 => Ok(events_to_stream(vec![
                         AssistantEvent::ToolUse {
                             id: "tool-1".to_string(),
                             name: "fail".to_string(),
@@ -1433,16 +1523,16 @@ mod tests {
                             thought_signature: None,
                         },
                         AssistantEvent::MessageStop,
-                    ]),
+                    ])),
                     2 => {
                         assert!(request
                             .messages
                             .iter()
                             .any(|message| message.role == MessageRole::Tool));
-                        Ok(vec![
+                        Ok(events_to_stream(vec![
                             AssistantEvent::TextDelta("done".to_string()),
                             AssistantEvent::MessageStop,
-                        ])
+                        ]))
                     }
                     _ => unreachable!("extra API call"),
                 }
@@ -1467,6 +1557,7 @@ mod tests {
         // when
         let summary = runtime
             .run_turn("use fail", None, None)
+            .await
             .expect("tool loop succeeds");
 
         // then
@@ -1495,8 +1586,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn runtime_observer_receives_text_delta_tool_use_and_tool_result_in_order() {
+    #[tokio::test]
+    async fn runtime_observer_receives_text_delta_tool_use_and_tool_result_in_order() {
         let mut runtime = ConversationRuntime::new(
             Session::new(),
             ScriptedApiClient { call_count: 0 },
@@ -1508,6 +1599,7 @@ mod tests {
 
         runtime
             .run_turn("what is 2 + 2?", None, Some(&mut observer))
+            .await
             .expect("conversation loop should succeed");
 
         assert_eq!(
@@ -1530,8 +1622,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn runtime_observer_receives_denied_tool_result() {
+    #[tokio::test]
+    async fn runtime_observer_receives_denied_tool_result() {
         struct RejectPrompter;
         impl PermissionPrompter for RejectPrompter {
             fn decide(&mut self, _request: &PermissionRequest) -> PermissionPromptDecision {
@@ -1542,19 +1634,23 @@ mod tests {
         }
 
         struct ToolUseApiClient;
+        #[async_trait]
         impl ApiClient for ToolUseApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 if request
                     .messages
                     .iter()
                     .any(|message| message.role == MessageRole::Tool)
                 {
-                    return Ok(vec![
+                    return Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("blocked".to_string()),
                         AssistantEvent::MessageStop,
-                    ]);
+                    ]));
                 }
-                Ok(vec![
+                Ok(events_to_stream(vec![
                     AssistantEvent::ToolUse {
                         id: "tool-1".to_string(),
                         name: "blocked".to_string(),
@@ -1562,7 +1658,7 @@ mod tests {
                         thought_signature: None,
                     },
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1582,6 +1678,7 @@ mod tests {
                 Some(&mut RejectPrompter),
                 Some(&mut observer),
             )
+            .await
             .expect("conversation should continue after denied tool");
 
         assert!(observer.events.contains(&ObservedRuntimeEvent::ToolResult {
@@ -1592,22 +1689,26 @@ mod tests {
         }));
     }
 
-    #[test]
-    fn runtime_observer_receives_error_tool_result() {
+    #[tokio::test]
+    async fn runtime_observer_receives_error_tool_result() {
         struct ToolUseApiClient;
+        #[async_trait]
         impl ApiClient for ToolUseApiClient {
-            fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 if request
                     .messages
                     .iter()
                     .any(|message| message.role == MessageRole::Tool)
                 {
-                    return Ok(vec![
+                    return Ok(events_to_stream(vec![
                         AssistantEvent::TextDelta("failed".to_string()),
                         AssistantEvent::MessageStop,
-                    ]);
+                    ]));
                 }
-                Ok(vec![
+                Ok(events_to_stream(vec![
                     AssistantEvent::ToolUse {
                         id: "tool-1".to_string(),
                         name: "fail".to_string(),
@@ -1615,7 +1716,7 @@ mod tests {
                         thought_signature: None,
                     },
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1630,6 +1731,7 @@ mod tests {
 
         runtime
             .run_turn("use the tool", None, Some(&mut observer))
+            .await
             .expect("conversation should continue after tool error");
 
         assert!(observer.events.contains(&ObservedRuntimeEvent::ToolResult {
@@ -1640,18 +1742,19 @@ mod tests {
         }));
     }
 
-    #[test]
-    fn reconstructs_usage_tracker_from_restored_session() {
+    #[tokio::test]
+    async fn reconstructs_usage_tracker_from_restored_session() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::TextDelta("done".to_string()),
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1682,18 +1785,19 @@ mod tests {
         assert_eq!(runtime.usage().cumulative_usage().total_tokens(), 21);
     }
 
-    #[test]
-    fn compacts_session_after_turns() {
+    #[tokio::test]
+    async fn compacts_session_after_turns() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::TextDelta("done".to_string()),
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1704,9 +1808,9 @@ mod tests {
             PermissionPolicy::new(PermissionMode::DangerFullAccess),
             SystemPrompt::default(),
         );
-        runtime.run_turn("a", None, None).expect("turn a");
-        runtime.run_turn("b", None, None).expect("turn b");
-        runtime.run_turn("c", None, None).expect("turn c");
+        runtime.run_turn("a", None, None).await.expect("turn a");
+        runtime.run_turn("b", None, None).await.expect("turn b");
+        runtime.run_turn("c", None, None).await.expect("turn c");
 
         let result = runtime.compact(CompactionConfig {
             preserve_recent_messages: 2,
@@ -1724,18 +1828,19 @@ mod tests {
         assert!(result.compacted_session.compaction.is_some());
     }
 
-    #[test]
-    fn persists_conversation_turn_messages_to_jsonl_session() {
+    #[tokio::test]
+    async fn persists_conversation_turn_messages_to_jsonl_session() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::TextDelta("done".to_string()),
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1751,6 +1856,7 @@ mod tests {
 
         runtime
             .run_turn("persist this turn", None, None)
+            .await
             .expect("turn should succeed");
 
         let restored = Session::load_from_path(&path).expect("persisted session should reload");
@@ -1762,8 +1868,8 @@ mod tests {
         assert_eq!(restored.session_id, runtime.session().session_id);
     }
 
-    #[test]
-    fn forks_runtime_session_without_mutating_original() {
+    #[tokio::test]
+    async fn forks_runtime_session_without_mutating_original() {
         let mut session = Session::new();
         session
             .push_user_text("branch me")
@@ -1809,15 +1915,16 @@ mod tests {
         script.to_string()
     }
 
-    #[test]
-    fn auto_compacts_when_cumulative_input_threshold_is_crossed() {
+    #[tokio::test]
+    async fn auto_compacts_when_cumulative_input_threshold_is_crossed() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::TextDelta("done".to_string()),
                     AssistantEvent::Usage(TokenUsage {
                         input_tokens: 120_000,
@@ -1826,7 +1933,7 @@ mod tests {
                         cache_read_input_tokens: 0,
                     }),
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1853,6 +1960,7 @@ mod tests {
 
         let summary = runtime
             .run_turn("trigger", None, None)
+            .await
             .expect("turn should succeed");
 
         assert_eq!(
@@ -1864,15 +1972,16 @@ mod tests {
         assert_eq!(runtime.session().messages[0].role, MessageRole::System);
     }
 
-    #[test]
-    fn skips_auto_compaction_below_threshold() {
+    #[tokio::test]
+    async fn skips_auto_compaction_below_threshold() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::TextDelta("done".to_string()),
                     AssistantEvent::Usage(TokenUsage {
                         input_tokens: 99_999,
@@ -1881,7 +1990,7 @@ mod tests {
                         cache_read_input_tokens: 0,
                     }),
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1896,13 +2005,14 @@ mod tests {
 
         let summary = runtime
             .run_turn("trigger", None, None)
+            .await
             .expect("turn should succeed");
         assert_eq!(summary.auto_compaction, None);
         assert_eq!(runtime.session().messages.len(), 2);
     }
 
-    #[test]
-    fn auto_compaction_threshold_defaults_and_parses_values() {
+    #[tokio::test]
+    async fn auto_compaction_threshold_defaults_and_parses_values() {
         assert_eq!(
             parse_auto_compaction_threshold(None),
             DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD
@@ -1918,14 +2028,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn compaction_health_probe_blocks_turn_when_tool_executor_is_broken() {
+    #[tokio::test]
+    async fn compaction_health_probe_blocks_turn_when_tool_executor_is_broken() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 panic!("API should not run when health probe fails");
             }
         }
@@ -1949,6 +2060,7 @@ mod tests {
 
         let error = runtime
             .run_turn("trigger", None, None)
+            .await
             .expect_err("health probe failure should abort the turn");
         assert!(
             error
@@ -1962,18 +2074,19 @@ mod tests {
         );
     }
 
-    #[test]
-    fn compaction_health_probe_skips_empty_compacted_session() {
+    #[tokio::test]
+    async fn compaction_health_probe_skips_empty_compacted_session() {
         struct SimpleApi;
+        #[async_trait]
         impl ApiClient for SimpleApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::TextDelta("done".to_string()),
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -1995,13 +2108,14 @@ mod tests {
 
         let summary = runtime
             .run_turn("trigger", None, None)
+            .await
             .expect("empty compacted session should not fail health probe");
         assert_eq!(summary.auto_compaction, None);
         assert_eq!(runtime.session().messages.len(), 2);
     }
 
-    #[test]
-    fn build_assistant_message_requires_message_stop_event() {
+    #[tokio::test]
+    async fn build_assistant_message_requires_message_stop_event() {
         // given
         let events = vec![AssistantEvent::TextDelta("hello".to_string())];
 
@@ -2015,8 +2129,8 @@ mod tests {
             .contains("assistant stream ended without a message stop event"));
     }
 
-    #[test]
-    fn build_assistant_message_requires_content() {
+    #[tokio::test]
+    async fn build_assistant_message_requires_content() {
         // given
         let events = vec![AssistantEvent::MessageStop];
 
@@ -2030,8 +2144,8 @@ mod tests {
             .contains("assistant stream produced no content"));
     }
 
-    #[test]
-    fn static_tool_executor_rejects_unknown_tools() {
+    #[tokio::test]
+    async fn static_tool_executor_rejects_unknown_tools() {
         // given
         let mut executor = StaticToolExecutor::new();
 
@@ -2044,16 +2158,17 @@ mod tests {
         assert_eq!(error.to_string(), "unknown tool: missing");
     }
 
-    #[test]
-    fn run_turn_errors_when_max_iterations_is_exceeded() {
+    #[tokio::test]
+    async fn run_turn_errors_when_max_iterations_is_exceeded() {
         struct LoopingApi;
 
+        #[async_trait]
         impl ApiClient for LoopingApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-                Ok(vec![
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Ok(events_to_stream(vec![
                     AssistantEvent::ToolUse {
                         id: "tool-1".to_string(),
                         name: "echo".to_string(),
@@ -2061,7 +2176,7 @@ mod tests {
                         thought_signature: None,
                     },
                     AssistantEvent::MessageStop,
-                ])
+                ]))
             }
         }
 
@@ -2078,6 +2193,7 @@ mod tests {
         // when
         let error = runtime
             .run_turn("loop", None, None)
+            .await
             .expect_err("conversation loop should stop after the configured limit");
 
         // then
@@ -2086,21 +2202,22 @@ mod tests {
             .contains("conversation loop exceeded the maximum number of iterations"));
     }
 
-    #[test]
-    fn conversation_runtime_is_send() {
+    #[tokio::test]
+    async fn conversation_runtime_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ConversationRuntime<ScriptedApiClient, StaticToolExecutor>>();
     }
 
-    #[test]
-    fn run_turn_propagates_api_errors() {
+    #[tokio::test]
+    async fn run_turn_propagates_api_errors() {
         struct FailingApi;
 
+        #[async_trait]
         impl ApiClient for FailingApi {
-            fn stream(
+            async fn stream(
                 &mut self,
                 _request: ApiRequest,
-            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            ) -> Result<AssistantEventStream, RuntimeError> {
                 Err(RuntimeError::new("upstream failed"))
             }
         }
@@ -2117,6 +2234,7 @@ mod tests {
         // when
         let error = runtime
             .run_turn("hello", None, None)
+            .await
             .expect_err("API failures should propagate");
 
         // then

--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -59,9 +59,19 @@ pub trait HookProgressReporter: Send {
     fn on_event(&mut self, event: &HookProgressEvent);
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct HookAbortSignal {
     aborted: Arc<AtomicBool>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl Default for HookAbortSignal {
+    fn default() -> Self {
+        Self {
+            aborted: Arc::new(AtomicBool::new(false)),
+            notify: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
 }
 
 impl HookAbortSignal {
@@ -72,6 +82,7 @@ impl HookAbortSignal {
 
     pub fn abort(&self) {
         self.aborted.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
     }
 
     /// Clear the abort flag so a new turn can run.
@@ -82,6 +93,15 @@ impl HookAbortSignal {
     #[must_use]
     pub fn is_aborted(&self) -> bool {
         self.aborted.load(Ordering::SeqCst)
+    }
+
+    /// Returns a future that resolves when the abort signal is triggered.
+    /// If already aborted, resolves immediately.
+    pub async fn cancelled(&self) {
+        if self.is_aborted() {
+            return;
+        }
+        self.notify.notified().await;
     }
 }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -76,9 +76,9 @@ pub use config_validate::{
     DiagnosticKind, ValidationResult,
 };
 pub use conversation::{
-    auto_compaction_threshold_from_env, ApiClient, ApiRequest, AssistantEvent, AutoCompactionEvent,
-    ConversationRuntime, PromptCacheEvent, RuntimeError, RuntimeObserver, StaticToolExecutor,
-    ToolError, ToolExecutor, TurnSummary,
+    auto_compaction_threshold_from_env, ApiClient, ApiRequest, AssistantEvent,
+    AssistantEventStream, AutoCompactionEvent, ConversationRuntime, PromptCacheEvent, RuntimeError,
+    RuntimeObserver, StaticToolExecutor, ToolError, ToolExecutor, TurnSummary,
 };
 pub use file_ops::{
     edit_file, glob_search, grep_search, read_file, write_file, EditFileOutput, GlobSearchOutput,

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -12,11 +12,13 @@ path = "src/main.rs"
 [dependencies]
 api = { path = "../api" }
 arboard = { version = "3", features = ["image-data"] }
+async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 commands = { path = "../commands" }
 compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
+futures = "0.3"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 pulldown-cmark = "0.13"
 rustyline = "15"

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::io::{self, Write};
 
 use api::{
@@ -6,9 +7,11 @@ use api::{
     MessageResponse, OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient,
     StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
+use async_trait::async_trait;
+use futures::StreamExt;
 use runtime::{
-    ApiClient, ApiRequest, AssistantEvent, ContentBlock, ConversationMessage, MessageRole,
-    PromptCacheEvent, RuntimeError, TokenUsage,
+    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ContentBlock, ConversationMessage,
+    MessageRole, PromptCacheEvent, RuntimeError, TokenUsage,
 };
 use telemetry::{JsonlTelemetrySink, SessionTracer};
 use tools::GlobalToolRegistry;
@@ -118,9 +121,10 @@ pub(crate) fn resolve_cli_auth_source_for_cwd() -> Result<AuthSource, api::ApiEr
     resolve_startup_auth_source(|| Ok(None))
 }
 
+#[async_trait]
 impl ApiClient for AnthropicRuntimeClient {
     #[allow(clippy::too_many_lines)]
-    fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+    async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
         if let Some(progress_reporter) = &self.progress_reporter {
             progress_reporter.mark_model_phase();
         }
@@ -145,51 +149,80 @@ impl ApiClient for AnthropicRuntimeClient {
             ..Default::default()
         };
 
-        self.runtime.block_on(async {
-            // When resuming after tool execution, apply a stall timeout on the
-            // first stream event.  If the model does not respond within the
-            // deadline we drop the stalled connection and re-send the request as
-            // a continuation nudge (one retry only).
-            let max_attempts: usize = if is_post_tool { 2 } else { 1 };
+        // When resuming after tool execution, apply a stall timeout on the
+        // first stream event.  If the model does not respond within the
+        // deadline we drop the stalled connection and re-send the request as
+        // a continuation nudge (one retry only).
+        let max_attempts: usize = if is_post_tool { 2 } else { 1 };
 
-            for attempt in 1..=max_attempts {
-                let result = self
-                    .consume_stream(&message_request, is_post_tool && attempt == 1)
-                    .await;
-                match result {
-                    Ok(events) => return Ok(events),
-                    Err(error)
-                        if error.to_string().contains("post-tool stall")
-                            && attempt < max_attempts =>
-                    {
-                        // Stalled after tool completion — nudge the model by
-                        // re-sending the same request.
-                    }
-                    Err(error) => return Err(error),
+        for attempt in 1..=max_attempts {
+            let result = self
+                .try_start_stream(&message_request, is_post_tool && attempt == 1)
+                .await;
+            match result {
+                Ok(stream) => return Ok(stream),
+                Err(error)
+                    if error.to_string().contains("post-tool stall") && attempt < max_attempts =>
+                {
+                    // Stalled after tool completion — nudge the model by
+                    // re-sending the same request.
                 }
+                Err(error) => return Err(error),
             }
+        }
 
-            Err(RuntimeError::new("post-tool continuation nudge exhausted"))
-        })
+        Err(RuntimeError::new("post-tool continuation nudge exhausted"))
     }
 }
 
-impl AnthropicRuntimeClient {
-    /// Consume a single streaming response, optionally applying a stall
-    /// timeout on the first event for post-tool continuations.
+/// Internal state for the unfold-based `AssistantEventStream` produced by
+/// [`AnthropicRuntimeClient::try_start_stream`].
+#[allow(clippy::struct_excessive_bools)]
+struct CliStreamState {
+    provider_stream: api::MessageStream,
+    session_id: String,
+    emit_output: bool,
+    progress_reporter: Option<InternalPromptProgressReporter>,
+    spinner_pause: Option<Arc<AtomicBool>>,
+    pending_tool: Option<(String, String, String, Option<String>)>,
+    block_has_thinking_summary: bool,
+    markdown_stream: MarkdownStreamState,
+    renderer: TerminalRenderer,
+    glyph_state: ResponseGlyphState,
+    buffer: VecDeque<AssistantEvent>,
+    saw_stop: bool,
+    has_content: bool,
+    received_any_event: bool,
+    apply_stall_timeout: bool,
+    done: bool,
+    /// Clone of the provider client used to extract prompt cache at end of stream.
+    client: ApiProviderClient,
+    /// Non-streaming fallback request (used when streaming yields no events).
+    fallback_request: Option<MessageRequest>,
+}
+
+impl CliStreamState {
+    fn pause_spinner(&self) {
+        if let Some(flag) = &self.spinner_pause {
+            flag.store(true, Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            let _ = write!(io::stdout(), "\r\x1b[2K");
+            let _ = io::stdout().flush();
+        }
+    }
+
+    fn resume_spinner(&self) {
+        if let Some(flag) = &self.spinner_pause {
+            flag.store(false, Ordering::SeqCst);
+        }
+    }
+
+    /// Process a single provider event, converting it into zero or more
+    /// [`AssistantEvent`]s pushed onto `self.buffer`.  All I/O (terminal
+    /// rendering) happens synchronously here so that no `dyn Write` reference
+    /// is held across an `.await` point.
     #[allow(clippy::too_many_lines)]
-    async fn consume_stream(
-        &self,
-        message_request: &MessageRequest,
-        apply_stall_timeout: bool,
-    ) -> Result<Vec<AssistantEvent>, RuntimeError> {
-        let mut stream = self
-            .client
-            .stream_message(message_request)
-            .await
-            .map_err(|error| {
-                RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-            })?;
+    fn process_provider_event(&mut self, event: ApiStreamEvent) -> Result<(), RuntimeError> {
         let mut stdout = io::stdout();
         let mut sink = io::sink();
         let out: &mut dyn Write = if self.emit_output {
@@ -197,168 +230,254 @@ impl AnthropicRuntimeClient {
         } else {
             &mut sink
         };
-        let renderer = TerminalRenderer::new();
-        let mut markdown_stream = MarkdownStreamState::default();
-        let mut events = Vec::new();
-        let mut pending_tool: Option<(String, String, String, Option<String>)> = None;
-        let mut block_has_thinking_summary = false;
-        let mut saw_stop = false;
-        let mut received_any_event = false;
-        let mut glyph_state = ResponseGlyphState::new(query_terminal_width());
-
-        loop {
-            let next = if apply_stall_timeout && !received_any_event {
-                match tokio::time::timeout(POST_TOOL_STALL_TIMEOUT, stream.next_event()).await {
-                    Ok(inner) => inner.map_err(|error| {
-                        RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-                    })?,
-                    Err(_elapsed) => {
-                        return Err(RuntimeError::new(
-                            "post-tool stall: model did not respond within timeout",
-                        ));
-                    }
-                }
-            } else {
-                stream.next_event().await.map_err(|error| {
-                    RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-                })?
-            };
-
-            let Some(event) = next else {
-                break;
-            };
-            received_any_event = true;
-
-            match event {
-                ApiStreamEvent::MessageStart(start) => {
-                    for block in start.message.content {
-                        push_output_block(
-                            block,
-                            out,
-                            &mut events,
-                            &mut pending_tool,
-                            true,
-                            &mut block_has_thinking_summary,
-                            &mut glyph_state,
-                        )?;
-                    }
-                }
-                ApiStreamEvent::ContentBlockStart(start) => {
+        match event {
+            ApiStreamEvent::MessageStart(start) => {
+                for block in start.message.content {
                     push_output_block(
-                        start.content_block,
+                        block,
                         out,
-                        &mut events,
-                        &mut pending_tool,
+                        &mut self.buffer,
+                        &mut self.pending_tool,
                         true,
-                        &mut block_has_thinking_summary,
-                        &mut glyph_state,
+                        &mut self.block_has_thinking_summary,
+                        &mut self.glyph_state,
                     )?;
                 }
-                ApiStreamEvent::ContentBlockDelta(delta) => match delta.delta {
-                    ContentBlockDelta::TextDelta { text } => {
-                        if !text.is_empty() {
-                            if let Some(progress_reporter) = &self.progress_reporter {
-                                progress_reporter.mark_text_phase(&text);
-                            }
-                            if let Some(rendered) = markdown_stream.push(&renderer, &text) {
-                                self.pause_spinner();
-                                let prefixed = glyph_state.apply(&rendered);
-                                write!(out, "{prefixed}")
-                                    .and_then(|()| out.flush())
-                                    .map_err(|error| RuntimeError::new(error.to_string()))?;
-                            }
-                            events.push(AssistantEvent::TextDelta(text));
-                        }
-                    }
-                    ContentBlockDelta::InputJsonDelta { partial_json } => {
-                        if let Some((_, _, input, _)) = &mut pending_tool {
-                            input.push_str(&partial_json);
-                        }
-                    }
-                    ContentBlockDelta::ThinkingDelta { .. } => {
-                        if !block_has_thinking_summary {
-                            self.pause_spinner();
-                            render_thinking_block_summary(out, None, false)?;
-                            block_has_thinking_summary = true;
-                            glyph_state.visible_col = 0;
-                        }
-                    }
-                    ContentBlockDelta::SignatureDelta { .. } => {}
-                },
-                ApiStreamEvent::ContentBlockStop(_) => {
-                    block_has_thinking_summary = false;
-                    if let Some(rendered) = markdown_stream.flush(&renderer) {
-                        let prefixed = glyph_state.apply(&rendered);
-                        write!(out, "{prefixed}")
-                            .and_then(|()| out.flush())
-                            .map_err(|error| RuntimeError::new(error.to_string()))?;
-                    }
-                    if let Some((id, name, input, thought_signature)) = pending_tool.take() {
+            }
+            ApiStreamEvent::ContentBlockStart(start) => {
+                push_output_block(
+                    start.content_block,
+                    out,
+                    &mut self.buffer,
+                    &mut self.pending_tool,
+                    true,
+                    &mut self.block_has_thinking_summary,
+                    &mut self.glyph_state,
+                )?;
+            }
+            ApiStreamEvent::ContentBlockDelta(delta) => match delta.delta {
+                ContentBlockDelta::TextDelta { text } => {
+                    if !text.is_empty() {
                         if let Some(progress_reporter) = &self.progress_reporter {
-                            progress_reporter.mark_tool_phase(&name, &input);
+                            progress_reporter.mark_text_phase(&text);
                         }
+                        if let Some(rendered) = self.markdown_stream.push(&self.renderer, &text) {
+                            self.pause_spinner();
+                            let prefixed = self.glyph_state.apply(&rendered);
+                            write!(out, "{prefixed}")
+                                .and_then(|()| out.flush())
+                                .map_err(|error| RuntimeError::new(error.to_string()))?;
+                        }
+                        self.has_content = true;
+                        self.buffer.push_back(AssistantEvent::TextDelta(text));
+                    }
+                }
+                ContentBlockDelta::InputJsonDelta { partial_json } => {
+                    if let Some((_, _, input, _)) = &mut self.pending_tool {
+                        input.push_str(&partial_json);
+                    }
+                }
+                ContentBlockDelta::ThinkingDelta { .. } => {
+                    if !self.block_has_thinking_summary {
                         self.pause_spinner();
-                        writeln!(out, "\n{}", format_tool_call_start(&name, &input))
-                            .and_then(|()| out.flush())
-                            .map_err(|error| RuntimeError::new(error.to_string()))?;
-                        glyph_state.visible_col = 0;
-                        // Resume spinner so it shows during tool execution.
-                        self.resume_spinner();
-                        events.push(AssistantEvent::ToolUse {
-                            id,
-                            name,
-                            input,
-                            thought_signature,
-                        });
+                        render_thinking_block_summary(out, None, false)?;
+                        self.block_has_thinking_summary = true;
+                        self.glyph_state.visible_col = 0;
                     }
                 }
-                ApiStreamEvent::MessageDelta(delta) => {
-                    events.push(AssistantEvent::Usage(delta.usage.token_usage()));
+                ContentBlockDelta::SignatureDelta { .. } => {}
+            },
+            ApiStreamEvent::ContentBlockStop(_) => {
+                self.block_has_thinking_summary = false;
+                if let Some(rendered) = self.markdown_stream.flush(&self.renderer) {
+                    let prefixed = self.glyph_state.apply(&rendered);
+                    write!(out, "{prefixed}")
+                        .and_then(|()| out.flush())
+                        .map_err(|error| RuntimeError::new(error.to_string()))?;
                 }
-                ApiStreamEvent::MessageStop(_) => {
-                    saw_stop = true;
-                    if let Some(rendered) = markdown_stream.flush(&renderer) {
-                        let prefixed = glyph_state.apply(&rendered);
-                        write!(out, "{prefixed}")
-                            .and_then(|()| out.flush())
-                            .map_err(|error| RuntimeError::new(error.to_string()))?;
+                if let Some((id, name, input, thought_signature)) = self.pending_tool.take() {
+                    if let Some(progress_reporter) = &self.progress_reporter {
+                        progress_reporter.mark_tool_phase(&name, &input);
                     }
-                    events.push(AssistantEvent::MessageStop);
+                    self.pause_spinner();
+                    writeln!(out, "\n{}", format_tool_call_start(&name, &input))
+                        .and_then(|()| out.flush())
+                        .map_err(|error| RuntimeError::new(error.to_string()))?;
+                    self.glyph_state.visible_col = 0;
+                    self.resume_spinner();
+                    self.has_content = true;
+                    self.buffer.push_back(AssistantEvent::ToolUse {
+                        id,
+                        name,
+                        input,
+                        thought_signature,
+                    });
                 }
             }
+            ApiStreamEvent::MessageDelta(delta) => {
+                self.buffer
+                    .push_back(AssistantEvent::Usage(delta.usage.token_usage()));
+            }
+            ApiStreamEvent::MessageStop(_) => {
+                self.saw_stop = true;
+                if let Some(rendered) = self.markdown_stream.flush(&self.renderer) {
+                    let prefixed = self.glyph_state.apply(&rendered);
+                    write!(out, "{prefixed}")
+                        .and_then(|()| out.flush())
+                        .map_err(|error| RuntimeError::new(error.to_string()))?;
+                }
+                self.buffer.push_back(AssistantEvent::MessageStop);
+            }
         }
+        Ok(())
+    }
+}
 
-        push_prompt_cache_record(&self.client, &mut events);
+impl AnthropicRuntimeClient {
+    /// Start a streaming response, optionally applying a stall timeout on the
+    /// first event for post-tool continuations.  Returns an incremental stream
+    /// of [`AssistantEvent`]s.  Dropping the stream cancels the underlying
+    /// HTTP request.
+    async fn try_start_stream(
+        &mut self,
+        message_request: &MessageRequest,
+        apply_stall_timeout: bool,
+    ) -> Result<AssistantEventStream, RuntimeError> {
+        let provider_stream =
+            self.client
+                .stream_message(message_request)
+                .await
+                .map_err(|error| {
+                    RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
+                })?;
 
-        if !saw_stop
-            && events.iter().any(|event| {
-                matches!(event, AssistantEvent::TextDelta(text) if !text.is_empty())
-                    || matches!(event, AssistantEvent::ToolUse { .. })
-            })
-        {
-            events.push(AssistantEvent::MessageStop);
-        }
-
-        if events
-            .iter()
-            .any(|event| matches!(event, AssistantEvent::MessageStop))
-        {
-            return Ok(events);
-        }
-
-        let response = self
-            .client
-            .send_message(&MessageRequest {
+        let state = CliStreamState {
+            provider_stream,
+            session_id: self.session_id.clone(),
+            emit_output: self.emit_output,
+            progress_reporter: self.progress_reporter.clone(),
+            spinner_pause: self.spinner_pause.clone(),
+            pending_tool: None,
+            block_has_thinking_summary: false,
+            markdown_stream: MarkdownStreamState::default(),
+            renderer: TerminalRenderer::new(),
+            glyph_state: ResponseGlyphState::new(query_terminal_width()),
+            buffer: VecDeque::new(),
+            saw_stop: false,
+            has_content: false,
+            received_any_event: false,
+            apply_stall_timeout,
+            done: false,
+            client: self.client.clone(),
+            fallback_request: Some(MessageRequest {
                 stream: false,
                 ..message_request.clone()
-            })
-            .await
-            .map_err(|error| {
-                RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-            })?;
-        let mut events = response_to_events(response, out)?;
-        push_prompt_cache_record(&self.client, &mut events);
-        Ok(events)
+            }),
+        };
+
+        Ok(Box::pin(futures::stream::try_unfold(
+            state,
+            |mut state| async move {
+                // Yield buffered events first.
+                if let Some(event) = state.buffer.pop_front() {
+                    return Ok(Some((event, state)));
+                }
+                if state.done {
+                    return Ok(None);
+                }
+
+                loop {
+                    let next = if state.apply_stall_timeout && !state.received_any_event {
+                        match tokio::time::timeout(
+                            POST_TOOL_STALL_TIMEOUT,
+                            state.provider_stream.next_event(),
+                        )
+                        .await
+                        {
+                            Ok(inner) => inner.map_err(|error| {
+                                RuntimeError::new(format_user_visible_api_error(
+                                    &state.session_id,
+                                    &error,
+                                ))
+                            })?,
+                            Err(_elapsed) => {
+                                return Err(RuntimeError::new(
+                                    "post-tool stall: model did not respond within timeout",
+                                ));
+                            }
+                        }
+                    } else {
+                        state.provider_stream.next_event().await.map_err(|error| {
+                            RuntimeError::new(format_user_visible_api_error(
+                                &state.session_id,
+                                &error,
+                            ))
+                        })?
+                    };
+
+                    let Some(event) = next else {
+                        // Provider stream ended — emit prompt cache and
+                        // synthetic stop if needed, then signal done.
+                        if let Some(record) = state.client.take_last_prompt_cache_record() {
+                            if let Some(evt) = prompt_cache_record_to_runtime_event(record) {
+                                state.buffer.push_back(AssistantEvent::PromptCache(evt));
+                            }
+                        }
+                        if !state.saw_stop && state.has_content {
+                            state.buffer.push_back(AssistantEvent::MessageStop);
+                        }
+
+                        // If stream produced nothing useful, fall back to
+                        // non-streaming request.
+                        if state.buffer.is_empty() && !state.saw_stop {
+                            if let Some(fallback_request) = state.fallback_request.take() {
+                                let response =
+                                    state.client.send_message(&fallback_request).await.map_err(
+                                        |error| {
+                                            RuntimeError::new(format_user_visible_api_error(
+                                                &state.session_id,
+                                                &error,
+                                            ))
+                                        },
+                                    )?;
+                                // response_to_events does sync I/O (no await),
+                                // so the dyn Write borrow is safe here.
+                                let mut stdout = io::stdout();
+                                let mut sink = io::sink();
+                                let out: &mut dyn Write = if state.emit_output {
+                                    &mut stdout
+                                } else {
+                                    &mut sink
+                                };
+                                let events = response_to_events(response, out)?;
+                                state.buffer.extend(events);
+                                if let Some(record) = state.client.take_last_prompt_cache_record() {
+                                    if let Some(evt) = prompt_cache_record_to_runtime_event(record)
+                                    {
+                                        state.buffer.push_back(AssistantEvent::PromptCache(evt));
+                                    }
+                                }
+                            }
+                        }
+
+                        state.done = true;
+                        return Ok(state.buffer.pop_front().map(|evt| (evt, state)));
+                    };
+                    state.received_any_event = true;
+
+                    // Process the provider event synchronously (all I/O
+                    // happens inside this call, no dyn Write held across
+                    // await points).
+                    state.process_provider_event(event)?;
+
+                    // If we produced any buffered events, yield the first one.
+                    if let Some(event) = state.buffer.pop_front() {
+                        return Ok(Some((event, state)));
+                    }
+                    // Otherwise loop to read more from the provider.
+                }
+            },
+        )))
     }
 }
 
@@ -565,7 +684,7 @@ fn query_terminal_width() -> usize {
 pub(crate) fn push_output_block(
     block: OutputContentBlock,
     out: &mut (impl Write + ?Sized),
-    events: &mut Vec<AssistantEvent>,
+    events: &mut VecDeque<AssistantEvent>,
     pending_tool: &mut Option<(String, String, String, Option<String>)>,
     streaming_tool_input: bool,
     block_has_thinking_summary: &mut bool,
@@ -579,7 +698,7 @@ pub(crate) fn push_output_block(
                 write!(out, "{prefixed}")
                     .and_then(|()| out.flush())
                     .map_err(|error| RuntimeError::new(error.to_string()))?;
-                events.push(AssistantEvent::TextDelta(text));
+                events.push_back(AssistantEvent::TextDelta(text));
             }
         }
         OutputContentBlock::ToolUse {
@@ -588,9 +707,6 @@ pub(crate) fn push_output_block(
             input,
             thought_signature,
         } => {
-            // During streaming, the initial content_block_start has an empty input ({}).
-            // The real input arrives via input_json_delta events. In
-            // non-streaming responses, preserve a legitimate empty object.
             let initial_input = if streaming_tool_input
                 && input.is_object()
                 && input.as_object().is_some_and(serde_json::Map::is_empty)
@@ -618,8 +734,8 @@ pub(crate) fn push_output_block(
 pub(crate) fn response_to_events(
     response: MessageResponse,
     out: &mut (impl Write + ?Sized),
-) -> Result<Vec<AssistantEvent>, RuntimeError> {
-    let mut events = Vec::new();
+) -> Result<VecDeque<AssistantEvent>, RuntimeError> {
+    let mut events = VecDeque::new();
     let mut pending_tool = None;
     let mut glyph_state = ResponseGlyphState::new(query_terminal_width());
 
@@ -635,7 +751,7 @@ pub(crate) fn response_to_events(
             &mut glyph_state,
         )?;
         if let Some((id, name, input, thought_signature)) = pending_tool.take() {
-            events.push(AssistantEvent::ToolUse {
+            events.push_back(AssistantEvent::ToolUse {
                 id,
                 name,
                 input,
@@ -644,25 +760,9 @@ pub(crate) fn response_to_events(
         }
     }
 
-    events.push(AssistantEvent::Usage(response.usage.token_usage()));
-    events.push(AssistantEvent::MessageStop);
+    events.push_back(AssistantEvent::Usage(response.usage.token_usage()));
+    events.push_back(AssistantEvent::MessageStop);
     Ok(events)
-}
-
-pub(crate) fn push_prompt_cache_record(
-    client: &ApiProviderClient,
-    events: &mut Vec<AssistantEvent>,
-) {
-    // `ApiProviderClient::take_last_prompt_cache_record` is a pass-through
-    // to the Anthropic variant and returns `None` for OpenAI-compat /
-    // xAI variants, which do not have a prompt cache. So this helper
-    // remains a no-op on non-Anthropic providers without any extra
-    // branching here.
-    if let Some(record) = client.take_last_prompt_cache_record() {
-        if let Some(event) = prompt_cache_record_to_runtime_event(record) {
-            events.push(AssistantEvent::PromptCache(event));
-        }
-    }
 }
 
 pub(crate) fn prompt_cache_record_to_runtime_event(

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1372,6 +1372,8 @@ struct LiveCli {
     runtime: BuiltRuntime,
     session: SessionHandle,
     prompt_history: Vec<PromptHistoryEntry>,
+    /// Shared tokio runtime used to drive async `run_turn` calls.
+    tokio_runtime: tokio::runtime::Runtime,
 }
 
 pub(crate) struct RuntimePluginState {
@@ -1491,6 +1493,7 @@ struct AcpCliAgent {
     reasoning_effort: Option<String>,
     auth_mode: Option<AuthMode>,
     sessions: HashMap<String, AcpCliSession>,
+    tokio_runtime: tokio::runtime::Runtime,
 }
 
 impl AcpCliAgent {
@@ -1510,6 +1513,8 @@ impl AcpCliAgent {
             reasoning_effort,
             auth_mode,
             sessions: HashMap::new(),
+            tokio_runtime: tokio::runtime::Runtime::new()
+                .expect("failed to create tokio runtime for ACP agent"),
         }
     }
 
@@ -2054,9 +2059,9 @@ impl AcpSdkDelegate {
         let _guard = ScopedCurrentDir::change_to(&session.cwd).map_err(|e| {
             runtime::AcpError::internal(format!("failed to enter session cwd: {e}"))
         })?;
-        session
-            .runtime
-            .run_turn(prompt, prompter, Some(observer))
+        self.inner
+            .tokio_runtime
+            .block_on(session.runtime.run_turn(prompt, prompter, Some(observer)))
             .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
         let usage = UsageTracker::from_session(session.runtime.session()).cumulative_usage();
         let prompt_usage = runtime::acp_sdk_server::PromptUsage {
@@ -2187,6 +2192,7 @@ impl LiveCli {
             runtime,
             session,
             prompt_history: Vec::new(),
+            tokio_runtime: tokio::runtime::Runtime::new()?,
         };
         cli.persist_session()?;
         Ok(cli)
@@ -2342,7 +2348,11 @@ impl LiveCli {
             .set_spinner_pause(pause_flag.clone());
         runtime.tool_executor_mut().set_spinner_pause(pause_flag);
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
-        let result = runtime.run_turn(input, Some(&mut permission_prompter), None);
+        let result = self.tokio_runtime.block_on(runtime.run_turn(
+            input,
+            Some(&mut permission_prompter),
+            None,
+        ));
         hook_abort_monitor.stop();
         match result {
             Ok(summary) => {
@@ -2393,7 +2403,11 @@ impl LiveCli {
     fn run_prompt_compact(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(false)?;
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
-        let result = runtime.run_turn(input, Some(&mut permission_prompter), None);
+        let result = self.tokio_runtime.block_on(runtime.run_turn(
+            input,
+            Some(&mut permission_prompter),
+            None,
+        ));
         hook_abort_monitor.stop();
         let summary = result?;
         self.replace_runtime(runtime)?;
@@ -2406,7 +2420,11 @@ impl LiveCli {
     fn run_prompt_compact_json(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(false)?;
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
-        let result = runtime.run_turn(input, Some(&mut permission_prompter), None);
+        let result = self.tokio_runtime.block_on(runtime.run_turn(
+            input,
+            Some(&mut permission_prompter),
+            None,
+        ));
         hook_abort_monitor.stop();
         let summary = result?;
         self.replace_runtime(runtime)?;
@@ -2431,7 +2449,11 @@ impl LiveCli {
     fn run_prompt_json(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(false)?;
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
-        let result = runtime.run_turn(input, Some(&mut permission_prompter), None);
+        let result = self.tokio_runtime.block_on(runtime.run_turn(
+            input,
+            Some(&mut permission_prompter),
+            None,
+        ));
         hook_abort_monitor.stop();
         let summary = result?;
         self.replace_runtime(runtime)?;
@@ -3202,7 +3224,11 @@ impl LiveCli {
             },
         )?;
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
-        let summary = runtime.run_turn(prompt, Some(&mut permission_prompter), None)?;
+        let summary = self.tokio_runtime.block_on(runtime.run_turn(
+            prompt,
+            Some(&mut permission_prompter),
+            None,
+        ))?;
         let text = final_assistant_text(&summary).trim().to_string();
         runtime.shutdown_plugins()?;
         Ok(text)

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2357,20 +2357,28 @@ impl LiveCli {
         match result {
             Ok(summary) => {
                 self.replace_runtime(runtime)?;
-                spinner.clear(&mut stdout)?;
-                if let Some(event) = summary.auto_compaction {
+                if summary.cancelled {
+                    spinner.fail(
+                        "⏹ Cancelled",
+                        TerminalRenderer::new().color_theme(),
+                        &mut stdout,
+                    )?;
+                } else {
+                    spinner.clear(&mut stdout)?;
+                    if let Some(event) = summary.auto_compaction {
+                        println!(
+                            "{}",
+                            format_auto_compaction_notice(event.removed_message_count)
+                        );
+                    }
+                    let elapsed = turn_start.elapsed();
+                    let usage = self.runtime.usage().current_turn_usage();
+                    let turns = self.runtime.usage().turns();
                     println!(
                         "{}",
-                        format_auto_compaction_notice(event.removed_message_count)
+                        format_turn_status_line(&self.config.model, turns, &usage, elapsed)
                     );
                 }
-                let elapsed = turn_start.elapsed();
-                let usage = self.runtime.usage().current_turn_usage();
-                let turns = self.runtime.usage().turns();
-                println!(
-                    "{}",
-                    format_turn_status_line(&self.config.model, turns, &usage, elapsed)
-                );
                 self.persist_session()?;
                 Ok(())
             }

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -7,8 +7,10 @@ publish.workspace = true
 
 [dependencies]
 api = { path = "../api" }
+async-trait = "0.1"
 commands = { path = "../commands" }
 flate2 = "1"
+futures = "0.3"
 plugins = { path = "../plugins" }
 runtime = { path = "../runtime" }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -22,12 +22,12 @@ use runtime::{
     task_registry::TaskRegistry,
     team_cron_registry::{CronRegistry, TeamRegistry},
     worker_boot::{WorkerReadySnapshot, WorkerRegistry, WorkerTaskReceipt},
-    write_file, ApiClient, ApiRequest, AssistantEvent, BashCommandInput, BashCommandOutput,
-    BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage, ConversationRuntime,
-    GrepSearchInput, LaneCommitProvenance, LaneEvent, LaneEventBlocker, LaneEventName,
-    LaneEventStatus, LaneFailureClass, McpDegradedReport, MessageRole, PermissionMode,
-    PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig, RuntimeError, Session,
-    SystemPrompt, TaskPacket, ToolError, ToolExecutor,
+    write_file, ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, BashCommandInput,
+    BashCommandOutput, BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage,
+    ConversationRuntime, GrepSearchInput, LaneCommitProvenance, LaneEvent, LaneEventBlocker,
+    LaneEventName, LaneEventStatus, LaneFailureClass, McpDegradedReport, MessageRole,
+    PermissionMode, PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig, RuntimeError,
+    Session, SystemPrompt, TaskPacket, ToolError, ToolExecutor,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -3588,8 +3588,9 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
 
 fn run_agent_job(job: &AgentJob) -> Result<(), String> {
     let mut runtime = build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
-    let summary = runtime
-        .run_turn(job.prompt.clone(), None, None)
+    let tokio_rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+    let summary = tokio_rt
+        .block_on(runtime.run_turn(job.prompt.clone(), None, None))
         .map_err(|error| error.to_string())?;
     let final_text = final_assistant_text(&summary);
     persist_agent_terminal_state(&job.manifest, "completed", Some(final_text.as_str()), None)
@@ -4508,7 +4509,6 @@ struct ProviderEntry {
 }
 
 struct ProviderRuntimeClient {
-    runtime: tokio::runtime::Runtime,
     chain: Vec<ProviderEntry>,
     allowed_tools: BTreeSet<String>,
 }
@@ -4540,7 +4540,6 @@ impl ProviderRuntimeClient {
             }
         }
         Ok(Self {
-            runtime: tokio::runtime::Runtime::new().map_err(|error| error.to_string())?,
             chain,
             allowed_tools,
         })
@@ -4580,8 +4579,9 @@ fn load_provider_fallback_config() -> ProviderFallbackConfig {
         })
 }
 
+#[async_trait::async_trait]
 impl ApiClient for ProviderRuntimeClient {
-    fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+    async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
         let tools = tool_specs_for_allowed_tools(Some(&self.allowed_tools))
             .into_iter()
             .map(|spec| ToolDefinition {
@@ -4594,7 +4594,6 @@ impl ApiClient for ProviderRuntimeClient {
         let system = (!request.system_prompt.is_empty()).then(|| request.system_prompt.render());
         let tool_choice = (!self.allowed_tools.is_empty()).then_some(ToolChoice::Auto);
 
-        let runtime = &self.runtime;
         let chain = &self.chain;
         let mut last_error: Option<ApiError> = None;
         for (index, entry) in chain.iter().enumerate() {
@@ -4609,9 +4608,11 @@ impl ApiClient for ProviderRuntimeClient {
                 ..Default::default()
             };
 
-            let attempt = runtime.block_on(stream_with_provider(&entry.client, &message_request));
+            let attempt = stream_with_provider(&entry.client, &message_request).await;
             match attempt {
-                Ok(events) => return Ok(events),
+                Ok(events) => {
+                    return Ok(Box::pin(futures::stream::iter(events.into_iter().map(Ok))));
+                }
                 Err(error) if error.is_retryable() && index + 1 < chain.len() => {
                     eprintln!(
                         "provider {} failed with retryable error, falling back: {error}",
@@ -8453,13 +8454,17 @@ mod tests {
         input_path: String,
     }
 
+    #[async_trait::async_trait]
     impl runtime::ApiClient for MockSubagentApiClient {
-        fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+        async fn stream(
+            &mut self,
+            request: ApiRequest,
+        ) -> Result<runtime::AssistantEventStream, RuntimeError> {
             self.calls += 1;
-            match self.calls {
+            let events = match self.calls {
                 1 => {
                     assert_eq!(request.messages.len(), 1);
-                    Ok(vec![
+                    vec![
                         AssistantEvent::ToolUse {
                             id: "tool-1".to_string(),
                             name: "read_file".to_string(),
@@ -8467,22 +8472,24 @@ mod tests {
                             thought_signature: None,
                         },
                         AssistantEvent::MessageStop,
-                    ])
+                    ]
                 }
                 2 => {
                     assert!(request.messages.len() >= 3);
-                    Ok(vec![
+                    vec![
                         AssistantEvent::TextDelta("Scope: completed mock review".to_string()),
                         AssistantEvent::MessageStop,
-                    ])
+                    ]
                 }
                 _ => unreachable!("extra mock stream call"),
-            }
+            };
+            Ok(Box::pin(futures::stream::iter(events.into_iter().map(Ok))))
         }
     }
 
-    #[test]
-    fn subagent_runtime_executes_tool_loop_with_isolated_session() {
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn subagent_runtime_executes_tool_loop_with_isolated_session() {
         let _guard = env_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -8502,6 +8509,7 @@ mod tests {
 
         let summary = runtime
             .run_turn("Inspect the delegated file", None, None)
+            .await
             .expect("subagent loop should succeed");
 
         assert_eq!(


### PR DESCRIPTION
## Summary

Closes #59.

- **Async `ApiClient` trait** — `stream()` now returns `Pin<Box<dyn Stream<Item = Result<AssistantEvent>>>>` instead of a blocking `Vec`, enabling incremental event consumption
- **Instant cancellation via `tokio::select!`** — the core loop in `run_turn_with_blocks` races each streamed event against `HookAbortSignal::cancelled()`, dropping the HTTP connection immediately on abort to stop token consumption
- **Async-aware `HookAbortSignal`** — backed by `tokio::sync::Notify` for zero-latency cancellation notification
- **Graceful interrupt handling** (matching Claude Code's pattern):
  - User prompt is **kept** in session
  - Partial assistant text is **preserved** with an `[Interrupted]` marker
  - Synthetic `tool_result` blocks (is_error) are generated for any pending `tool_use` blocks
  - Cancellation returns `Ok(TurnSummary { cancelled: true })` so the CLI saves the session
- **Updated all provider implementations** — CLI's `AnthropicRuntimeClient` streams events incrementally via `try_unfold`; tools crate uses collected-then-streamed approach
- **Nested runtime guard** — `execute_bash` detects existing tokio context via `Handle::try_current()` to avoid panics

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace -- --test-threads=1` — all tests pass
- [x] Built release binary and tested interactively:
  - Streaming text response works correctly
  - Ctrl+C during streaming shows "Cancelled", preserves partial progress
  - Cancelled turn visible in conversation history with `[Interrupted]` marker
  - Next turn has full context of what was interrupted
  - Compact and JSON output modes work

🤖 Generated with [Claude Code](https://claude.com/claude-code)