### PR TITLE
[codex] Add README terminal demo GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
   Rust-native · model-agnostic · headless-first · safe by design.
 </p>
 
+<p align="center">
+  <img src="assets/scode-demo.gif" alt="Sudo Code terminal demo highlighting Rust-native speed, model-agnostic providers, headless ACP infrastructure, and safe-by-design permissions" width="900" />
+</p>
+
 ---
 
 ## What is Sudo Code?


### PR DESCRIPTION
## Summary

- Add a README-ready terminal demo GIF at `assets/scode-demo.gif`.
- Embed the GIF below the Sudo Code hero tagline.
- Highlight the four core README themes: Rust-native speed, model-agnostic providers, headless-first infrastructure, and safe-by-design permissions.

Closes #124.

## Validation

- Ran HyperFrames `lint`, `validate`, and `inspect` with 0 issues.
- Rendered the final GIF from the HyperFrames source composition.
- Verified GIF metadata with `ffprobe`: 800x450, 53s, ~15MB.
- Ran `git diff --cached --check` before commit.