### PR TITLE
fix: emit JSON error envelope to stdout instead of stderr

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -237,9 +237,10 @@ fn main() {
         if json_output {
             // #77: classify error by prefix so downstream consumers can route without
             // regex-scraping the prose. Split short-reason from hint-runbook.
+            // Emit to stdout (not stderr) so ACP and other JSON consumers can parse it.
             let kind = classify_error_kind(&message);
             let (short_reason, hint) = split_error_hint(&message);
-            eprintln!(
+            println!(
                 "{}",
                 serde_json::json!({
                     "type": "error",

--- a/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
@@ -366,6 +366,39 @@ fn resumed_version_and_init_emit_structured_json_when_requested() {
     assert!(root.join("CLAUDE.md").exists());
 }
 
+#[test]
+fn clap_parse_error_emits_json_envelope_to_stdout() {
+    let root = unique_temp_dir("clap-error-json");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    let output = run_scode(
+        &root,
+        &["--output-format", "json", "--unknown-flag-that-does-not-exist"],
+        &[],
+    );
+    assert!(
+        !output.status.success(),
+        "a bad flag should exit non-zero"
+    );
+    // JSON envelope must land on stdout so ACP can parse it.
+    assert!(
+        !output.stdout.is_empty(),
+        "stdout should contain a JSON error envelope, got empty stdout\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(parsed["type"], "error", "envelope type should be 'error'");
+    assert!(
+        parsed["error"].is_string(),
+        "envelope should have an 'error' string field"
+    );
+    assert!(
+        parsed["kind"].is_string(),
+        "envelope should have a 'kind' string field"
+    );
+}
+
 fn assert_json_command(current_dir: &Path, args: &[&str]) -> Value {
     assert_json_command_with_env(current_dir, args, &[])
 }


### PR DESCRIPTION
Fixes #69

When `--output-format json` is active, the top-level error handler in `main()` was writing the JSON envelope via `eprintln!` (stderr). The ACP desktop app reads stdout for JSON, so it never received the error object and fell back to plain-text stderr parsing.

Change the JSON branch to `println!` so the envelope lands on stdout, consistent with every other JSON output path in the CLI. Text-mode errors continue to go to stderr unchanged.

Also adds a contract test: `clap_parse_error_emits_json_envelope_to_stdout` verifies that an unrecognised flag with `--output-format json` exits non-zero and writes a parseable `{"type":"error",...}` object to stdout.

Generated with [Claude Code](https://claude.ai/code)