### PR TITLE
feat(tools): managed_agent factory for spawn_task v2

### DIFF
--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -39,8 +39,10 @@
 use std::sync::Arc;
 use std::thread;
 
-use kernel::abi::KernelAbi;
-use kernel::core::agents::registry::AgentDescriptor;
+// Re-export kernel types so downstream crates (e.g. `tools`) can
+// reference them without adding a direct `kernel` dependency.
+pub use kernel::abi::KernelAbi;
+pub use kernel::core::agents::registry::AgentDescriptor;
 use kernel::kernel::OperationContext;
 
 use crate::conversation::{ApiClient, ConversationRuntime, ToolExecutor};

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod managed_agent;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -4835,14 +4837,14 @@ struct ProviderEntry {
     client: ProviderClient,
 }
 
-struct ProviderRuntimeClient {
+pub(crate) struct ProviderRuntimeClient {
     chain: Vec<ProviderEntry>,
     allowed_tools: BTreeSet<String>,
 }
 
 impl ProviderRuntimeClient {
-    #[allow(dead_code, clippy::needless_pass_by_value)]
-    fn new(model: String, allowed_tools: BTreeSet<String>) -> Result<Self, String> {
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn new(model: String, allowed_tools: BTreeSet<String>) -> Result<Self, String> {
         let fallback_config = load_provider_fallback_config();
         Self::new_with_fallback_config(model, allowed_tools, &fallback_config)
     }

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -1,0 +1,101 @@
+//! Factory for the managed-agent spawn body (v2 ConversationRuntime).
+//!
+//! Constructs the `ApiClient`, `ToolExecutor`, `SystemPrompt`, and
+//! `PermissionPolicy` dependencies from the `AgentDescriptor` metadata
+//! and calls `runtime::spawn_task::spawn_task` to launch the full LLM
+//! loop. The nexus cdylib's `SudoCodeSpawnAdapter` calls this instead
+//! of `spawn_task_echo`.
+//!
+//! Lives in the `tools` crate because it needs both the `api` crate
+//! (for `ProviderClient` / `resolve_provider_from_config`) and the
+//! `runtime` crate (for `spawn_task`, `SystemPrompt`, etc.). The
+//! `tools` crate is the natural composition point that already depends
+//! on both.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use runtime::spawn_task::{AgentDescriptor, AgentLoopState, KernelAbi, SpawnHandle};
+use runtime::{
+    ModelFamilyIdentity, PermissionMode, PermissionPolicy, SystemPromptBuilder, ToolError,
+    ToolExecutor,
+};
+
+use crate::{execute_tool, ProviderRuntimeClient};
+
+/// Label key where `ManagedAgentService` stores the model id in the
+/// `AgentDescriptor.labels` map.
+const MODEL_LABEL: &str = "model";
+
+/// Default model used when the descriptor has no `model` label.
+const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+
+/// Spawn a managed-agent loop with the full ConversationRuntime.
+///
+/// This is the v2 upgrade of `spawn_task_echo`. The caller
+/// (nexus cdylib `SudoCodeSpawnAdapter`) invokes this after
+/// `register_proc_entry` stamps the per-pid procfs subtree.
+///
+/// # Arguments
+///
+/// * `kernel` — shared kernel handle (in-process, monomorphised)
+/// * `desc` — agent descriptor planted by `ManagedAgentService`
+/// * `state_callback` — called on every state transition so the caller
+///   can forward to `AgentRegistry::update_state`
+pub fn spawn_managed_agent<K, F>(
+    kernel: Arc<K>,
+    desc: AgentDescriptor,
+    state_callback: F,
+) -> SpawnHandle
+where
+    K: KernelAbi + Send + Sync + 'static,
+    F: Fn(AgentLoopState) + Send + 'static,
+{
+    let model = desc
+        .labels
+        .get(MODEL_LABEL)
+        .filter(|m| !m.is_empty())
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+    // -- ApiClient: provider chain from model id --
+    let api_client = ProviderRuntimeClient::new(model, BTreeSet::new())
+        .expect("failed to construct API client from model label");
+
+    // -- ToolExecutor: dispatch through the global tool registry --
+    let tool_executor = ManagedToolExecutor;
+
+    // -- SystemPrompt: minimal prompt for managed-agent context --
+    let system_prompt = SystemPromptBuilder::new()
+        .with_model_family(ModelFamilyIdentity::Claude)
+        .build();
+
+    // -- PermissionPolicy: managed agents run with full access --
+    // Nexus enforces permissions at the VFS layer (ReBAC +
+    // WorkspaceBoundaryHook), so the in-process runtime grants all
+    // tool invocations.
+    let permission_policy = PermissionPolicy::new(PermissionMode::Allow);
+
+    runtime::spawn_task::spawn_task(
+        kernel,
+        desc,
+        api_client,
+        tool_executor,
+        system_prompt,
+        permission_policy,
+        state_callback,
+    )
+}
+
+/// Tool executor that dispatches through the `tools` crate's global
+/// registry. Wraps `execute_tool(name, input)` into the `ToolExecutor`
+/// trait expected by `ConversationRuntime`.
+struct ManagedToolExecutor;
+
+impl ToolExecutor for ManagedToolExecutor {
+    fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError> {
+        let input_value: serde_json::Value =
+            serde_json::from_str(input).map_err(|e| ToolError::new(e.to_string()))?;
+        execute_tool(tool_name, &input_value).map_err(ToolError::new)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `tools::managed_agent::spawn_managed_agent()` factory that constructs all ConversationRuntime dependencies from `AgentDescriptor` metadata and calls `spawn_task` v2
- Re-export `KernelAbi` and `AgentDescriptor` from `runtime::spawn_task` so downstream crates don't need a direct `kernel` dependency
- Make `ProviderRuntimeClient` `pub(crate)` for use by the factory

The factory constructs:
- `ProviderRuntimeClient` (ApiClient) from `desc.labels["model"]`
- `ManagedToolExecutor` (ToolExecutor) dispatching through the global tool registry
- `SystemPrompt` with Claude model family identity
- `PermissionPolicy::Allow` (nexus enforces permissions at VFS layer)

## Context

This is the sudocode side of the spawn_task v2 wiring. The nexus cdylib (`nexi-lab/nexus`) will depend on this crate and call `spawn_managed_agent()` from its `SudoCodeSpawnAdapter`, replacing the echo-only `spawn_task_echo` stub.

Companion PR: nexi-lab/nexus (feat/spawn-task-v2-wiring)

## Test plan

- [x] `cargo check` — full workspace compiles
- [x] `cargo test -p tools --lib` — 100 tests pass
- [x] nexus cdylib compiles against this rev (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)