### PR TITLE
feat(runtime): complete FsBackend migration for all remaining std::fs calls

### DIFF
--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -324,6 +324,23 @@ pub fn edit_file(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Intentional std::fs exclusions (NOT migrated to FsBackend)
+//
+// The following functions remain on std::fs because they depend on host
+// filesystem traversal (WalkDir) or host-only metadata that has no VFS
+// equivalent:
+//
+// - glob_search: WalkDir-based host traversal + fs::metadata for mtime sort
+// - grep_search: WalkDir-based host traversal + fs::read_to_string per file
+//
+// Other intentional exclusions in the runtime crate:
+// - sandbox.rs: /proc/1/cgroup — host OS container detection
+// - bash.rs: sandbox dirs — host filesystem isolation
+// - oauth.rs: /dev/urandom — crypto random source (File::open)
+// - trust_resolver.rs: #[cfg(test)] only module
+// ---------------------------------------------------------------------------
+
 /// Expands a glob pattern and returns matching filenames.
 pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOutput> {
     let started = Instant::now();
@@ -689,13 +706,25 @@ pub fn edit_file_in_workspace(
 /// Check whether a path is a symlink that resolves outside the workspace.
 #[allow(dead_code)]
 pub fn is_symlink_escape(path: &Path, workspace_root: &Path) -> io::Result<bool> {
-    let metadata = fs::symlink_metadata(path)?;
-    if !metadata.is_symlink() {
+    is_symlink_escape_with(path, workspace_root, &crate::fs_backend::StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`is_symlink_escape`].
+#[allow(dead_code)]
+pub fn is_symlink_escape_with(
+    path: &Path,
+    workspace_root: &Path,
+    fs: &dyn FsBackend,
+) -> io::Result<bool> {
+    let path_str = path.to_string_lossy();
+    let metadata = fs.symlink_metadata(&path_str)?;
+    if !metadata.is_symlink {
         return Ok(false);
     }
-    let resolved = path.canonicalize()?;
-    let canonical_root = workspace_root
-        .canonicalize()
+    let resolved = fs.canonicalize(&path_str).map(PathBuf::from)?;
+    let canonical_root = fs
+        .canonicalize(&workspace_root.to_string_lossy())
+        .map(PathBuf::from)
         .unwrap_or_else(|_| workspace_root.to_path_buf());
     Ok(!resolved.starts_with(&canonical_root))
 }

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -291,7 +291,9 @@ impl<K: KernelAbi + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
         Ok(entries
             .into_iter()
             .map(|child_path| {
-                let is_dir = self.kernel.sys_stat(&child_path, zone)
+                let is_dir = self
+                    .kernel
+                    .sys_stat(&child_path, zone)
                     .map_or(false, |s| s.is_directory);
                 let name = child_path
                     .rsplit('/')

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -53,6 +53,8 @@ pub trait FsBackend: Send + Sync + 'static {
     fn exists(&self, path: &str) -> io::Result<bool>;
     fn create_dir_all(&self, path: &str) -> io::Result<()>;
     fn rename(&self, from: &str, to: &str) -> io::Result<()>;
+    fn canonicalize(&self, path: &str) -> io::Result<String>;
+    fn symlink_metadata(&self, path: &str) -> io::Result<FsMetadata>;
 
     /// Convenience: read a file and decode as UTF-8.
     fn read_to_string(&self, path: &str) -> io::Result<String> {
@@ -97,6 +99,12 @@ impl FsBackend for Arc<dyn FsBackend> {
     }
     fn rename(&self, from: &str, to: &str) -> io::Result<()> {
         (**self).rename(from, to)
+    }
+    fn canonicalize(&self, path: &str) -> io::Result<String> {
+        (**self).canonicalize(path)
+    }
+    fn symlink_metadata(&self, path: &str) -> io::Result<FsMetadata> {
+        (**self).symlink_metadata(path)
     }
     fn read_to_string(&self, path: &str) -> io::Result<String> {
         (**self).read_to_string(path)
@@ -172,6 +180,21 @@ impl FsBackend for StdFsBackend {
 
     fn rename(&self, from: &str, to: &str) -> io::Result<()> {
         std::fs::rename(from, to)
+    }
+
+    fn canonicalize(&self, path: &str) -> io::Result<String> {
+        Ok(std::fs::canonicalize(path)?.to_string_lossy().into_owned())
+    }
+
+    fn symlink_metadata(&self, path: &str) -> io::Result<FsMetadata> {
+        let meta = std::fs::symlink_metadata(path)?;
+        Ok(FsMetadata {
+            len: meta.len(),
+            is_dir: meta.is_dir(),
+            is_file: meta.is_file(),
+            is_symlink: meta.is_symlink(),
+            modified: meta.modified().ok(),
+        })
     }
 
     fn read_to_string(&self, path: &str) -> io::Result<String> {
@@ -264,19 +287,18 @@ impl<K: KernelAbi + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
 
     fn readdir(&self, path: &str) -> io::Result<Vec<FsDirEntry>> {
         let zone = &self.ctx.zone_id;
-        let entries = self.kernel.readdir(path, zone, false);
+        let entries = self.kernel.sys_readdir_backend(path, zone);
         Ok(entries
             .into_iter()
-            .map(|(child_path, entry_type)| {
+            .map(|child_path| {
+                let is_dir = self.kernel.sys_stat(&child_path, zone)
+                    .map_or(false, |s| s.is_directory);
                 let name = child_path
                     .rsplit('/')
                     .next()
                     .unwrap_or(&child_path)
                     .to_string();
-                FsDirEntry {
-                    name,
-                    is_dir: entry_type == 1, // DT_DIR
-                }
+                FsDirEntry { name, is_dir }
             })
             .collect())
     }
@@ -297,6 +319,16 @@ impl<K: KernelAbi + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
         self.write(to, &data)?;
         self.delete(from)?;
         Ok(())
+    }
+
+    fn canonicalize(&self, path: &str) -> io::Result<String> {
+        // VFS paths are already canonical — no host symlinks to resolve.
+        Ok(path.to_string())
+    }
+
+    fn symlink_metadata(&self, path: &str) -> io::Result<FsMetadata> {
+        // VFS has no symlinks — delegate to regular stat.
+        self.stat(path)
     }
 
     fn write_atomic(&self, path: &str, data: &[u8]) -> io::Result<()> {
@@ -380,6 +412,16 @@ impl FsBackend for NexusVfsFsBackend {
         self.write(to, &data)?;
         self.delete(from)?;
         Ok(())
+    }
+
+    fn canonicalize(&self, path: &str) -> io::Result<String> {
+        // VFS paths are already canonical over gRPC — no host symlinks.
+        Ok(path.to_string())
+    }
+
+    fn symlink_metadata(&self, path: &str) -> io::Result<FsMetadata> {
+        // VFS has no symlinks — delegate to regular stat.
+        self.stat(path)
     }
 }
 

--- a/rust/crates/runtime/src/image_registry.rs
+++ b/rust/crates/runtime/src/image_registry.rs
@@ -1,9 +1,11 @@
-use std::fs;
 use std::io::{self, Cursor};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use base64::Engine;
 use sha2::{Digest, Sha256};
+
+use crate::fs_backend::{FsBackend, StdFsBackend};
 
 /// Maximum raw image size before downsampling (5 MB).
 const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
@@ -17,6 +19,7 @@ const MAX_IMAGE_DIMENSION: u32 = 8000;
 /// `<image:HASH>` tag inside the prompt text.
 pub struct ImageRegistry {
     cache_dir: PathBuf,
+    fs: Arc<dyn FsBackend>,
 }
 
 /// Information about a successfully registered image.
@@ -34,9 +37,16 @@ impl ImageRegistry {
     /// Create a new registry backed by the default cache directory
     /// (`<config_home>/image_cache`, typically `~/.nexus/sudocode/image_cache`).
     pub fn default_cache() -> io::Result<Self> {
+        let fs: Arc<dyn FsBackend> = Arc::new(StdFsBackend);
         let cache_dir = crate::config::default_config_home().join("image_cache");
-        fs::create_dir_all(&cache_dir)?;
-        Ok(Self { cache_dir })
+        fs.create_dir_all(&cache_dir.to_string_lossy())?;
+        Ok(Self { cache_dir, fs })
+    }
+
+    /// Create a registry with a custom cache directory and filesystem backend.
+    pub fn new(cache_dir: PathBuf, fs: Arc<dyn FsBackend>) -> io::Result<Self> {
+        fs.create_dir_all(&cache_dir.to_string_lossy())?;
+        Ok(Self { cache_dir, fs })
     }
 
     /// Register raw RGBA image data (as provided by `arboard`).
@@ -64,7 +74,7 @@ impl ImageRegistry {
     /// Load a previously stored image by its hex hash. Returns `(base64_data, mime_type)`.
     pub fn load(&self, hash: &str) -> io::Result<(String, String)> {
         let entry = self.find_by_hash(hash)?;
-        let bytes = fs::read(&entry.0)?;
+        let bytes = self.fs.read(&entry.0.to_string_lossy())?;
         let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
         Ok((b64, entry.1))
     }
@@ -83,8 +93,8 @@ impl ImageRegistry {
         let filename = format!("{hash}.{ext}");
         let path = self.cache_dir.join(&filename);
 
-        if !path.exists() {
-            fs::write(&path, bytes)?;
+        if !self.fs.exists(&path.to_string_lossy()).unwrap_or(false) {
+            self.fs.write(&path.to_string_lossy(), bytes)?;
         }
 
         Ok(RegisteredImage {
@@ -97,7 +107,7 @@ impl ImageRegistry {
     fn find_by_hash(&self, hash: &str) -> io::Result<(PathBuf, String)> {
         for ext in &["png", "jpg", "jpeg", "gif", "webp"] {
             let path = self.cache_dir.join(format!("{hash}.{ext}"));
-            if path.exists() {
+            if self.fs.exists(&path.to_string_lossy()).unwrap_or(false) {
                 let mime = ext_to_mime(ext);
                 return Ok((path, mime.to_string()));
             }
@@ -212,8 +222,9 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ));
-        fs::create_dir_all(&dir).unwrap();
-        ImageRegistry { cache_dir: dir }
+        let fs: Arc<dyn FsBackend> = Arc::new(StdFsBackend);
+        fs.create_dir_all(&dir.to_string_lossy()).unwrap();
+        ImageRegistry { cache_dir: dir, fs }
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -154,9 +154,10 @@ pub use recovery_recipes::{
     RecoveryEvent, RecoveryRecipe, RecoveryResult, RecoveryStep,
 };
 pub use remote::{
-    inherited_upstream_proxy_env, no_proxy_list, read_token, upstream_proxy_ws_url,
-    RemoteSessionContext, UpstreamProxyBootstrap, UpstreamProxyState, DEFAULT_REMOTE_BASE_URL,
-    DEFAULT_SESSION_TOKEN_PATH, DEFAULT_SYSTEM_CA_BUNDLE, NO_PROXY_HOSTS, UPSTREAM_PROXY_ENV_KEYS,
+    inherited_upstream_proxy_env, no_proxy_list, read_token, read_token_with,
+    upstream_proxy_ws_url, RemoteSessionContext, UpstreamProxyBootstrap, UpstreamProxyState,
+    DEFAULT_REMOTE_BASE_URL, DEFAULT_SESSION_TOKEN_PATH, DEFAULT_SYSTEM_CA_BUNDLE, NO_PROXY_HOSTS,
+    UPSTREAM_PROXY_ENV_KEYS,
 };
 pub use sandbox::{
     build_linux_sandbox_command, detect_container_environment, detect_container_environment_from,
@@ -170,8 +171,8 @@ pub use session::{
 };
 pub use sse::{IncrementalSseParser, SseEvent};
 pub use stale_base::{
-    check_base_commit, format_stale_base_warning, read_sudocode_base_file, resolve_expected_base,
-    BaseCommitSource, BaseCommitState,
+    check_base_commit, format_stale_base_warning, read_sudocode_base_file,
+    read_sudocode_base_file_with, resolve_expected_base, BaseCommitSource, BaseCommitState,
 };
 pub use stale_branch::{
     apply_policy, check_freshness, BranchFreshness, StaleBranchAction, StaleBranchEvent,

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -125,12 +125,13 @@ pub use mcp_stdio::{
     UnsupportedMcpServer,
 };
 pub use oauth::{
-    clear_oauth_credentials, clear_oauth_credentials_from_keyring, code_challenge_s256,
-    credentials_path, generate_pkce_pair, generate_state, import_claude_code_credentials,
-    load_oauth_credentials, loopback_redirect_uri, parse_oauth_callback_query,
-    parse_oauth_callback_request_target, save_oauth_credentials, OAuthAuthorizationRequest,
-    OAuthCallbackParams, OAuthRefreshRequest, OAuthTokenExchangeRequest, OAuthTokenSet,
-    PkceChallengeMethod, PkceCodePair,
+    clear_oauth_credentials, clear_oauth_credentials_from_keyring, clear_oauth_credentials_with,
+    code_challenge_s256, credentials_path, generate_pkce_pair, generate_state,
+    import_claude_code_credentials, import_claude_code_credentials_with, load_oauth_credentials,
+    load_oauth_credentials_with, loopback_redirect_uri, parse_oauth_callback_query,
+    parse_oauth_callback_request_target, save_oauth_credentials, save_oauth_credentials_with,
+    OAuthAuthorizationRequest, OAuthCallbackParams, OAuthRefreshRequest,
+    OAuthTokenExchangeRequest, OAuthTokenSet, PkceChallengeMethod, PkceCodePair,
 };
 pub use permissions::{
     PermissionContext, PermissionMode, PermissionOutcome, PermissionOverride, PermissionPolicy,

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -146,9 +146,9 @@ pub use policy_engine::{
     PolicyEngine, PolicyRule, ReconcileReason, ReviewStatus,
 };
 pub use prompt::{
-    load_system_prompt, prepend_bullets, ContextFile, ModelFamilyIdentity, ProjectContext,
-    PromptBuildError, SystemPrompt, SystemPromptBuilder, FRONTIER_MODEL_NAME,
-    SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+    load_system_prompt, load_system_prompt_with, prepend_bullets, ContextFile,
+    ModelFamilyIdentity, ProjectContext, PromptBuildError, SystemPrompt, SystemPromptBuilder,
+    FRONTIER_MODEL_NAME, SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
 };
 pub use recovery_recipes::{
     attempt_recovery, recipe_for, EscalationPolicy, FailureScenario, RecoveryContext,

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -130,8 +130,8 @@ pub use oauth::{
     import_claude_code_credentials, import_claude_code_credentials_with, load_oauth_credentials,
     load_oauth_credentials_with, loopback_redirect_uri, parse_oauth_callback_query,
     parse_oauth_callback_request_target, save_oauth_credentials, save_oauth_credentials_with,
-    OAuthAuthorizationRequest, OAuthCallbackParams, OAuthRefreshRequest,
-    OAuthTokenExchangeRequest, OAuthTokenSet, PkceChallengeMethod, PkceCodePair,
+    OAuthAuthorizationRequest, OAuthCallbackParams, OAuthRefreshRequest, OAuthTokenExchangeRequest,
+    OAuthTokenSet, PkceChallengeMethod, PkceCodePair,
 };
 pub use permissions::{
     PermissionContext, PermissionMode, PermissionOutcome, PermissionOverride, PermissionPolicy,
@@ -146,9 +146,9 @@ pub use policy_engine::{
     PolicyEngine, PolicyRule, ReconcileReason, ReviewStatus,
 };
 pub use prompt::{
-    load_system_prompt, load_system_prompt_with, prepend_bullets, ContextFile,
-    ModelFamilyIdentity, ProjectContext, PromptBuildError, SystemPrompt, SystemPromptBuilder,
-    FRONTIER_MODEL_NAME, SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+    load_system_prompt, load_system_prompt_with, prepend_bullets, ContextFile, ModelFamilyIdentity,
+    ProjectContext, PromptBuildError, SystemPrompt, SystemPromptBuilder, FRONTIER_MODEL_NAME,
+    SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
 };
 pub use recovery_recipes::{
     attempt_recovery, recipe_for, EscalationPolicy, FailureScenario, RecoveryContext,

--- a/rust/crates/runtime/src/oauth.rs
+++ b/rust/crates/runtime/src/oauth.rs
@@ -540,7 +540,10 @@ fn write_credentials_root_with(
     let rendered = serde_json::to_string_pretty(&Value::Object(root.clone()))
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let temp_path = path.with_extension("json.tmp");
-    fs.write(&temp_path.to_string_lossy(), format!("{rendered}\n").as_bytes())?;
+    fs.write(
+        &temp_path.to_string_lossy(),
+        format!("{rendered}\n").as_bytes(),
+    )?;
     fs.rename(&temp_path.to_string_lossy(), &path.to_string_lossy())
 }
 

--- a/rust/crates/runtime/src/oauth.rs
+++ b/rust/crates/runtime/src/oauth.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -8,6 +8,7 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::config::OAuthConfig;
+use crate::fs_backend::{FsBackend, StdFsBackend};
 
 /// Persisted OAuth access token bundle used by the CLI.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -268,12 +269,17 @@ pub fn credentials_path() -> io::Result<PathBuf> {
 }
 
 pub fn load_oauth_credentials() -> io::Result<Option<OAuthTokenSet>> {
+    load_oauth_credentials_with(&StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`load_oauth_credentials`].
+pub fn load_oauth_credentials_with(fs: &dyn FsBackend) -> io::Result<Option<OAuthTokenSet>> {
     // Try keyring first, fall back to file.
     if let Some(token_set) = load_oauth_credentials_from_keyring() {
         return Ok(Some(token_set));
     }
     let path = credentials_path()?;
-    let root = read_credentials_root(&path)?;
+    let root = read_credentials_root_with(&path, fs)?;
     let Some(oauth) = root.get("oauth") else {
         return Ok(None);
     };
@@ -286,24 +292,37 @@ pub fn load_oauth_credentials() -> io::Result<Option<OAuthTokenSet>> {
 }
 
 pub fn save_oauth_credentials(token_set: &OAuthTokenSet) -> io::Result<()> {
+    save_oauth_credentials_with(token_set, &StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`save_oauth_credentials`].
+pub fn save_oauth_credentials_with(
+    token_set: &OAuthTokenSet,
+    fs: &dyn FsBackend,
+) -> io::Result<()> {
     // Write to both keyring and file for redundancy.
     save_oauth_credentials_to_keyring(token_set);
     let path = credentials_path()?;
-    let mut root = read_credentials_root(&path)?;
+    let mut root = read_credentials_root_with(&path, fs)?;
     root.insert(
         "oauth".to_string(),
         serde_json::to_value(StoredOAuthCredentials::from(token_set.clone()))
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
     );
-    write_credentials_root(&path, &root)
+    write_credentials_root_with(&path, &root, fs)
 }
 
 pub fn clear_oauth_credentials() -> io::Result<()> {
+    clear_oauth_credentials_with(&StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`clear_oauth_credentials`].
+pub fn clear_oauth_credentials_with(fs: &dyn FsBackend) -> io::Result<()> {
     clear_oauth_credentials_from_keyring();
     let path = credentials_path()?;
-    let mut root = read_credentials_root(&path)?;
+    let mut root = read_credentials_root_with(&path, fs)?;
     root.remove("oauth");
-    write_credentials_root(&path, &root)
+    write_credentials_root_with(&path, &root, fs)
 }
 
 pub fn parse_oauth_callback_request_target(target: &str) -> Result<OAuthCallbackParams, String> {
@@ -393,6 +412,11 @@ struct CcOAuthEntry {
 ///
 /// Returns the imported token set, or a human-readable error string.
 pub fn import_claude_code_credentials() -> Result<OAuthTokenSet, String> {
+    import_claude_code_credentials_with(&StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`import_claude_code_credentials`].
+pub fn import_claude_code_credentials_with(fs: &dyn FsBackend) -> Result<OAuthTokenSet, String> {
     let json = read_cc_keychain_password()?;
     let payload: CcKeychainPayload = serde_json::from_str(&json)
         .map_err(|e| format!("failed to parse Claude Code keychain data: {e}"))?;
@@ -408,7 +432,7 @@ pub fn import_claude_code_credentials() -> Result<OAuthTokenSet, String> {
         scopes: cc.scopes,
     };
 
-    save_oauth_credentials(&token_set)
+    save_oauth_credentials_with(&token_set, fs)
         .map_err(|e| format!("failed to save imported credentials: {e}"))?;
 
     Ok(token_set)
@@ -473,7 +497,14 @@ fn credentials_home_dir() -> io::Result<PathBuf> {
 }
 
 fn read_credentials_root(path: &PathBuf) -> io::Result<Map<String, Value>> {
-    match fs::read_to_string(path) {
+    read_credentials_root_with(path, &StdFsBackend)
+}
+
+fn read_credentials_root_with(
+    path: &PathBuf,
+    fs: &dyn FsBackend,
+) -> io::Result<Map<String, Value>> {
+    match fs.read_to_string(&path.to_string_lossy()) {
         Ok(contents) => {
             if contents.trim().is_empty() {
                 return Ok(Map::new());
@@ -495,14 +526,22 @@ fn read_credentials_root(path: &PathBuf) -> io::Result<Map<String, Value>> {
 }
 
 fn write_credentials_root(path: &PathBuf, root: &Map<String, Value>) -> io::Result<()> {
+    write_credentials_root_with(path, root, &StdFsBackend)
+}
+
+fn write_credentials_root_with(
+    path: &PathBuf,
+    root: &Map<String, Value>,
+    fs: &dyn FsBackend,
+) -> io::Result<()> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+        fs.create_dir_all(&parent.to_string_lossy())?;
     }
     let rendered = serde_json::to_string_pretty(&Value::Object(root.clone()))
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let temp_path = path.with_extension("json.tmp");
-    fs::write(&temp_path, format!("{rendered}\n"))?;
-    fs::rename(temp_path, path)
+    fs.write(&temp_path.to_string_lossy(), format!("{rendered}\n").as_bytes())?;
+    fs.rename(&temp_path.to_string_lossy(), &path.to_string_lossy())
 }
 
 fn base64url_encode(bytes: &[u8]) -> String {

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -296,10 +296,7 @@ pub fn prepend_bullets(items: Vec<String>) -> Vec<String> {
     items.into_iter().map(|item| format!(" - {item}")).collect()
 }
 
-fn discover_instruction_files(
-    cwd: &Path,
-    fs: &dyn FsBackend,
-) -> std::io::Result<Vec<ContextFile>> {
+fn discover_instruction_files(cwd: &Path, fs: &dyn FsBackend) -> std::io::Result<Vec<ContextFile>> {
     let mut directories = Vec::new();
     let mut cursor = Some(cwd);
     while let Some(dir) = cursor {
@@ -537,7 +534,14 @@ pub fn load_system_prompt(
     os_version: impl Into<String>,
     model_family: ModelFamilyIdentity,
 ) -> Result<SystemPrompt, PromptBuildError> {
-    load_system_prompt_with(cwd, current_date, os_name, os_version, model_family, &StdFsBackend)
+    load_system_prompt_with(
+        cwd,
+        current_date,
+        os_name,
+        os_version,
+        model_family,
+        &StdFsBackend,
+    )
 }
 
 /// Backend-parameterised variant of [`load_system_prompt`].

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -1,9 +1,9 @@
-use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::config::{ConfigError, ConfigLoader, RuntimeConfig};
+use crate::fs_backend::{FsBackend, StdFsBackend};
 use crate::git_context::GitContext;
 
 /// Errors raised while assembling the final system prompt.
@@ -125,8 +125,17 @@ impl ProjectContext {
         cwd: impl Into<PathBuf>,
         current_date: impl Into<String>,
     ) -> std::io::Result<Self> {
+        Self::discover_with_fs(cwd, current_date, &StdFsBackend)
+    }
+
+    /// Backend-parameterised variant of [`ProjectContext::discover`].
+    pub fn discover_with_fs(
+        cwd: impl Into<PathBuf>,
+        current_date: impl Into<String>,
+        fs: &dyn FsBackend,
+    ) -> std::io::Result<Self> {
         let cwd = cwd.into();
-        let instruction_files = discover_instruction_files(&cwd)?;
+        let instruction_files = discover_instruction_files(&cwd, fs)?;
         Ok(Self {
             cwd,
             current_date: current_date.into(),
@@ -141,7 +150,16 @@ impl ProjectContext {
         cwd: impl Into<PathBuf>,
         current_date: impl Into<String>,
     ) -> std::io::Result<Self> {
-        let mut context = Self::discover(cwd, current_date)?;
+        Self::discover_with_git_fs(cwd, current_date, &StdFsBackend)
+    }
+
+    /// Backend-parameterised variant of [`ProjectContext::discover_with_git`].
+    pub fn discover_with_git_fs(
+        cwd: impl Into<PathBuf>,
+        current_date: impl Into<String>,
+        fs: &dyn FsBackend,
+    ) -> std::io::Result<Self> {
+        let mut context = Self::discover_with_fs(cwd, current_date, fs)?;
         context.git_status = read_git_status(&context.cwd);
         context.git_diff = read_git_diff(&context.cwd);
         context.git_context = GitContext::detect(&context.cwd);
@@ -278,7 +296,10 @@ pub fn prepend_bullets(items: Vec<String>) -> Vec<String> {
     items.into_iter().map(|item| format!(" - {item}")).collect()
 }
 
-fn discover_instruction_files(cwd: &Path) -> std::io::Result<Vec<ContextFile>> {
+fn discover_instruction_files(
+    cwd: &Path,
+    fs: &dyn FsBackend,
+) -> std::io::Result<Vec<ContextFile>> {
     let mut directories = Vec::new();
     let mut cursor = Some(cwd);
     while let Some(dir) = cursor {
@@ -293,14 +314,18 @@ fn discover_instruction_files(cwd: &Path) -> std::io::Result<Vec<ContextFile>> {
             dir.join("AGENTS.md"),
             dir.join(".nexus").join("sudocode").join("AGENTS.md"),
         ] {
-            push_context_file(&mut files, candidate)?;
+            push_context_file(&mut files, candidate, fs)?;
         }
     }
     Ok(dedupe_instruction_files(files))
 }
 
-fn push_context_file(files: &mut Vec<ContextFile>, path: PathBuf) -> std::io::Result<()> {
-    match fs::read_to_string(&path) {
+fn push_context_file(
+    files: &mut Vec<ContextFile>,
+    path: PathBuf,
+    fs: &dyn FsBackend,
+) -> std::io::Result<()> {
+    match fs.read_to_string(&path.to_string_lossy()) {
         Ok(content) if !content.trim().is_empty() => {
             files.push(ContextFile { path, content });
             Ok(())
@@ -512,8 +537,20 @@ pub fn load_system_prompt(
     os_version: impl Into<String>,
     model_family: ModelFamilyIdentity,
 ) -> Result<SystemPrompt, PromptBuildError> {
+    load_system_prompt_with(cwd, current_date, os_name, os_version, model_family, &StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`load_system_prompt`].
+pub fn load_system_prompt_with(
+    cwd: impl Into<PathBuf>,
+    current_date: impl Into<String>,
+    os_name: impl Into<String>,
+    os_version: impl Into<String>,
+    model_family: ModelFamilyIdentity,
+    fs: &dyn FsBackend,
+) -> Result<SystemPrompt, PromptBuildError> {
     let cwd = cwd.into();
-    let project_context = ProjectContext::discover_with_git(&cwd, current_date.into())?;
+    let project_context = ProjectContext::discover_with_git_fs(&cwd, current_date.into(), fs)?;
     let config = ConfigLoader::default_for(&cwd).load()?;
     Ok(SystemPromptBuilder::new()
         .with_os(os_name, os_version)

--- a/rust/crates/runtime/src/remote.rs
+++ b/rust/crates/runtime/src/remote.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 use std::env;
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+
+use crate::fs_backend::{FsBackend, StdFsBackend};
 
 pub const DEFAULT_REMOTE_BASE_URL: &str = "https://api.anthropic.com";
 pub const DEFAULT_SESSION_TOKEN_PATH: &str = "/run/ccr/session_token";
@@ -183,7 +184,12 @@ impl UpstreamProxyState {
 }
 
 pub fn read_token(path: &Path) -> io::Result<Option<String>> {
-    match fs::read_to_string(path) {
+    read_token_with(path, &StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`read_token`].
+pub fn read_token_with(path: &Path, fs: &dyn FsBackend) -> io::Result<Option<String>> {
+    match fs.read_to_string(&path.to_string_lossy()) {
         Ok(contents) => {
             let token = contents.trim();
             if token.is_empty() {

--- a/rust/crates/runtime/src/session_control.rs
+++ b/rust/crates/runtime/src/session_control.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 use std::env;
 use std::fmt::{Display, Formatter};
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
+use crate::fs_backend::{FsBackend, StdFsBackend};
 use crate::session::{Session, SessionError};
 
 /// Per-worktree session store that namespaces on-disk session files by
@@ -16,13 +17,14 @@ use crate::session::{Session, SessionError};
 /// explicit `--data-dir` flag).  Both constructors produce a directory layout
 /// of `<data_dir>/sessions/<workspace_hash>/` where `<workspace_hash>` is a
 /// stable hex digest of the canonical workspace root.
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionStore {
     /// Resolved root of the session namespace, e.g.
     /// `/home/user/project/.scode/sessions/a1b2c3d4e5f60718/`.
     sessions_root: PathBuf,
     /// The canonical workspace path that was fingerprinted.
     workspace_root: PathBuf,
+    /// Filesystem backend for all I/O.
+    fs: Arc<dyn FsBackend>,
 }
 
 impl SessionStore {
@@ -30,20 +32,32 @@ impl SessionStore {
     ///
     /// The on-disk layout becomes `<cwd>/.scode/sessions/<workspace_hash>/`.
     pub fn from_cwd(cwd: impl AsRef<Path>) -> Result<Self, SessionControlError> {
+        Self::from_cwd_with(cwd, Arc::new(StdFsBackend))
+    }
+
+    /// Backend-parameterised variant of [`SessionStore::from_cwd`].
+    pub fn from_cwd_with(
+        cwd: impl AsRef<Path>,
+        fs: Arc<dyn FsBackend>,
+    ) -> Result<Self, SessionControlError> {
         let cwd = cwd.as_ref();
         // #151: canonicalize so equivalent paths (symlinks, relative vs
         // absolute, /tmp vs /private/tmp on macOS) produce the same
         // workspace_fingerprint. Falls back to the raw path if canonicalize
         // fails (e.g. the directory doesn't exist yet).
-        let canonical_cwd = fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
+        let canonical_cwd = fs
+            .canonicalize(&cwd.to_string_lossy())
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| cwd.to_path_buf());
         let sessions_root = canonical_cwd
             .join(".scode")
             .join("sessions")
             .join(workspace_fingerprint(&canonical_cwd));
-        fs::create_dir_all(&sessions_root)?;
+        fs.create_dir_all(&sessions_root.to_string_lossy())?;
         Ok(Self {
             sessions_root,
             workspace_root: canonical_cwd,
+            fs,
         })
     }
 
@@ -55,19 +69,31 @@ impl SessionStore {
         data_dir: impl AsRef<Path>,
         workspace_root: impl AsRef<Path>,
     ) -> Result<Self, SessionControlError> {
+        Self::from_data_dir_with(data_dir, workspace_root, Arc::new(StdFsBackend))
+    }
+
+    /// Backend-parameterised variant of [`SessionStore::from_data_dir`].
+    pub fn from_data_dir_with(
+        data_dir: impl AsRef<Path>,
+        workspace_root: impl AsRef<Path>,
+        fs: Arc<dyn FsBackend>,
+    ) -> Result<Self, SessionControlError> {
         let workspace_root = workspace_root.as_ref();
         // #151: canonicalize workspace_root for consistent fingerprinting
         // across equivalent path representations.
-        let canonical_workspace =
-            fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
+        let canonical_workspace = fs
+            .canonicalize(&workspace_root.to_string_lossy())
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| workspace_root.to_path_buf());
         let sessions_root = data_dir
             .as_ref()
             .join("sessions")
             .join(workspace_fingerprint(&canonical_workspace));
-        fs::create_dir_all(&sessions_root)?;
+        fs.create_dir_all(&sessions_root.to_string_lossy())?;
         Ok(Self {
             sessions_root,
             workspace_root: canonical_workspace,
+            fs,
         })
     }
 
@@ -195,14 +221,14 @@ impl SessionStore {
         session: &Session,
     ) -> Result<(), SessionControlError> {
         let Some(actual) = session.workspace_root() else {
-            if path_is_within_workspace(session_path, &self.workspace_root) {
+            if path_is_within_workspace(session_path, &self.workspace_root, &*self.fs) {
                 return Ok(());
             }
             return Err(SessionControlError::Format(
                 format_session_missing_workspace_root(session_path, &self.workspace_root),
             ));
         };
-        if workspace_roots_match(actual, &self.workspace_root) {
+        if workspace_roots_match(actual, &self.workspace_root, &*self.fs) {
             return Ok(());
         }
         Err(SessionControlError::WorkspaceMismatch {
@@ -216,21 +242,22 @@ impl SessionStore {
         directory: &Path,
         sessions: &mut Vec<ManagedSessionSummary>,
     ) -> Result<(), SessionControlError> {
-        let entries = match fs::read_dir(directory) {
+        let dir_str = directory.to_string_lossy();
+        let entries = match self.fs.readdir(&dir_str) {
             Ok(entries) => entries,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
             Err(err) => return Err(err.into()),
         };
         for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
+            let path = directory.join(&entry.name);
             if !is_managed_session_file(&path) {
                 continue;
             }
-            let metadata = entry.metadata()?;
-            let modified_epoch_millis = metadata
-                .modified()
+            let modified_epoch_millis = self
+                .fs
+                .stat(&path.to_string_lossy())
                 .ok()
+                .and_then(|m| m.modified)
                 .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
                 .map(|duration| duration.as_millis())
                 .unwrap_or_default();
@@ -530,16 +557,18 @@ fn format_session_missing_workspace_root(session_path: &Path, workspace_root: &P
     )
 }
 
-fn workspace_roots_match(left: &Path, right: &Path) -> bool {
-    canonicalize_for_compare(left) == canonicalize_for_compare(right)
+fn workspace_roots_match(left: &Path, right: &Path, fs: &dyn FsBackend) -> bool {
+    canonicalize_for_compare(left, fs) == canonicalize_for_compare(right, fs)
 }
 
-fn canonicalize_for_compare(path: &Path) -> PathBuf {
-    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+fn canonicalize_for_compare(path: &Path, fs: &dyn FsBackend) -> PathBuf {
+    fs.canonicalize(&path.to_string_lossy())
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn path_is_within_workspace(path: &Path, workspace_root: &Path) -> bool {
-    canonicalize_for_compare(path).starts_with(canonicalize_for_compare(workspace_root))
+fn path_is_within_workspace(path: &Path, workspace_root: &Path, fs: &dyn FsBackend) -> bool {
+    canonicalize_for_compare(path, fs).starts_with(canonicalize_for_compare(workspace_root, fs))
 }
 
 #[cfg(test)]

--- a/rust/crates/runtime/src/stale_base.rs
+++ b/rust/crates/runtime/src/stale_base.rs
@@ -2,6 +2,8 @@
 use std::path::Path;
 use std::process::Command;
 
+use crate::fs_backend::{FsBackend, StdFsBackend};
+
 /// Outcome of comparing the worktree HEAD against the expected base commit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BaseCommitState {
@@ -25,8 +27,13 @@ pub enum BaseCommitSource {
 /// Read the `.sudocode-base` file from the given directory and return the trimmed
 /// commit hash, or `None` when the file is absent or empty.
 pub fn read_sudocode_base_file(cwd: &Path) -> Option<String> {
+    read_sudocode_base_file_with(cwd, &StdFsBackend)
+}
+
+/// Backend-parameterised variant of [`read_sudocode_base_file`].
+pub fn read_sudocode_base_file_with(cwd: &Path, fs: &dyn FsBackend) -> Option<String> {
     let path = cwd.join(".sudocode-base");
-    let content = std::fs::read_to_string(path).ok()?;
+    let content = fs.read_to_string(&path.to_string_lossy()).ok()?;
     let trimmed = content.trim();
     if trimmed.is_empty() {
         None


### PR DESCRIPTION
## Summary

- Extend `FsBackend` trait with `canonicalize` + `symlink_metadata` methods (all 3 impls: Std, Kernel, NexusVfs)
- Migrate 10 remaining `std::fs` call sites across 8 files to use `FsBackend` via `_with(fs)` variants
- Add `fs: Arc<dyn FsBackend>` field to `ImageRegistry` and `SessionStore` structs
- Document intentional `std::fs` exclusions (glob/grep WalkDir, sandbox, bash sandbox dirs, `/dev/urandom`, trust_resolver test-only)
- Fix pre-existing `KernelFsBackend::readdir` breakage (was calling non-existent renamed method instead of `sys_readdir_backend`)

## Migrated files

| File | Calls migrated |
|------|---------------|
| `fs_backend.rs` | 2 new trait methods + impls |
| `stale_base.rs` | `read_sudocode_base_file` |
| `remote.rs` | `read_token` |
| `oauth.rs` | `load/save/clear/import_oauth_credentials` + internal helpers |
| `image_registry.rs` | `create_dir_all`, `read`, `write`, `exists` |
| `prompt.rs` | `push_context_file`, `discover_instruction_files`, `load_system_prompt` |
| `session_control.rs` | `canonicalize`, `create_dir_all`, `read_dir`, `stat` |
| `file_ops.rs` | `is_symlink_escape` |

## Test plan

- [x] `cargo check` — full workspace compiles
- [x] `cargo test -p runtime --lib` — 483 tests pass
- [x] `cargo test -p runtime --test spawn_task` — 3 integration tests pass
- [x] `cargo test -p tools --lib` — 100 tests pass
- [x] `grep '\bfs::' runtime/src` non-test code → only documented exclusions remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)