### PR TITLE
ci: grant write permissions to Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Upgrade `contents`, `pull-requests`, and `issues` permissions from `read` to `write` in `.github/workflows/claude.yml`
- Enables Claude Code Action to create branches, push commits, open PRs, and comment on issues when triggered via `@claude` on a GitHub issue

## Test plan
- [ ] Trigger `@claude` on an issue and verify it can create a PR
- [ ] Verify existing `@claude` comment/review triggers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)