### PR TITLE
fix: cache session-start date in system prompt and append date_change reminder on rollover

### DIFF
--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -12,6 +12,7 @@ agent-client-protocol-tokio = { workspace = true }
 async-trait = "0.1"
 axum = { workspace = true }
 base64 = "0.22"
+chrono = "0.4"
 futures = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 # Nexus kernel rlib — provides `kernel::abi::KernelAbi` trait that

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -176,6 +176,16 @@ pub struct ConversationRuntime<C, T> {
     tool_executor: T,
     permission_policy: PermissionPolicy,
     system_prompt: SystemPrompt,
+    /// Date (`YYYY-MM-DD`) baked into the cacheable system prompt at session
+    /// start. When `Some`, [`ConversationRuntime::run_turn_with_blocks`]
+    /// compares it against today's local date at turn time and prepends a
+    /// `<system-reminder>` content block when the date has rolled over,
+    /// instead of mutating the system prompt itself (which would invalidate
+    /// the prompt-cache prefix).
+    prompt_known_date: Option<String>,
+    /// Override for "today" used in tests. Always `None` outside tests.
+    #[cfg(test)]
+    today_override: Option<String>,
     max_iterations: usize,
     usage_tracker: UsageTracker,
     hook_runner: HookRunner,
@@ -225,6 +235,9 @@ where
             tool_executor,
             permission_policy,
             system_prompt,
+            prompt_known_date: None,
+            #[cfg(test)]
+            today_override: None,
             max_iterations: usize::MAX,
             usage_tracker,
             hook_runner: HookRunner::from_feature_config(feature_config),
@@ -233,6 +246,17 @@ where
             hook_progress_reporter: None,
             session_tracer: None,
         }
+    }
+
+    /// Records the date (`YYYY-MM-DD`) that was frozen into the cacheable
+    /// system prompt at session start. Each turn compares this against the
+    /// local date and emits a `<system-reminder>` content block when the
+    /// date has rolled over, leaving the system prompt itself untouched so
+    /// the prompt cache prefix stays warm.
+    #[must_use]
+    pub fn with_session_known_date(mut self, date: impl Into<String>) -> Self {
+        self.prompt_known_date = Some(date.into());
+        self
     }
 
     #[must_use]
@@ -337,6 +361,45 @@ where
                 None,
             )
         }
+    }
+
+    /// Returns the date the runtime should treat as "today" for the
+    /// purpose of inter-turn date-change detection.
+    fn current_local_date(&self) -> String {
+        #[cfg(test)]
+        {
+            if let Some(ref overridden) = self.today_override {
+                return overridden.clone();
+            }
+        }
+        crate::time::today_local()
+    }
+
+    /// If the session-start date frozen into the cacheable system prompt no
+    /// longer matches today's local date, prepend a `<system-reminder>`
+    /// content block so the assistant learns about the rollover without
+    /// invalidating the prompt-cache prefix. The known date is then advanced
+    /// so the reminder fires only once per rollover.
+    fn inject_date_change_reminder(&mut self, blocks: Vec<ContentBlock>) -> Vec<ContentBlock> {
+        let Some(known) = self.prompt_known_date.clone() else {
+            return blocks;
+        };
+        let today = self.current_local_date();
+        if today == known {
+            return blocks;
+        }
+        let reminder = ContentBlock::Text {
+            text: format!(
+                "<system-reminder>The local calendar date has changed since this session started. \
+                 The system prompt was cached on {known}; today is now {today}. \
+                 Treat {today} as the current date for any reasoning that depends on it.</system-reminder>"
+            ),
+        };
+        self.prompt_known_date = Some(today);
+        let mut combined = Vec::with_capacity(blocks.len() + 1);
+        combined.push(reminder);
+        combined.extend(blocks);
+        combined
     }
 
     /// Run a session health probe to verify the runtime is functional after compaction.
