### PR TITLE
feat: track model per-message in session JSONL

### DIFF
--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -167,6 +167,7 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
         role: MessageRole::System,
         blocks: vec![ContentBlock::Text { text: continuation }],
         usage: None,
+        model: None,
     }];
     compacted_messages.extend(preserved);
 
@@ -596,6 +597,7 @@ mod tests {
                     text: "recent".to_string(),
                 }],
                 usage: None,
+                model: None,
             },
         ];
 
@@ -708,6 +710,7 @@ mod tests {
                     text: get_compact_continuation_message(summary, true, true),
                 }],
                 usage: None,
+                model: None,
             },
             ConversationMessage::user_text("tiny"),
             ConversationMessage::assistant(vec![ContentBlock::Text {

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -568,7 +568,7 @@ where
                 collected
             };
 
-            let (assistant_message, usage, turn_prompt_cache_events) =
+            let (mut assistant_message, usage, turn_prompt_cache_events) =
                 match build_assistant_message(events) {
                     Ok(result) => result,
                     Err(error) => {
@@ -576,6 +576,7 @@ where
                         return Err(error);
                     }
                 };
+            assistant_message.model.clone_from(&self.session.model);
             if let Some(usage) = usage {
                 self.usage_tracker.record(usage);
             }

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -56,6 +56,8 @@ pub struct ConversationMessage {
     pub role: MessageRole,
     pub blocks: Vec<ContentBlock>,
     pub usage: Option<TokenUsage>,
+    /// The model that generated this message (set only for assistant messages).
+    pub model: Option<String>,
 }
 
 /// Metadata describing the latest compaction that summarized a session.
@@ -259,6 +261,7 @@ impl Session {
             role: MessageRole::User,
             blocks,
             usage: None,
+            model: None,
         })
     }
 
@@ -644,6 +647,7 @@ impl ConversationMessage {
             role: MessageRole::User,
             blocks: vec![ContentBlock::Text { text: text.into() }],
             usage: None,
+            model: None,
         }
     }
 
@@ -653,6 +657,7 @@ impl ConversationMessage {
             role: MessageRole::Assistant,
             blocks,
             usage: None,
+            model: None,
         }
     }
 
@@ -662,6 +667,7 @@ impl ConversationMessage {
             role: MessageRole::Assistant,
             blocks,
             usage,
+            model: None,
         }
     }
 
@@ -681,6 +687,7 @@ impl ConversationMessage {
                 is_error,
             }],
             usage: None,
+            model: None,
         }
     }
 
@@ -705,6 +712,9 @@ impl ConversationMessage {
         );
         if let Some(usage) = self.usage {
             object.insert("usage".to_string(), usage_to_json(usage));
+        }
+        if let Some(model) = &self.model {
+            object.insert("model".to_string(), JsonValue::String(model.clone()));
         }
         JsonValue::Object(object)
     }
@@ -736,10 +746,15 @@ impl ConversationMessage {
             .map(ContentBlock::from_json)
             .collect::<Result<Vec<_>, _>>()?;
         let usage = object.get("usage").map(usage_from_json).transpose()?;
+        let model = object
+            .get("model")
+            .and_then(JsonValue::as_str)
+            .map(String::from);
         Ok(Self {
             role,
             blocks,
             usage,
+            model,
         })
     }
 }
