### PR TITLE
refactor(acp): clean up cancel interface and fix cross-connection cancel

### DIFF
--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -94,8 +94,9 @@ pub(crate) struct SetPermissionModeResponse {}
 /// this crate.
 pub trait SdkAcpDelegate: Send + 'static {
     /// Create a new session for the given working directory, returning
-    /// `(session_id, cwd)` on success.
-    fn new_session(&mut self, cwd: PathBuf) -> Result<(String, PathBuf), AcpError>;
+    /// `(session_id, cwd, abort_signal)` on success.
+    fn new_session(&mut self, cwd: PathBuf)
+        -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
 
     /// Run a prompt turn. The implementation should call observer methods
     /// to stream session updates.
@@ -129,14 +130,6 @@ pub trait SdkAcpDelegate: Send + 'static {
     /// Close (drop) a session by ID. Returns true if it existed.
     fn close_session(&mut self, session_id: &str) -> bool;
 
-    /// Cancel a running prompt for the given session by setting its abort
-    /// signal. Returns true if the session exists.
-    fn cancel_session(&mut self, session_id: &str) -> bool;
-
-    /// Return the abort signal for a session so it can be triggered without
-    /// holding the delegate lock.
-    fn get_abort_signal(&self, session_id: &str) -> Option<HookAbortSignal>;
-
     /// Switch the model for a session. Returns a human-readable report.
     fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, AcpError>;
 
@@ -158,12 +151,12 @@ pub trait SdkAcpDelegate: Send + 'static {
     ) -> Result<(), AcpError>;
 
     /// Load an existing persisted session by its ID and working directory,
-    /// returning `(session_id, cwd)` on success.
+    /// returning `(session_id, cwd, abort_signal)` on success.
     fn load_session(
         &mut self,
         session_id: &str,
         cwd: PathBuf,
-    ) -> Result<(String, PathBuf), AcpError>;
+    ) -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
 }
 
 /// Observer that streams session update notifications to the ACP client in
@@ -309,7 +302,15 @@ pub type SharedDelegate = Arc<Mutex<Box<dyn SdkAcpDelegate>>>;
 
 /// Separate registry of abort signals so that `session/cancel` can fire
 /// without contending on the main delegate mutex.
-type AbortRegistry = Arc<Mutex<HashMap<String, HookAbortSignal>>>;
+pub type AbortRegistry = Arc<Mutex<HashMap<String, HookAbortSignal>>>;
+
+/// Create a new empty abort registry. Share this across connections so that
+/// cancel notifications on a reconnected transport can still reach sessions
+/// created on a previous connection.
+#[must_use]
+pub fn new_abort_registry() -> AbortRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
 
 /// A permission prompter that bridges to the ACP client over channels.
 ///
