### PR TITLE
fix(acp): resolve session/cancel deadlock

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "base64",
  "criterion",
@@ -446,7 +446,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "commands"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "plugins",
  "runtime",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "commands",
  "runtime",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "api",
  "serde_json",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -2343,7 +2343,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "api",
  "arboard",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -4,6 +4,7 @@
 //! including capabilities declaration, session cancel, permission-mode switching,
 //! model switching, image input, and permission-prompt bridging (elicitation).
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -12,6 +13,7 @@ use agent_client_protocol::role::acp::{Agent, Client};
 //   - `ConnectTo<R>`:    trait for wiring up a transport (Stdio, Lines, etc.)
 //   - `ConnectionTo<R>`: runtime handle passed to handlers for sending messages
 use crate::conversation::RuntimeObserver;
+use crate::hooks::HookAbortSignal;
 use crate::permissions::{
     PermissionMode, PermissionPromptDecision, PermissionPrompter, PermissionRequest,
 };
@@ -130,6 +132,10 @@ pub trait SdkAcpDelegate: Send + 'static {
     /// Cancel a running prompt for the given session by setting its abort
     /// signal. Returns true if the session exists.
     fn cancel_session(&mut self, session_id: &str) -> bool;
+
+    /// Return the abort signal for a session so it can be triggered without
+    /// holding the delegate lock.
+    fn get_abort_signal(&self, session_id: &str) -> Option<HookAbortSignal>;
 
     /// Switch the model for a session. Returns a human-readable report.
     fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, AcpError>;
@@ -302,6 +308,10 @@ pub struct PromptUsage {
 /// Thread-safe handle to a delegate, shared across async handlers.
 pub type SharedDelegate = Arc<Mutex<Box<dyn SdkAcpDelegate>>>;
 
+/// Separate registry of abort signals so that `session/cancel` can fire
+/// without contending on the main delegate mutex.
+type AbortRegistry = Arc<Mutex<HashMap<String, HookAbortSignal>>>;
+
 /// A permission prompter that bridges to the ACP client over channels.
 ///
 /// From inside the blocking `spawn_blocking` context, `decide()` sends
@@ -413,6 +423,7 @@ pub(crate) async fn run_acp_on_transport(
     transport: impl ConnectTo<Agent>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let agent_version = config.agent_version.clone();
+    let abort_registry: AbortRegistry = Arc::new(Mutex::new(HashMap::new()));
 
     Agent
         .builder()
@@ -444,21 +455,31 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
+                let abort_registry = Arc::clone(&abort_registry);
                 async move |req: NewSessionRequest,
                             responder: Responder<NewSessionResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
+                    let registry = Arc::clone(&abort_registry);
                     cx.spawn(async move {
                         let result = tokio::task::spawn_blocking(move || {
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .new_session(req.cwd)
+                            let mut delegate =
+                                d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let res = delegate.new_session(req.cwd)?;
+                            let signal = delegate.get_abort_signal(&res.0);
+                            Ok((res.0, res.1, signal))
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
 
                         match result {
-                            Ok((session_id, _cwd)) => {
+                            Ok((session_id, _cwd, signal)) => {
+                                if let Some(sig) = signal {
+                                    registry
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .insert(session_id.clone(), sig);
+                                }
                                 responder.respond(NewSessionResponse::new(session_id))?;
                             }
                             Err(e) => {
@@ -605,15 +626,17 @@ pub(crate) async fn run_acp_on_transport(
         // --- session/cancel (notification) ---
         .on_receive_notification(
             {
-                let delegate = Arc::clone(&delegate);
+                let abort_registry = Arc::clone(&abort_registry);
                 async move |notif: CancelNotification, _cx: ConnectionTo<Client>| {
-                    let d = Arc::clone(&delegate);
                     let sid = notif.session_id.to_string();
-                    tokio::task::spawn_blocking(move || {
-                        d.lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner)
-                            .cancel_session(&sid);
-                    });
+                    let signal = abort_registry
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .get(&sid)
+                        .cloned();
+                    if let Some(signal) = signal {
+                        signal.abort();
+                    }
                     Ok(())
                 }
             },
@@ -623,19 +646,26 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
+                let abort_registry = Arc::clone(&abort_registry);
                 async move |req: CloseSessionRequest,
                             responder: Responder<CloseSessionResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
+                    let registry = Arc::clone(&abort_registry);
                     let sid = req.session_id.to_string();
                     cx.spawn(async move {
+                        let sid_clone = sid.clone();
                         tokio::task::spawn_blocking(move || {
                             d.lock()
                                 .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .close_session(&sid);
+                                .close_session(&sid_clone);
                         })
                         .await
                         .ok();
+                        registry
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .remove(&sid);
                         responder.respond(CloseSessionResponse::new())?;
                         Ok(())
                     })?;
@@ -710,23 +740,33 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
+                let abort_registry = Arc::clone(&abort_registry);
                 async move |req: LoadSessionRequest,
                             responder: Responder<LoadSessionResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
+                    let registry = Arc::clone(&abort_registry);
                     let sid = req.session_id.to_string();
                     let cwd = req.cwd;
                     cx.spawn(async move {
                         let result = tokio::task::spawn_blocking(move || {
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .load_session(&sid, cwd)
+                            let mut delegate =
+                                d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let res = delegate.load_session(&sid, cwd)?;
+                            let signal = delegate.get_abort_signal(&res.0);
+                            Ok((res.0, res.1, signal))
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
 
                         match result {
-                            Ok((_session_id, _cwd)) => {
+                            Ok((session_id, _cwd, signal)) => {
+                                if let Some(sig) = signal {
+                                    registry
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .insert(session_id, sig);
+                                }
                                 responder.respond(LoadSessionResponse::new())?;
                             }
                             Err(e) => {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1919,6 +1919,13 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         }
     }
 
+    fn get_abort_signal(&self, session_id: &str) -> Option<runtime::HookAbortSignal> {
+        self.inner
+            .sessions
+            .get(session_id)
+            .map(|s| s.abort_signal.clone())
+    }
+
     fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, runtime::AcpError> {
         self.inner
             .handle_acp_model_switch(session_id, Some(model_id.to_string()))


### PR DESCRIPTION
## Summary
- `session/cancel` was blocked on the delegate `Mutex` held by the running `session/prompt`, making cancellation impossible during execution
- Introduce a separate `AbortRegistry` (`HashMap<String, HookAbortSignal>`) so the cancel handler can trigger the abort signal without contending on the delegate lock
- Register abort signals on `session/new` and `session/load`, clean up on `session/close`

## Test plan
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] `cargo test --workspace` pass (including ACP integration tests)
- [x] Manual test: send `session/cancel` during a running prompt, confirmed prompt aborts promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)