### PR TITLE
feat: add scripts/fmt.sh root-level Rust formatting wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Frameworks: none detected from the supported starter markers.
 
 ## Verification
-- Run Rust verification from `rust/`: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
+- Run Rust verification from `rust/`: `scripts/fmt.sh` (or `cargo fmt` from `rust/`), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
+- Use `scripts/fmt.sh` from the repo root to format Rust code (forwards flags, e.g. `scripts/fmt.sh --check`)
 - `src/` and `tests/` are both present; update both surfaces together when behavior changes.
 
 ## Repository shape

--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Sudo Code (sudocode.dev) when working with code i
 - Frameworks: none detected from the supported starter markers.
 
 ## Verification
-- Run Rust verification from the repo root: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
+- Run Rust verification from the repo root: `cargo fmt` (or use `scripts/fmt.sh` from the repo root as a wrapper), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
 
 ## Working agreement
 - Prefer small, reviewable changes and keep generated bootstrap files aligned with actual repo workflows.

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUST_DIR="$SCRIPT_DIR/../rust"
+
+cd "$RUST_DIR"
+exec cargo fmt "$@"


### PR DESCRIPTION
Adds a repo-root wrapper script `scripts/fmt.sh` that resolves its own directory via `${BASH_SOURCE[0]}`, changes to `rust/`, and execs `cargo fmt` forwarding all user flags.

Updates root `CLAUDE.md` and `rust/CLAUDE.md` to reference the new stable formatting entry point.

Closes #75

Generated with [Claude Code](https://claude.ai/code)