### PR TITLE
feat(acp): stream session/update notifications in real time

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "base64",
  "criterion",
@@ -446,7 +446,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "commands"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "plugins",
  "runtime",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "commands",
  "runtime",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "api",
  "serde_json",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -2343,7 +2343,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "api",
  "arboard",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -160,32 +160,31 @@ pub trait SdkAcpDelegate: Send + 'static {
     ) -> Result<(String, PathBuf), AcpError>;
 }
 
-/// Observer that collects session update notifications to be forwarded to
-/// the ACP client. Implements [`RuntimeObserver`] so existing `run_turn()`
-/// machinery can drive it.
+/// Observer that streams session update notifications to the ACP client in
+/// real time via a channel. Implements [`RuntimeObserver`] so existing
+/// `run_turn()` machinery can drive it.
 pub struct SdkSessionObserver {
     session_id: String,
-    updates: Vec<SessionNotification>,
+    tx: tokio::sync::mpsc::UnboundedSender<SessionNotification>,
 }
 
 impl SdkSessionObserver {
-    /// Create a new observer for the given session.
+    /// Create a new observer that sends notifications through `tx`.
     #[must_use]
-    pub fn new(session_id: impl Into<String>) -> Self {
+    pub fn new(
+        session_id: impl Into<String>,
+        tx: tokio::sync::mpsc::UnboundedSender<SessionNotification>,
+    ) -> Self {
         Self {
             session_id: session_id.into(),
-            updates: Vec::new(),
+            tx,
         }
     }
 
-    /// Drain all buffered notifications.
-    pub fn drain(&mut self) -> Vec<SessionNotification> {
-        std::mem::take(&mut self.updates)
-    }
-
     fn push(&mut self, update: SessionUpdate) {
-        self.updates
-            .push(SessionNotification::new(self.session_id.clone(), update));
+        let _ = self
+            .tx
+            .send(SessionNotification::new(self.session_id.clone(), update));
     }
 }
 
@@ -507,10 +506,14 @@ pub(crate) async fn run_acp_on_transport(
                             tokio::sync::oneshot::Sender<PermissionPromptDecision>,
                         )>();
 
+                        // Set up notification streaming channel.
+                        let (notif_tx, mut notif_rx) =
+                            tokio::sync::mpsc::unbounded_channel::<SessionNotification>();
+
                         let sid_for_blocking = sid.clone();
                         let sid_for_perm = sid.clone();
                         let blocking_handle = tokio::task::spawn_blocking(move || {
-                            let mut observer = SdkSessionObserver::new(&sid_for_blocking);
+                            let mut observer = SdkSessionObserver::new(&sid_for_blocking, notif_tx);
                             let mut bridge = AcpPermissionBridge { tx: bridge_tx };
                             let mut delegate =
                                 d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -537,18 +540,25 @@ pub(crate) async fn run_acp_on_transport(
                                     &mut bridge,
                                 )
                             };
-                            let notifications = observer.drain();
-                            let (reason, usage) = stop.unwrap_or((StopReason::EndTurn, None));
-                            (reason, usage, notifications)
+                            stop.unwrap_or((StopReason::EndTurn, None))
                         });
 
-                        // Concurrently serve permission requests from the
-                        // blocking thread and wait for the blocking task to
-                        // finish.
+                        // Concurrently serve permission requests and stream
+                        // notifications from the blocking thread while waiting
+                        // for it to finish.
                         let mut blocking_handle = blocking_handle;