@@ -419,10 +420,10 @@ fn uuid_v4() -> String {
 pub(crate) async fn run_acp_on_transport(
     config: &SdkAcpConfig,
     delegate: SharedDelegate,
+    abort_registry: AbortRegistry,
     transport: impl ConnectTo<Agent>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let agent_version = config.agent_version.clone();
-    let abort_registry: AbortRegistry = Arc::new(Mutex::new(HashMap::new()));
 
     Agent
         .builder()
@@ -462,23 +463,19 @@ pub(crate) async fn run_acp_on_transport(
                     let registry = Arc::clone(&abort_registry);
                     cx.spawn(async move {
                         let result = tokio::task::spawn_blocking(move || {
-                            let mut delegate =
-                                d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                            let res = delegate.new_session(req.cwd)?;
-                            let signal = delegate.get_abort_signal(&res.0);
-                            Ok((res.0, res.1, signal))
+                            d.lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .new_session(req.cwd)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
 
                         match result {
                             Ok((session_id, _cwd, signal)) => {
-                                if let Some(sig) = signal {
-                                    registry
-                                        .lock()
-                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                        .insert(session_id.clone(), sig);
-                                }
+                                registry
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .insert(session_id.clone(), signal);
                                 responder.respond(NewSessionResponse::new(session_id))?;
                             }
                             Err(e) => {
@@ -763,23 +760,19 @@ pub(crate) async fn run_acp_on_transport(
                     let cwd = req.cwd;
                     cx.spawn(async move {
                         let result = tokio::task::spawn_blocking(move || {
-                            let mut delegate =
-                                d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                            let res = delegate.load_session(&sid, cwd)?;
-                            let signal = delegate.get_abort_signal(&res.0);
-                            Ok((res.0, res.1, signal))
+                            d.lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .load_session(&sid, cwd)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
 
                         match result {
                             Ok((session_id, _cwd, signal)) => {
-                                if let Some(sig) = signal {
-                                    registry
-                                        .lock()
-                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                        .insert(session_id, sig);
-                                }
+                                registry
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .insert(session_id, signal);
                                 responder.respond(LoadSessionResponse::new())?;
                             }
                             Err(e) => {

--- a/rust/crates/runtime/src/acp_stdio_server.rs
+++ b/rust/crates/runtime/src/acp_stdio_server.rs
@@ -6,7 +6,9 @@ use std::sync::{Arc, Mutex};
 
 use agent_client_protocol_tokio::Stdio;
 
-use crate::acp_sdk_server::{run_acp_on_transport, SdkAcpConfig, SdkAcpDelegate, SharedDelegate};
+use crate::acp_sdk_server::{
+    new_abort_registry, run_acp_on_transport, SdkAcpConfig, SdkAcpDelegate, SharedDelegate,
+};
 
 /// Run the ACP server on stdin/stdout.
 ///
@@ -18,5 +20,5 @@ pub async fn run_acp_stdio_server(
     delegate: Box<dyn SdkAcpDelegate>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let delegate: SharedDelegate = Arc::new(Mutex::new(delegate));
-    run_acp_on_transport(&config, delegate, Stdio::new()).await
+    run_acp_on_transport(&config, delegate, new_abort_registry(), Stdio::new()).await
 }

--- a/rust/crates/runtime/src/acp_web_ui.html
+++ b/rust/crates/runtime/src/acp_web_ui.html
@@ -64,8 +64,10 @@ body { display: flex; flex-direction: column; }
 .input-bar input { flex: 1; background: var(--bg); color: var(--fg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; font-size: 14px; outline: none; }
 .input-bar input:focus { border-color: var(--accent); }
 .input-bar input:disabled { opacity: 0.5; }
-.send-btn { background: var(--accent); color: var(--bg); border: none; border-radius: 6px; padding: 8px 16px; cursor: pointer; font-weight: 600; font-size: 14px; }
+.send-btn { background: var(--accent); color: var(--bg); border: none; border-radius: 6px; padding: 8px 16px; cursor: pointer; font-weight: 600; font-size: 14px; min-width: 80px; }
 .send-btn:disabled { opacity: 0.4; cursor: default; }
+.send-btn.cancel { background: var(--err); cursor: pointer; opacity: 1; }
+.send-btn.cancelling { background: var(--err); opacity: 0.5; cursor: default; }
 </style>
 </head>
 <body>
@@ -116,6 +118,7 @@ body { display: flex; flex-direction: column; }
   let currentSession = '';
   let pendingCallbacks = {};
   let agentMsgEl = null; // accumulator for streaming agent text
+  let prompting = false; // true while a prompt is in-flight
 
   function connect() {
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -151,6 +154,12 @@ body { display: flex; flex-direction: column; }
     logInspector('out', msg);
     ws.send(JSON.stringify(msg));
     return new Promise(resolve => { pendingCallbacks[id] = resolve; });
+  }
+
+  function sendNotification(method, params) {
+    const msg = { jsonrpc: '2.0', method, params: params || {} };
+    logInspector('out', msg);
+    ws.send(JSON.stringify(msg));
   }
 
   async function doInitialize() {
@@ -192,13 +201,38 @@ body { display: flex; flex-direction: column; }
     }
   }
 
+  function setPrompting(active) {
+    prompting = active;
+    inputEl.disabled = active;
+    if (active) {
+      sendBtn.disabled = false;
+      sendBtn.textContent = 'Cancel';
+      sendBtn.classList.remove('cancelling');
+      sendBtn.classList.add('cancel');
+    } else {
+      sendBtn.disabled = false;
+      sendBtn.textContent = 'Send';
+      sendBtn.classList.remove('cancel');
+      sendBtn.classList.remove('cancelling');
+    }
+  }
+
+  function cancelPrompt() {
+    if (!prompting || !currentSession) return;
+    sendNotification('session/cancel', { sessionId: currentSession });
+    // Immediately show "Cancelling..." so the user knows it was received.
+    sendBtn.textContent = 'Cancelling\u2026';
+    sendBtn.classList.remove('cancel');
+    sendBtn.classList.add('cancelling');
+    sendBtn.disabled = true;
+  }
+
   async function sendPrompt(text) {
     if (!currentSession || !text.trim()) return;
     addChatMsg('user', text);
     inputEl.value = '';
-    inputEl.disabled = true;
-    sendBtn.disabled = true;
     agentMsgEl = null;
+    setPrompting(true);
 
     const resp = await sendRpc('session/prompt', {
       sessionId: currentSession,
@@ -207,8 +241,7 @@ body { display: flex; flex-direction: column; }
 
     // Finalize any streaming agent message
     agentMsgEl = null;
-    inputEl.disabled = false;
-    sendBtn.disabled = false;
+    setPrompting(false);
     inputEl.focus();
   }
 
@@ -297,11 +330,16 @@ body { display: flex; flex-direction: column; }
   }
 
   // Event listeners
-  sendBtn.addEventListener('click', () => sendPrompt(inputEl.value));
+  sendBtn.addEventListener('click', () => {
+    if (prompting) { cancelPrompt(); } else { sendPrompt(inputEl.value); }
+  });
   inputEl.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && !e.shiftKey && !inputEl.disabled) {
       e.preventDefault();
       sendPrompt(inputEl.value);
+    }
+    if (e.key === 'Escape' && prompting) {
+      cancelPrompt();
     }
   });
   newSessionBtn.addEventListener('click', createNewSession);

--- a/rust/crates/runtime/src/acp_ws_server.rs
+++ b/rust/crates/runtime/src/acp_ws_server.rs
@@ -14,7 +14,10 @@ use axum::Router;
 use futures::{SinkExt, StreamExt};
 use tokio::net::TcpListener;
 
-use crate::acp_sdk_server::{run_acp_on_transport, SdkAcpConfig, SdkAcpDelegate, SharedDelegate};
+use crate::acp_sdk_server::{
+    new_abort_registry, run_acp_on_transport, AbortRegistry, SdkAcpConfig, SdkAcpDelegate,
+    SharedDelegate,
+};
 
 static WEB_UI_HTML: &str = include_str!("acp_web_ui.html");
 
@@ -22,6 +25,7 @@ static WEB_UI_HTML: &str = include_str!("acp_web_ui.html");
 struct AppState {
     config: SdkAcpConfig,
     delegate: SharedDelegate,
+    abort_registry: AbortRegistry,
 }
 
 /// Run an ACP server over WebSocket + serve the embedded web UI.
@@ -37,6 +41,7 @@ pub async fn run_acp_ws_server(
     let state = AppState {
         config,
         delegate: Arc::new(Mutex::new(delegate)),
+        abort_registry: new_abort_registry(),
     };
     let app = Router::new()
         .route("/", get(serve_html))
@@ -83,8 +88,13 @@ async fn handle_ws(socket: WebSocket, state: AppState) {
 
     let transport = agent_client_protocol::Lines::new(outgoing, incoming);
 
-    if let Err(e) =
-        run_acp_on_transport(&state.config, Arc::clone(&state.delegate), transport).await
+    if let Err(e) = run_acp_on_transport(
+        &state.config,
+        Arc::clone(&state.delegate),
+        Arc::clone(&state.abort_registry),
+        transport,
+    )
+    .await
     {
         eprintln!("[acp-ws] transport error: {e}");
     }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1756,12 +1756,16 @@ impl AcpSdkDelegate {
 }
 
 impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
-    fn new_session(&mut self, cwd: PathBuf) -> Result<(String, PathBuf), runtime::AcpError> {
+    fn new_session(
+        &mut self,
+        cwd: PathBuf,
+    ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
         let session = self.inner.build_session(&cwd)?;
         let session_id = session.handle.id.clone();
         let session_cwd = session.cwd.clone();
+        let abort_signal = session.abort_signal.clone();
         self.inner.sessions.insert(session_id.clone(), session);
-        Ok((session_id, session_cwd))
+        Ok((session_id, session_cwd, abort_signal))
     }
 
     fn run_prompt(
@@ -1910,22 +1914,6 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         self.inner.sessions.remove(session_id).is_some()
     }
 
-    fn cancel_session(&mut self, session_id: &str) -> bool {
-        if let Some(session) = self.inner.sessions.get(session_id) {
-            session.abort_signal.abort();
-            true
-        } else {
-            false
-        }
-    }
-
-    fn get_abort_signal(&self, session_id: &str) -> Option<runtime::HookAbortSignal> {
-        self.inner
-            .sessions
-            .get(session_id)
-            .map(|s| s.abort_signal.clone())
-    }
-
     fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, runtime::AcpError> {
         self.inner
             .handle_acp_model_switch(session_id, Some(model_id.to_string()))
@@ -1985,7 +1973,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         &mut self,
         session_id: &str,
         cwd: PathBuf,
-    ) -> Result<(String, PathBuf), runtime::AcpError> {
+    ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
         let cwd = canonical_session_cwd(&cwd)?;
         let _guard = ScopedCurrentDir::change_to(&cwd)
             .map_err(|e| runtime::AcpError::internal(format!("failed to enter cwd: {e}")))?;
@@ -2031,6 +2019,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         }
 
         let loaded_session_id = handle.id.clone();
+        let signal = abort_signal.clone();
         self.inner.sessions.insert(
             loaded_session_id.clone(),
             AcpCliSession {
@@ -2040,7 +2029,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 abort_signal,
             },
         );
-        Ok((loaded_session_id, cwd))
+        Ok((loaded_session_id, cwd, signal))
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove `cancel_session` and `get_abort_signal` from `SdkAcpDelegate` trait — these were ACP transport implementation details that didn't belong on the delegate interface
- Return `HookAbortSignal` directly from `new_session`/`load_session` instead of fetching it via a separate trait method call under the delegate lock
- Share `AbortRegistry` across WebSocket reconnections so cancel notifications on a new connection can reach sessions created on a previous one (previously each WS connection had its own registry, making cancel silently no-op after reconnect)
- Add Cancel button to the ACP web UI with `session/cancel` notification, "Cancelling..." feedback state, and Escape key shortcut

## Test plan

- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass
- [x] Manually tested cancel via web UI: send long prompt, press Cancel mid-stream, confirm prompt stops
- [x] Verified cancel works after page reconnect (shared abort registry fix)
- [x] "Cancelling..." button state provides clear feedback during the ~1s wind-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)