### PR TITLE
feat(cli): JSON output format parity for config, agents, version

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -312,7 +312,10 @@ pub(crate) enum CliAction {
         allow_broad_cwd: bool,
         auth_mode: Option<AuthMode>,
     },
-    HelpTopic(LocalHelpTopic),
+    HelpTopic {
+        topic: LocalHelpTopic,
+        output_format: CliOutputFormat,
+    },
     Help {
         output_format: CliOutputFormat,
     },
@@ -330,7 +333,7 @@ impl CliAction {
             self,
             CliAction::Help { .. }
                 | CliAction::Version { .. }
-                | CliAction::HelpTopic(_)
+                | CliAction::HelpTopic { .. }
                 | CliAction::Config { .. }
                 | CliAction::Login
                 | CliAction::Logout
@@ -401,6 +404,12 @@ pub(crate) fn parse_args(args: &[String]) -> Result<CliAction, String> {
         if first.starts_with('/') {
             return parse_slash_command_invocation(args);
         }
+    }
+
+    // Intercept `<subcommand> --help [--output-format json]` before clap
+    // so we can emit structured JSON help instead of clap's default text.
+    if let Some(action) = parse_local_help_action(args) {
+        return action;
     }
 
     let cli = Cli::try_parse_from(std::iter::once("scode".to_string()).chain(args.iter().cloned()));
@@ -850,6 +859,67 @@ fn levenshtein_distance(left: &str, right: &str) -> usize {
 }
 
 // ---------------------------------------------------------------------------
+// Local help interception
+// ---------------------------------------------------------------------------
+
+fn is_help_flag(value: &str) -> bool {
+    value == "--help" || value == "-h"
+}
+
+/// Detect `<subcommand> --help [--output-format json]` before clap parses args.
+/// Returns `Some(Ok(..))` when matched, `None` otherwise.
+fn parse_local_help_action(args: &[String]) -> Option<Result<CliAction, String>> {
+    // We need at least 2 args: `<subcommand> --help`
+    if args.len() < 2 {
+        return None;
+    }
+
+    // Find the help flag position and extract output_format
+    let has_help = args.iter().any(|a| is_help_flag(a));
+    if !has_help {
+        return None;
+    }
+
+    // Determine output format from remaining args
+    let mut output_format = CliOutputFormat::Text;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--output-format" {
+            if let Some(fmt) = args.get(i + 1) {
+                match CliOutputFormat::parse(fmt) {
+                    Ok(f) => output_format = f,
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+
+    // The first non-flag arg should be the subcommand
+    let subcommand = args[0].as_str();
+    let topic = match subcommand {
+        "status" => LocalHelpTopic::Status,
+        "sandbox" => LocalHelpTopic::Sandbox,
+        "doctor" => LocalHelpTopic::Doctor,
+        "acp" => LocalHelpTopic::Acp,
+        "init" => LocalHelpTopic::Init,
+        "state" => LocalHelpTopic::State,
+        "export" => LocalHelpTopic::Export,
+        "version" => LocalHelpTopic::Version,
+        "system-prompt" => LocalHelpTopic::SystemPrompt,
+        "dump-manifests" => LocalHelpTopic::DumpManifests,
+        "bootstrap-plan" => LocalHelpTopic::BootstrapPlan,
+        _ => return None,
+    };
+    Some(Ok(CliAction::HelpTopic {
+        topic,
+        output_format,
+    }))
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1083,7 +1153,11 @@ mod tests {
             output_format: CliOutputFormat::Json
         }
         .is_informational());
-        assert!(CliAction::HelpTopic(LocalHelpTopic::Status).is_informational());
+        assert!(CliAction::HelpTopic {
+            topic: LocalHelpTopic::Status,
+            output_format: CliOutputFormat::Text,
+        }
+        .is_informational());
         assert!(CliAction::Config {
             section: None,
             output_format: CliOutputFormat::Text

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -123,8 +123,90 @@ pub(crate) fn render_help_topic(topic: LocalHelpTopic) -> String {
     }
 }
 
-pub(crate) fn print_help_topic(topic: LocalHelpTopic) {
-    println!("{}", render_help_topic(topic));
+fn local_help_topic_command(topic: LocalHelpTopic) -> &'static str {
+    match topic {
+        LocalHelpTopic::Status => "status",
+        LocalHelpTopic::Sandbox => "sandbox",
+        LocalHelpTopic::Doctor => "doctor",
+        LocalHelpTopic::Acp => "acp",
+        LocalHelpTopic::Init => "init",
+        LocalHelpTopic::State => "state",
+        LocalHelpTopic::Export => "export",
+        LocalHelpTopic::Version => "version",
+        LocalHelpTopic::SystemPrompt => "system-prompt",
+        LocalHelpTopic::DumpManifests => "dump-manifests",
+        LocalHelpTopic::BootstrapPlan => "bootstrap-plan",
+    }
+}
+
+fn render_export_help_json() -> serde_json::Value {
+    json!({
+        "kind": "help",
+        "topic": "export",
+        "command": "export",
+        "usage": "scode export [--session <id|latest>] [--output <path>] [--output-format <format>]",
+        "purpose": "serialize a managed session to JSON for review, transfer, or archival",
+        "defaults": {
+            "session": LATEST_SESSION_REFERENCE,
+            "session_source": ".scode/sessions/",
+            "output": "derived from the selected session when omitted"
+        },
+        "formats": ["text", "json"],
+        "options": [
+            {
+                "name": "--session",
+                "value": "<id|latest>",
+                "default": LATEST_SESSION_REFERENCE,
+                "description": "managed session to export"
+            },
+            {
+                "name": "--output",
+                "aliases": ["-o"],
+                "value": "<path>",
+                "description": "write the exported transcript to this path"
+            },
+            {
+                "name": "--output-format",
+                "value": "<format>",
+                "values": ["text", "json"],
+                "default": "text",
+                "description": "format for the command result envelope"
+            },
+            {
+                "name": "--help",
+                "aliases": ["-h"],
+                "description": "show help for the export command"
+            }
+        ],
+        "related": ["/session list", "scode --resume latest"]
+    })
+}
+
+pub(crate) fn render_help_topic_json(topic: LocalHelpTopic) -> serde_json::Value {
+    if topic == LocalHelpTopic::Export {
+        return render_export_help_json();
+    }
+
+    json!({
+        "kind": "help",
+        "topic": local_help_topic_command(topic),
+        "command": local_help_topic_command(topic),
+        "message": render_help_topic(topic),
+    })
+}
+
+pub(crate) fn print_help_topic(
+    topic: LocalHelpTopic,
+    output_format: CliOutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match output_format {
+        CliOutputFormat::Text => println!("{}", render_help_topic(topic)),
+        CliOutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&render_help_topic_json(topic))?
+        ),
+    }
+    Ok(())
 }
 
 pub(crate) fn render_config_report(
@@ -209,7 +291,7 @@ pub(crate) fn render_config_report(
 }
 
 pub(crate) fn render_config_json(
-    _section: Option<&str>,
+    section: Option<&str>,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
     let loader = ConfigLoader::default_for(&cwd);
@@ -242,13 +324,52 @@ pub(crate) fn render_config_json(
         })
         .collect();
 
-    Ok(serde_json::json!({
+    let base = serde_json::json!({
         "kind": "config",
         "cwd": cwd.display().to_string(),
         "loaded_files": loaded_paths.len(),
         "merged_keys": runtime_config.merged().len(),
         "files": files,
-    }))
+    });
+
+    if let Some(section) = section {
+        let section_rendered: Option<String> = match section {
+            "env" => runtime_config.get("env").map(|v| v.render()),
+            "hooks" => runtime_config.get("hooks").map(|v| v.render()),
+            "model" => runtime_config.get("model").map(|v| v.render()),
+            "plugins" => runtime_config
+                .get("plugins")
+                .or_else(|| runtime_config.get("enabledPlugins"))
+                .map(|v| v.render()),
+            other => {
+                return Ok(serde_json::json!({
+                    "kind": "config",
+                    "section": other,
+                    "ok": false,
+                    "error": format!("Unsupported config section '{other}'. Use env, hooks, model, or plugins."),
+                    "cwd": cwd.display().to_string(),
+                    "loaded_files": loaded_paths.len(),
+                    "files": files,
+                }));
+            }
+        };
+        // Parse the rendered JSON string back into serde_json::Value so that
+        // section_value is a real JSON object/array in the envelope, not a quoted string.
+        let section_value: serde_json::Value = section_rendered
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or(serde_json::Value::Null);
+        let mut obj = base;
+        let map = obj.as_object_mut().expect("base is object");
+        map.insert(
+            "section".to_string(),
+            serde_json::Value::String(section.to_string()),
+        );
+        map.insert("section_value".to_string(), section_value);
+        return Ok(obj);
+    }
+
+    Ok(base)
 }
 
 pub(crate) fn render_memory_report() -> Result<String, Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-sudocode-cli/src/cli/status.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/status.rs
@@ -354,12 +354,17 @@ pub(crate) fn normalize_permission_mode(mode: &str) -> Option<&'static str> {
 }
 
 pub(crate) fn version_json_value() -> serde_json::Value {
+    let executable_path = std::env::current_exe()
+        .ok()
+        .map(|p| p.display().to_string());
     json!({
         "kind": "version",
         "message": render_version_report(),
         "version": VERSION,
         "git_sha": crate::GIT_SHA,
         "target": crate::BUILD_TARGET,
+        "build_date": crate::DEFAULT_DATE,
+        "executable_path": executable_path,
     })
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -517,7 +517,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             allow_broad_cwd,
             auth_mode,
         )?,
-        CliAction::HelpTopic(topic) => print_help_topic(topic),
+        CliAction::HelpTopic {
+            topic,
+            output_format,
+        } => print_help_topic(topic, output_format)?,
         CliAction::Help { output_format } => print_help(output_format)?,
         CliAction::Login => run_login()?,
         CliAction::Logout => run_logout()?,
@@ -1120,10 +1123,10 @@ fn run_resume_command(
             Ok(ResumeCommandOutcome {
                 session: session.clone(),
                 message: Some(handle_agents_slash_command(args.as_deref(), &cwd)?),
-                json: Some(serde_json::json!({
-                    "kind": "agents",
-                    "text": handle_agents_slash_command(args.as_deref(), &cwd)?,
-                })),
+                json: Some(
+                    serde_json::to_value(handle_agents_slash_command_json(args.as_deref(), &cwd)?)
+                        .unwrap_or_else(|_| serde_json::json!(null)),
+                ),
             })
         }
         SlashCommand::Skills { args } => {

--- a/rust/crates/rusty-sudocode-cli/tests/cli_flags_and_config_defaults.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/cli_flags_and_config_defaults.rs
@@ -256,8 +256,8 @@ fn local_subcommand_help_does_not_fall_through_to_runtime_or_provider_calls() {
     assert_success(&status_help);
     let status_stdout = String::from_utf8(status_help.stdout).expect("stdout should be utf8");
     assert!(
-        status_stdout.contains("workspace status snapshot"),
-        "status --help should contain subcommand description: {status_stdout}"
+        status_stdout.contains("Status"),
+        "status --help should contain help topic header: {status_stdout}"
     );
     assert!(!status_stdout.contains("Thinking"));
 

--- a/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
@@ -30,6 +30,15 @@ fn version_emits_json_when_requested() {
     let parsed = assert_json_command(&root, &["--output-format", "json", "version"]);
     assert_eq!(parsed["kind"], "version");
     assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+    // Provenance fields must be present for binary identification.
+    assert!(
+        parsed["build_date"].is_string(),
+        "build_date must be a string in version JSON"
+    );
+    assert!(
+        parsed["executable_path"].is_string(),
+        "executable_path must be a string in version JSON so callers can identify which binary is running"
+    );
 }
 
 #[test]
@@ -330,6 +339,34 @@ fn resumed_inventory_commands_emit_structured_json_when_requested() {
     assert_eq!(skills["action"], "list");
     assert!(skills["summary"]["total"].is_number());
     assert!(skills["skills"].is_array());
+
+    let agents = assert_json_command_with_env(
+        &root,
+        &[
+            "--output-format",
+            "json",
+            "--resume",
+            session_path.to_str().expect("utf8 session path"),
+            "/agents",
+        ],
+        &[
+            (
+                "SUDO_CODE_CONFIG_HOME",
+                config_home.to_str().expect("utf8 config home"),
+            ),
+            ("HOME", home.to_str().expect("utf8 home")),
+        ],
+    );
+    assert_eq!(agents["kind"], "agents");
+    assert_eq!(agents["action"], "list");
+    assert!(
+        agents["agents"].is_array(),
+        "agents field must be a JSON array"
+    );
+    assert!(
+        agents["count"].is_number(),
+        "count must be a number, not a text render"
+    );
 }
 
 #[test]
@@ -364,6 +401,80 @@ fn resumed_version_and_init_emit_structured_json_when_requested() {
     );
     assert_eq!(init["kind"], "init");
     assert!(root.join("CLAUDE.md").exists());
+}
+
+#[test]
+fn config_section_json_emits_section_and_value() {
+    let root = unique_temp_dir("config-section-json");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    // Without a section: should return base envelope (no section field).
+    let base = assert_json_command(&root, &["--output-format", "json", "config"]);
+    assert_eq!(base["kind"], "config");
+    assert!(base["loaded_files"].is_number());
+    assert!(base["merged_keys"].is_number());
+    assert!(
+        base.get("section").is_none(),
+        "no section field without section arg"
+    );
+
+    // With a known section: should add section + section_value fields.
+    for section in &["model", "env", "hooks", "plugins"] {
+        let result = assert_json_command(&root, &["--output-format", "json", "config", section]);
+        assert_eq!(result["kind"], "config", "section={section}");
+        assert_eq!(
+            result["section"].as_str(),
+            Some(*section),
+            "section field must match requested section, got {result:?}"
+        );
+        assert!(
+            result.get("section_value").is_some(),
+            "section_value field must be present for section={section}"
+        );
+    }
+
+    // With an unsupported section: should return ok:false + error field.
+    let bad = assert_json_command(&root, &["--output-format", "json", "config", "unknown"]);
+    assert_eq!(bad["kind"], "config");
+    assert_eq!(bad["ok"], false);
+    assert!(bad["error"].as_str().is_some());
+    assert!(bad["section"].as_str().is_some());
+}
+
+#[test]
+fn export_help_emits_bounded_json_when_requested() {
+    let root = unique_temp_dir("export-help-json");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    let parsed = assert_json_command(&root, &["export", "--help", "--output-format", "json"]);
+    assert_eq!(parsed["kind"], "help");
+    assert_eq!(parsed["topic"], "export");
+    assert_eq!(parsed["command"], "export");
+    assert_eq!(
+        parsed["usage"],
+        "scode export [--session <id|latest>] [--output <path>] [--output-format <format>]"
+    );
+    assert_eq!(parsed["defaults"]["session"], "latest");
+    assert!(parsed["options"].as_array().expect("options").len() >= 4);
+    assert!(parsed.get("message").is_none());
+}
+
+#[test]
+fn export_help_preserves_plaintext_in_text_mode() {
+    let root = unique_temp_dir("export-help-text");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    let output = run_scode(&root, &["export", "--help"], &[]);
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(stdout.starts_with("Export\n"));
+    assert!(stdout.contains("Usage            scode export"));
+    serde_json::from_str::<Value>(&stdout).expect_err("text help should remain plaintext");
 }
 
 fn assert_json_command(current_dir: &Path, args: &[&str]) -> Value {


### PR DESCRIPTION
## Summary
- **config**: `render_config_json` now passes `section` through instead of discarding it; emits `section` + `section_value` fields for known sections, or `ok:false` + `error` for unsupported ones
- **agents (resume)**: `run_resume_command` now uses `handle_agents_slash_command_json` for the JSON field, matching the pattern used by `/skills` and `/plugins`
- **version**: `version_json_value()` includes `build_date` and `executable_path` for binary identification
- **export help**: `HelpTopic` now carries `output_format`; added `parse_local_help_action` to intercept `<subcommand> --help [--output-format json]` before clap; `render_export_help_json` emits a bounded structured envelope instead of plaintext-wrapped JSON

Upstream refs: ac8a24b, 1206f41, c993303, 51b9e6b

Closes #107
Tracking: #101

## Test plan
- [x] `version_emits_json_when_requested` — asserts `build_date` and `executable_path` are strings
- [x] `resumed_inventory_commands_emit_structured_json_when_requested` — asserts resumed `/agents` returns structured JSON (kind, action, agents array, count number)
- [x] `config_section_json_emits_section_and_value` — asserts section/section_value for known sections, ok:false for unknown
- [x] `export_help_emits_bounded_json_when_requested` — asserts structured JSON envelope with kind, topic, usage, options
- [x] `export_help_preserves_plaintext_in_text_mode` — asserts text mode still returns plaintext
- [x] `local_subcommand_help_does_not_fall_through_to_runtime_or_provider_calls` — updated assertion for new help topic output
- [x] All existing tests pass (`cargo test -p rusty-sudocode-cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)