+                        let mut notif_rx_open = true;
                         let result = loop {
                             tokio::select! {
                                 biased;
+                                notif = notif_rx.recv(), if notif_rx_open => {
+                                    if let Some(n) = notif {
+                                        let _ = cx_inner.send_notification(n);
+                                    } else {
+                                        // Sender dropped — stop polling this channel.
+                                        notif_rx_open = false;
+                                    }
+                                }
                                 perm = bridge_rx.recv() => {
                                     if let Some((perm_req, response_tx)) = perm {
                                         let acp_req = build_acp_permission_request(
@@ -572,19 +582,22 @@ pub(crate) async fn run_acp_on_transport(
                                         // Await the result directly to avoid a busy loop
                                         // (biased select would keep picking this branch).
                                         break blocking_handle.await
-                                            .unwrap_or((StopReason::EndTurn, None, Vec::new()));
+                                            .unwrap_or((StopReason::EndTurn, None));
                                     }
                                 }
                                 done = &mut blocking_handle => {
-                                    break done.unwrap_or((StopReason::EndTurn, None, Vec::new()));
+                                    break done.unwrap_or((StopReason::EndTurn, None));
                                 }
                             }
                         };
 
-                        let (stop_reason, prompt_usage, notifications) = result;
-                        for notif in notifications {
-                            cx_inner.send_notification(notif)?;
+                        // Drain any residual notifications that were buffered
+                        // before the blocking task returned.
+                        while let Ok(n) = notif_rx.try_recv() {
+                            let _ = cx_inner.send_notification(n);
                         }
+
+                        let (stop_reason, prompt_usage) = result;
 
                         let mut response = PromptResponse::new(stop_reason);
                         if let Some(u) = prompt_usage {

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -539,7 +539,23 @@ where
                         }
                         next = stream.next() => {
                             match next {
-                                Some(Ok(event)) => collected.push(event),
+                                Some(Ok(event)) => {
+                                    // Notify the observer in real time as events
+                                    // arrive from the API stream so ACP clients
+                                    // receive incremental updates.
+                                    if let Some(obs) = observer.as_mut() {
+                                        match &event {
+                                            AssistantEvent::TextDelta(delta) => {
+                                                obs.on_text_delta(delta);
+                                            }
+                                            AssistantEvent::ToolUse { id, name, input, .. } => {
+                                                obs.on_tool_use(id, name, input);
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                    collected.push(event);
+                                }
                                 Some(Err(error)) => {
                                     self.record_turn_failed(iterations, &error);
                                     return Err(error);
@@ -553,7 +569,7 @@ where
             };
 
             let (assistant_message, usage, turn_prompt_cache_events) =
-                match build_assistant_message(events, runtime_observer_mut(&mut observer)) {
+                match build_assistant_message(events) {
                     Ok(result) => result,
                     Err(error) => {
                         self.record_turn_failed(iterations, &error);
@@ -913,7 +929,6 @@ fn parse_auto_compaction_threshold(value: Option<&str>) -> u32 {
 
 fn build_assistant_message(
     events: Vec<AssistantEvent>,
-    mut observer: Option<&mut dyn RuntimeObserver>,
 ) -> Result<
     (
         ConversationMessage,
@@ -931,9 +946,6 @@ fn build_assistant_message(
     for event in events {
         match event {
             AssistantEvent::TextDelta(delta) => {
-                if let Some(observer) = observer.as_mut() {
-                    observer.on_text_delta(&delta);
-                }
                 text.push_str(&delta);
             }
             AssistantEvent::ToolUse {
@@ -942,9 +954,6 @@ fn build_assistant_message(
                 input,
                 thought_signature,
             } => {
-                if let Some(observer) = observer.as_mut() {
-                    observer.on_tool_use(&id, &name, &input);
-                }
                 flush_text_block(&mut text, &mut blocks);
                 blocks.push(ContentBlock::ToolUse {
                     id,
@@ -2217,7 +2226,7 @@ mod tests {
         let events = vec![AssistantEvent::TextDelta("hello".to_string())];
 
         // when
-        let error = build_assistant_message(events, None)
+        let error = build_assistant_message(events)
             .expect_err("assistant messages should require a stop event");
 
         // then
@@ -2232,8 +2241,8 @@ mod tests {
         let events = vec![AssistantEvent::MessageStop];
 
         // when
-        let error = build_assistant_message(events, None)
-            .expect_err("assistant messages should require content");
+        let error =
+            build_assistant_message(events).expect_err("assistant messages should require content");
 
         // then
         assert!(error


### PR DESCRIPTION
## Summary
- Replace `Vec` buffer in `SdkSessionObserver` with `UnboundedSender` channel, forwarding notifications to the ACP client as they arrive instead of batching after the turn completes
- Add notification forwarding arm to the `tokio::select!` loop in the `session/prompt` handler
- Move observer callbacks (`on_text_delta`, `on_tool_use`) into the API stream consumption loop in `conversation.rs` so events are emitted in real time

## Test plan
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] `cargo test --workspace` pass (including ACP integration tests with mock server)
- [ ] Manual test with a valid API key: connect an ACP client, send a prompt, verify `session/update` notifications arrive incrementally during generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)