### PR TITLE
chore(test): test infrastructure improvements from upstream

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use runtime::{load_oauth_credentials, resolve_sandbox_status, ConfigLoader, ProjectContext};
 use serde_json::{json, Map, Value};
 
+use crate::cli::lifecycle::classify_session_lifecycle_for;
 use crate::{
     parse_git_status_metadata, parse_git_workspace_summary, CliOutputFormat, StatusContext,
     BUILD_TARGET, DEFAULT_DATE, DEPRECATED_INSTALL_COMMAND, GIT_SHA, OFFICIAL_REPO_SLUG,
@@ -196,6 +197,7 @@ pub(crate) fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error:
         project_root,
         git_branch,
         git_summary,
+        session_lifecycle: classify_session_lifecycle_for(&cwd),
         sandbox_status: resolve_sandbox_status(sandbox_config.sandbox(), &cwd),
         // Doctor path has its own config check; StatusContext here is only
         // fed into health renderers that don't read config_load_error.

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -637,6 +637,7 @@ pub(crate) fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out)?;
     let resume_commands = resume_supported_slash_commands()
         .into_iter()
+        .filter(|spec| !STUB_COMMANDS.contains(&spec.name))
         .map(|spec| match spec.argument_hint {
             Some(argument_hint) => format!("/{} {}", spec.name, argument_hint),
             None => format!("/{}", spec.name),
@@ -704,4 +705,35 @@ pub(crate) fn print_help(output_format: CliOutputFormat) -> Result<(), Box<dyn s
         ),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_commands_absent_from_resume_safe_help() {
+        let mut help = Vec::new();
+        print_help_to(&mut help).expect("help should render");
+        let help = String::from_utf8(help).expect("help should be utf8");
+        let resume_line = help
+            .lines()
+            .find(|line| line.starts_with("Resume-safe commands:"))
+            .expect("resume-safe command line should exist");
+        let resume_roots = resume_line
+            .trim_start_matches("Resume-safe commands:")
+            .split(',')
+            .filter_map(|entry| entry.trim().strip_prefix('/'))
+            .filter_map(|entry| entry.split_whitespace().next())
+            .collect::<Vec<_>>();
+
+        for stub in STUB_COMMANDS {
+            assert!(
+                !resume_roots.contains(stub),
+                "stub command /{stub} should not appear in resume-safe command list"
+            );
+        }
+
+        assert!(resume_roots.contains(&"status"));
+    }
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/lifecycle.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/lifecycle.rs
@@ -1,0 +1,262 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::json;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionLifecycleKind {
+    RunningProcess,
+    IdleShell,
+    SavedOnly,
+}
+
+impl SessionLifecycleKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RunningProcess => "running_process",
+            Self::IdleShell => "idle_shell",
+            Self::SavedOnly => "saved_only",
+        }
+    }
+
+    pub(crate) fn human_label(self) -> &'static str {
+        match self {
+            Self::RunningProcess => "running process",
+            Self::IdleShell => "idle shell",
+            Self::SavedOnly => "saved only",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionLifecycleSummary {
+    pub(crate) kind: SessionLifecycleKind,
+    pub(crate) pane_id: Option<String>,
+    pub(crate) pane_command: Option<String>,
+    pub(crate) pane_path: Option<PathBuf>,
+    pub(crate) workspace_dirty: bool,
+    pub(crate) abandoned: bool,
+}
+
+impl SessionLifecycleSummary {
+    pub(crate) fn signal(&self) -> String {
+        let mut parts = vec![self.kind.human_label().to_string()];
+        if self.workspace_dirty {
+            parts.push("dirty worktree".to_string());
+        }
+        if self.abandoned {
+            parts.push("abandoned?".to_string());
+        }
+        if let Some(command) = self.pane_command.as_deref() {
+            parts.push(format!("cmd={command}"));
+        }
+        parts.join(" · ")
+    }
+
+    pub(crate) fn json_value(&self) -> serde_json::Value {
+        json!({
+            "kind": self.kind.as_str(),
+            "pane_id": self.pane_id,
+            "pane_command": self.pane_command,
+            "pane_path": self.pane_path.as_ref().map(|path| path.display().to_string()),
+            "workspace_dirty": self.workspace_dirty,
+            "abandoned": self.abandoned,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TmuxPaneSnapshot {
+    pub(crate) pane_id: String,
+    pub(crate) current_command: String,
+    pub(crate) current_path: PathBuf,
+}
+
+pub(crate) fn classify_session_lifecycle_for(workspace: &Path) -> SessionLifecycleSummary {
+    classify_session_lifecycle_from_panes(workspace, discover_tmux_panes())
+}
+
+pub(crate) fn classify_session_lifecycle_from_panes(
+    workspace: &Path,
+    panes: Vec<TmuxPaneSnapshot>,
+) -> SessionLifecycleSummary {
+    let workspace_dirty = git_worktree_is_dirty(workspace);
+    let mut idle_shell = None;
+    for pane in panes {
+        if !pane_path_matches_workspace(&pane.current_path, workspace) {
+            continue;
+        }
+        if is_idle_shell_command(&pane.current_command) {
+            idle_shell.get_or_insert(pane);
+        } else {
+            return SessionLifecycleSummary {
+                kind: SessionLifecycleKind::RunningProcess,
+                pane_id: Some(pane.pane_id),
+                pane_command: Some(pane.current_command),
+                pane_path: Some(pane.current_path),
+                workspace_dirty,
+                abandoned: false,
+            };
+        }
+    }
+
+    if let Some(pane) = idle_shell {
+        SessionLifecycleSummary {
+            kind: SessionLifecycleKind::IdleShell,
+            pane_id: Some(pane.pane_id),
+            pane_command: Some(pane.current_command),
+            pane_path: Some(pane.current_path),
+            workspace_dirty,
+            abandoned: workspace_dirty,
+        }
+    } else {
+        SessionLifecycleSummary {
+            kind: SessionLifecycleKind::SavedOnly,
+            pane_id: None,
+            pane_command: None,
+            pane_path: None,
+            workspace_dirty,
+            abandoned: workspace_dirty,
+        }
+    }
+}
+
+fn discover_tmux_panes() -> Vec<TmuxPaneSnapshot> {
+    let output = Command::new("tmux")
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{pane_id}\t#{pane_current_command}\t#{pane_current_path}",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_tmux_pane_snapshots(&stdout)
+}
+
+fn parse_tmux_pane_snapshots(output: &str) -> Vec<TmuxPaneSnapshot> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            let pane_id = fields.next()?.trim();
+            let current_command = fields.next()?.trim();
+            let current_path = fields.next()?.trim();
+            if pane_id.is_empty() || current_path.is_empty() {
+                return None;
+            }
+            Some(TmuxPaneSnapshot {
+                pane_id: pane_id.to_string(),
+                current_command: current_command.to_string(),
+                current_path: PathBuf::from(current_path),
+            })
+        })
+        .collect()
+}
+
+fn pane_path_matches_workspace(pane_path: &Path, workspace: &Path) -> bool {
+    let pane_path = fs::canonicalize(pane_path).unwrap_or_else(|_| pane_path.to_path_buf());
+    let workspace = fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    pane_path == workspace || pane_path.starts_with(&workspace)
+}
+
+fn is_idle_shell_command(command: &str) -> bool {
+    let command = command.rsplit('/').next().unwrap_or(command);
+    matches!(
+        command,
+        "bash" | "zsh" | "sh" | "fish" | "nu" | "pwsh" | "powershell" | "cmd"
+    )
+}
+
+fn git_worktree_is_dirty(workspace: &Path) -> bool {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(["status", "--porcelain"])
+        .output();
+    output
+        .ok()
+        .filter(|output| output.status.success())
+        .is_some_and(|output| !output.stdout.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_lifecycle_prefers_running_process_over_idle_shell() {
+        let workspace = PathBuf::from("/tmp/project");
+        let lifecycle = classify_session_lifecycle_from_panes(
+            &workspace,
+            vec![
+                TmuxPaneSnapshot {
+                    pane_id: "%1".to_string(),
+                    current_command: "zsh".to_string(),
+                    current_path: workspace.clone(),
+                },
+                TmuxPaneSnapshot {
+                    pane_id: "%2".to_string(),
+                    current_command: "scode".to_string(),
+                    current_path: workspace.join("rust"),
+                },
+            ],
+        );
+
+        assert_eq!(lifecycle.kind, SessionLifecycleKind::RunningProcess);
+        assert_eq!(lifecycle.pane_id.as_deref(), Some("%2"));
+        assert_eq!(lifecycle.pane_command.as_deref(), Some("scode"));
+        assert!(!lifecycle.abandoned);
+    }
+
+    #[test]
+    fn session_lifecycle_marks_dirty_idle_shell_as_abandoned() {
+        let workspace = std::env::temp_dir().join(format!(
+            "scode-lifecycle-dirty-idle-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        ));
+        fs::create_dir_all(&workspace).expect("workspace should create");
+
+        // Set up a git repo with a dirty working tree
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(&workspace)
+                .output()
+                .expect("git should run");
+        };
+        git(&["init", "--quiet"]);
+        git(&["config", "user.email", "tests@example.com"]);
+        git(&["config", "user.name", "Sudocode Tests"]);
+        fs::write(workspace.join("tracked.txt"), "hello\n").expect("write tracked");
+        git(&["add", "tracked.txt"]);
+        git(&["commit", "-m", "init", "--quiet"]);
+        fs::write(workspace.join("tracked.txt"), "hello\nchanged\n").expect("dirty tracked");
+
+        let lifecycle = classify_session_lifecycle_from_panes(
+            &workspace,
+            vec![TmuxPaneSnapshot {
+                pane_id: "%3".to_string(),
+                current_command: "bash".to_string(),
+                current_path: workspace.clone(),
+            }],
+        );
+
+        assert_eq!(lifecycle.kind, SessionLifecycleKind::IdleShell);
+        assert!(lifecycle.workspace_dirty);
+        assert!(lifecycle.abandoned);
+
+        fs::remove_dir_all(workspace).expect("cleanup temp dir");
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/src/cli/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod export;
 pub(crate) mod format;
 pub(crate) mod git;
 pub(crate) mod help;
+pub(crate) mod lifecycle;
 pub(crate) mod mcp;
 pub(crate) mod session;
 pub(crate) mod status;

--- a/rust/crates/rusty-sudocode-cli/src/cli/session.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/session.rs
@@ -6,6 +6,8 @@ use std::time::UNIX_EPOCH;
 
 use runtime::{Session, SessionStore};
 
+use crate::cli::lifecycle::{classify_session_lifecycle_for, SessionLifecycleSummary};
+
 pub(crate) const LATEST_SESSION_REFERENCE: &str = "latest";
 pub(crate) const SESSION_REFERENCE_ALIASES: &[&str] = &[LATEST_SESSION_REFERENCE, "last", "recent"];
 
@@ -24,6 +26,7 @@ pub(crate) struct ManagedSessionSummary {
     pub(crate) message_count: usize,
     pub(crate) parent_session_id: Option<String>,
     pub(crate) branch_name: Option<String>,
+    pub(crate) lifecycle: SessionLifecycleSummary,
 }
 
 pub(crate) fn sessions_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
@@ -85,7 +88,9 @@ pub(crate) fn resolve_managed_session_path(
 
 pub(crate) fn list_managed_sessions(
 ) -> Result<Vec<ManagedSessionSummary>, Box<dyn std::error::Error>> {
-    Ok(current_session_store()?
+    let store = current_session_store()?;
+    let lifecycle = classify_session_lifecycle_for(store.workspace_root());
+    Ok(store
         .list_sessions()
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?
         .into_iter()
@@ -97,13 +102,16 @@ pub(crate) fn list_managed_sessions(
             message_count: session.message_count,
             parent_session_id: session.parent_session_id,
             branch_name: session.branch_name,
+            lifecycle: lifecycle.clone(),
         })
         .collect())
 }
 
 pub(crate) fn latest_managed_session() -> Result<ManagedSessionSummary, Box<dyn std::error::Error>>
 {
-    let session = current_session_store()?
+    let store = current_session_store()?;
+    let lifecycle = classify_session_lifecycle_for(store.workspace_root());
+    let session = store
         .latest_session()
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
     Ok(ManagedSessionSummary {
@@ -114,6 +122,7 @@ pub(crate) fn latest_managed_session() -> Result<ManagedSessionSummary, Box<dyn 
         message_count: session.message_count,
         parent_session_id: session.parent_session_id,
         branch_name: session.branch_name,
+        lifecycle,
     })
 }
 
@@ -180,8 +189,9 @@ pub(crate) fn render_session_list(
             (None, None) => String::new(),
         };
         lines.push(format!(
-            "  {id:<20} {marker:<10} msgs={msgs:<4} modified={modified}{lineage} path={path}",
+            "  {id:<20} {marker:<10} lifecycle={lifecycle} msgs={msgs:<4} modified={modified}{lineage} path={path}",
             id = session.id,
+            lifecycle = session.lifecycle.signal(),
             msgs = session.message_count,
             modified = format_session_modified_age(session.modified_epoch_millis),
             lineage = lineage,

--- a/rust/crates/rusty-sudocode-cli/src/cli/status.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/status.rs
@@ -8,6 +8,7 @@ use crate::cli::format::format_sandbox_report;
 use crate::cli::git::{
     parse_git_status_metadata, parse_git_workspace_summary, GitWorkspaceSummary,
 };
+use crate::cli::lifecycle::{classify_session_lifecycle_for, SessionLifecycleSummary};
 use crate::{CliOutputFormat, ModelProvenance, ModelSource, DEFAULT_DATE, VERSION};
 
 use super::format::render_version_report;
@@ -22,6 +23,7 @@ pub(crate) struct StatusContext {
     pub(crate) project_root: Option<PathBuf>,
     pub(crate) git_branch: Option<String>,
     pub(crate) git_summary: GitWorkspaceSummary,
+    pub(crate) session_lifecycle: SessionLifecycleSummary,
     pub(crate) sandbox_status: runtime::SandboxStatus,
     /// #143: when `.scode.json` (or another loaded config file) fails to parse,
     /// we capture the parse error here and still populate every field that
@@ -143,6 +145,7 @@ pub(crate) fn status_json_value(
                 // .scode/sessions/. Extract the stem (drop the .jsonl extension).
                 path.file_stem().map(|n| n.to_string_lossy().into_owned())
             }),
+            "session_lifecycle": context.session_lifecycle.json_value(),
             "loaded_config_files": context.loaded_config_files,
             "discovered_config_files": context.discovered_config_files,
             "memory_file_count": context.memory_file_count,
@@ -198,7 +201,7 @@ pub(crate) fn status_context(
         parse_git_status_metadata(project_context.git_status.as_deref());
     let git_summary = parse_git_workspace_summary(project_context.git_status.as_deref());
     Ok(StatusContext {
-        cwd,
+        cwd: cwd.clone(),
         session_path: session_path.map(Path::to_path_buf),
         loaded_config_files,
         discovered_config_files,
@@ -206,6 +209,7 @@ pub(crate) fn status_context(
         project_root,
         git_branch,
         git_summary,
+        session_lifecycle: classify_session_lifecycle_for(&cwd),
         sandbox_status,
         config_load_error,
     })
@@ -279,6 +283,7 @@ pub(crate) fn format_status_report(
   Unstaged         {}
   Untracked        {}
   Session          {}
+  Lifecycle        {}
   Config files     loaded {}/{}
   Memory files     {}
   Suggested flow   /status → /diff → /commit",
@@ -297,6 +302,7 @@ pub(crate) fn format_status_report(
                 || "live-repl".to_string(),
                 |path| path.display().to_string()
             ),
+            context.session_lifecycle.signal(),
             context.loaded_config_files,
             context.discovered_config_files,
             context.memory_file_count,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1189,6 +1189,18 @@ fn run_resume_command(
         } if act == "list" => {
             let sessions = list_managed_sessions().unwrap_or_default();
             let session_ids: Vec<String> = sessions.iter().map(|s| s.id.clone()).collect();
+            let session_details: Vec<serde_json::Value> = sessions
+                .iter()
+                .map(|session| {
+                    serde_json::json!({
+                        "id": session.id,
+                        "path": session.path.display().to_string(),
+                        "message_count": session.message_count,
+                        "updated_at_ms": session.updated_at_ms,
+                        "lifecycle": session.lifecycle.json_value(),
+                    })
+                })
+                .collect();
             let active_id = session.session_id.clone();
             let text = render_session_list(&active_id).unwrap_or_else(|e| format!("error: {e}"));
             Ok(ResumeCommandOutcome {
@@ -1197,6 +1209,7 @@ fn run_resume_command(
                 json: Some(serde_json::json!({
                     "kind": "session_list",
                     "sessions": session_ids,
+                    "session_details": session_details,
                     "active": active_id,
                 })),
             })

--- a/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
@@ -87,6 +87,18 @@ fn inventory_commands_emit_structured_json_when_requested() {
     let skills = assert_json_command(&root, &["--output-format", "json", "skills"]);
     assert_eq!(skills["kind"], "skills");
     assert_eq!(skills["action"], "list");
+
+    let plugins = assert_json_command(&root, &["--output-format", "json", "plugins"]);
+    assert_eq!(plugins["kind"], "plugin");
+    assert_eq!(plugins["action"], "list");
+    assert!(
+        plugins["reload_runtime"].is_boolean(),
+        "plugins reload_runtime should be a boolean"
+    );
+    assert!(
+        plugins["target"].is_null(),
+        "plugins target should be null when no plugin is targeted"
+    );
 }
 
 #[test]

--- a/rust/crates/rusty-sudocode-cli/tests/resume_slash_commands.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/resume_slash_commands.rs
@@ -235,6 +235,8 @@ fn resumed_status_command_emits_structured_json_when_requested() {
     // given
     let temp_dir = unique_temp_dir("resume-status-json");
     fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let config_home = temp_dir.join("config-home");
+    fs::create_dir_all(&config_home).expect("isolated config home should exist");
     let session_path = temp_dir.join("session.jsonl");
 
     let mut session = workspace_session(&temp_dir);
@@ -246,7 +248,9 @@ fn resumed_status_command_emits_structured_json_when_requested() {
         .expect("session should persist");
 
     // when
-    let output = run_scode(
+    // Use an isolated SUDO_CODE_CONFIG_HOME so ~/.nexus/sudocode/settings.json
+    // is not loaded, which would cause loaded_config_files to be non-zero.
+    let output = run_scode_with_env(
         &temp_dir,
         &[
             "--output-format",
@@ -255,6 +259,10 @@ fn resumed_status_command_emits_structured_json_when_requested() {
             session_path.to_str().expect("utf8 path"),
             "/status",
         ],
+        &[(
+            "SUDO_CODE_CONFIG_HOME",
+            config_home.to_str().expect("utf8 path"),
+        )],
     );
 
     // then

--- a/scripts/dogfood-build.sh
+++ b/scripts/dogfood-build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# dogfood-build.sh — Build scode from current checkout and verify provenance.
+#
+# Injects GIT_SHA at build time so version JSON is non-null.
+# Suppresses Cargo compile noise on stderr.
+# Prints the verified binary path on success. Use as:
+#
+#   SCODE=$(bash scripts/dogfood-build.sh)
+#
+# Then dogfood with config isolation (avoids real user config bleeding in):
+#
+#   SUDO_CODE_CONFIG_HOME=$(mktemp -d) $SCODE plugins list --output-format json
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUST_DIR="$REPO_ROOT/rust"
+BINARY="$RUST_DIR/target/debug/scode"
+EXPECTED_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
+echo "▶ Building scode from $REPO_ROOT" >&2
+echo "  Commit: $(git -C "$REPO_ROOT" log --oneline -1)" >&2
+
+# Inject GIT_SHA so version JSON returns a non-null sha.
+# Redirect cargo stderr to /dev/null to suppress compile noise;
+# on build failure cargo exits non-zero and set -e aborts.
+if ! GIT_SHA="$EXPECTED_SHA" cargo build \
+        --manifest-path "$RUST_DIR/Cargo.toml" \
+        -p rusty-sudocode-cli -q 2>/dev/null; then
+    # Re-run with visible output so the user sees the error
+    echo "✗ Build failed — rerunning with output:" >&2
+    GIT_SHA="$EXPECTED_SHA" cargo build \
+        --manifest-path "$RUST_DIR/Cargo.toml" \
+        -p rusty-sudocode-cli 2>&1 | sed 's/^/  /' >&2
+    exit 1
+fi
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "✗ Binary not found at $BINARY" >&2
+    exit 1
+fi
+
+BINARY_SHA=$("$BINARY" version --output-format json 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('git_sha') or 'null')" 2>/dev/null \
+    || echo "null")
+
+if [[ "$BINARY_SHA" == "null" || -z "$BINARY_SHA" ]]; then
+    echo "✗ Provenance check failed: binary reports git_sha: null" >&2
+    exit 1
+fi
+
+if [[ "$BINARY_SHA" != "$EXPECTED_SHA" ]]; then
+    echo "✗ Provenance mismatch: binary=$BINARY_SHA, HEAD=$EXPECTED_SHA" >&2
+    exit 1
+fi
+
+echo "✓ Binary verified: $BINARY_SHA == HEAD" >&2
+echo "" >&2
+echo "  export SCODE=$BINARY" >&2
+echo "" >&2
+echo "  Dogfood with isolated config (no real user config on stderr):" >&2
+echo "    SCODE_ISOLATED=\$(mktemp -d)" >&2
+echo "    SUDO_CODE_CONFIG_HOME=\$SCODE_ISOLATED \$SCODE plugins list --output-format json" >&2
+echo "    rm -rf \$SCODE_ISOLATED" >&2
+echo "" >&2
+echo "  cargo run overhead: ~1s/invocation vs 7ms for pre-built binary." >&2
+echo "  Prefer pre-built binary (\$SCODE) for dogfood loops." >&2
+echo "$BINARY"


### PR DESCRIPTION
## Summary
- Port plugins JSON output format contract test (upstream 8e45f18)
- Isolate `SUDO_CODE_CONFIG_HOME` in `resumed_status` JSON test to prevent real user config from causing `loaded_config_files` mismatch (upstream 9b97c4d)
- Add `scripts/dogfood-build.sh` with `GIT_SHA` injection for provenance verification (upstream ab44985)
- Filter stub commands from resume-safe help listing + regression test (upstream 1376d92)
- Add session lifecycle classification: tmux pane detection, idle/running/saved states, dirty-worktree abandoned markers in status and session-list output (upstream be53e04)

Closes #108
Tracking: #101

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p rusty-sudocode-cli --all-targets -- -D warnings` — no new warnings (pre-existing `nexus-vfs-client` issue only)
- [x] `cargo test -p rusty-sudocode-cli` — all 44 tests pass, including 3 new unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)