### PR TITLE
feat(runtime): spawn_task<K: KernelAbi> (PR-C v1, lockstep with nexus #4026)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -75,6 +75,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +95,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -189,6 +208,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,12 +319,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bloomfilter"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d7f06817e48ea4e17532fa61bc4e8b9a101437f0623f69d2ea54284f3a817"
+dependencies = [
+ "getrandom 0.2.17",
+ "siphasher",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -307,6 +372,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -476,6 +547,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "contracts"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus?rev=064c33742#064c33742f025a8e54632ec422e59f2c4f7188d5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +580,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -645,6 +739,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +890,12 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fastcdc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
 
 [[package]]
 name = "fastrand"
@@ -839,6 +962,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1048,6 +1177,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,11 +1227,20 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1097,6 +1248,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1493,6 +1649,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel"
+version = "0.10.0"
+source = "git+https://github.com/nexi-lab/nexus?rev=064c33742#064c33742f025a8e54632ec422e59f2c4f7188d5"
+dependencies = [
+ "ahash",
+ "base64",
+ "blake3",
+ "bloomfilter",
+ "chrono",
+ "contracts",
+ "crc32fast",
+ "dashmap",
+ "encoding_rs",
+ "fastcdc",
+ "futures",
+ "globset",
+ "lib",
+ "libc",
+ "lru",
+ "memchr",
+ "memmap2",
+ "parking_lot",
+ "prost",
+ "protoc-bin-vendored",
+ "rayon",
+ "redb",
+ "regex",
+ "roaring",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "simsimd",
+ "string-interner",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1705,35 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lib"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus?rev=064c33742#064c33742f025a8e54632ec422e59f2c4f7188d5"
+dependencies = [
+ "ahash",
+ "base64",
+ "blake3",
+ "crc32fast",
+ "dashmap",
+ "getrandom 0.3.4",
+ "globset",
+ "memchr",
+ "parking_lot",
+ "pem",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "serde",
+ "serde_json",
+ "sha2",
+ "string-interner",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tonic",
+ "tracing",
+]
 
 [[package]]
 name = "libc"
@@ -1554,6 +1781,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1806,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1818,6 +2063,16 @@ name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2264,6 +2519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2675,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "runtime"
 version = "0.1.4"
 dependencies = [
@@ -2423,6 +2697,7 @@ dependencies = [
  "futures",
  "glob",
  "image",
+ "kernel",
  "keyring",
  "nexus-vfs-client",
  "plugins",
@@ -2483,6 +2758,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2749,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2760,7 +3036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2814,6 +3090,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +3147,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
@@ -3183,6 +3491,7 @@ dependencies = [
  "prost",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -14,6 +14,19 @@ axum = { workspace = true }
 base64 = "0.22"
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+# Nexus kernel rlib — provides `kernel::abi::KernelAbi` trait that
+# `runtime::spawn_task::<K>` is generic over. `default-features =
+# false` keeps the kernel runtime defaults (mimalloc, connector
+# stack, py-hook adapters) off in the sudocode build — sudocode does
+# not need them and they would bloat the standalone CLI.
+#
+# Cross-repo git-dep pinned to the nexus PR branch that introduced
+# the trait (PR #4026, `feat/kernel-abi-trait`). Bump the rev when
+# nexus pushes new commits to the branch; the lockstep merge order
+# is "nexus PR #4026 lands → bump rev to merged commit on develop →
+# this sudocode PR lands". Until the nexus PR lands, this pin is
+# the one stable rev both repos see.
+kernel = { git = "https://github.com/nexi-lab/nexus", rev = "064c33742", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -42,6 +42,7 @@ pub mod sandbox;
 mod session;
 pub mod session_control;
 pub use session_control::SessionStore;
+pub mod spawn_task;
 mod sse;
 pub mod stale_base;
 pub mod stale_branch;

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -1,0 +1,194 @@
+//! Managed-agent loop spawn entry — v1 echo scaffolding (PR-C v1).
+//!
+//! Wires the per-pid agent loop into a sudocode-driven body that polls
+//! `/proc/{pid}/chat-with-me` for inbound JSON envelopes and writes
+//! responses back through the same mailbox path. The full LLM
+//! turn-driver wiring (constructing a [`crate::ConversationRuntime`]
+//! with a provider client + tool executor and calling `run_turn` per
+//! inbound prompt) lands in PR-C v2 — v1 ships the scaffolding
+//! (procfs poll loop, [`crate::HookAbortSignal`] plumbing, envelope
+//! round-trip pass-through) so the nexus-side `ManagedAgentService`
+//! wiring + e2e round-trip can land alongside.
+//!
+//! Cancellation: callers reuse [`crate::HookAbortSignal`] (the same
+//! signal `with_hook_abort_signal` threads into a
+//! [`crate::ConversationRuntime`] when v2 lands). At the nexus
+//! boundary, `cancel(Turn)` and `cancel(Session)` both translate to
+//! `abort_signal.abort()`; the difference falls out of the loop body
+//! once the v2 `run_turn` driver lands. v1's body has no per-turn
+//! boundary, so today turn-cancel and session-cancel both terminate
+//! the loop on the next poll iteration.
+//!
+//! ## v0 → v1 migration
+//!
+//! v0 (commit `869e80a`, reverted as `17bc205`) was generic over a
+//! concrete `Arc<Kernel>` and used a path-dep on the nexus kernel rlib.
+//! That coupled sudocode's build to a specific side-by-side dev layout
+//! and pinned the kernel concrete type into the spawn API.
+//!
+//! v1 takes `Arc<K: KernelAbi + Send + Sync + 'static>` so production
+//! (`K = Kernel`, monomorphised at the binary link site → identical
+//! perf to a direct inherent call) and tests (`K = MockKernel` once
+//! that lands) share one entry. The kernel rlib is reached through a
+//! `kernel = { git = ..., rev = ..., default-features = false }` git
+//! dep on the nexus repo's `feat/kernel-abi-trait` rev (the PR that
+//! introduced `KernelAbi`).
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use kernel::abi::KernelAbi;
+use kernel::core::agents::registry::AgentDescriptor;
+use kernel::kernel::OperationContext;
+
+use crate::hooks::HookAbortSignal;
+
+/// Sleep between `sys_read` polls when the canonical mailbox is idle.
+/// Kept short so prompt-to-response latency stays bounded by a single
+/// sleep tick once the v2 LLM body lands; today's echo body returns
+/// even faster because each iteration writes the reply inline.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Per-call `sys_read` blocking timeout. `0` keeps the call
+/// non-blocking — `FileWatchRegistry::wait_for_event` is a stub today
+/// (returns `None` immediately), so any non-zero timeout would
+/// degrade to a busy wait inside the kernel. Once `sys_watch` lands
+/// the loop can drop the explicit `thread::sleep` below and let the
+/// kernel block for it.
+const READ_TIMEOUT_MS: u64 = 0;
+
+/// Handle returned by [`spawn_task`]. Caller (typically nexus's
+/// `ManagedAgentService::start_session`) holds this so cancel paths
+/// can call `abort_signal.abort()` without caring whether the per-pid
+/// task is mid-turn or idle in the poll loop, and so observability
+/// code can wait for the loop to actually leave by joining the
+/// thread.
+pub struct SpawnHandle {
+    /// Shared abort signal — the same [`HookAbortSignal`] the v2 LLM
+    /// runtime threads through to [`crate::ConversationRuntime`] via
+    /// `with_hook_abort_signal`. v1's loop checks `is_aborted()`
+    /// between poll iterations.
+    pub abort_signal: HookAbortSignal,
+    /// Join handle for the spawned worker thread. v1 uses
+    /// [`std::thread`] because the body has no async work; v2 will
+    /// switch this to a `tokio::task::JoinHandle` so the LLM stream
+    /// can run inside `spawn_blocking` and bubble structured errors
+    /// up through the join surface.
+    pub join: thread::JoinHandle<()>,
+}
+
+/// Spawn the managed-agent loop for a freshly-allocated pid.
+///
+/// `desc` is the descriptor nexus's
+/// `ManagedAgentService::start_session` already planted in
+/// `AgentRegistry`; we read `pid` (which procfs path to poll),
+/// `name` (the agent_id we stamp our writes with), `owner_id` and
+/// `zone_id` (carried into the per-call `OperationContext`).
+///
+/// `kernel` is the same `Arc<K>` the service holds (concrete `Kernel`
+/// in production, mock in tests). Every `sys_read` / `sys_write`
+/// rides through the [`KernelAbi`] trait as a system-tier call
+/// (`is_system = true` so workspace-boundary checks pass).
+///
+/// v1 body: for each inbound envelope where `from != desc.name`,
+/// write back `{"to": <inbound from>, "from": <self>, "body":
+/// "echo: <inbound body>"}`. The explicit self-`from` lets the loop
+/// guard skip our own writes without depending on
+/// `MailboxStampingHook` being installed (kernel can run
+/// without the hook in unit tests). When the hook is installed the
+/// stamp is a no-op because the field already matches.
+///
+/// v2 body (future PR): construct [`crate::ConversationRuntime`] +
+/// call `run_turn` per inbound prompt. The [`HookAbortSignal`]
+/// returned in the handle is the wiring point —
+/// `with_hook_abort_signal(handle.abort_signal.clone())` on the
+/// runtime gives turn-level abort the same wire that session-level
+/// abort already uses.
+#[must_use]
+pub fn spawn_task<K: KernelAbi + Send + Sync + 'static>(
+    kernel: Arc<K>,
+    desc: AgentDescriptor,
+) -> SpawnHandle {
+    let abort_signal = HookAbortSignal::default();
+    let abort_for_thread = abort_signal.clone();
+
+    let join = thread::Builder::new()
+        .name(format!("managed-agent-{}", desc.pid))
+        .spawn(move || {
+            run_loop(&kernel, &desc, &abort_for_thread);
+        })
+        .expect("OS refused to spawn managed-agent thread");
+
+    SpawnHandle { abort_signal, join }
+}
+
+fn run_loop<K: KernelAbi>(kernel: &Arc<K>, desc: &AgentDescriptor, abort: &HookAbortSignal) {
+    let cwm_path = format!("/proc/{}/chat-with-me", desc.pid);
+    let agent_id = desc.name.as_str();
+    let ctx = OperationContext::new(
+        &desc.owner_id,
+        &desc.zone_id,
+        /* is_admin */ false,
+        Some(agent_id),
+        /* is_system */ true,
+    );
+
+    let mut next_offset: u64 = 0;
+    while !abort.is_aborted() {
+        match kernel.sys_read(&cwm_path, &ctx, READ_TIMEOUT_MS, next_offset) {
+            Ok(result) => {
+                if let Some(bytes) = result.data.as_ref() {
+                    if !bytes.is_empty() {
+                        if let Some(reply) = build_echo_reply(bytes, agent_id) {
+                            // Pass-through if write fails — v1 does
+                            // not retry; the abort path wins on the
+                            // next poll. Real failure modes (mailbox
+                            // capacity exceeded, federation lost
+                            // quorum) are surfaced when the v2 LLM
+                            // body wraps writes with structured
+                            // RuntimeError reporting.
+                            let _ = kernel.sys_write(&cwm_path, &ctx, &reply, 0);
+                        }
+                    }
+                }
+                if let Some(advanced) = result.stream_next_offset {
+                    next_offset = advanced as u64;
+                }
+            }
+            Err(_) => {
+                // Path tear-down (cancel(Session) → procfs unregister)
+                // arrives as FileNotFound; other transient kernel
+                // errors share the same path. v1 treats every kernel
+                // error as terminal because the loop's lifetime is
+                // bounded by the pid's procfs subtree anyway.
+                break;
+            }
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Build the echo response envelope, or `None` when the inbound
+/// envelope should be skipped (own write, no `from` field, non-JSON,
+/// non-object).
+fn build_echo_reply(inbound: &[u8], self_agent_id: &str) -> Option<Vec<u8>> {
+    let value: serde_json::Value = serde_json::from_slice(inbound).ok()?;
+    let obj = value.as_object()?;
+    let from = obj.get("from").and_then(|v| v.as_str())?;
+    if from == self_agent_id {
+        return None;
+    }
+    let body = obj.get("body").and_then(|v| v.as_str()).unwrap_or("");
+    let reply = serde_json::json!({
+        "to": from,
+        "from": self_agent_id,
+        "body": format!("echo: {body}"),
+    });
+    serde_json::to_vec(&reply).ok()
+}
+
+// Tests live under `runtime/tests/spawn_task.rs` as an integration
+// test binary so they can compile without bringing in the rest of
+// the lib's test target (which has pre-existing platform-specific
+// fixtures unrelated to spawn_task).

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -1,0 +1,232 @@
+//! Integration tests for `runtime::spawn_task`. Lives outside the
+//! lib's `#[cfg(test)] mod` so it compiles as its own test binary
+//! and stays decoupled from unrelated lib-test fixtures.
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
+use kernel::kernel::{Kernel, OperationContext};
+use runtime::spawn_task::spawn_task;
+
+const DT_STREAM: i32 = 4;
+const STREAM_CAPACITY: usize = 65_536;
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Add the `/proc` mount to the kernel's VFSRouter. Without this,
+/// `sys_read` / `sys_write` against `/proc/*` paths errors at
+/// `vfs_router.route()` before consulting the metastore. Mirrors
+/// `mount_proc` in the nexus-side managed_agent integration tests.
+fn mount_proc(kernel: &Kernel) {
+    kernel
+        .vfs_router_arc()
+        .add_mount("/proc", "root", None, false);
+}
+
+fn plant_chat_stream(kernel: &Kernel, pid: &str) {
+    let path = format!("/proc/{pid}/chat-with-me");
+    kernel
+        .sys_setattr(
+            &path,
+            DT_STREAM,
+            /* backend_name */ "",
+            /* backend */ None,
+            /* metastore */ None,
+            /* raft_backend */ None,
+            /* io_profile */ "memory",
+            /* zone_id */ "root",
+            /* is_external */ false,
+            STREAM_CAPACITY,
+            /* read_fd */ None,
+            /* write_fd */ None,
+            /* mime_type */ None,
+            /* modified_at_ms */ None,
+            /* link_target */ None,
+            /* source */ None,
+            /* remote_metastore */ None,
+        )
+        .expect("plant /proc/{pid}/chat-with-me DT_STREAM");
+}
+
+fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
+    AgentDescriptor {
+        pid: pid.to_string(),
+        name: name.to_string(),
+        kind: AgentKind::Managed,
+        owner_id: "test-owner".to_string(),
+        zone_id: "root".to_string(),
+        ..Default::default()
+    }
+}
+
+fn user_ctx() -> OperationContext {
+    OperationContext::new(
+        "test-user",
+        "root",
+        /* is_admin */ false,
+        Some("user-test"),
+        /* is_system */ true,
+    )
+}
+
+fn read_envelopes(
+    kernel: &Kernel,
+    path: &str,
+    ctx: &OperationContext,
+    from_offset: u64,
+) -> (Vec<serde_json::Value>, u64) {
+    let mut offset = from_offset;
+    let mut out = Vec::new();
+    loop {
+        match kernel.sys_read(path, ctx, 0, offset) {
+            Ok(result) => {
+                if let Some(bytes) = result.data.as_ref() {
+                    if !bytes.is_empty() {
+                        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+                            out.push(v);
+                        }
+                    }
+                }
+                let next = result.stream_next_offset.map_or(offset, |o| o as u64);
+                if next == offset {
+                    break;
+                }
+                offset = next;
+            }
+            Err(_) => break,
+        }
+    }
+    (out, offset)
+}
+
+fn wait_for_envelope_with_body(
+    kernel: &Kernel,
+    path: &str,
+    ctx: &OperationContext,
+    body_eq: &str,
+    timeout: Duration,
+) -> Option<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    let mut offset = 0u64;
+    while Instant::now() < deadline {
+        let (envelopes, next) = read_envelopes(kernel, path, ctx, offset);
+        offset = next;
+        for env in envelopes {
+            if env.get("body").and_then(|v| v.as_str()) == Some(body_eq) {
+                return Some(env);
+            }
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+#[test]
+fn echo_round_trip_through_proc_pid_chat_with_me() {
+    let kernel = Arc::new(Kernel::new());
+    mount_proc(&kernel);
+    plant_chat_stream(&kernel, "v0-echo-1");
+    let desc = make_desc("v0-echo-1", "agent-v0");
+    let handle = spawn_task(Arc::clone(&kernel), desc);
+
+    let ctx = user_ctx();
+    let cwm_path = "/proc/v0-echo-1/chat-with-me";
+    let prompt = serde_json::json!({
+        "from": "user-test",
+        "to": "agent-v0",
+        "body": "hello",
+    });
+    kernel
+        .sys_write(cwm_path, &ctx, &serde_json::to_vec(&prompt).unwrap(), 0)
+        .expect("user write to chat-with-me");
+
+    let echo = wait_for_envelope_with_body(
+        &kernel,
+        cwm_path,
+        &ctx,
+        "echo: hello",
+        Duration::from_secs(2),
+    );
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+    let echo = echo.expect("agent echo response did not arrive within 2s");
+
+    assert_eq!(echo.get("from").and_then(|v| v.as_str()), Some("agent-v0"));
+    assert_eq!(echo.get("to").and_then(|v| v.as_str()), Some("user-test"));
+}
+
+#[test]
+fn loop_exits_on_abort_signal() {
+    let kernel = Arc::new(Kernel::new());
+    mount_proc(&kernel);
+    plant_chat_stream(&kernel, "v0-abort-1");
+    let desc = make_desc("v0-abort-1", "agent-abort");
+
+    let handle = spawn_task(Arc::clone(&kernel), desc);
+    // No prompt sent — the loop is sitting in the poll sleep.
+    // abort() must wake it within one POLL_INTERVAL + a sys_read
+    // round trip.
+    handle.abort_signal.abort();
+
+    let watcher = thread::Builder::new()
+        .spawn(move || handle.join.join())
+        .expect("watcher thread");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !watcher.is_finished() {
+        if Instant::now() >= deadline {
+            panic!("spawn_task thread did not exit within 2s of abort()");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    let _ = watcher.join();
+}
+
+#[test]
+fn skips_own_writes_to_avoid_echo_loop() {
+    // The agent's own echo writes carry from=self_agent_id; the
+    // loop must filter these out so the mailbox does not
+    // exponentially explode. Walks one round trip and asserts the
+    // stream contains exactly one agent echo (no echo-of-echo).
+    let kernel = Arc::new(Kernel::new());
+    mount_proc(&kernel);
+    plant_chat_stream(&kernel, "v0-loop-1");
+    let desc = make_desc("v0-loop-1", "agent-loop");
+    let handle = spawn_task(Arc::clone(&kernel), desc);
+
+    let ctx = user_ctx();
+    let cwm_path = "/proc/v0-loop-1/chat-with-me";
+    let prompt = serde_json::json!({
+        "from": "user-test",
+        "to": "agent-loop",
+        "body": "ping",
+    });
+    kernel
+        .sys_write(cwm_path, &ctx, &serde_json::to_vec(&prompt).unwrap(), 0)
+        .unwrap();
+
+    let _ = wait_for_envelope_with_body(
+        &kernel,
+        cwm_path,
+        &ctx,
+        "echo: ping",
+        Duration::from_secs(2),
+    )
+    .expect("first echo did not arrive");
+    // Settle for several poll intervals so any bug-induced
+    // echo-of-echo would have written by now.
+    thread::sleep(POLL_INTERVAL * 4);
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+
+    let (envelopes, _) = read_envelopes(&kernel, cwm_path, &ctx, 0);
+    let agent_echoes = envelopes
+        .iter()
+        .filter(|v| v.get("from").and_then(|f| f.as_str()) == Some("agent-loop"))
+        .count();
+    assert_eq!(
+        agent_echoes, 1,
+        "expected exactly one agent echo, got {agent_echoes} — \
+         loop is echoing its own writes"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `runtime::spawn_task::<K: KernelAbi + Send + Sync + 'static>` — the in-process entry the nexus-side `ManagedAgentService<K>::start_session` calls after `register_proc_entry` succeeds, kicking off the per-pid agent loop.

## v0 → v1 migration

The earlier v0 (commit `869e80a`, reverted as `17bc205`) was generic over a concrete `Arc<Kernel>` and used a path-dep on the nexus kernel rlib. That coupled sudocode's build to a specific side-by-side dev layout and pinned the kernel concrete type into the spawn API.

v1:

- Takes `Arc<K: KernelAbi + Send + Sync + 'static>` — production (`K = Kernel`, monomorphised at link → identical perf to direct inherent call) and tests (`K = MockKernel` once that fixture lands) share one entry.
- Reaches the kernel rlib through a **git-dep** on the nexus PR branch that introduced `KernelAbi` (`nexi-lab/nexus#4026`, `feat/kernel-abi-trait`, rev `064c33742`). No more side-by-side path-dep.

## Lockstep merge order with nexus #4026

1. Nexus PR #4026 (`feat/kernel-abi-trait`) merges to nexus `develop`
2. This sudocode PR's `kernel` rev pin gets bumped to the merged develop commit
3. This sudocode PR merges to sudocode `main`
4. Nexus follow-up PR adds `sudocode-runtime = { git = ..., rev = "<this PR merged rev>" }` git-dep + `ManagedAgentService::start_session` calls `spawn_task` (separate nexus PR — out of scope for #4026 scope)

## Body shape

v1 body is an echo stub: poll `/proc/{pid}/chat-with-me` via `kernel.sys_read` with stream-offset advancement, and for each inbound envelope where `from != desc.name`, write back `{"to": <orig from>, "from": <self>, "body": "echo: <orig body>"}`. Cancellation reuses `runtime::HookAbortSignal` (the same signal `Conversation::with_hook_abort_signal` reads when the v2 LLM turn-driver lands).

The full LLM `ConversationRuntime::run_turn` wiring is PR-C v2 — `ConversationRuntime<C, T>` is generic over `ApiClient + ToolExecutor` and today's concrete impls live in `rusty-claude-cli` as `pub(crate)` and TTY-coupled.

## Test plan

- [x] `cargo test -p runtime --test spawn_task` — 3/3 green (echo round-trip, abort exit, own-write loop guard)
- [ ] CI on this PR
- [ ] Lockstep with nexus PR #4026 + nexus follow-up PR for `start_session` integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)