### PR TITLE
fix(agent): make Agent tool sync by default and add AwaitAgent via TaskOutput

### DIFF
--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -571,7 +571,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "Agent",
-            description: "Launch a specialized agent task and persist its handoff metadata.",
+            description: "Launch a specialized agent task. By default runs synchronously and returns the result. Set run_in_background=true to launch asynchronously and retrieve results later with TaskOutput(agent_id, block=true).",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -579,7 +579,8 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                     "prompt": { "type": "string" },
                     "subagent_type": { "type": "string" },
                     "name": { "type": "string" },
-                    "model": { "type": "string" }
+                    "model": { "type": "string" },
+                    "run_in_background": { "type": "boolean" }
                 },
                 "required": ["description", "prompt"],
                 "additionalProperties": false
@@ -842,13 +843,15 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "TaskOutput",
-            description: "Retrieve the output produced by a background task.",
+            description: "Retrieve output from a background task or agent. Use task_id for TaskRegistry tasks. Use agent_id to retrieve (and optionally await) a background agent launched with Agent(run_in_background=true). Set block=true to wait until the agent finishes.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "task_id": { "type": "string" }
+                    "task_id": { "type": "string" },
+                    "agent_id": { "type": "string" },
+                    "block": { "type": "boolean" },
+                    "timeout_ms": { "type": "integer", "minimum": 0 }
                 },
