### PR TITLE
fix(mcp): exit 1 when JSON envelope contains ok:false

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2992,10 +2992,16 @@ impl LiveCli {
         let cwd = env::current_dir()?;
         match output_format {
             CliOutputFormat::Text => println!("{}", handle_mcp_slash_command(args, &cwd)?),
-            CliOutputFormat::Json => println!(
-                "{}",
-                serde_json::to_string_pretty(&handle_mcp_slash_command_json(args, &cwd)?)?
-            ),
+            CliOutputFormat::Json => {
+                let value = handle_mcp_slash_command_json(args, &cwd)?;
+                // Propagate ok:false → non-zero exit so automation callers
+                // can rely on exit code instead of inspecting the envelope.
+                let is_error = value.get("ok").and_then(|v| v.as_bool()) == Some(false);
+                println!("{}", serde_json::to_string_pretty(&value)?);
+                if is_error {
+                    std::process::exit(1);
+                }
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Port upstream commit d074d1c: MCP subcommands (`mcp info`, `mcp describe`, `mcp list-filter`) returning `{"ok":false,...}` now exit 1 instead of 0
- Enables automation callers to rely on exit code rather than inspecting the JSON envelope

Closes #105
Tracking: #101

## Test plan
- [x] `cargo check -p rusty-sudocode-cli` passes
- [x] `cargo test -p rusty-sudocode-cli` — 12 tests pass
- [ ] Manual: `sudocode mcp info nonexistent --output-format json; echo $?` → should print 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)