### PR TITLE
feat(telemetry): add SudoclawLogSink for model call logging

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -817,6 +817,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1764,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2060,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking"
@@ -2539,6 +2575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,6 +2910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2961,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -3015,6 +3077,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -3250,8 +3338,11 @@ dependencies = [
 name = "telemetry"
 version = "0.1.4"
 dependencies = [
+ "chrono",
+ "dirs",
  "serde",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]
@@ -3977,6 +4068,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4009,6 +4109,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4046,6 +4161,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4058,6 +4179,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4067,6 +4194,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4094,6 +4227,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4103,6 +4242,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4118,6 +4263,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4127,6 +4278,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -165,6 +165,17 @@ impl ProviderClient {
     }
 
     #[must_use]
+    pub fn session_tracer(&self) -> Option<&SessionTracer> {
+        match self {
+            Self::Anthropic(client) => client.session_tracer(),
+            Self::Xai(client) => client.session_tracer(),
+            Self::OpenAi(client) => client.session_tracer(),
+            Self::Codex(client) => client.session_tracer(),
+            Self::Gemini(client) => client.session_tracer(),
+        }
+    }
+
+    #[must_use]
     pub fn with_prompt_cache(self, prompt_cache: PromptCache) -> Self {
         match self {
             Self::Anthropic(client) => Self::Anthropic(client.with_prompt_cache(prompt_cache)),

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -111,6 +111,11 @@ impl CodexClient {
         self
     }
 
+    #[must_use]
+    pub fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
+        self.http.session_tracer()
+    }
+
     /// Build from `~/.codex/auth.json`.
     pub fn from_auth_file() -> Result<Self, ApiError> {
         let (access_token, account_id) = read_auth_file()?;

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -126,6 +126,11 @@ impl GeminiClient {
         self
     }
 
+    #[must_use]
+    pub fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
+        self.http.session_tracer()
+    }
+
     // -----------------------------------------------------------------------
     // Auth helpers
     // -----------------------------------------------------------------------

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -143,6 +143,11 @@ impl OpenAiCompatClient {
     }
 
     #[must_use]
+    pub fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
+        self.http.session_tracer()
+    }
+
+    #[must_use]
     pub fn with_retry_policy(
         mut self,
         max_retries: u32,

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -759,6 +759,11 @@ where
         &self.session
     }
 
+    #[must_use]
+    pub fn api_client(&self) -> &C {
+        &self.api_client
+    }
+
     pub fn api_client_mut(&mut self) -> &mut C {
         &mut self.api_client
     }

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -13,7 +13,7 @@ use runtime::{
     ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ContentBlock, ConversationMessage,
     MessageRole, PromptCacheEvent, RuntimeError, TokenUsage,
 };
-use telemetry::{JsonlTelemetrySink, SessionTracer};
+use telemetry::{SessionTracer, SudoclawLogSink};
 use tools::GlobalToolRegistry;
 
 use super::format::{format_tool_call_start, format_user_visible_api_error};
@@ -64,11 +64,10 @@ impl AnthropicRuntimeClient {
         let mut client = ApiProviderClient::from_resolved(&resolved, Some(effective_mode))?
             .with_prompt_cache(PromptCache::new(session_id));
 
-        if let Ok(capture_path) = std::env::var("SCODE_HTTP_DEBUG") {
-            let sink = Arc::new(JsonlTelemetrySink::new(&capture_path)?);
-            let tracer = SessionTracer::new(session_id, sink);
-            client = client.with_session_tracer(tracer);
-        }
+        // 默认启用日志追踪
+        let sink = Arc::new(SudoclawLogSink::new()?);
+        let tracer = SessionTracer::new(session_id, sink);
+        client = client.with_session_tracer(tracer);
 
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
@@ -110,6 +109,11 @@ impl AnthropicRuntimeClient {
 
     pub(crate) fn set_reasoning_effort(&mut self, effort: Option<String>) {
         self.reasoning_effort = effort;
+    }
+
+    /// Returns a reference to the session tracer, if available.
+    pub(crate) fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
+        self.client.session_tracer()
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -447,11 +447,17 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             cli.set_reasoning_effort(reasoning_effort);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
 
-            // Record session ended event for non-interactive prompt mode
+            // Record token usage and session ended event for non-interactive prompt mode
             let duration_ms = session_start.elapsed().as_millis() as u64;
             let usage = cli.runtime.usage().cumulative_usage();
             let total_turns = cli.runtime.usage().turns();
             if let Some(tracer) = cli.session_tracer() {
+                tracer.record_usage(
+                    usage.input_tokens,
+                    usage.output_tokens,
+                    usage.cache_creation_input_tokens,
+                    usage.cache_read_input_tokens,
+                );
                 tracer.record_session_ended(
                     total_turns,
                     usage.input_tokens as u64,
@@ -1413,11 +1419,17 @@ fn run_repl(
         }
     }
 
-    // Record session ended event
+    // Record token usage and session ended event
     let duration_ms = session_start.elapsed().as_millis() as u64;
     let usage = cli.runtime.usage().cumulative_usage();
     let total_turns = cli.runtime.usage().turns();
     if let Some(tracer) = cli.session_tracer() {
+        tracer.record_usage(
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cache_creation_input_tokens,
+            usage.cache_read_input_tokens,
+        );
         tracer.record_session_ended(
             total_turns,
             usage.input_tokens as u64,
@@ -1997,11 +2009,17 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
     fn close_session(&mut self, session_id: &str) -> bool {
         if let Some(session) = self.inner.sessions.remove(session_id) {
-            // Record session ended event
+            // Record token usage and session ended event
             let duration_ms = session.started_at.elapsed().as_millis() as u64;
             let usage = session.runtime.usage().cumulative_usage();
             let total_turns = session.runtime.usage().turns();
             if let Some(tracer) = session.runtime.session_tracer() {
+                tracer.record_usage(
+                    usage.input_tokens,
+                    usage.output_tokens,
+                    usage.cache_creation_input_tokens,
+                    usage.cache_read_input_tokens,
+                );
                 tracer.record_session_ended(
                     total_turns,
                     usage.input_tokens as u64,
@@ -2170,6 +2188,15 @@ impl AcpSdkDelegate {
             cache_read_tokens: Some(u64::from(usage.cache_read_input_tokens)),
             cache_write_tokens: Some(u64::from(usage.cache_creation_input_tokens)),
         };
+        // Record token usage to telemetry log
+        if let Some(tracer) = session.runtime.session_tracer() {
+            tracer.record_usage(
+                usage.input_tokens,
+                usage.output_tokens,
+                usage.cache_creation_input_tokens,
+                usage.cache_read_input_tokens,
+            );
+        }
         session
             .runtime
             .session()

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1639,14 +1639,13 @@ impl AcpCliAgent {
 
         // Record session started event
         let is_child_process = std::env::var("SUDOWORK_CHILD_PROCESS").is_ok();
-        let mode = if is_child_process { "child" } else { "standalone" };
+        let mode = if is_child_process {
+            "child"
+        } else {
+            "standalone"
+        };
         if let Some(tracer) = runtime.session_tracer() {
-            tracer.record_session_started(
-                VERSION,
-                cwd.to_string_lossy(),
-                mode,
-                &model,
-            );
+            tracer.record_session_started(VERSION, cwd.to_string_lossy(), mode, &model);
         }
 
         Ok(AcpCliSession {
@@ -2299,14 +2298,13 @@ impl LiveCli {
 
         // Record session started event
         let is_child_process = std::env::var("SUDOWORK_CHILD_PROCESS").is_ok();
-        let mode = if is_child_process { "child" } else { "standalone" };
+        let mode = if is_child_process {
+            "child"
+        } else {
+            "standalone"
+        };
         if let Some(tracer) = cli.runtime.session_tracer() {
-            tracer.record_session_started(
-                VERSION,
-                cwd.to_string_lossy(),
-                mode,
-                &cli.config.model,
-            );
+            tracer.record_session_started(VERSION, cwd.to_string_lossy(), mode, &cli.config.model);
         }
 
         Ok(cli)

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -442,9 +442,23 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 None
             };
             let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
+            let session_start = Instant::now();
             let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode, auth_mode)?;
             cli.set_reasoning_effort(reasoning_effort);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
+
+            // Record session ended event for non-interactive prompt mode
+            let duration_ms = session_start.elapsed().as_millis() as u64;
+            let usage = cli.runtime.usage().cumulative_usage();
+            let total_turns = cli.runtime.usage().turns();
+            if let Some(tracer) = cli.session_tracer() {
+                tracer.record_session_ended(
+                    total_turns,
+                    usage.input_tokens as u64,
+                    usage.output_tokens as u64,
+                    duration_ms,
+                );
+            }
         }
         CliAction::Doctor { output_format } => run_doctor(output_format)?,
         CliAction::Acp {
@@ -1316,6 +1330,9 @@ fn run_repl(
         input::LineEditor::new("❯ ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
 
+    // Track session metrics for session_ended event
+    let session_start = Instant::now();
+
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
         let term_width = crossterm::terminal::size()
@@ -1394,6 +1411,19 @@ fn run_repl(
                 break;
             }
         }
+    }
+
+    // Record session ended event
+    let duration_ms = session_start.elapsed().as_millis() as u64;
+    let usage = cli.runtime.usage().cumulative_usage();
+    let total_turns = cli.runtime.usage().turns();
+    if let Some(tracer) = cli.session_tracer() {
+        tracer.record_session_ended(
+            total_turns,
+            usage.input_tokens as u64,
+            usage.output_tokens as u64,
+            duration_ms,
+        );
     }
 
     Ok(())
@@ -1483,6 +1513,15 @@ impl BuiltRuntime {
         }
         Ok(())
     }
+
+    /// Returns a reference to the session tracer, if available.
+    fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
+        self.runtime
+            .as_ref()
+            .expect("runtime should exist while built runtime is alive")
+            .api_client()
+            .session_tracer()
+    }
 }
 
 impl Deref for BuiltRuntime {
@@ -1515,6 +1554,8 @@ struct AcpCliSession {
     handle: SessionHandle,
     runtime: BuiltRuntime,
     abort_signal: runtime::HookAbortSignal,
+    /// Session start time for duration tracking.
+    started_at: Instant,
 }
 
 struct AcpCliAgent {
@@ -1572,7 +1613,7 @@ impl AcpCliAgent {
                 let auth_mode = resolve_auth_mode(&model, self.auth_mode, &sudocode_config)
                     .map_err(|e| AcpError::internal(format!("failed to resolve auth mode: {e}")))?;
                 RuntimeConfig {
-                    model,
+                    model: model.clone(),
                     system_prompt,
                     enable_tools: true,
                     emit_output: false,
@@ -1596,11 +1637,24 @@ impl AcpCliAgent {
             .save_to_path(&handle.path)
             .map_err(|error| AcpError::internal(format!("failed to persist session: {error}")))?;
 
+        // Record session started event
+        let is_child_process = std::env::var("SUDOWORK_CHILD_PROCESS").is_ok();
+        let mode = if is_child_process { "child" } else { "standalone" };
+        if let Some(tracer) = runtime.session_tracer() {
+            tracer.record_session_started(
+                VERSION,
+                cwd.to_string_lossy(),
+                mode,
+                &model,
+            );
+        }
+
         Ok(AcpCliSession {
             cwd,
             handle,
             runtime,
             abort_signal,
+            started_at: Instant::now(),
         })
     }
 
@@ -1943,7 +1997,23 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
     }
 
     fn close_session(&mut self, session_id: &str) -> bool {
-        self.inner.sessions.remove(session_id).is_some()
+        if let Some(session) = self.inner.sessions.remove(session_id) {
+            // Record session ended event
+            let duration_ms = session.started_at.elapsed().as_millis() as u64;
+            let usage = session.runtime.usage().cumulative_usage();
+            let total_turns = session.runtime.usage().turns();
+            if let Some(tracer) = session.runtime.session_tracer() {
+                tracer.record_session_ended(
+                    total_turns,
+                    usage.input_tokens as u64,
+                    usage.output_tokens as u64,
+                    duration_ms,
+                );
+            }
+            true
+        } else {
+            false
+        }
     }
 
     fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, runtime::AcpError> {
@@ -2060,6 +2130,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 handle,
                 runtime,
                 abort_signal,
+                started_at: Instant::now(),
             },
         );
         Ok((loaded_session_id, cwd, signal))
@@ -2225,7 +2296,25 @@ impl LiveCli {
             tokio_runtime: tokio::runtime::Runtime::new()?,
         };
         cli.persist_session()?;
+
+        // Record session started event
+        let is_child_process = std::env::var("SUDOWORK_CHILD_PROCESS").is_ok();
+        let mode = if is_child_process { "child" } else { "standalone" };
+        if let Some(tracer) = cli.runtime.session_tracer() {
+            tracer.record_session_started(
+                VERSION,
+                cwd.to_string_lossy(),
+                mode,
+                &cli.config.model,
+            );
+        }
+
         Ok(cli)
+    }
+
+    /// Returns a reference to the session tracer, if available.
+    fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
+        self.runtime.session_tracer()
     }
 
     fn set_reasoning_effort(&mut self, effort: Option<String>) {

--- a/rust/crates/telemetry/Cargo.toml
+++ b/rust/crates/telemetry/Cargo.toml
@@ -8,6 +8,11 @@ publish.workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = "0.4"
+dirs = "5.0"
+
+[dev-dependencies]
+serial_test = "3"
 
 [lints]
 workspace = true

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -6,8 +6,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use chrono::Local;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+
+const SUDOCLAW_LOG_ROTATE_AFTER_BYTES: u64 = 10 * 1024 * 1024; // 10MB
+const SUDOCLAW_LOG_MAX_ROTATED_FILES: usize = 3;
 
 pub const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
 pub const DEFAULT_APP_NAME: &str = "claude-code";
@@ -224,6 +228,24 @@ pub enum TelemetryEvent {
     },
     Analytics(AnalyticsEvent),
     SessionTrace(SessionTraceRecord),
+    /// Emitted when a scode session starts.
+    SessionStarted {
+        session_id: String,
+        timestamp_ms: u64,
+        version: String,
+        cwd: String,
+        mode: String,
+        model: String,
+    },
+    /// Emitted when a scode session ends.
+    SessionEnded {
+        session_id: String,
+        timestamp_ms: u64,
+        total_turns: u32,
+        total_input_tokens: u64,
+        total_output_tokens: u64,
+        duration_ms: u64,
+    },
 }
 
 pub trait TelemetrySink: Send + Sync {
@@ -298,6 +320,335 @@ impl TelemetrySink for JsonlTelemetrySink {
         let _ = writeln!(file, "{line}");
         let _ = file.flush();
     }
+}
+
+/// A telemetry sink that writes logs to sudoclaw.log or scode.log.
+///
+/// This sink detects the runtime mode:
+/// - If `SCODE_LOG_PATH` environment variable is set, uses that path
+/// - If `SUDOWORK_CHILD_PROCESS` is set, writes to ~/.nexus/logs/sudoclaw.log (child process mode)
+/// - Otherwise, writes to ~/.nexus/logs/scode.log (standalone mode)
+///
+/// Supports log rotation when file exceeds 10MB, keeping up to 3 rotated files.
+pub struct SudoclawLogSink {
+    path: PathBuf,
+    file: Mutex<File>,
+}
+
+impl Debug for SudoclawLogSink {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SudoclawLogSink")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SudoclawLogSink {
+    /// Creates a new SudoclawLogSink with automatic path detection.
+    pub fn new() -> Result<Self, std::io::Error> {
+        let path = Self::resolve_log_path()?;
+        Self::with_path(&path)
+    }
+
+    /// Creates a new SudoclawLogSink with a specific path.
+    pub fn with_path(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        Ok(Self {
+            path,
+            file: Mutex::new(file),
+        })
+    }
+
+    /// Resolves the log file path based on environment variables and runtime mode.
+    ///
+    /// Priority:
+    /// 1. `SCODE_LOG_PATH` environment variable (if set)
+    /// 2. `SUDOWORK_CHILD_PROCESS` environment variable (if set) -> ~/.nexus/logs/sudoclaw.log
+    /// 3. Default -> ~/.nexus/logs/scode.log
+    fn resolve_log_path() -> Result<PathBuf, std::io::Error> {
+        // Check for explicit log path override
+        if let Ok(log_path) = std::env::var("SCODE_LOG_PATH") {
+            return Ok(PathBuf::from(log_path));
+        }
+
+        // Determine log directory
+        let log_dir = dirs::home_dir()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "Could not determine home directory",
+                )
+            })?
+            .join(".nexus")
+            .join("logs");
+
+        // Check if running as child process
+        let log_filename = if std::env::var("SUDOWORK_CHILD_PROCESS").is_ok() {
+            "sudoclaw.log"
+        } else {
+            "scode.log"
+        };
+
+        Ok(log_dir.join(log_filename))
+    }
+
+    /// Returns the path to the log file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Rotates the log file, keeping up to SUDOCLAW_LOG_MAX_ROTATED_FILES rotated files.
+    fn rotate_log_file(&self) -> Result<(), std::io::Error> {
+        // Remove the oldest rotated file if it exists
+        let oldest_rotated = format!("{}.{}", self.path.display(), SUDOCLAW_LOG_MAX_ROTATED_FILES);
+        if Path::new(&oldest_rotated).exists() {
+            std::fs::remove_file(&oldest_rotated)?;
+        }
+
+        // Shift existing rotated files
+        for i in (1..=SUDOCLAW_LOG_MAX_ROTATED_FILES - 1).rev() {
+            let current = format!("{}.{}", self.path.display(), i);
+            let next = format!("{}.{}", self.path.display(), i + 1);
+            if Path::new(&current).exists() {
+                std::fs::rename(&current, &next)?;
+            }
+        }
+
+        // Rename current log to .1
+        let first_rotated = format!("{}.1", self.path.display());
+        std::fs::rename(&self.path, &first_rotated)?;
+
+        // Reopen the log file (it will be created on next write)
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        let mut file_guard = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *file_guard = file;
+
+        Ok(())
+    }
+}
+
+impl TelemetrySink for SudoclawLogSink {
+    fn record(&self, event: TelemetryEvent) {
+        let log_entry = format_log_entry(&event);
+        let Ok(json) = serde_json::to_string(&log_entry) else {
+            return;
+        };
+
+        // Acquire lock first to prevent race condition during rotation check
+        let mut file = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Check for rotation while holding the lock
+        if let Ok(metadata) = std::fs::metadata(&self.path) {
+            if metadata.len() >= SUDOCLAW_LOG_ROTATE_AFTER_BYTES {
+                // Flush before rotation
+                let _ = file.flush();
+                // Release lock before rotation (rotate_log_file needs to acquire it)
+                drop(file);
+
+                // Perform rotation
+                if let Err(e) = self.rotate_log_file() {
+                    eprintln!("[scode telemetry] Failed to rotate log: {}", e);
+                }
+
+                // Re-acquire lock after rotation
+                file = self
+                    .file
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+        }
+
+        if let Err(e) = writeln!(file, "{json}") {
+            eprintln!("[scode telemetry] Failed to write log: {}", e);
+        }
+        if let Err(e) = file.flush() {
+            eprintln!("[scode telemetry] Failed to flush log: {}", e);
+        }
+    }
+}
+
+/// Formats a TelemetryEvent into a structured log entry.
+fn format_log_entry(event: &TelemetryEvent) -> Map<String, Value> {
+    let mut entry = Map::new();
+
+    entry.insert("timestamp".to_string(), Value::String(format_timestamp()));
+    entry.insert("level".to_string(), Value::String("info".to_string()));
+
+    let (session_id, event_name, attributes) = extract_event_info(event);
+
+    entry.insert("session_id".to_string(), Value::String(session_id));
+    entry.insert("component".to_string(), Value::String("scode".to_string()));
+    entry.insert("event".to_string(), Value::String(event_name));
+
+    if !attributes.is_empty() {
+        entry.insert("attributes".to_string(), Value::Object(attributes));
+    }
+
+    entry
+}
+
+/// Extracts event information from a TelemetryEvent.
+fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Value>) {
+    match event {
+        TelemetryEvent::HttpRequestStarted {
+            session_id,
+            attempt,
+            method,
+            path,
+            attributes,
+        } => {
+            let mut attrs = attributes.clone();
+            attrs.insert("attempt".to_string(), Value::from(*attempt));
+            attrs.insert("method".to_string(), Value::String(method.clone()));
+            attrs.insert("path".to_string(), Value::String(path.clone()));
+            (session_id.clone(), "request_started".to_string(), attrs)
+        }
+        TelemetryEvent::HttpRequestSucceeded {
+            session_id,
+            attempt,
+            method,
+            path,
+            status,
+            request_id,
+            attributes,
+        } => {
+            let mut attrs = attributes.clone();
+            attrs.insert("attempt".to_string(), Value::from(*attempt));
+            attrs.insert("method".to_string(), Value::String(method.clone()));
+            attrs.insert("path".to_string(), Value::String(path.clone()));
+            attrs.insert("status".to_string(), Value::from(*status));
+            if let Some(rid) = request_id {
+                attrs.insert("request_id".to_string(), Value::String(rid.clone()));
+            }
+            (session_id.clone(), "request_succeeded".to_string(), attrs)
+        }
+        TelemetryEvent::HttpRequestFailed {
+            session_id,
+            attempt,
+            method,
+            path,
+            error,
+            retryable,
+            attributes,
+        } => {
+            let mut attrs = attributes.clone();
+            attrs.insert("attempt".to_string(), Value::from(*attempt));
+            attrs.insert("method".to_string(), Value::String(method.clone()));
+            attrs.insert("path".to_string(), Value::String(path.clone()));
+            attrs.insert("error".to_string(), Value::String(error.clone()));
+            attrs.insert("retryable".to_string(), Value::Bool(*retryable));
+            (session_id.clone(), "request_failed".to_string(), attrs)
+        }
+        TelemetryEvent::HttpRequestDebug {
+            session_id,
+            timestamp_ms,
+            url,
+            method,
+            headers,
+            body,
+        } => {
+            let mut attrs = Map::new();
+            attrs.insert("timestamp_ms".to_string(), Value::from(*timestamp_ms));
+            attrs.insert("url".to_string(), Value::String(url.clone()));
+            attrs.insert("method".to_string(), Value::String(method.clone()));
+            attrs.insert("headers".to_string(), Value::Object(headers.clone()));
+            attrs.insert("body".to_string(), body.clone());
+            (session_id.clone(), "request_debug".to_string(), attrs)
+        }
+        TelemetryEvent::HttpResponseUsage {
+            session_id,
+            timestamp_ms,
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        } => {
+            let mut attrs = Map::new();
+            attrs.insert("timestamp_ms".to_string(), Value::from(*timestamp_ms));
+            attrs.insert("input_tokens".to_string(), Value::from(*input_tokens));
+            attrs.insert("output_tokens".to_string(), Value::from(*output_tokens));
+            attrs.insert(
+                "cache_creation_input_tokens".to_string(),
+                Value::from(*cache_creation_input_tokens),
+            );
+            attrs.insert(
+                "cache_read_input_tokens".to_string(),
+                Value::from(*cache_read_input_tokens),
+            );
+            (session_id.clone(), "response_usage".to_string(), attrs)
+        }
+        TelemetryEvent::Analytics(event) => {
+            let mut attrs = event.properties.clone();
+            attrs.insert(
+                "namespace".to_string(),
+                Value::String(event.namespace.clone()),
+            );
+            attrs.insert("action".to_string(), Value::String(event.action.clone()));
+            (String::new(), "event".to_string(), attrs)
+        }
+        TelemetryEvent::SessionTrace(record) => (
+            record.session_id.clone(),
+            record.name.clone(),
+            record.attributes.clone(),
+        ),
+        TelemetryEvent::SessionStarted {
+            session_id,
+            timestamp_ms: _,
+            version,
+            cwd,
+            mode,
+            model,
+        } => {
+            let attrs = Map::from_iter([
+                ("version".to_string(), Value::String(version.clone())),
+                ("cwd".to_string(), Value::String(cwd.clone())),
+                ("mode".to_string(), Value::String(mode.clone())),
+                ("model".to_string(), Value::String(model.clone())),
+            ]);
+            (session_id.clone(), "session_started".to_string(), attrs)
+        }
+        TelemetryEvent::SessionEnded {
+            session_id,
+            timestamp_ms: _,
+            total_turns,
+            total_input_tokens,
+            total_output_tokens,
+            duration_ms,
+        } => {
+            let attrs = Map::from_iter([
+                ("total_turns".to_string(), Value::from(*total_turns)),
+                (
+                    "total_input_tokens".to_string(),
+                    Value::from(*total_input_tokens),
+                ),
+                (
+                    "total_output_tokens".to_string(),
+                    Value::from(*total_output_tokens),
+                ),
+                ("duration_ms".to_string(), Value::from(*duration_ms)),
+            ]);
+            (session_id.clone(), "session_ended".to_string(), attrs)
+        }
+    }
+}
+
+/// Formats the current timestamp in ISO 8601 format.
+fn format_timestamp() -> String {
+    Local::now().format("%Y-%m-%dT%H:%M:%S%.3f%:z").to_string()
 }
 
 #[derive(Clone)]
@@ -462,6 +813,62 @@ impl SessionTracer {
         self.sink.record(TelemetryEvent::Analytics(event));
         self.record("analytics", attributes);
     }
+
+    pub fn record_session_started(
+        &self,
+        version: impl Into<String>,
+        cwd: impl Into<String>,
+        mode: impl Into<String>,
+        model: impl Into<String>,
+    ) {
+        let version = version.into();
+        let cwd = cwd.into();
+        let mode = mode.into();
+        let model = model.into();
+        self.sink.record(TelemetryEvent::SessionStarted {
+            session_id: self.session_id.clone(),
+            timestamp_ms: current_timestamp_ms(),
+            version: version.clone(),
+            cwd: cwd.clone(),
+            mode: mode.clone(),
+            model: model.clone(),
+        });
+        let mut attributes = Map::new();
+        attributes.insert("version".to_string(), Value::String(version));
+        attributes.insert("cwd".to_string(), Value::String(cwd));
+        attributes.insert("mode".to_string(), Value::String(mode));
+        attributes.insert("model".to_string(), Value::String(model));
+        self.record("session_started", attributes);
+    }
+
+    pub fn record_session_ended(
+        &self,
+        total_turns: u32,
+        total_input_tokens: u64,
+        total_output_tokens: u64,
+        duration_ms: u64,
+    ) {
+        self.sink.record(TelemetryEvent::SessionEnded {
+            session_id: self.session_id.clone(),
+            timestamp_ms: current_timestamp_ms(),
+            total_turns,
+            total_input_tokens,
+            total_output_tokens,
+            duration_ms,
+        });
+        let mut attributes = Map::new();
+        attributes.insert("total_turns".to_string(), Value::from(total_turns));
+        attributes.insert(
+            "total_input_tokens".to_string(),
+            Value::from(total_input_tokens),
+        );
+        attributes.insert(
+            "total_output_tokens".to_string(),
+            Value::from(total_output_tokens),
+        );
+        attributes.insert("duration_ms".to_string(), Value::from(duration_ms));
+        self.record("session_ended", attributes);
+    }
 }
 
 /// Mask sensitive header values for debug capture logs.
@@ -515,6 +922,7 @@ fn current_timestamp_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn request_profile_emits_headers_and_merges_body() {
@@ -607,5 +1015,75 @@ mod tests {
         assert!(contents.contains("\"action\":\"turn_completed\""));
 
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    #[serial]
+    fn sudoclaw_log_sink_resolves_child_process_path() {
+        std::env::set_var("SUDOWORK_CHILD_PROCESS", "1");
+        let path = SudoclawLogSink::resolve_log_path().expect("should resolve path");
+        assert!(path.to_string_lossy().contains("sudoclaw.log"));
+        std::env::remove_var("SUDOWORK_CHILD_PROCESS");
+    }
+
+    #[test]
+    #[serial]
+    fn sudoclaw_log_sink_resolves_standalone_path() {
+        std::env::remove_var("SUDOWORK_CHILD_PROCESS");
+        std::env::remove_var("SCODE_LOG_PATH");
+        let path = SudoclawLogSink::resolve_log_path().expect("should resolve path");
+        assert!(path.to_string_lossy().contains("scode.log"));
+    }
+
+    #[test]
+    #[serial]
+    fn sudoclaw_log_sink_respects_env_override() {
+        std::env::set_var("SCODE_LOG_PATH", "/custom/path.log");
+        let path = SudoclawLogSink::resolve_log_path().expect("should resolve path");
+        assert_eq!(path.to_string_lossy(), "/custom/path.log");
+        std::env::remove_var("SCODE_LOG_PATH");
+    }
+
+    #[test]
+    fn sudoclaw_log_sink_writes_json_events() {
+        let temp_dir = std::env::temp_dir();
+        let log_path = temp_dir.join(format!("test-sudoclaw-{}.log", current_timestamp_ms()));
+
+        let sink = SudoclawLogSink::with_path(&log_path).expect("sink should create file");
+        sink.record(TelemetryEvent::SessionStarted {
+            session_id: "test-session".to_string(),
+            timestamp_ms: 1234567890,
+            version: "0.1.0".to_string(),
+            cwd: "/test".to_string(),
+            mode: "standalone".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+        });
+
+        let contents = std::fs::read_to_string(&log_path).expect("log should be readable");
+        assert!(contents.contains("\"event\":\"session_started\""));
+        assert!(contents.contains("\"session_id\":\"test-session\""));
+        assert!(contents.contains("\"model\":\"claude-sonnet-4-6\""));
+
+        let _ = std::fs::remove_file(log_path);
+    }
+
+    #[test]
+    fn format_log_entry_produces_valid_json() {
+        let event = TelemetryEvent::HttpRequestStarted {
+            session_id: "session-123".to_string(),
+            attempt: 1,
+            method: "POST".to_string(),
+            path: "/v1/messages".to_string(),
+            attributes: Map::new(),
+        };
+
+        let entry = format_log_entry(&event);
+        let json = serde_json::to_string(&entry).expect("should serialize to JSON");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("should be valid JSON");
+
+        assert_eq!(parsed["level"], "info");
+        assert_eq!(parsed["session_id"], "session-123");
+        assert_eq!(parsed["event"], "request_started");
+        assert_eq!(parsed["component"], "scode");
     }
 }

--- a/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
+++ b/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
@@ -1,8 +1,12 @@
-use telemetry::{SudoclawLogSink, TelemetryEvent, TelemetrySink};
 use std::path::PathBuf;
+use telemetry::{SudoclawLogSink, TelemetryEvent, TelemetrySink};
 
 fn temp_log_path(name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("sudoclaw-integration-{}-{}.log", name, std::process::id()))
+    std::env::temp_dir().join(format!(
+        "sudoclaw-integration-{}-{}.log",
+        name,
+        std::process::id()
+    ))
 }
 
 #[test]
@@ -110,24 +114,31 @@ fn multiple_events_in_sequence() {
 
     // Verify each line is valid JSON with correct session_id
     for line in &lines {
-        let parsed: serde_json::Value = serde_json::from_str(line).expect("each line should be JSON");
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).expect("each line should be JSON");
         assert_eq!(parsed["session_id"], "trace-test");
         assert_eq!(parsed["component"], "scode");
     }
 
     // Verify event order
-    let events: Vec<String> = lines.iter().map(|l| {
-        let parsed: serde_json::Value = serde_json::from_str(l).unwrap();
-        parsed["event"].as_str().unwrap().to_string()
-    }).collect();
+    let events: Vec<String> = lines
+        .iter()
+        .map(|l| {
+            let parsed: serde_json::Value = serde_json::from_str(l).unwrap();
+            parsed["event"].as_str().unwrap().to_string()
+        })
+        .collect();
 
-    assert_eq!(events, vec![
-        "session_started",
-        "request_started",
-        "request_succeeded",
-        "response_usage",
-        "session_ended"
-    ]);
+    assert_eq!(
+        events,
+        vec![
+            "session_started",
+            "request_started",
+            "request_succeeded",
+            "response_usage",
+            "session_ended"
+        ]
+    );
 
     let _ = std::fs::remove_file(path);
 }

--- a/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
+++ b/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
@@ -1,0 +1,133 @@
+use telemetry::{SudoclawLogSink, TelemetryEvent, TelemetrySink};
+use std::path::PathBuf;
+
+fn temp_log_path(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("sudoclaw-integration-{}-{}.log", name, std::process::id()))
+}
+
+#[test]
+fn sink_creates_log_file_and_directory() {
+    let path = temp_log_path("create-dir");
+    let nested = path.join("nested").join("dir").join("test.log");
+
+    let _sink = SudoclawLogSink::with_path(&nested).expect("should create nested path");
+
+    assert!(nested.exists());
+    let _ = std::fs::remove_file(nested);
+    let _ = std::fs::remove_dir(path.join("nested").join("dir"));
+    let _ = std::fs::remove_dir(path.join("nested"));
+}
+
+#[test]
+fn sink_appends_to_existing_file() {
+    let path = temp_log_path("append");
+
+    // First write
+    let sink1 = SudoclawLogSink::with_path(&path).expect("sink1 should work");
+    sink1.record(TelemetryEvent::SessionStarted {
+        session_id: "session-1".to_string(),
+        timestamp_ms: 1000,
+        version: "0.1.0".to_string(),
+        cwd: "/test".to_string(),
+        mode: "standalone".to_string(),
+        model: "claude-sonnet".to_string(),
+    });
+
+    // Second write (append)
+    let sink2 = SudoclawLogSink::with_path(&path).expect("sink2 should work");
+    sink2.record(TelemetryEvent::SessionStarted {
+        session_id: "session-2".to_string(),
+        timestamp_ms: 2000,
+        version: "0.1.0".to_string(),
+        cwd: "/test".to_string(),
+        mode: "standalone".to_string(),
+        model: "claude-sonnet".to_string(),
+    });
+
+    let contents = std::fs::read_to_string(&path).expect("should read log");
+    assert!(contents.contains("session-1"));
+    assert!(contents.contains("session-2"));
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn multiple_events_in_sequence() {
+    let path = temp_log_path("sequence");
+
+    let sink = SudoclawLogSink::with_path(&path).expect("sink should work");
+
+    // Simulate a complete session
+    sink.record(TelemetryEvent::SessionStarted {
+        session_id: "trace-test".to_string(),
+        timestamp_ms: 1000,
+        version: "0.1.5".to_string(),
+        cwd: "/workspace".to_string(),
+        mode: "standalone".to_string(),
+        model: "claude-sonnet-4-6".to_string(),
+    });
+
+    sink.record(TelemetryEvent::HttpRequestStarted {
+        session_id: "trace-test".to_string(),
+        attempt: 1,
+        method: "POST".to_string(),
+        path: "/v1/messages".to_string(),
+        attributes: serde_json::Map::new(),
+    });
+
+    sink.record(TelemetryEvent::HttpRequestSucceeded {
+        session_id: "trace-test".to_string(),
+        attempt: 1,
+        method: "POST".to_string(),
+        path: "/v1/messages".to_string(),
+        status: 200,
+        request_id: Some("req-123".to_string()),
+        attributes: serde_json::Map::new(),
+    });
+
+    sink.record(TelemetryEvent::HttpResponseUsage {
+        session_id: "trace-test".to_string(),
+        timestamp_ms: 2000,
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 100,
+    });
+
+    sink.record(TelemetryEvent::SessionEnded {
+        session_id: "trace-test".to_string(),
+        timestamp_ms: 3000,
+        total_turns: 1,
+        total_input_tokens: 500,
+        total_output_tokens: 200,
+        duration_ms: 2000,
+    });
+
+    let contents = std::fs::read_to_string(&path).expect("should read log");
+    let lines: Vec<&str> = contents.lines().collect();
+
+    assert_eq!(lines.len(), 5);
+
+    // Verify each line is valid JSON with correct session_id
+    for line in &lines {
+        let parsed: serde_json::Value = serde_json::from_str(line).expect("each line should be JSON");
+        assert_eq!(parsed["session_id"], "trace-test");
+        assert_eq!(parsed["component"], "scode");
+    }
+
+    // Verify event order
+    let events: Vec<String> = lines.iter().map(|l| {
+        let parsed: serde_json::Value = serde_json::from_str(l).unwrap();
+        parsed["event"].as_str().unwrap().to_string()
+    }).collect();
+
+    assert_eq!(events, vec![
+        "session_started",
+        "request_started",
+        "request_succeeded",
+        "response_usage",
+        "session_ended"
+    ]);
+
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
## Summary

- Add structured JSON logging for scode model calls with session tracing
- Add `SudoclawLogSink` that auto-detects runtime mode:
  - Child process mode: writes to `~/.nexus/logs/sudoclaw.log`
  - Standalone mode: writes to `~/.nexus/logs/scode.log`
  - Supports `SCODE_LOG_PATH` env override
- Add session-level telemetry events (`SessionStarted`, `SessionEnded`)
- Log format: JSON with `timestamp`, `level`, `session_id`, `component`, `event`, `attributes`
- Features: log rotation (10MB threshold, 3 rotated files), error logging to stderr, thread-safe

## Test plan

- [x] Unit tests for SudoclawLogSink path resolution
- [x] Unit tests for JSON format output
- [x] Integration tests for log file creation, append, and event sequence
- [x] Manual verification: logs correctly written to `~/.nexus/logs/scode.log`
- [x] Verified JSON structure and session_id tracing

🤖 Generated with [Claude Code](https://claude.com/claude-code)