-                "required": ["task_id"],
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::ReadOnly,
@@ -1256,7 +1259,7 @@ fn execute_tool_with_enforcer(
         "TaskList" => run_task_list(input.clone()),
         "TaskStop" => from_value::<TaskIdInput>(input).and_then(run_task_stop),
         "TaskUpdate" => from_value::<TaskUpdateInput>(input).and_then(run_task_update),
-        "TaskOutput" => from_value::<TaskIdInput>(input).and_then(run_task_output),
+        "TaskOutput" => from_value::<TaskOutputInput>(input).and_then(run_task_output),
         "WorkerCreate" => from_value::<WorkerCreateInput>(input).and_then(run_worker_create),
         "WorkerGet" => from_value::<WorkerIdInput>(input).and_then(run_worker_get),
         "WorkerObserve" => from_value::<WorkerObserveInput>(input).and_then(run_worker_observe),
@@ -1477,15 +1480,62 @@ fn run_task_update(input: TaskUpdateInput) -> Result<String, String> {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_task_output(input: TaskIdInput) -> Result<String, String> {
+fn run_task_output(input: TaskOutputInput) -> Result<String, String> {
+    if let Some(agent_id) = &input.agent_id {
+        let value = await_agent_output(agent_id, input.block, input.timeout_ms)?;
+        return to_pretty_json(value);
+    }
+    let task_id = input
+        .task_id
+        .as_deref()
+        .ok_or_else(|| String::from("either task_id or agent_id is required"))?;
     let registry = global_task_registry();
-    match registry.output(&input.task_id) {
+    match registry.output(task_id) {
         Ok(output) => to_pretty_json(json!({
-            "task_id": input.task_id,
+            "task_id": task_id,
             "output": output,
             "has_output": !output.is_empty()
         })),
         Err(e) => Err(e),
+    }
+}
+
+fn await_agent_output(agent_id: &str, block: bool, timeout_ms: u64) -> Result<Value, String> {
+    let output_dir = agent_store_dir()?;
+    let manifest_path = output_dir.join(format!("{agent_id}.json"));
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+
+    loop {
+        if !manifest_path.exists() {
+            return Err(format!("agent not found: {agent_id}"));
+        }
+        let contents =
+            std::fs::read_to_string(&manifest_path).map_err(|e| e.to_string())?;
+        let manifest: AgentOutput =
+            serde_json::from_str(&contents).map_err(|e| e.to_string())?;
+
+        if manifest.status != "running" || !block {
+            return Ok(json!({
+                "agent_id": manifest.agent_id,
+                "status": manifest.status,
+                "retrieval_status": if manifest.status == "running" { "not_ready" } else { "success" },
+                "result": manifest.result,
+                "error": manifest.error,
+                "output_file": manifest.output_file,
+                "manifest_file": manifest.manifest_file,
+            }));
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Ok(json!({
+                "agent_id": agent_id,
+                "status": "running",
+                "retrieval_status": "timeout",
+            }));
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
     }
 }
 
@@ -2310,6 +2360,8 @@ struct AgentInput {
     subagent_type: Option<String>,
     name: Option<String>,
     model: Option<String>,
+    #[serde(default)]
+    run_in_background: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2425,6 +2477,20 @@ struct TaskIdInput {
 struct TaskUpdateInput {
     task_id: String,
     message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskOutputInput {
+    task_id: Option<String>,
+    agent_id: Option<String>,
+    #[serde(default)]
+    block: bool,
+    #[serde(default = "default_task_output_timeout_ms")]
+    timeout_ms: u64,
+}
+
+const fn default_task_output_timeout_ms() -> u64 {
+    30_000
 }
 
 #[derive(Debug, Deserialize)]
@@ -2608,6 +2674,8 @@ struct AgentOutput {
     derived_state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -3476,13 +3544,19 @@ const DEFAULT_AGENT_SYSTEM_DATE: &str = "2026-03-31";
 const DEFAULT_AGENT_MAX_ITERATIONS: usize = 32;
 
 fn execute_agent(input: AgentInput) -> Result<AgentOutput, String> {
-    execute_agent_with_spawn(input, spawn_agent_job)
+    if input.run_in_background.unwrap_or(false) {
+        execute_agent_with_spawn(input, spawn_agent_job)
+    } else {
+        execute_agent_inline(input)
+    }
 }
 
-fn execute_agent_with_spawn<F>(input: AgentInput, spawn_fn: F) -> Result<AgentOutput, String>
-where
-    F: FnOnce(AgentJob) -> Result<(), String>,
-{
+struct PreparedAgent {
+    manifest: AgentOutput,
+    job: AgentJob,
+}
+
+fn prepare_agent_job(input: AgentInput) -> Result<PreparedAgent, String> {
     if input.description.trim().is_empty() {
         return Err(String::from("description must not be empty"));
     }
@@ -3540,23 +3614,61 @@ where
         current_blocker: None,
         derived_state: String::from("working"),
         error: None,
+        result: None,
     };
     write_agent_manifest(&manifest)?;
 
-    let manifest_for_spawn = manifest.clone();
     let job = AgentJob {
-        manifest: manifest_for_spawn,
+        manifest: manifest.clone(),
         prompt: input.prompt,
         system_prompt,
         allowed_tools,
     };
+    Ok(PreparedAgent { manifest, job })
+}
+
+fn execute_agent_with_spawn<F>(input: AgentInput, spawn_fn: F) -> Result<AgentOutput, String>
+where
+    F: FnOnce(AgentJob) -> Result<(), String>,
+{
+    let PreparedAgent { manifest, job } = prepare_agent_job(input)?;
     if let Err(error) = spawn_fn(job) {
         let error = format!("failed to spawn sub-agent: {error}");
         persist_agent_terminal_state(&manifest, "failed", None, Some(error.clone()))?;
         return Err(error);
     }
-
     Ok(manifest)
+}
+
+fn execute_agent_inline(input: AgentInput) -> Result<AgentOutput, String> {
+    let PreparedAgent { manifest, job } = prepare_agent_job(input)?;
+    match run_agent_job_returning_text(&job) {
+        Ok(final_text) => {
+            persist_agent_terminal_state(
+                &manifest,
+                "completed",
+                Some(final_text.as_str()),
+                None,
+            )?;
+            // Re-read manifest so lane events and result written by persist are present.
+            let output = std::fs::read_to_string(&manifest.manifest_file)
+                .map_err(|e| e.to_string())
+                .and_then(|s| {
+                    serde_json::from_str::<AgentOutput>(&s).map_err(|e| e.to_string())
+                })
+                .unwrap_or(manifest);
+            Ok(output)
+        }
+        Err(error) => {
+            let _ = persist_agent_terminal_state(
+                &manifest,
+                "failed",
+                None,
+                Some(error.clone()),
+            );
+            Err(format!("sub-agent failed: {error}"))
+        }
+    }
 }
 
 fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
@@ -3564,8 +3676,16 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
     std::thread::Builder::new()
         .name(thread_name)
         .spawn(move || {
-            let result =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_agent_job(&job)));
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                run_agent_job_returning_text(&job).and_then(|text| {
+                    persist_agent_terminal_state(
+                        &job.manifest,
+                        "completed",
+                        Some(text.as_str()),
+                        None,
+                    )
+                })
+            }));
             match result {
                 Ok(Ok(())) => {}
                 Ok(Err(error)) => {
@@ -3586,14 +3706,13 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
         .map_err(|error| error.to_string())
 }
 
-fn run_agent_job(job: &AgentJob) -> Result<(), String> {
+fn run_agent_job_returning_text(job: &AgentJob) -> Result<String, String> {
     let mut runtime = build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
     let tokio_rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
     let summary = tokio_rt
         .block_on(runtime.run_turn(job.prompt.clone(), None, None))
         .map_err(|error| error.to_string())?;
-    let final_text = final_assistant_text(&summary);
-    persist_agent_terminal_state(&job.manifest, "completed", Some(final_text.as_str()), None)
+    Ok(final_assistant_text(&summary))
 }
 
 fn build_agent_runtime(
@@ -3756,6 +3875,10 @@ fn persist_agent_terminal_state(
     next_manifest.current_blocker.clone_from(&blocker);
     next_manifest.derived_state =
         derive_agent_state(status, result, error.as_deref(), blocker.as_ref()).to_string();
+    next_manifest.result = result
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
     next_manifest.error = error;
     if let Some(blocker) = blocker {
         next_manifest
@@ -7794,6 +7917,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("ship-audit".to_string()),
                 model: None,
+                run_in_background: None,
             },
             move |job| {
                 *captured_for_spawn
@@ -7837,7 +7961,8 @@ mod tests {
             &json!({
                 "description": "Verify the branch",
                 "prompt": "Check tests.",
-                "subagent_type": "explorer"
+                "subagent_type": "explorer",
+                "run_in_background": true
             }),
         )
         .expect("Agent should normalize built-in aliases");
@@ -7850,7 +7975,8 @@ mod tests {
             &json!({
                 "description": "Review the branch",
                 "prompt": "Inspect diff.",
-                "name": "Ship Audit!!!"
+                "name": "Ship Audit!!!",
+                "run_in_background": true
             }),
         )
         .expect("Agent should normalize explicit names");
@@ -7875,6 +8001,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("complete-task".to_string()),
                 model: Some("claude-sonnet-4-6".to_string()),
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -7932,6 +8059,7 @@ mod tests {
                 subagent_type: Some("Verification".to_string()),
                 name: Some("fail-task".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -7979,6 +8107,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("summary-floor".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -8024,6 +8153,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("recovery-lane".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -8072,6 +8202,7 @@ mod tests {
                 subagent_type: Some("Verification".to_string()),
                 name: Some("review-lane".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -8112,6 +8243,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("backlog-scan".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -8158,6 +8290,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("artifact-lane".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -8228,6 +8361,7 @@ mod tests {
                 subagent_type: Some("Explore".to_string()),
                 name: Some("cron-closeout".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |job| {
                 persist_agent_terminal_state(
@@ -8269,6 +8403,7 @@ mod tests {
                 subagent_type: None,
                 name: Some("spawn-error".to_string()),
                 model: None,
+                run_in_background: None,
             },
             |_| Err(String::from("thread creation failed")),
         )

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -32,6 +32,15 @@ use runtime::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+/// Global abort flag for agent polling loops. Callers (e.g. Ctrl-C handlers) set this to true
+/// to unblock any in-progress `await_agent_output` poll.
+static AGENT_POLL_ABORT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_agent_poll_abort(aborted: bool) {
+    AGENT_POLL_ABORT.store(aborted, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// Global task registry shared across tool invocations within a session.
 fn global_lsp_registry() -> &'static LspRegistry {
     use std::sync::OnceLock;
@@ -575,12 +584,12 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "description": { "type": "string" },
-                    "prompt": { "type": "string" },
-                    "subagent_type": { "type": "string" },
-                    "name": { "type": "string" },
-                    "model": { "type": "string" },
-                    "run_in_background": { "type": "boolean" }
+                    "description": { "type": "string", "description": "A short (3-5 word) description of the task" },
+                    "prompt": { "type": "string", "description": "The full task prompt for the agent" },
+                    "subagent_type": { "type": "string", "description": "Agent type specialization (e.g. Explore, general-purpose)" },
+                    "name": { "type": "string", "description": "Optional human-readable label for this agent" },
+                    "model": { "type": "string", "description": "Model ID override; defaults to the system default" },
+                    "run_in_background": { "type": "boolean", "description": "Set true to launch async and retrieve result later with TaskOutput(agent_id=..., block=true); defaults to false (synchronous)" }
                 },
                 "required": ["description", "prompt"],
                 "additionalProperties": false
@@ -847,10 +856,10 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "task_id": { "type": "string" },
-                    "agent_id": { "type": "string" },
-                    "block": { "type": "boolean" },
-                    "timeout_ms": { "type": "integer", "minimum": 0 }
+                    "task_id": { "type": "string", "description": "ID of a TaskRegistry task to retrieve output from" },
+                    "agent_id": { "type": "string", "description": "ID of a background agent launched with Agent(run_in_background=true)" },
+                    "block": { "type": "boolean", "description": "When true (default), wait until the agent finishes before returning" },
+                    "timeout_ms": { "type": "integer", "minimum": 0, "description": "Maximum milliseconds to wait when block=true (default 30000)" }
                 },
                 "additionalProperties": false
             }),
@@ -1507,11 +1516,17 @@ fn await_agent_output(agent_id: &str, block: bool, timeout_ms: u64) -> Result<Va
         std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
 
     loop {
-        if !manifest_path.exists() {
-            return Err(format!("agent not found: {agent_id}"));
+        if AGENT_POLL_ABORT.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(String::from("agent polling aborted by shutdown signal"));
         }
-        let contents =
-            std::fs::read_to_string(&manifest_path).map_err(|e| e.to_string())?;
+
+        let contents = match std::fs::read_to_string(&manifest_path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(format!("agent not found: {agent_id}"));
+            }
+            Err(e) => return Err(e.to_string()),
+        };
         let manifest: AgentOutput =
             serde_json::from_str(&contents).map_err(|e| e.to_string())?;
 
@@ -2483,10 +2498,14 @@ struct TaskUpdateInput {
 struct TaskOutputInput {
     task_id: Option<String>,
     agent_id: Option<String>,
-    #[serde(default)]
+    #[serde(default = "default_block_true")]
     block: bool,
     #[serde(default = "default_task_output_timeout_ms")]
     timeout_ms: u64,
+}
+
+const fn default_block_true() -> bool {
+    true
 }
 
 const fn default_task_output_timeout_ms() -> u64 {
@@ -3708,10 +3727,21 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
 
 fn run_agent_job_returning_text(job: &AgentJob) -> Result<String, String> {
     let mut runtime = build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
-    let tokio_rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
-    let summary = tokio_rt
-        .block_on(runtime.run_turn(job.prompt.clone(), None, None))
-        .map_err(|error| error.to_string())?;
+    // When called from within a tokio context (inline agent), use block_in_place to avoid
+    // "Cannot start a runtime from within a runtime". When called from a plain std thread
+    // (background agent via spawn_agent_job), fall back to a fresh runtime.
+    let summary = match tokio::runtime::Handle::try_current() {
+        Ok(handle) => tokio::task::block_in_place(|| {
+            handle
+                .block_on(runtime.run_turn(job.prompt.clone(), None, None))
+                .map_err(|e| e.to_string())
+        })?,
+        Err(_) => {
+            let rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+            rt.block_on(runtime.run_turn(job.prompt.clone(), None, None))
+                .map_err(|e| e.to_string())?
+        }
+    };
     Ok(final_assistant_text(&summary))
 }
 
@@ -3851,11 +3881,12 @@ fn agent_permission_policy() -> PermissionPolicy {
 fn write_agent_manifest(manifest: &AgentOutput) -> Result<(), String> {
     let mut normalized = manifest.clone();
     normalized.lane_events = dedupe_superseded_commit_events(&normalized.lane_events);
-    std::fs::write(
-        &normalized.manifest_file,
-        serde_json::to_string_pretty(&normalized).map_err(|error| error.to_string())?,
-    )
-    .map_err(|error| error.to_string())
+    let json = serde_json::to_string_pretty(&normalized).map_err(|e| e.to_string())?;
+    // Write to a temp file then rename for atomic visibility — prevents a poller
+    // reading a partially-written file during truncate-then-write.
+    let tmp_path = format!("{}.tmp", normalized.manifest_file);
+    std::fs::write(&tmp_path, &json).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp_path, &normalized.manifest_file).map_err(|e| e.to_string())
 }
 
 fn persist_agent_terminal_state(

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -32,13 +32,31 @@ use runtime::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-/// Global abort flag for agent polling loops. Callers (e.g. Ctrl-C handlers) set this to true
-/// to unblock any in-progress `await_agent_output` poll.
-static AGENT_POLL_ABORT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+/// Registry of per-call abort tokens for agent polling loops. Each `await_agent_output`
+/// call registers its own token; callers (e.g. Ctrl-C handlers) invoke
+/// `set_agent_poll_abort(true)` to cancel all currently-active polls without cross-talk
+/// between concurrent calls or stale state carrying over to subsequent calls.
+fn active_poll_abort_tokens(
+) -> &'static std::sync::Mutex<Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>> {
+    use std::sync::OnceLock;
+    static TOKENS: OnceLock<
+        std::sync::Mutex<Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>>,
+    > = OnceLock::new();
+    TOKENS.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
 
 pub fn set_agent_poll_abort(aborted: bool) {
-    AGENT_POLL_ABORT.store(aborted, std::sync::atomic::Ordering::Relaxed);
+    if !aborted {
+        return;
+    }
+    let mut tokens = active_poll_abort_tokens()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    for token in tokens.drain(..) {
+        if let Some(arc) = token.upgrade() {
+            arc.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
 }
 
 /// Global task registry shared across tool invocations within a session.
@@ -1512,11 +1530,21 @@ fn run_task_output(input: TaskOutputInput) -> Result<String, String> {
 fn await_agent_output(agent_id: &str, block: bool, timeout_ms: u64) -> Result<Value, String> {
     let output_dir = agent_store_dir()?;
     let manifest_path = output_dir.join(format!("{agent_id}.json"));
-    let deadline =
-        std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+
+    // Per-call abort token. Registered in the global registry so set_agent_poll_abort
+    // can cancel it; auto-resets because each call creates a fresh Arc starting false.
+    let abort = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    {
+        let mut tokens = active_poll_abort_tokens()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        tokens.retain(|w| w.strong_count() > 0);
+        tokens.push(std::sync::Arc::downgrade(&abort));
+    }
 
     loop {
-        if AGENT_POLL_ABORT.load(std::sync::atomic::Ordering::Relaxed) {
+        if abort.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(String::from("agent polling aborted by shutdown signal"));
         }
 
@@ -3586,6 +3614,7 @@ fn prepare_agent_job(input: AgentInput) -> Result<PreparedAgent, String> {
     let agent_id = make_agent_id();
     let output_dir = agent_store_dir()?;
     std::fs::create_dir_all(&output_dir).map_err(|error| error.to_string())?;
+    sweep_orphaned_tmp_files(&output_dir);
     let output_file = output_dir.join(format!("{agent_id}.md"));
     let manifest_file = output_dir.join(format!("{agent_id}.json"));
     let normalized_subagent_type = normalize_subagent_type(input.subagent_type.as_deref());
@@ -3726,21 +3755,27 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
 }
 
 fn run_agent_job_returning_text(job: &AgentJob) -> Result<String, String> {
-    let mut runtime = build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
-    // When called from within a tokio context (inline agent), use block_in_place to avoid
-    // "Cannot start a runtime from within a runtime". When called from a plain std thread
-    // (background agent via spawn_agent_job), fall back to a fresh runtime.
-    let summary = match tokio::runtime::Handle::try_current() {
-        Ok(handle) => tokio::task::block_in_place(|| {
-            handle
-                .block_on(runtime.run_turn(job.prompt.clone(), None, None))
-                .map_err(|e| e.to_string())
-        })?,
-        Err(_) => {
-            let rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
-            rt.block_on(runtime.run_turn(job.prompt.clone(), None, None))
-                .map_err(|e| e.to_string())?
-        }
+    let mut conv_runtime =
+        build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
+    let prompt = job.prompt.clone();
+
+    // When inside a tokio context, spawn a fresh OS thread so we can create a new
+    // tokio Runtime without nesting. block_in_place is not used here because it
+    // panics on current_thread runtimes (the MCP server entry path uses one).
+    let summary = if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                let rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+                rt.block_on(conv_runtime.run_turn(prompt, None, None))
+                    .map_err(|e| e.to_string())
+            })
+            .join()
+            .map_err(|_| String::from("sub-agent thread panicked"))?
+        })?
+    } else {
+        let rt = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+        rt.block_on(conv_runtime.run_turn(prompt, None, None))
+            .map_err(|e| e.to_string())?
     };
     Ok(final_assistant_text(&summary))
 }
@@ -3876,6 +3911,20 @@ fn agent_permission_policy() -> PermissionPolicy {
         PermissionPolicy::new(PermissionMode::DangerFullAccess),
         |policy, spec| policy.with_tool_requirement(spec.name, spec.required_permission),
     )
+}
+
+/// Best-effort removal of `*.tmp` files left behind by a previous crash between
+/// `fs::write` and `fs::rename` in `write_agent_manifest`. Called once per agent
+/// launch so the directory stays clean without a separate startup sweep.
+fn sweep_orphaned_tmp_files(dir: &std::path::Path) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("tmp") {
+                let _ = std::fs::remove_file(path);
+            }
+        }
+    }
 }
 
 fn write_agent_manifest(manifest: &AgentOutput) -> Result<(), String> {
@@ -6331,12 +6380,13 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        agent_permission_policy, allowed_tools_for_subagent, classify_lane_failure,
-        derive_agent_state, execute_agent_with_spawn, execute_tool, extract_recovery_outcome,
-        final_assistant_text, global_cron_registry, maybe_commit_provenance, mvp_tool_specs,
-        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_task_packet, AgentInput, AgentJob, GlobalToolRegistry, LaneEventName, LaneFailureClass,
-        SubagentToolExecutor,
+        agent_permission_policy, agent_store_dir, allowed_tools_for_subagent,
+        await_agent_output, classify_lane_failure, derive_agent_state, execute_agent_with_spawn,
+        execute_tool, extract_recovery_outcome, final_assistant_text, global_cron_registry,
+        maybe_commit_provenance, mvp_tool_specs, permission_mode_from_plugin,
+        persist_agent_terminal_state, push_output_block, run_task_packet, set_agent_poll_abort,
+        sweep_orphaned_tmp_files, AgentInput, AgentJob, GlobalToolRegistry, LaneEventName,
+        LaneFailureClass, SubagentToolExecutor,
     };
     use api::OutputContentBlock;
     use runtime::{
@@ -8717,6 +8767,204 @@ mod tests {
         )
         .expect_err("blank prompt should fail");
         assert!(missing_prompt.contains("prompt must not be empty"));
+    }
+
+    #[test]
+    fn await_agent_output_returns_not_ready_for_running_non_blocking() {
+        let _guard = env_guard();
+        let dir = temp_path("agent-poll-nonblocking");
+        std::env::set_var("SUDOCODE_AGENT_STORE", &dir);
+
+        let manifest = execute_agent_with_spawn(
+            AgentInput {
+                description: "Slow task".to_string(),
+                prompt: "Run slowly".to_string(),
+                subagent_type: None,
+                name: None,
+                model: None,
+                run_in_background: None,
+            },
+            |_job| Ok(()), // spawn but don't complete — manifest stays "running"
+        )
+        .expect("spawn should succeed");
+
+        // block=false should return immediately with not_ready.
+        let value = await_agent_output(&manifest.agent_id, false, 5_000)
+            .expect("non-blocking poll should not error");
+        assert_eq!(value["retrieval_status"], "not_ready");
+        assert_eq!(value["status"], "running");
+
+        std::env::remove_var("SUDOCODE_AGENT_STORE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn await_agent_output_returns_timeout_when_deadline_exceeded() {
+        let _guard = env_guard();
+        let dir = temp_path("agent-poll-timeout");
+        std::env::set_var("SUDOCODE_AGENT_STORE", &dir);
+
+        let manifest = execute_agent_with_spawn(
+            AgentInput {
+                description: "Never completes".to_string(),
+                prompt: "Spin forever".to_string(),
+                subagent_type: None,
+                name: None,
+                model: None,
+                run_in_background: None,
+            },
+            |_job| Ok(()),
+        )
+        .expect("spawn should succeed");
+
+        // timeout_ms=1 should expire almost immediately for a still-running agent.
+        let value = await_agent_output(&manifest.agent_id, true, 1)
+            .expect("timeout path should return Ok");
+        assert_eq!(value["retrieval_status"], "timeout");
+        assert_eq!(value["status"], "running");
+
+        std::env::remove_var("SUDOCODE_AGENT_STORE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn await_agent_output_returns_success_after_completion() {
+        let _guard = env_guard();
+        let dir = temp_path("agent-poll-completed");
+        std::env::set_var("SUDOCODE_AGENT_STORE", &dir);
+
+        let manifest = execute_agent_with_spawn(
+            AgentInput {
+                description: "Quick task".to_string(),
+                prompt: "Finish fast".to_string(),
+                subagent_type: None,
+                name: None,
+                model: None,
+                run_in_background: None,
+            },
+            |job| persist_agent_terminal_state(&job.manifest, "completed", Some("done"), None),
+        )
+        .expect("spawn should succeed");
+
+        // Agent is already completed — blocking poll should return success immediately.
+        let value = await_agent_output(&manifest.agent_id, true, 5_000)
+            .expect("completed agent poll should succeed");
+        assert_eq!(value["retrieval_status"], "success");
+        assert_eq!(value["status"], "completed");
+
+        std::env::remove_var("SUDOCODE_AGENT_STORE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn await_agent_output_returns_error_for_missing_agent() {
+        let _guard = env_guard();
+        let dir = temp_path("agent-poll-missing");
+        std::fs::create_dir_all(&dir).expect("create dir");
+        std::env::set_var("SUDOCODE_AGENT_STORE", &dir);
+
+        let err = await_agent_output("agent-nonexistent", false, 5_000)
+            .expect_err("missing agent should error");
+        assert!(err.contains("agent not found"), "got: {err}");
+
+        std::env::remove_var("SUDOCODE_AGENT_STORE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn await_agent_output_handles_truncated_manifest_gracefully() {
+        let _guard = env_guard();
+        let dir = temp_path("agent-poll-truncated");
+        std::fs::create_dir_all(&dir).expect("create dir");
+        std::env::set_var("SUDOCODE_AGENT_STORE", &dir);
+
+        // Write a truncated (invalid) JSON file where the manifest would be.
+        let agent_id = "agent-malformed-12345";
+        std::fs::write(dir.join(format!("{agent_id}.json")), b"{ \"status\": \"runn")
+            .expect("write truncated manifest");
+
+        let err = await_agent_output(agent_id, false, 5_000)
+            .expect_err("truncated manifest should return Err, not panic");
+        assert!(!err.is_empty(), "error message should be non-empty");
+
+        std::env::remove_var("SUDOCODE_AGENT_STORE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn set_agent_poll_abort_cancels_active_poll_without_affecting_new_ones() {
+        let _guard = env_guard();
+        let dir = temp_path("agent-poll-abort");
+        std::env::set_var("SUDOCODE_AGENT_STORE", &dir);
+
+        let manifest = execute_agent_with_spawn(
+            AgentInput {
+                description: "Abortable task".to_string(),
+                prompt: "Stay running".to_string(),
+                subagent_type: None,
+                name: None,
+                model: None,
+                run_in_background: None,
+            },
+            |_job| Ok(()),
+        )
+        .expect("spawn should succeed");
+        let agent_id = manifest.agent_id.clone();
+
+        // Spawn a thread to poll, then abort it from the main thread.
+        let poll_handle = std::thread::spawn(move || {
+            await_agent_output(&agent_id, true, 60_000)
+        });
+
+        // Give the poll thread a moment to register its abort token.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        set_agent_poll_abort(true);
+
+        let result = poll_handle.join().expect("poll thread should not panic");
+        assert!(result.is_err(), "aborted poll should return Err");
+        let msg = result.unwrap_err();
+        assert!(msg.contains("aborted"), "got: {msg}");
+
+        // After the abort, a brand-new poll should NOT be immediately aborted
+        // (auto-reset: each call creates a fresh token starting false).
+        let manifest2 = execute_agent_with_spawn(
+            AgentInput {
+                description: "Second task".to_string(),
+                prompt: "Also running".to_string(),
+                subagent_type: None,
+                name: None,
+                model: None,
+                run_in_background: None,
+            },
+            |_job| Ok(()),
+        )
+        .expect("second spawn should succeed");
+
+        // block=false so it returns immediately — key check: not erroring with "aborted".
+        let value = await_agent_output(&manifest2.agent_id, false, 5_000)
+            .expect("fresh poll after abort should not be pre-aborted");
+        assert_eq!(value["retrieval_status"], "not_ready");
+
+        std::env::remove_var("SUDOCODE_AGENT_STORE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn sweep_orphaned_tmp_files_removes_tmp_and_leaves_json() {
+        let dir = temp_path("agent-sweep-tmp");
+        std::fs::create_dir_all(&dir).expect("create dir");
+
+        let tmp_path = dir.join("agent-123.json.tmp");
+        let json_path = dir.join("agent-123.json");
+        std::fs::write(&tmp_path, b"partial").expect("write tmp");
+        std::fs::write(&json_path, b"{}").expect("write json");
+
+        sweep_orphaned_tmp_files(&dir);
+
+        assert!(!tmp_path.exists(), ".tmp file should be removed");
+        assert!(json_path.exists(), ".json file should be kept");
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #87

Agent tool now blocks until completion by default (run_in_background=false), returns result in the response, and TaskOutput gains agent_id+block+timeout_ms for awaiting async agents.

Generated with [Claude Code](https://claude.ai/code)