@@ -1492,6 +1507,39 @@ mod tests {
         // then
         assert_eq!(restored.workspace_root(), Some(workspace_root.as_path()));
         assert_eq!(forked.workspace_root(), Some(workspace_root.as_path()));
+    }
+
+    #[test]
+    fn per_message_model_round_trips_through_jsonl() {
+        // given
+        let path = temp_session_path("per-message-model");
+        let mut session = Session::new();
+        let mut assistant_msg = ConversationMessage::assistant(vec![ContentBlock::Text {
+            text: "response".to_string(),
+        }]);
+        assistant_msg.model = Some("claude-sonnet-4-6".to_string());
+        session
+            .push_user_text("hello")
+            .expect("user message should append");
+        session
+            .push_message(assistant_msg)
+            .expect("assistant message should append");
+
+        // when
+        session.save_to_path(&path).expect("session should save");
+        let restored = Session::load_from_path(&path).expect("session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        // then
+        assert_eq!(
+            restored.messages[1].model.as_deref(),
+            Some("claude-sonnet-4-6"),
+            "assistant message model should survive JSONL round-trip"
+        );
+        assert_eq!(
+            restored.messages[0].model, None,
+            "user message model should be None"
+        );
     }
 
     fn temp_session_path(label: &str) -> PathBuf {

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -304,6 +304,7 @@ mod tests {
                 cache_creation_input_tokens: 1,
                 cache_read_input_tokens: 0,
             }),
+            model: None,
         }];
 
         let tracker = UsageTracker::from_session(&session);

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1959,6 +1959,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                     mime_type: mime_type.clone(),
                 }],
                 usage: None,
+                model: None,
             };
             session
                 .runtime

--- a/rust/crates/rusty-sudocode-cli/tests/acp_live_smoke.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_live_smoke.rs
@@ -517,6 +517,55 @@ async fn run_live_scenarios(client: &mut AcpTestClient, workspace: &TestWorkspac
     scenario_initialize(client).await;
     let session_id = scenario_session_new(client, &workspace.root).await;
     scenario_session_prompt(client, &session_id).await;
+    verify_session_model_in_jsonl(workspace);
+}
+
+/// After a prompt completes, find the persisted session JSONL and verify
+/// that assistant messages carry a `model` field.
+fn verify_session_model_in_jsonl(workspace: &TestWorkspace) {
+    // Session files live under <workspace.root>/.scode/sessions/<fingerprint>/*.jsonl
+    let sessions_dir = workspace.root.join(".scode").join("sessions");
+    assert!(
+        sessions_dir.exists(),
+        "session directory should exist at {}",
+        sessions_dir.display()
+    );
+
+    // Find any .jsonl file (simple recursive search).
+    let jsonl_path = find_jsonl_file(&sessions_dir).expect("should find a session .jsonl file");
+
+    let contents = fs::read_to_string(&jsonl_path).expect("should read session jsonl");
+
+    // Parse each line; find message records with role=assistant.
+    let mut found_assistant = false;
+    for line in contents.lines() {
+        let Ok(record) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if record["type"] != "message" {
+            continue;
+        }
+        let msg = &record["message"];
+        if msg["role"] != "assistant" {
+            continue;
+        }
+        found_assistant = true;
+        let model = msg.get("model").and_then(Value::as_str);
+        assert!(
+            model.is_some_and(|m| !m.is_empty()),
+            "assistant message in session JSONL should have a non-empty model field, \
+             but got: {:?}",
+            model
+        );
+        eprintln!(
+            "session JSONL: assistant message model = {:?}",
+            model.unwrap()
+        );
+    }
+    assert!(
+        found_assistant,
+        "session JSONL should contain at least one assistant message"
+    );
 }
 
 async fn run_subagent_scenarios(client: &mut AcpTestClient, workspace: &TestWorkspace) {
@@ -575,4 +624,23 @@ async fn live_anthropic_smoke_ws() {
     run_live_scenarios(&mut client, &workspace).await;
     client.shutdown().await;
     workspace.cleanup();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Recursively find the first `.jsonl` file under `dir`.
+fn find_jsonl_file(dir: &std::path::Path) -> Option<PathBuf> {
+    for entry in fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = find_jsonl_file(&path) {
+                return Some(found);
+            }
+        } else if path.extension().is_some_and(|ext| ext == "jsonl") {
+            return Some(path);
+        }
+    }
+    None
 }


### PR DESCRIPTION
Track which model generated each assistant message in the session JSONL, rather than only recording the model once in `session_meta`.

## Changes
- `ConversationMessage` gains an optional `model` field
- `to_json` / `from_json` serialize/deserialize it (backward-compatible)
- The runtime stamps `session.model` onto every assistant message before persisting, so mid-session `/model` switches are correctly attributed
- New round-trip test in `session.rs`

Closes #35

Generated with [Claude Code](https://claude.ai/code)