### PR TITLE
fix(runtime): set stdin to null for foreground bash execution

### DIFF
--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -183,6 +183,7 @@ async fn execute_bash_async(
     detect_and_emit_ship_prepared(&input.command);
 
     let mut command = prepare_tokio_command(&input.command, &cwd, &sandbox_status, true);
+    command.stdin(Stdio::null());
 
     let output_result = if let Some(timeout_ms) = input.timeout {
         match timeout(Duration::from_millis(timeout_ms), command.output()).await {


### PR DESCRIPTION
## Summary
- Fix bash commands hanging in ACP mode by adding `Stdio::null()` for stdin in the foreground execution path
- Root cause: `sh -lc` (login shell) blocks on inherited stdin pipe during initialization, preventing commands from ever executing

## Test plan
- [ ] Verify bash commands execute normally in ACP mode
- [ ] Verify background bash execution still works
- [ ] Run `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)