### PR TITLE
feat: add auto-compact and user-friendly error for context overflow

### DIFF
--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -59,23 +59,37 @@ impl AcpError {
         };
 
         // Check for specific error types and provide friendly messages
-        if raw_message.contains("context_window_blocked") || raw_message.contains("Context window blocked") {
+        if raw_message.contains("context_window_blocked")
+            || raw_message.contains("Context window blocked")
+        {
             return "图片或文本内容过大，超出了模型的处理限制。\n\n建议解决方案：\n1. 使用较小的图片（建议压缩或缩小图片尺寸）\n2. 简化输入内容\n3. 使用支持更大上下文的模型\n4. 清除对话历史后重新开始".to_string();
         }
 
-        if raw_message.contains("authentication") || raw_message.contains("认证失败") || raw_message.contains("AUTH") {
+        if raw_message.contains("authentication")
+            || raw_message.contains("认证失败")
+            || raw_message.contains("AUTH")
+        {
             return "认证失败，请检查您的账户配置。\n\n建议解决方案：\n1. 检查 API 密钥或订阅是否有效\n2. 重新登录账户\n3. 检查网络连接".to_string();
         }
 
-        if raw_message.contains("timeout") || raw_message.contains("Timeout") || raw_message.contains("timed out") {
+        if raw_message.contains("timeout")
+            || raw_message.contains("Timeout")
+            || raw_message.contains("timed out")
+        {
             return "请求超时，模型响应时间过长。\n\n建议解决方案：\n1. 简化输入内容\n2. 检查网络连接\n3. 稍后重试".to_string();
         }
 
-        if raw_message.contains("rate limit") || raw_message.contains("RateLimit") || raw_message.contains("429") {
+        if raw_message.contains("rate limit")
+            || raw_message.contains("RateLimit")
+            || raw_message.contains("429")
+        {
             return "请求频率过高，请稍后重试。\n\n建议解决方案：\n1. 等待几分钟后重试\n2. 减少请求频率".to_string();
         }
 
-        if raw_message.contains("network") || raw_message.contains("connection") || raw_message.contains("Connection") {
+        if raw_message.contains("network")
+            || raw_message.contains("connection")
+            || raw_message.contains("Connection")
+        {
             return "网络连接出现问题。\n\n建议解决方案：\n1. 检查网络连接\n2. 检查代理设置\n3. 稍后重试".to_string();
         }
 
@@ -85,7 +99,10 @@ impl AcpError {
 
         // Default: return a simplified message
         if raw_message.len() > 200 {
-            format!("发生错误：{}\n\n请尝试简化输入或稍后重试。", raw_message.chars().take(100).collect::<String>())
+            format!(
+                "发生错误：{}\n\n请尝试简化输入或稍后重试。",
+                raw_message.chars().take(100).collect::<String>()
+            )
         } else {
             format!("发生错误：{}\n\n请尝试简化输入或稍后重试。", raw_message)
         }

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -50,6 +50,46 @@ impl AcpError {
     pub fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
     }
+
+    /// Generate a user-friendly error message with actionable suggestions.
+    #[must_use]
+    pub fn user_friendly_message(&self) -> String {
+        let raw_message = match self {
+            Self::InvalidParams(msg) | Self::Internal(msg) => msg,
+        };
+
+        // Check for specific error types and provide friendly messages
+        if raw_message.contains("context_window_blocked") || raw_message.contains("Context window blocked") {
+            return "图片或文本内容过大，超出了模型的处理限制。\n\n建议解决方案：\n1. 使用较小的图片（建议压缩或缩小图片尺寸）\n2. 简化输入内容\n3. 使用支持更大上下文的模型\n4. 清除对话历史后重新开始".to_string();
+        }
+
+        if raw_message.contains("authentication") || raw_message.contains("认证失败") || raw_message.contains("AUTH") {
+            return "认证失败，请检查您的账户配置。\n\n建议解决方案：\n1. 检查 API 密钥或订阅是否有效\n2. 重新登录账户\n3. 检查网络连接".to_string();
+        }
+
+        if raw_message.contains("timeout") || raw_message.contains("Timeout") || raw_message.contains("timed out") {
+            return "请求超时，模型响应时间过长。\n\n建议解决方案：\n1. 简化输入内容\n2. 检查网络连接\n3. 稍后重试".to_string();
+        }
+
+        if raw_message.contains("rate limit") || raw_message.contains("RateLimit") || raw_message.contains("429") {
+            return "请求频率过高，请稍后重试。\n\n建议解决方案：\n1. 等待几分钟后重试\n2. 减少请求频率".to_string();
+        }
+
+        if raw_message.contains("network") || raw_message.contains("connection") || raw_message.contains("Connection") {
+            return "网络连接出现问题。\n\n建议解决方案：\n1. 检查网络连接\n2. 检查代理设置\n3. 稍后重试".to_string();
+        }
+
+        if raw_message.contains("permission") || raw_message.contains("Permission") {
+            return "权限不足，无法执行此操作。\n\n建议解决方案：\n1. 检查文件或目录权限\n2. 检查账户权限配置".to_string();
+        }
+
+        // Default: return a simplified message
+        if raw_message.len() > 200 {
+            format!("发生错误：{}\n\n请尝试简化输入或稍后重试。", raw_message.chars().take(100).collect::<String>())
+        } else {
+            format!("发生错误：{}\n\n请尝试简化输入或稍后重试。", raw_message)
+        }
+    }
 }
 
 impl std::fmt::Display for AcpError {
@@ -530,6 +570,8 @@ pub(crate) async fn run_acp_on_transport(
 
                         let sid_for_blocking = sid.clone();
                         let sid_for_perm = sid.clone();
+                        let images_for_blocking = images.clone();
+                        let prompt_text_for_blocking = prompt_text.clone();
                         let blocking_handle = tokio::task::spawn_blocking(move || {
                             let mut observer = SdkSessionObserver::new(&sid_for_blocking, notif_tx);
                             let mut bridge = AcpPermissionBridge { tx: bridge_tx };
@@ -538,27 +580,28 @@ pub(crate) async fn run_acp_on_transport(
 
                             // Push image content blocks into the session before
                             // running the prompt so the API client includes them.
-                            if !images.is_empty() {
-                                let _ = delegate.push_images(&sid_for_blocking, &images);
+                            if !images_for_blocking.is_empty() {
+                                let _ = delegate.push_images(&sid_for_blocking, &images_for_blocking);
                             }
 
-                            let stop = if prompt_text.starts_with('/') {
+                            let stop = if prompt_text_for_blocking.starts_with('/') {
                                 delegate
                                     .handle_slash_command(
                                         &sid_for_blocking,
-                                        &prompt_text,
+                                        &prompt_text_for_blocking,
                                         &mut observer,
                                     )
                                     .map(|()| (StopReason::EndTurn, None))
                             } else {
                                 delegate.run_prompt_with_prompter(
                                     &sid_for_blocking,
-                                    prompt_text,
+                                    prompt_text_for_blocking,
                                     &mut observer,
                                     &mut bridge,
                                 )
                             };
-                            stop.unwrap_or((StopReason::EndTurn, None))
+                            // Return the Result instead of unwrapping, so we can handle errors
+                            stop
                         });
 
                         // Concurrently serve permission requests and stream
@@ -566,7 +609,7 @@ pub(crate) async fn run_acp_on_transport(
                         // for it to finish.
                         let mut blocking_handle = blocking_handle;
                         let mut notif_rx_open = true;
-                        let result = loop {
+                        let result: Result<(StopReason, Option<PromptUsage>), AcpError> = loop {
                             tokio::select! {
                                 biased;
                                 notif = notif_rx.recv(), if notif_rx_open => {
@@ -600,11 +643,11 @@ pub(crate) async fn run_acp_on_transport(
                                         // Await the result directly to avoid a busy loop
                                         // (biased select would keep picking this branch).
                                         break blocking_handle.await
-                                            .unwrap_or((StopReason::EndTurn, None));
+                                            .unwrap_or(Err(AcpError::internal("blocking task failed")));
                                     }
                                 }
                                 done = &mut blocking_handle => {
-                                    break done.unwrap_or((StopReason::EndTurn, None));
+                                    break done.unwrap_or(Err(AcpError::internal("blocking task join failed")));
                                 }
                             }
                         };
@@ -615,17 +658,34 @@ pub(crate) async fn run_acp_on_transport(
                             let _ = cx_inner.send_notification(n);
                         }
 
-                        let (stop_reason, prompt_usage) = result;
+                        // Handle errors by sending an error message notification to the client
+                        match result {
+                            Ok((stop_reason, prompt_usage)) => {
+                                let mut response = PromptResponse::new(stop_reason);
+                                if let Some(u) = prompt_usage {
+                                    response = response.usage(
+                                        Usage::new(u.total_tokens, u.input_tokens, u.output_tokens)
+                                            .cached_read_tokens(u.cache_read_tokens)
+                                            .cached_write_tokens(u.cache_write_tokens),
+                                    );
+                                }
+                                responder.respond(response)?;
+                            }
+                            Err(error) => {
+                                // Send user-friendly error message as a notification to the client
+                                let user_message = error.user_friendly_message();
+                                let error_notification = SessionNotification::new(
+                                    sid.clone(),
+                                    SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                        ContentBlock::Text(TextContent::new(&user_message)),
+                                    )),
+                                );
+                                let _ = cx_inner.send_notification(error_notification);
 
-                        let mut response = PromptResponse::new(stop_reason);
-                        if let Some(u) = prompt_usage {
-                            response = response.usage(
-                                Usage::new(u.total_tokens, u.input_tokens, u.output_tokens)
-                                    .cached_read_tokens(u.cache_read_tokens)
-                                    .cached_write_tokens(u.cache_write_tokens),
-                            );
+                                // Respond with an error
+                                responder.respond_with_error(acp_error_to_sdk(&error))?;
+                            }
                         }
-                        responder.respond(response)?;
                         Ok(())
                     })?;
                     Ok(())

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -36,6 +36,41 @@ pub fn estimate_session_tokens(session: &Session) -> usize {
     session.messages.iter().map(estimate_message_tokens).sum()
 }
 
+/// Estimate tokens for a single message block.
+/// This is useful for preflight checks before sending a request.
+#[must_use]
+pub fn estimate_block_tokens(block: &ContentBlock) -> usize {
+    estimate_single_block_tokens(block)
+}
+
+fn estimate_single_block_tokens(block: &ContentBlock) -> usize {
+    match block {
+        ContentBlock::Text { text } => text.len() / 4 + 1,
+        ContentBlock::Image { data, .. } => {
+            let base64_len = data.len();
+            if base64_len < 50_000 {
+                85
+            } else if base64_len < 200_000 {
+                256
+            } else if base64_len < 500_000 {
+                512
+            } else if base64_len < 1_000_000 {
+                1000
+            } else {
+                base64_len / 1000
+            }
+        }
+        ContentBlock::ToolUse { name, input, .. } => (name.len() + input.len()) / 4 + 1,
+        ContentBlock::ToolResult {
+            tool_name, output, ..
+        } => (tool_name.len() + output.len()) / 4 + 1,
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => thinking.len() / 4 + signature.as_ref().map_or(0, |value| value.len() / 4 + 1),
+    }
+}
+
 /// Returns `true` when the session exceeds the configured compaction budget.
 #[must_use]
 pub fn should_compact(session: &Session, config: CompactionConfig) -> bool {
@@ -455,18 +490,7 @@ fn estimate_message_tokens(message: &ConversationMessage) -> usize {
     message
         .blocks
         .iter()
-        .map(|block| match block {
-            ContentBlock::Text { text } => text.len() / 4 + 1,
-            ContentBlock::Image { data, .. } => data.len() / 4 + 1,
-            ContentBlock::ToolUse { name, input, .. } => (name.len() + input.len()) / 4 + 1,
-            ContentBlock::ToolResult {
-                tool_name, output, ..
-            } => (tool_name.len() + output.len()) / 4 + 1,
-            ContentBlock::Thinking {
-                thinking,
-                signature,
-            } => thinking.len() / 4 + signature.as_ref().map_or(0, |value| value.len() / 4 + 1),
-        })
+        .map(estimate_single_block_tokens)
         .sum()
 }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -61,7 +61,7 @@ pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};
 pub use compact::{
-    compact_session, estimate_session_tokens, format_compact_summary,
+    compact_session, estimate_block_tokens, estimate_session_tokens, format_compact_summary,
     get_compact_continuation_message, should_compact, CompactionConfig, CompactionResult,
 };
 pub use config::{

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -31,11 +31,11 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    base_url_for_mode, model_family_identity_for, resolve_startup_auth_source, AnthropicClient,
-    AuthMode, AuthSource, ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest,
-    MessageResponse, OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient,
-    ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
-    ToolResultContentBlock,
+    base_url_for_mode, model_family_identity_for, model_token_limit, resolve_startup_auth_source,
+    AnthropicClient, AuthMode, AuthSource, ContentBlockDelta, InputContentBlock, InputMessage,
+    MessageRequest, MessageResponse, OutputContentBlock, PromptCache,
+    ProviderClient as ApiProviderClient, ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice,
+    ToolDefinition, ToolResultContentBlock,
 };
 
 use cli::api_client::{
@@ -98,8 +98,9 @@ use init::initialize_repo;
 use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
-    check_base_commit, format_stale_base_warning, format_usd, load_oauth_credentials,
-    load_system_prompt, pricing_for_model, resolve_expected_base, resolve_sandbox_status, AcpError,
+    check_base_commit, compact_session, estimate_block_tokens, estimate_session_tokens,
+    format_stale_base_warning, format_usd, load_oauth_credentials, load_system_prompt,
+    pricing_for_model, resolve_expected_base, resolve_sandbox_status, should_compact, AcpError,
     ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
     ContentBlock, ConversationMessage, ConversationRuntime, McpServer, McpServerManager,
     McpServerSpec, McpTool, MessageRole, ModelPricing, PermissionMode, PermissionPolicy,
@@ -2176,10 +2177,97 @@ impl AcpSdkDelegate {
         let _guard = ScopedCurrentDir::change_to(&session.cwd).map_err(|e| {
             runtime::AcpError::internal(format!("failed to enter session cwd: {e}"))
         })?;
+
+        // Pre-send token estimation and auto-compact logic
+        let model = session.runtime.session().model.as_ref().unwrap_or(&self.inner.model);
+        let context_limit = model_token_limit(model)
+            .map(|limit| limit.context_window_tokens as usize)
+            .unwrap_or(200_000);
+
+        // Estimate current session tokens
+        let estimated_tokens = estimate_session_tokens(session.runtime.session());
+        let threshold = (context_limit as f64 * 0.85) as usize; // 85% threshold
+
+        // If approaching limit, try auto-compact
+        if estimated_tokens > threshold {
+            // Check if we have enough messages to compact
+            let message_count = session.runtime.session().messages.len();
+            let can_compact = message_count > 4; // Need more than preserve_recent_messages
+
+            if let Some(tracer) = session.runtime.session_tracer() {
+                tracer.record("auto_compact_check", {
+                    let mut attrs = Map::new();
+                    attrs.insert("estimated_tokens".to_string(), Value::Number(estimated_tokens.into()));
+                    attrs.insert("threshold".to_string(), Value::Number(threshold.into()));
+                    attrs.insert("context_limit".to_string(), Value::Number(context_limit.into()));
+                    attrs.insert("message_count".to_string(), Value::Number(message_count.into()));
+                    attrs.insert("can_compact".to_string(), Value::Bool(can_compact));
+                    attrs
+                });
+            }
+
+            if can_compact {
+                // Perform compaction with aggressive settings for overflow scenario
+                let compaction_config = CompactionConfig {
+                    preserve_recent_messages: 2,
+                    max_estimated_tokens: 0, // Force compaction
+                };
+                let result = compact_session(session.runtime.session(), compaction_config);
+                if result.removed_message_count > 0 {
+                    // Update session with compacted version
+                    *session.runtime.session_mut() = result.compacted_session.clone();
+                    if let Some(tracer) = session.runtime.session_tracer() {
+                        tracer.record("auto_compact_result", {
+                            let mut attrs = Map::new();
+                            attrs.insert("removed_messages".to_string(), Value::Number(result.removed_message_count.into()));
+                            attrs
+                        });
+                    }
+                }
+
+                // Re-estimate after compaction
+                let new_estimated_tokens = estimate_session_tokens(session.runtime.session());
+
+                // If still over limit after compaction, return friendly error
+                if new_estimated_tokens > context_limit {
+                    let user_message = format!(
+                        "对话内容过长，即使压缩后仍超出模型限制。\n\n\
+                        当前估算: {} tokens\n\
+                        模型限制: {} tokens\n\n\
+                        建议解决方案：\n\
+                        1. 开始新对话\n\
+                        2. 使用支持更大上下文的模型\n\
+                        3. 减少图片或大文本内容的发送",
+                        new_estimated_tokens, context_limit
+                    );
+                    return Err(runtime::AcpError::internal(user_message));
+                }
+            } else {
+                // No messages to compact, but request is too large
+                let user_message = format!(
+                    "当前请求内容过大，超出模型处理限制。\n\n\
+                    当前估算: {} tokens\n\
+                    模型限制: {} tokens\n\n\
+                    建议解决方案：\n\
+                    1. 使用较小的图片（压缩或缩小图片尺寸）\n\
+                    2. 简化输入内容\n\
+                    3. 使用支持更大上下文的模型",
+                    estimated_tokens, context_limit
+                );
+                return Err(runtime::AcpError::internal(user_message));
+            }
+        }
+
         self.inner
             .tokio_runtime
             .block_on(session.runtime.run_turn(prompt, prompter, Some(observer)))
-            .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
+            .map_err(|e| {
+                // Record error to telemetry log if available
+                if let Some(tracer) = session.runtime.session_tracer() {
+                    tracer.record_prompt_error("runtime_error", e.to_string());
+                }
+                runtime::AcpError::internal(e.to_string())
+            })?;
         let usage = UsageTracker::from_session(session.runtime.session()).cumulative_usage();
         let prompt_usage = runtime::acp_sdk_server::PromptUsage {
             input_tokens: u64::from(usage.input_tokens),

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2179,7 +2179,12 @@ impl AcpSdkDelegate {
         })?;
 
         // Pre-send token estimation and auto-compact logic
-        let model = session.runtime.session().model.as_ref().unwrap_or(&self.inner.model);
+        let model = session
+            .runtime
+            .session()
+            .model
+            .as_ref()
+            .unwrap_or(&self.inner.model);
         let context_limit = model_token_limit(model)
             .map(|limit| limit.context_window_tokens as usize)
             .unwrap_or(200_000);
@@ -2197,10 +2202,19 @@ impl AcpSdkDelegate {
             if let Some(tracer) = session.runtime.session_tracer() {
                 tracer.record("auto_compact_check", {
                     let mut attrs = Map::new();
-                    attrs.insert("estimated_tokens".to_string(), Value::Number(estimated_tokens.into()));
+                    attrs.insert(
+                        "estimated_tokens".to_string(),
+                        Value::Number(estimated_tokens.into()),
+                    );
                     attrs.insert("threshold".to_string(), Value::Number(threshold.into()));
-                    attrs.insert("context_limit".to_string(), Value::Number(context_limit.into()));
-                    attrs.insert("message_count".to_string(), Value::Number(message_count.into()));
+                    attrs.insert(
+                        "context_limit".to_string(),
+                        Value::Number(context_limit.into()),
+                    );
+                    attrs.insert(
+                        "message_count".to_string(),
+                        Value::Number(message_count.into()),
+                    );
                     attrs.insert("can_compact".to_string(), Value::Bool(can_compact));
                     attrs
                 });
@@ -2219,7 +2233,10 @@ impl AcpSdkDelegate {
                     if let Some(tracer) = session.runtime.session_tracer() {
                         tracer.record("auto_compact_result", {
                             let mut attrs = Map::new();
-                            attrs.insert("removed_messages".to_string(), Value::Number(result.removed_message_count.into()));
+                            attrs.insert(
+                                "removed_messages".to_string(),
+                                Value::Number(result.removed_message_count.into()),
+                            );
                             attrs
                         });
                     }

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -871,7 +871,11 @@ impl SessionTracer {
     }
 
     /// Record a prompt error that occurred during a turn.
-    pub fn record_prompt_error(&self, error_type: impl Into<String>, error_message: impl Into<String>) {
+    pub fn record_prompt_error(
+        &self,
+        error_type: impl Into<String>,
+        error_message: impl Into<String>,
+    ) {
         let error_type = error_type.into();
         let error_message = error_message.into();
         let mut attributes = Map::new();

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -869,6 +869,16 @@ impl SessionTracer {
         attributes.insert("duration_ms".to_string(), Value::from(duration_ms));
         self.record("session_ended", attributes);
     }
+
+    /// Record a prompt error that occurred during a turn.
+    pub fn record_prompt_error(&self, error_type: impl Into<String>, error_message: impl Into<String>) {
+        let error_type = error_type.into();
+        let error_message = error_message.into();
+        let mut attributes = Map::new();
+        attributes.insert("error_type".to_string(), Value::String(error_type));
+        attributes.insert("error_message".to_string(), Value::String(error_message));
+        self.record("prompt_error", attributes);
+    }
 }
 
 /// Mask sensitive header values for debug capture logs.


### PR DESCRIPTION
## Summary
- Add pre-send token estimation before running prompt to detect context overflow early
- Auto-compact session when approaching context limit (85% threshold)
- Use aggressive compaction config (preserve only 2 recent messages) when overflow detected
- Return user-friendly Chinese error messages for context overflow scenarios
- Optimize image token estimation with tiered approach for more accurate estimates

## Changes
- `acp_sdk_server.rs`: Add `user_friendly_message()` method to AcpError for localized error messages
- `compact.rs`: Optimize image token estimation, add `estimate_block_tokens()` public function
- `main.rs`: Add auto-compact logic in `run_prompt_impl` with pre-send estimation
- `telemetry`: Add `record_prompt_error()` for error logging to scode.log

## Error Handling
Two scenarios with different user messages:
1. **Has compactable messages**: Compact first, then show error if still over limit
2. **No messages to compact**: Show error immediately suggesting smaller images or different model

## Test plan
- [ ] Test with large image that exceeds context limit on new session
- [ ] Test with long conversation that triggers auto-compact
- [ ] Verify error messages are user-friendly in Chinese
- [ ] Check scode.log for auto_compact_check and auto_compact_result entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)