@@ -465,6 +528,7 @@ where
         mut prompter: Option<&mut dyn PermissionPrompter>,
         mut observer: Option<&mut dyn RuntimeObserver>,
     ) -> Result<TurnSummary, RuntimeError> {
+        let blocks = self.inject_date_change_reminder(blocks);
         let label = blocks
             .iter()
             .find_map(|b| match b {
@@ -2375,5 +2439,177 @@ mod tests {
 
         // then
         assert_eq!(error.to_string(), "upstream failed");
+    }
+
+    /// Captures the [`ApiRequest`] sent on each turn so tests can assert on
+    /// the messages and system prompt that the model would actually see.
+    #[derive(Default)]
+    struct CapturingApi {
+        requests: Arc<std::sync::Mutex<Vec<ApiRequest>>>,
+    }
+
+    #[async_trait]
+    impl ApiClient for CapturingApi {
+        async fn stream(
+            &mut self,
+            request: ApiRequest,
+        ) -> Result<AssistantEventStream, RuntimeError> {
+            self.requests
+                .lock()
+                .expect("requests mutex should not be poisoned")
+                .push(request);
+            Ok(events_to_stream(vec![
+                AssistantEvent::TextDelta("done".to_string()),
+                AssistantEvent::MessageStop,
+            ]))
+        }
+    }
+
+    #[tokio::test]
+    async fn skips_date_change_reminder_when_known_date_unchanged() {
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_date("2026-05-15");
+        runtime.today_override = Some("2026-05-15".to_string());
+
+        runtime
+            .run_turn("hello", None, None)
+            .await
+            .expect("turn should succeed");
+
+        let requests = captured.lock().expect("captured mutex");
+        let user_blocks = &requests[0].messages[0].blocks;
+        assert_eq!(user_blocks.len(), 1, "no reminder should be prepended");
+        assert!(matches!(
+            &user_blocks[0],
+            ContentBlock::Text { text } if text == "hello"
+        ));
+    }
+
+    #[tokio::test]
+    async fn injects_date_change_reminder_when_local_date_rolls_over() {
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_date("2026-05-15");
+        runtime.today_override = Some("2026-05-16".to_string());
+
+        runtime
+            .run_turn("hello", None, None)
+            .await
+            .expect("turn should succeed");
+
+        let requests = captured.lock().expect("captured mutex");
+        let user_blocks = &requests[0].messages[0].blocks;
+        assert_eq!(
+            user_blocks.len(),
+            2,
+            "rollover should prepend exactly one reminder block"
+        );
+        let ContentBlock::Text { text: reminder } = &user_blocks[0] else {
+            panic!("first block should be the reminder text block");
+        };
+        assert!(
+            reminder.contains("<system-reminder>"),
+            "reminder should be wrapped in a system-reminder tag, got {reminder}"
+        );
+        assert!(
+            reminder.contains("2026-05-15") && reminder.contains("2026-05-16"),
+            "reminder should mention old and new date, got {reminder}"
+        );
+        assert!(matches!(
+            &user_blocks[1],
+            ContentBlock::Text { text } if text == "hello"
+        ));
+    }
+
+    #[tokio::test]
+    async fn date_change_reminder_fires_only_once_per_rollover() {
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_date("2026-05-15");
+        runtime.today_override = Some("2026-05-16".to_string());
+
+        runtime
+            .run_turn("first", None, None)
+            .await
+            .expect("first turn");
+        runtime
+            .run_turn("second", None, None)
+            .await
+            .expect("second turn");
+
+        let requests = captured.lock().expect("captured mutex");
+        // first turn carries the reminder + user text
+        assert_eq!(requests[0].messages[0].blocks.len(), 2);
+        // second turn (still on 2026-05-16) carries only the user text;
+        // the runtime's known date was advanced after firing the reminder.
+        let second_turn_user_blocks = requests[1]
+            .messages
+            .iter()
+            .filter(|m| m.role == MessageRole::User)
+            .last()
+            .expect("user message")
+            .blocks
+            .clone();
+        assert_eq!(
+            second_turn_user_blocks.len(),
+            1,
+            "reminder must not repeat after rollover acknowledged"
+        );
+        assert!(matches!(
+            &second_turn_user_blocks[0],
+            ContentBlock::Text { text } if text == "second"
+        ));
+    }
+
+    #[tokio::test]
+    async fn no_reminder_when_session_known_date_unset() {
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        );
+        runtime.today_override = Some("2099-12-31".to_string());
+
+        runtime
+            .run_turn("hello", None, None)
+            .await
+            .expect("turn should succeed");
+
+        let requests = captured.lock().expect("captured mutex");
+        assert_eq!(
+            requests[0].messages[0].blocks.len(),
+            1,
+            "no reminder should fire without a known date"
+        );
     }
 }

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -51,6 +51,7 @@ pub mod summary_compression;
 pub mod task_packet;
 pub mod task_registry;
 pub mod team_cron_registry;
+mod time;
 #[cfg(test)]
 mod trust_resolver;
 mod usage;
@@ -180,6 +181,7 @@ pub use stale_branch::{
     StaleBranchPolicy,
 };
 pub use task_packet::{validate_packet, TaskPacket, TaskPacketValidationError, ValidatedPacket};
+pub use time::today_local;
 #[cfg(test)]
 pub use trust_resolver::{TrustConfig, TrustDecision, TrustEvent, TrustPolicy, TrustResolver};
 pub use usage::{

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -189,6 +189,7 @@ fn run_loop<K, C, T, F>(
         permission_policy,
         system_prompt,
     )
+    .with_session_known_date(crate::time::today_local())
     .with_hook_abort_signal(abort.clone());
 
     // -- READY --

--- a/rust/crates/runtime/src/time.rs
+++ b/rust/crates/runtime/src/time.rs
@@ -1,0 +1,32 @@
+//! Date/time helpers used by prompt assembly and runtime turn dispatch.
+//!
+//! Centralised here so the system prompt and the conversation runtime agree
+//! on what "today" means without duplicating chrono usage across crates.
+
+use chrono::Local;
+
+/// Returns today's local calendar date as `YYYY-MM-DD`.
+///
+/// Used both when freezing the session-start date into the cacheable system
+/// prompt and when the conversation runtime checks for an inter-turn date
+/// rollover.
+#[must_use]
+pub fn today_local() -> String {
+    Local::now().format("%Y-%m-%d").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::today_local;
+
+    #[test]
+    fn today_local_returns_iso_date() {
+        let date = today_local();
+        assert_eq!(date.len(), 10, "expected YYYY-MM-DD format, got {date}");
+        let bytes = date.as_bytes();
+        assert!(bytes[4] == b'-' && bytes[7] == b'-', "got {date}");
+        assert!(date[..4].chars().all(|c| c.is_ascii_digit()), "got {date}");
+        assert!(date[5..7].chars().all(|c| c.is_ascii_digit()), "got {date}");
+        assert!(date[8..].chars().all(|c| c.is_ascii_digit()), "got {date}");
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -16,7 +16,7 @@ use runtime::{ConfigLoader, PermissionMode, ResolvedPermissionMode};
 use tools::GlobalToolRegistry;
 
 use super::session::LATEST_SESSION_REFERENCE;
-use crate::{normalize_permission_mode, DEFAULT_DATE, DEFAULT_MODEL};
+use crate::{normalize_permission_mode, DEFAULT_MODEL};
 
 pub(crate) type AllowedToolSet = BTreeSet<String>;
 
@@ -525,7 +525,7 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
             }),
             Cmd::SystemPrompt { cwd, date } => {
                 let resolved_cwd = cwd.unwrap_or(env::current_dir().map_err(|e| e.to_string())?);
-                let resolved_date = date.unwrap_or_else(|| DEFAULT_DATE.to_string());
+                let resolved_date = date.unwrap_or_else(runtime::today_local);
                 Ok(CliAction::PrintSystemPrompt {
                     cwd: resolved_cwd,
                     date: resolved_date,

--- a/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
@@ -7,8 +7,8 @@ use serde_json::{json, Map, Value};
 use crate::cli::lifecycle::classify_session_lifecycle_for;
 use crate::{
     parse_git_status_metadata, parse_git_workspace_summary, CliOutputFormat, StatusContext,
-    BUILD_TARGET, DEFAULT_DATE, DEPRECATED_INSTALL_COMMAND, GIT_SHA, OFFICIAL_REPO_SLUG,
-    OFFICIAL_REPO_URL, VERSION,
+    BUILD_TARGET, DEPRECATED_INSTALL_COMMAND, GIT_SHA, OFFICIAL_REPO_SLUG, OFFICIAL_REPO_URL,
+    VERSION,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -179,7 +179,7 @@ pub(crate) fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error:
     let config_loader = ConfigLoader::default_for(&cwd);
     let config = config_loader.load();
     let discovered_config = config_loader.discover();
-    let project_context = ProjectContext::discover_with_git(&cwd, DEFAULT_DATE)?;
+    let project_context = ProjectContext::discover_with_git(&cwd, runtime::today_local())?;
     let (project_root, git_branch) =
         parse_git_status_metadata(project_context.git_status.as_deref());
     let git_summary = parse_git_workspace_summary(project_context.git_status.as_deref());

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use crate::cli::session::LATEST_SESSION_REFERENCE;
 use crate::PRIMARY_SESSION_EXTENSION;
 use crate::{
-    truncate_for_prompt, CliOutputFormat, LocalHelpTopic, DEFAULT_DATE, DEPRECATED_INSTALL_COMMAND,
+    truncate_for_prompt, CliOutputFormat, LocalHelpTopic, DEPRECATED_INSTALL_COMMAND,
     OFFICIAL_REPO_SLUG, OFFICIAL_REPO_URL, STUB_COMMANDS, VERSION,
 };
 
@@ -374,7 +374,7 @@ pub(crate) fn render_config_json(
 
 pub(crate) fn render_memory_report() -> Result<String, Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
-    let project_context = ProjectContext::discover(&cwd, DEFAULT_DATE)?;
+    let project_context = ProjectContext::discover(&cwd, runtime::today_local())?;
     let mut lines = vec![format!(
         "Memory
   Working directory {}
@@ -413,7 +413,7 @@ pub(crate) fn render_memory_report() -> Result<String, Box<dyn std::error::Error
 
 pub(crate) fn render_memory_json() -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
-    let project_context = ProjectContext::discover(&cwd, DEFAULT_DATE)?;
+    let project_context = ProjectContext::discover(&cwd, runtime::today_local())?;
     let files: Vec<_> = project_context
         .instruction_files
         .iter()

--- a/rust/crates/rusty-sudocode-cli/src/cli/status.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/status.rs
@@ -196,7 +196,7 @@ pub(crate) fn status_context(
             Some(err.to_string()),
         ),
     };
-    let project_context = ProjectContext::discover_with_git(&cwd, DEFAULT_DATE)?;
+    let project_context = ProjectContext::discover_with_git(&cwd, runtime::today_local())?;
     let (project_root, git_branch) =
         parse_git_status_metadata(project_context.git_status.as_deref());
     let git_summary = parse_git_workspace_summary(project_context.git_status.as_deref());

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3608,9 +3608,14 @@ fn build_system_prompt_for(
     cwd: &Path,
     model: &str,
 ) -> Result<SystemPrompt, Box<dyn std::error::Error>> {
+    // Use the local date at session-start time (not the build date baked
+    // into DEFAULT_DATE) so the cacheable system prompt reflects when the
+    // user actually started talking. ConversationRuntime separately tracks
+    // this date and emits a system-reminder if the date rolls over
+    // mid-session, keeping the prompt cache prefix warm.
     Ok(load_system_prompt(
         cwd.to_path_buf(),
-        DEFAULT_DATE,
+        runtime::today_local(),
         env::consts::OS,
         "unknown",
         model_family_identity_for(model),
@@ -3969,7 +3974,8 @@ fn build_runtime_with_plugin_state(
         policy,
         system_prompt,
         &feature_config,
-    );
+    )
+    .with_session_known_date(runtime::today_local());
     if emit_output {
         runtime = runtime.with_hook_progress_reporter(Box::new(CliHookProgressReporter));
     }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -3799,7 +3799,6 @@ fn parse_skill_frontmatter_value(contents: &str, key: &str) -> Option<String> {
 }
 
 const DEFAULT_AGENT_MODEL: &str = "claude-opus-4-6";
-const DEFAULT_AGENT_SYSTEM_DATE: &str = "2026-03-31";
 const DEFAULT_AGENT_MAX_ITERATIONS: usize = 32;
 
 fn execute_agent(input: AgentInput) -> Result<AgentOutput, String> {
@@ -4039,14 +4038,15 @@ fn build_agent_runtime(
         tool_executor,
         permission_policy,
         job.system_prompt.clone(),
-    ))
+    )
+    .with_session_known_date(runtime::today_local()))
 }
 
 fn build_agent_system_prompt(subagent_type: &str, model: &str) -> Result<SystemPrompt, String> {
     let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
     let mut prompt = load_system_prompt(
         cwd,
-        DEFAULT_AGENT_SYSTEM_DATE.to_string(),
+        runtime::today_local(),
         std::env::consts::OS,
         "unknown",
         model_family_identity_for(model),


### PR DESCRIPTION
Closes #127.

## Summary

- 将系统提示词中的 `Today's date` 从 构建日期 替换为 session 启动时的本地日期，仍然可缓存。
- 在 `ConversationRuntime` 中增加跨日检测：日期变化时在当前 turn 的用户 blocks 前面注入一个 `<system-reminder>` 块，需更新已知日期，免于改写系统提示词和失效 KV 缓存。
- CLI 入口（main/status/doctor/help/args）和子代理入口全部接入新的 `runtime::today_local()`。

## Test plan

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] 手动：在一个 session 中跨天发送一个 turn，确认出现 `<system-reminder>` 块且日期已更新。

🤖 Generated with [Claude Code](https://claude.ai/code)