### PR TITLE
feat: Add AskUserQuestion tool support for ACP protocol

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//Users/zhangdongdong/**)",
+      "Read(//Users/zhangdongdong/.config/sudocode/**)"
+    ]
+  }
+}

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -402,8 +402,23 @@ async fn check_gemini_response(response: reqwest::Response) -> Result<reqwest::R
 fn build_gemini_request_body(request: &MessageRequest) -> Value {
     let mut contents: Vec<Value> = Vec::new();
 
+    // Gemini requires `functionResponse.name` to match the original
+    // `functionCall.name`. Build a tool_use_id -> name lookup from all prior
+    // assistant turns so each tool result can recover the original function
+    // name. Without this, Gemini rejects (or silently drops) the response
+    // turn, manifesting as an empty assistant stream.
+    let mut tool_name_by_id: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     for msg in &request.messages {
-        translate_input_message(msg, &mut contents);
+        for block in &msg.content {
+            if let InputContentBlock::ToolUse { id, name, .. } = block {
+                tool_name_by_id.insert(id.clone(), name.clone());
+            }
+        }
+    }
+
+    for msg in &request.messages {
+        translate_input_message(msg, &mut contents, &tool_name_by_id);
     }
 
     let mut body = json!({
@@ -435,7 +450,11 @@ fn build_gemini_request_body(request: &MessageRequest) -> Value {
     body
 }
 
-fn translate_input_message(message: &InputMessage, contents: &mut Vec<Value>) {
+fn translate_input_message(
+    message: &InputMessage,
+    contents: &mut Vec<Value>,
+    tool_name_by_id: &std::collections::HashMap<String, String>,
+) {
     let role = match message.role.as_str() {
         "assistant" => "model",
         _ => "user",
@@ -466,7 +485,7 @@ fn translate_input_message(message: &InputMessage, contents: &mut Vec<Value>) {
                 parts.push(part);
             }
             InputContentBlock::ToolResult {
-                tool_use_id: _,
+                tool_use_id,
                 content,
                 ..
             } => {
@@ -481,11 +500,19 @@ fn translate_input_message(message: &InputMessage, contents: &mut Vec<Value>) {
                     parts = Vec::new();
                 }
                 let response_text = flatten_tool_result(content);
+                // Gemini requires the functionResponse name to match the
+                // original functionCall name. Look it up from the map built
+                // by scanning prior assistant turns. Fall back to the id only
+                // if we somehow never saw the corresponding tool_use.
+                let fn_name = tool_name_by_id
+                    .get(tool_use_id)
+                    .cloned()
+                    .unwrap_or_else(|| tool_use_id.clone());
                 contents.push(json!({
                     "role": "user",
                     "parts": [{
                         "functionResponse": {
-                            "name": "_tool_result",
+                            "name": fn_name,
                             "response": {
                                 "result": response_text,
                             }
@@ -547,8 +574,13 @@ fn sanitize_schema_for_gemini(schema: &Value) -> Value {
             let mut out = serde_json::Map::new();
             for (key, value) in map {
                 match key.as_str() {
-                    // Remove unsupported fields.
-                    "additionalProperties" | "$schema" | "default" => {}
+                    // Remove unsupported fields. Gemini's function-calling schema is
+                    // an OpenAPI subset that does not accept JSON Schema combinators
+                    // (anyOf/oneOf/allOf), `additionalProperties`, `$schema`, or `default`.
+                    // We drop them here so upstream ToolSpec authors can keep the full
+                    // JSON Schema form for OpenAI/Anthropic without breaking Gemini.
+                    "additionalProperties" | "$schema" | "default" | "anyOf" | "oneOf"
+                    | "allOf" => {}
 
                     // Flatten type arrays: ["string","null"] → "string"
                     "type" => {
@@ -1079,8 +1111,15 @@ mod tests {
             contents[1]["parts"][0]["functionCall"]["name"],
             "get_weather"
         );
-        // Tool result is a functionResponse.
+        // Tool result is a functionResponse. Gemini requires that the
+        // functionResponse name matches the original functionCall name —
+        // anything else (e.g. a generic "_tool_result") causes Gemini to
+        // reject the turn or emit an empty assistant stream.
         assert!(contents[2]["parts"][0].get("functionResponse").is_some());
+        assert_eq!(
+            contents[2]["parts"][0]["functionResponse"]["name"],
+            "get_weather"
+        );
 
         let tools = payload["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 1);

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -579,7 +579,11 @@ fn sanitize_schema_for_gemini(schema: &Value) -> Value {
                     // (anyOf/oneOf/allOf), `additionalProperties`, `$schema`, or `default`.
                     // We drop them here so upstream ToolSpec authors can keep the full
                     // JSON Schema form for OpenAI/Anthropic without breaking Gemini.
-                    "additionalProperties" | "$schema" | "default" | "anyOf" | "oneOf"
+                    "additionalProperties"
+                    | "$schema"
+                    | "default"
+                    | "anyOf"
+                    | "oneOf"
                     | "allOf" => {}
 
                     // Flatten type arrays: ["string","null"] → "string"

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::sync::Arc as StdArc;
 
 use agent_client_protocol::role::acp::{Agent, Client};
 // NOTE: `ConnectTo` and `ConnectionTo` are different SDK concepts:
@@ -16,14 +17,15 @@ use crate::conversation::RuntimeObserver;
 use crate::hooks::HookAbortSignal;
 use crate::permissions::{
     PermissionMode, PermissionPromptDecision, PermissionPrompter, PermissionRequest,
+    QuestionPromptAnswer, QuestionPromptRequest, QuestionPrompter,
 };
 use agent_client_protocol::{
     on_receive_dispatch, on_receive_notification, on_receive_request, ConnectTo, ConnectionTo,
-    Dispatch, Error, JsonRpcRequest, JsonRpcResponse, Responder,
+    Dispatch, Error, Handled, JsonRpcRequest, JsonRpcResponse, Responder,
 };
 use agent_client_protocol_schema::{
-    AgentCapabilities, CancelNotification, CloseSessionRequest, CloseSessionResponse, ContentBlock,
-    ContentChunk, Implementation, InitializeRequest, InitializeResponse, ListSessionsRequest,
+    AgentCapabilities, CancelNotification, ClientRequest, CloseSessionRequest, CloseSessionResponse, ContentBlock,
+    ContentChunk, ExtRequest, Implementation, InitializeRequest, InitializeResponse, ListSessionsRequest,
     ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
     NewSessionResponse, PermissionOption, PermissionOptionId, PermissionOptionKind,
     PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
@@ -32,6 +34,7 @@ use agent_client_protocol_schema::{
     SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, ToolCall,
     ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage,
 };
+use serde::{Deserialize, Serialize};
 
 /// Error type returned by ACP agent implementations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -172,6 +175,13 @@ pub trait SdkAcpDelegate: Send + 'static {
         observer: &mut SdkSessionObserver,
         prompter: &mut dyn PermissionPrompter,
     ) -> Result<(StopReason, Option<PromptUsage>), AcpError>;
+
+    /// Install a question prompter for AskUserQuestion tool execution within a session.
+    fn set_question_prompter(
+        &mut self,
+        session_id: &str,
+        prompter: Box<dyn QuestionPrompter>,
+    ) -> Result<(), AcpError>;
 
     /// Handle a slash command, returning text output.
     fn handle_slash_command(
@@ -397,6 +407,90 @@ impl PermissionPrompter for AcpPermissionBridge {
     }
 }
 
+impl QuestionPrompter for AcpQuestionBridge {
+    fn ask(&mut self, request: &QuestionPromptRequest) -> Result<Vec<QuestionPromptAnswer>, String> {
+        let tool_call_id = format!("ask-{}", uuid_v4());
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        if self
+            .tx
+            .send((tool_call_id, request.clone(), response_tx))
+            .is_err()
+        {
+            return Err("question bridge closed".to_string());
+        }
+        // The LLM tool loop runs synchronously inside the conversation runtime's
+        // `tokio_runtime.block_on(run_turn)` (multi-thread runtime), so this
+        // `ask()` is reached from a tokio worker thread. Plain `blocking_recv()`
+        // there triggers tokio's "Cannot block the current thread from within a
+        // runtime" panic, which aborts the entire prompt task and surfaces to
+        // the client as a generic "blocking task failed" / Internal error.
+        // `block_in_place` informs the multi-thread scheduler that this worker
+        // is about to block, allowing the recv to complete safely.
+        tokio::task::block_in_place(|| {
+            response_rx
+                .blocking_recv()
+                .unwrap_or_else(|_| Err("question response channel closed".to_string()))
+        })
+    }
+}
+
+struct AcpQuestionBridge {
+    tx: tokio::sync::mpsc::UnboundedSender<(
+        String,
+        QuestionPromptRequest,
+        tokio::sync::oneshot::Sender<Result<Vec<QuestionPromptAnswer>, String>>,
+    )>,
+}
+
+const ACP_ASK_USER_QUESTION_METHOD: &str = "_scode/ask_user_question";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpQuestionOptionPayload {
+    label: String,
+    value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(default)]
+    recommended: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpQuestionFieldPayload {
+    id: String,
+    prompt: String,
+    kind: String,
+    required: bool,
+    allow_custom_input: bool,
+    custom_input_hint: Option<String>,
+    options: Vec<AcpQuestionOptionPayload>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpAskUserQuestionRequestPayload {
+    session_id: String,
+    tool_call_id: String,
+    title: Option<String>,
+    description: Option<String>,
+    questions: Vec<AcpQuestionFieldPayload>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpAskUserQuestionAnswerPayload {
+    id: String,
+    value: String,
+    label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpAskUserQuestionResponsePayload {
+    answers: Vec<AcpAskUserQuestionAnswerPayload>,
+}
+
 /// Build an ACP `RequestPermissionRequest` from a runtime `PermissionRequest`.
 fn build_acp_permission_request(
     session_id: String,
@@ -580,6 +674,11 @@ pub(crate) async fn run_acp_on_transport(
                             PermissionRequest,
                             tokio::sync::oneshot::Sender<PermissionPromptDecision>,
                         )>();
+                        let (question_tx, mut question_rx) = tokio::sync::mpsc::unbounded_channel::<(
+                            String,
+                            QuestionPromptRequest,
+                            tokio::sync::oneshot::Sender<Result<Vec<QuestionPromptAnswer>, String>>,
+                        )>();
 
                         // Set up notification streaming channel.
                         let (notif_tx, mut notif_rx) =
@@ -592,8 +691,28 @@ pub(crate) async fn run_acp_on_transport(
                         let blocking_handle = tokio::task::spawn_blocking(move || {
                             let mut observer = SdkSessionObserver::new(&sid_for_blocking, notif_tx);
                             let mut bridge = AcpPermissionBridge { tx: bridge_tx };
+                            let question_bridge = AcpQuestionBridge { tx: question_tx };
                             let mut delegate =
                                 d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let set_result = delegate.set_question_prompter(
+                                &sid_for_blocking,
+                                Box::new(question_bridge),
+                            );
+                            {
+                                use std::io::Write as _;
+                                if let Ok(mut f) = std::fs::OpenOptions::new()
+                                    .create(true)
+                                    .append(true)
+                                    .open("/tmp/scode-acp-diag.log")
+                                {
+                                    let _ = writeln!(
+                                        f,
+                                        "[ACP-DIAG] set_question_prompter sid={} ok={}",
+                                        sid_for_blocking,
+                                        set_result.is_ok()
+                                    );
+                                }
+                            }
 
                             // Push image content blocks into the session before
                             // running the prompt so the API client includes them.
@@ -659,6 +778,136 @@ pub(crate) async fn run_acp_on_transport(
                                         // Channel closed — blocking task dropped the sender.
                                         // Await the result directly to avoid a busy loop
                                         // (biased select would keep picking this branch).
+                                        break blocking_handle.await
+                                            .unwrap_or(Err(AcpError::internal("blocking task failed")));
+                                    }
+                                }
+                                question = question_rx.recv() => {
+                                    if let Some((tool_call_id, question_req, response_tx)) = question {
+                                        let payload = AcpAskUserQuestionRequestPayload {
+                                            session_id: sid_for_perm.clone(),
+                                            tool_call_id,
+                                            title: question_req.title.clone(),
+                                            description: question_req.description.clone(),
+                                            questions: question_req
+                                                .fields
+                                                .iter()
+                                                .map(|field| AcpQuestionFieldPayload {
+                                                    id: field.id.clone(),
+                                                    prompt: field.prompt.clone(),
+                                                    kind: field.kind.as_str().to_string(),
+                                                    required: field.required,
+                                                    allow_custom_input: field.allow_custom_input,
+                                                    custom_input_hint: field.custom_input_hint.clone(),
+                                                    options: field
+                                                        .options
+                                                        .iter()
+                                                        .map(|option| AcpQuestionOptionPayload {
+                                                            label: option.label.clone(),
+                                                            value: option.value.clone(),
+                                                            description: option.description.clone(),
+                                                            recommended: option.recommended,
+                                                        })
+                                                        .collect(),
+                                                })
+                                                .collect(),
+                                        };
+
+                                        {
+                                            use std::io::Write as _;
+                                            if let Ok(mut f) = std::fs::OpenOptions::new()
+                                                .create(true)
+                                                .append(true)
+                                                .open("/tmp/scode-acp-diag.log")
+                                            {
+                                                let _ = writeln!(
+                                                    f,
+                                                    "[ACP-DIAG] sending {} request",
+                                                    ACP_ASK_USER_QUESTION_METHOD
+                                                );
+                                            }
+                                        }
+                                        let outcome = match serde_json::value::to_raw_value(&payload) {
+                                            Ok(raw) => {
+                                                let raw_for_diag = raw.clone();
+                                                match cx_perm
+                                                    .send_request(ClientRequest::ExtMethodRequest(
+                                                        ExtRequest::new(ACP_ASK_USER_QUESTION_METHOD, StdArc::from(raw)),
+                                                    ))
+                                                    .block_task()
+                                                    .await
+                                                {
+                                                    Ok(resp) => {
+                                                        {
+                                                            use std::io::Write;
+                                                            if let Ok(mut f) = std::fs::OpenOptions::new()
+                                                                .create(true)
+                                                                .append(true)
+                                                                .open("/tmp/scode-acp-diag.log")
+                                                            {
+                                                                let _ = writeln!(
+                                                                    f,
+                                                                    "[ACP-DIAG] question raw_resp: {}",
+                                                                    resp,
+                                                                );
+                                                            }
+                                                        }
+                                                        serde_json::from_value::<AcpAskUserQuestionResponsePayload>(resp)
+                                                            .map_err(|error| format!("deserialize: {}", error))
+                                                            .map(|payload| {
+                                                                payload
+                                                                    .answers
+                                                                    .into_iter()
+                                                                    .map(|answer| QuestionPromptAnswer {
+                                                                        id: answer.id,
+                                                                        value: answer.value,
+                                                                        label: answer.label,
+                                                                    })
+                                                                    .collect::<Vec<_>>()
+                                                            })
+                                                    }
+                                                    Err(error) => {
+                                                        {
+                                                            use std::io::Write;
+                                                            if let Ok(mut f) = std::fs::OpenOptions::new()
+                                                                .create(true)
+                                                                .append(true)
+                                                                .open("/tmp/scode-acp-diag.log")
+                                                            {
+                                                                let _ = writeln!(
+                                                                    f,
+                                                                    "[ACP-DIAG] question send_request Err debug: {:?} payload_size={}",
+                                                                    error,
+                                                                    raw_for_diag.get().len(),
+                                                                );
+                                                            }
+                                                        }
+                                                        Err(error.to_string())
+                                                    }
+                                                }
+                                            }
+                                            Err(error) => Err(error.to_string()),
+                                        };
+                                        {
+                                            use std::io::Write;
+                                            if let Ok(mut f) = std::fs::OpenOptions::new()
+                                                .create(true)
+                                                .append(true)
+                                                .open("/tmp/scode-acp-diag.log")
+                                            {
+                                                let summary = match &outcome {
+                                                    Ok(answers) => format!("Ok n_answers={}", answers.len()),
+                                                    Err(e) => format!("Err {}", e),
+                                                };
+                                                let _ = writeln!(
+                                                    f,
+                                                    "[ACP-DIAG] question outcome: {}",
+                                                    summary
+                                                );
+                                            }
+                                        }
+                                        let _ = response_tx.send(outcome);
+                                    } else {
                                         break blocking_handle.await
                                             .unwrap_or(Err(AcpError::internal("blocking task failed")));
                                     }
@@ -909,10 +1158,24 @@ pub(crate) async fn run_acp_on_transport(
             on_receive_request!(),
         )
         // --- catch-all for unhandled methods ---
+        // Only respond with method_not_found for Request/Notification.
+        // Response MUST be passed through (Handled::No) so the SDK's ResponseRouter
+        // can deliver the result to the waiting oneshot channel.
         .on_receive_dispatch(
             async move |dispatch: Dispatch, cx: ConnectionTo<Client>| {
-                dispatch.respond_with_error(Error::method_not_found(), cx)?;
-                Ok(())
+                match &dispatch {
+                    Dispatch::Request(_, _) | Dispatch::Notification(_) => {
+                        dispatch.respond_with_error(Error::method_not_found(), cx)?;
+                        Ok(Handled::Yes)
+                    }
+                    Dispatch::Response(_, _) => {
+                        // Pass through to SDK's default ResponseRouter
+                        Ok(Handled::No {
+                            message: dispatch,
+                            retry: false,
+                        })
+                    }
+                }
             },
             on_receive_dispatch!(),
         )

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -6,8 +6,8 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 use std::sync::Arc as StdArc;
+use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::role::acp::{Agent, Client};
 // NOTE: `ConnectTo` and `ConnectionTo` are different SDK concepts:
@@ -24,13 +24,13 @@ use agent_client_protocol::{
     Dispatch, Error, Handled, JsonRpcRequest, JsonRpcResponse, Responder,
 };
 use agent_client_protocol_schema::{
-    AgentCapabilities, CancelNotification, ClientRequest, CloseSessionRequest, CloseSessionResponse, ContentBlock,
-    ContentChunk, ExtRequest, Implementation, InitializeRequest, InitializeResponse, ListSessionsRequest,
-    ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
-    NewSessionResponse, PermissionOption, PermissionOptionId, PermissionOptionKind,
-    PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SessionCapabilities,
-    SessionCloseCapabilities, SessionInfo, SessionNotification, SessionUpdate,
+    AgentCapabilities, CancelNotification, ClientRequest, CloseSessionRequest,
+    CloseSessionResponse, ContentBlock, ContentChunk, ExtRequest, Implementation,
+    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse,
+    PermissionOption, PermissionOptionId, PermissionOptionKind, PromptCapabilities, PromptRequest,
+    PromptResponse, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SessionCapabilities, SessionCloseCapabilities, SessionInfo, SessionNotification, SessionUpdate,
     SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, ToolCall,
     ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage,
 };
@@ -408,7 +408,10 @@ impl PermissionPrompter for AcpPermissionBridge {
 }
 
 impl QuestionPrompter for AcpQuestionBridge {
-    fn ask(&mut self, request: &QuestionPromptRequest) -> Result<Vec<QuestionPromptAnswer>, String> {
+    fn ask(
+        &mut self,
+        request: &QuestionPromptRequest,
+    ) -> Result<Vec<QuestionPromptAnswer>, String> {
         let tool_call_id = format!("ask-{}", uuid_v4());
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
         if self

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -135,7 +135,8 @@ pub use oauth::{
 };
 pub use permissions::{
     PermissionContext, PermissionMode, PermissionOutcome, PermissionOverride, PermissionPolicy,
-    PermissionPromptDecision, PermissionPrompter, PermissionRequest,
+    PermissionPromptDecision, PermissionPrompter, PermissionRequest, QuestionField, QuestionKind,
+    QuestionOption, QuestionPromptAnswer, QuestionPromptRequest, QuestionPrompter,
 };
 pub use plugin_lifecycle::{
     DegradedMode, DiscoveryResult, PluginHealthcheck, PluginLifecycle, PluginLifecycleEvent,

--- a/rust/crates/runtime/src/permissions.rs
+++ b/rust/crates/runtime/src/permissions.rs
@@ -87,6 +87,72 @@ pub trait PermissionPrompter {
     fn decide(&mut self, request: &PermissionRequest) -> PermissionPromptDecision;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuestionOption {
+    pub label: String,
+    pub value: String,
+    pub description: Option<String>,
+    pub recommended: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuestionField {
+    pub id: String,
+    pub prompt: String,
+    pub kind: QuestionKind,
+    pub required: bool,
+    pub allow_custom_input: bool,
+    pub custom_input_hint: Option<String>,
+    pub options: Vec<QuestionOption>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuestionKind {
+    SingleSelect,
+    MultiSelect,
+    Text,
+    Boolean,
+}
+
+impl QuestionKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QuestionKind::SingleSelect => "single_select",
+            QuestionKind::MultiSelect => "multi_select",
+            QuestionKind::Text => "text",
+            QuestionKind::Boolean => "boolean",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "single_select" => Some(QuestionKind::SingleSelect),
+            "multi_select" => Some(QuestionKind::MultiSelect),
+            "text" => Some(QuestionKind::Text),
+            "boolean" => Some(QuestionKind::Boolean),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuestionPromptRequest {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub fields: Vec<QuestionField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuestionPromptAnswer {
+    pub id: String,
+    pub value: String,
+    pub label: Option<String>,
+}
+
+pub trait QuestionPrompter: Send {
+    fn ask(&mut self, request: &QuestionPromptRequest) -> Result<Vec<QuestionPromptAnswer>, String>;
+}
+
 /// Final authorization result after evaluating static rules and prompts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionOutcome {

--- a/rust/crates/runtime/src/permissions.rs
+++ b/rust/crates/runtime/src/permissions.rs
@@ -150,7 +150,8 @@ pub struct QuestionPromptAnswer {
 }
 
 pub trait QuestionPrompter: Send {
-    fn ask(&mut self, request: &QuestionPromptRequest) -> Result<Vec<QuestionPromptAnswer>, String>;
+    fn ask(&mut self, request: &QuestionPromptRequest)
+        -> Result<Vec<QuestionPromptAnswer>, String>;
 }
 
 /// Final authorization result after evaluating static rules and prompts.

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -645,10 +645,11 @@ fn get_using_tools_section() -> String {
      - Do NOT use Bash to run commands when a relevant dedicated tool is provided. Using dedicated tools allows the user to better understand and review your work:\n\
        - To read files use Read instead of cat, head, tail, or sed\n\
        - To edit files use Edit instead of sed or awk\n\
-       - To create files use Write instead of cat with heredoc or echo redirection\n\
-       - To search for files use Glob instead of find or ls\n\
-       - To search file contents use Grep instead of grep or rg\n\
-       - Reserve Bash exclusively for system commands and terminal operations that require shell execution.\n\
+     - To create files use Write instead of cat with heredoc or echo redirection\n\
+     - To search for files use Glob instead of find or ls\n\
+     - To search file contents use Grep instead of grep or rg\n\
+      - Reserve Bash exclusively for system commands and terminal operations that require shell execution.\n\
+     - When you need the user to provide structured preferences, configuration values, setup answers, yes/no choices, save locations, style/layout/language selections, or other form-like input, use AskUserQuestion instead of asking in plain assistant text. Do not present numbered questionnaires directly in normal assistant prose when AskUserQuestion is available.\n\
      - You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, make all independent tool calls in parallel for optimal performance. However, if some tool calls depend on previous calls, do NOT call these in parallel — call them sequentially.\n\
      - For simple, directed codebase searches (e.g. for a specific file/class/function) use Glob or Grep directly.\n\n\
      # Committing changes with git\n\n\

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -789,9 +789,7 @@ pub(crate) fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMes
             .blocks
             .iter()
             .filter_map(|block| match block {
-                ContentBlock::Text { text } => {
-                    Some(InputContentBlock::Text { text: text.clone() })
-                }
+                ContentBlock::Text { text } => Some(InputContentBlock::Text { text: text.clone() }),
                 ContentBlock::Image { data, mime_type } => Some(InputContentBlock::Image {
                     source: ImageSource {
                         source_type: "base64".to_string(),
@@ -841,9 +839,10 @@ pub(crate) fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMes
         if matches!(message.role, MessageRole::Tool) {
             if let Some(last) = result.last_mut() {
                 if last.role == "user"
-                    && last.content.iter().all(|block| {
-                        matches!(block, InputContentBlock::ToolResult { .. })
-                    })
+                    && last
+                        .content
+                        .iter()
+                        .all(|block| matches!(block, InputContentBlock::ToolResult { .. }))
                 {
                     last.content.extend(content);
                     continue;

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -779,60 +779,84 @@ pub(crate) fn prompt_cache_record_to_runtime_event(
 }
 
 pub(crate) fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
-    messages
-        .iter()
-        .filter_map(|message| {
-            let role = match message.role {
-                MessageRole::System | MessageRole::User | MessageRole::Tool => "user",
-                MessageRole::Assistant => "assistant",
-            };
-            let content = message
-                .blocks
-                .iter()
-                .filter_map(|block| match block {
-                    ContentBlock::Text { text } => {
-                        Some(InputContentBlock::Text { text: text.clone() })
-                    }
-                    ContentBlock::Image { data, mime_type } => Some(InputContentBlock::Image {
-                        source: ImageSource {
-                            source_type: "base64".to_string(),
-                            media_type: mime_type.clone(),
-                            data: data.clone(),
-                        },
-                    }),
-                    ContentBlock::Thinking { .. } => None,
-                    ContentBlock::ToolUse {
-                        id,
-                        name,
-                        input,
-                        thought_signature,
-                    } => Some(InputContentBlock::ToolUse {
-                        id: id.clone(),
-                        name: name.clone(),
-                        input: serde_json::from_str(input)
-                            .unwrap_or_else(|_| serde_json::json!({ "raw": input })),
-                        thought_signature: thought_signature.clone(),
-                    }),
-                    ContentBlock::ToolResult {
-                        tool_use_id,
-                        output,
-                        is_error,
-                        ..
-                    } => Some(InputContentBlock::ToolResult {
-                        tool_use_id: tool_use_id.clone(),
-                        content: vec![ToolResultContentBlock::Text {
-                            text: output.clone(),
-                        }],
-                        is_error: *is_error,
-                    }),
-                })
-                .collect::<Vec<_>>();
-            (!content.is_empty()).then(|| InputMessage {
-                role: role.to_string(),
-                content,
+    let mut result: Vec<InputMessage> = Vec::with_capacity(messages.len());
+    for message in messages {
+        let role = match message.role {
+            MessageRole::System | MessageRole::User | MessageRole::Tool => "user",
+            MessageRole::Assistant => "assistant",
+        };
+        let content = message
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => {
+                    Some(InputContentBlock::Text { text: text.clone() })
+                }
+                ContentBlock::Image { data, mime_type } => Some(InputContentBlock::Image {
+                    source: ImageSource {
+                        source_type: "base64".to_string(),
+                        media_type: mime_type.clone(),
+                        data: data.clone(),
+                    },
+                }),
+                ContentBlock::Thinking { .. } => None,
+                ContentBlock::ToolUse {
+                    id,
+                    name,
+                    input,
+                    thought_signature,
+                } => Some(InputContentBlock::ToolUse {
+                    id: id.clone(),
+                    name: name.clone(),
+                    input: serde_json::from_str(input)
+                        .unwrap_or_else(|_| serde_json::json!({ "raw": input })),
+                    thought_signature: thought_signature.clone(),
+                }),
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    output,
+                    is_error,
+                    ..
+                } => Some(InputContentBlock::ToolResult {
+                    tool_use_id: tool_use_id.clone(),
+                    content: vec![ToolResultContentBlock::Text {
+                        text: output.clone(),
+                    }],
+                    is_error: *is_error,
+                }),
             })
-        })
-        .collect()
+            .collect::<Vec<_>>();
+        if content.is_empty() {
+            continue;
+        }
+
+        // Merge consecutive Tool-role messages into the previous user-role
+        // InputMessage. The runtime pushes each tool_result as its own
+        // Tool-role ConversationMessage, but Anthropic requires every
+        // `tool_use` in an assistant turn to have its matching `tool_result`
+        // in the SAME next user message — splitting them across consecutive
+        // user messages triggers `messages.N: tool_use ids` 400 errors.
+        // OpenAI and Gemini conversions iterate per content block and emit
+        // their own per-result messages, so merging here is a no-op for them.
+        if matches!(message.role, MessageRole::Tool) {
+            if let Some(last) = result.last_mut() {
+                if last.role == "user"
+                    && last.content.iter().all(|block| {
+                        matches!(block, InputContentBlock::ToolResult { .. })
+                    })
+                {
+                    last.content.extend(content);
+                    continue;
+                }
+            }
+        }
+
+        result.push(InputMessage {
+            role: role.to_string(),
+            content,
+        });
+    }
+    result
 }
 
 pub(crate) fn filter_tool_specs(
@@ -840,4 +864,110 @@ pub(crate) fn filter_tool_specs(
     allowed_tools: Option<&AllowedToolSet>,
 ) -> Vec<ToolDefinition> {
     tool_registry.definitions(allowed_tools)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_use(id: &str, name: &str) -> ConversationMessage {
+        ConversationMessage {
+            role: MessageRole::Assistant,
+            blocks: vec![ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: name.to_string(),
+                input: "{}".to_string(),
+                thought_signature: None,
+            }],
+            usage: None,
+            model: None,
+        }
+    }
+
+    fn tool_use_multi(ids_and_names: &[(&str, &str)]) -> ConversationMessage {
+        ConversationMessage {
+            role: MessageRole::Assistant,
+            blocks: ids_and_names
+                .iter()
+                .map(|(id, name)| ContentBlock::ToolUse {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    input: "{}".to_string(),
+                    thought_signature: None,
+                })
+                .collect(),
+            usage: None,
+            model: None,
+        }
+    }
+
+    fn tool_result(id: &str, name: &str, output: &str) -> ConversationMessage {
+        ConversationMessage {
+            role: MessageRole::Tool,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                tool_name: name.to_string(),
+                output: output.to_string(),
+                is_error: false,
+            }],
+            usage: None,
+            model: None,
+        }
+    }
+
+    #[test]
+    fn convert_messages_merges_consecutive_tool_results_into_single_user_message() {
+        // Assistant emits two parallel tool_use blocks; runtime appends each
+        // tool_result as its own Tool-role ConversationMessage. Anthropic
+        // requires both tool_results in the same next user message — without
+        // the merge, the second tool_use's id has no matching tool_result in
+        // the immediately-following user turn, triggering a 400 error.
+        let messages = vec![
+            tool_use_multi(&[("call_a", "fn_a"), ("call_b", "fn_b")]),
+            tool_result("call_a", "fn_a", "result_a"),
+            tool_result("call_b", "fn_b", "result_b"),
+        ];
+
+        let converted = convert_messages(&messages);
+
+        assert_eq!(converted.len(), 2, "tool_results must be merged");
+        assert_eq!(converted[0].role, "assistant");
+        assert_eq!(converted[1].role, "user");
+        assert_eq!(converted[1].content.len(), 2);
+        for block in &converted[1].content {
+            assert!(matches!(block, InputContentBlock::ToolResult { .. }));
+        }
+    }
+
+    #[test]
+    fn convert_messages_does_not_merge_tool_result_into_plain_user_text() {
+        // If the previous user message is plain text (not a tool_result
+        // bundle), we must not merge a fresh tool_result into it.
+        let messages = vec![
+            ConversationMessage {
+                role: MessageRole::User,
+                blocks: vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+                usage: None,
+                model: None,
+            },
+            tool_use("call_a", "fn_a"),
+            tool_result("call_a", "fn_a", "ok"),
+        ];
+
+        let converted = convert_messages(&messages);
+
+        assert_eq!(converted.len(), 3);
+        assert_eq!(converted[0].role, "user");
+        assert!(matches!(
+            converted[0].content[0],
+            InputContentBlock::Text { .. }
+        ));
+        assert_eq!(converted[2].role, "user");
+        assert!(matches!(
+            converted[2].content[0],
+            InputContentBlock::ToolResult { .. }
+        ));
+    }
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -276,7 +276,8 @@ impl CliToolExecutor {
         };
 
         let fields = if !input.questions.is_empty() {
-            input.questions
+            input
+                .questions
                 .into_iter()
                 .map(|field| {
                     let options = field

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -2,7 +2,10 @@ use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use runtime::{PermissionMode, PermissionPolicy, ToolError, ToolExecutor};
+use runtime::{
+    PermissionMode, PermissionPolicy, QuestionField, QuestionKind, QuestionOption,
+    QuestionPromptAnswer, QuestionPromptRequest, QuestionPrompter, ToolError, ToolExecutor,
+};
 use serde::Deserialize;
 use tools::GlobalToolRegistry;
 
@@ -42,6 +45,7 @@ pub(crate) struct CliToolExecutor {
     tool_registry: GlobalToolRegistry,
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     spinner_pause: Option<Arc<AtomicBool>>,
+    question_prompter: Option<Box<dyn QuestionPrompter>>,
 }
 
 impl CliToolExecutor {
@@ -58,11 +62,16 @@ impl CliToolExecutor {
             tool_registry,
             mcp_state,
             spinner_pause: None,
+            question_prompter: None,
         }
     }
 
     pub(crate) fn set_spinner_pause(&mut self, flag: Arc<AtomicBool>) {
         self.spinner_pause = Some(flag);
+    }
+
+    pub(crate) fn set_question_prompter(&mut self, prompter: Box<dyn QuestionPrompter>) {
+        self.question_prompter = Some(prompter);
     }
 
     /// Pause the spinner and clear its line before writing content.
@@ -145,6 +154,21 @@ impl CliToolExecutor {
 
 impl ToolExecutor for CliToolExecutor {
     fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError> {
+        {
+            use std::io::Write as _;
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open("/tmp/scode-acp-diag.log")
+            {
+                let _ = writeln!(
+                    f,
+                    "[ACP-DIAG] execute tool_name={} prompter_set={}",
+                    tool_name,
+                    self.question_prompter.is_some()
+                );
+            }
+        }
         if self
             .allowed_tools
             .as_ref()
@@ -156,6 +180,9 @@ impl ToolExecutor for CliToolExecutor {
         }
         let value = serde_json::from_str(input)
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+        if tool_name == "AskUserQuestion" && self.question_prompter.is_some() {
+            return self.execute_ask_user_question(value);
+        }
         let result = if tool_name == "ToolSearch" {
             self.execute_search_tool(value)
         } else if self.tool_registry.has_runtime_tool(tool_name) {
@@ -189,6 +216,167 @@ impl ToolExecutor for CliToolExecutor {
                 Err(error)
             }
         }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AskUserQuestionCliInput {
+    question: Option<String>,
+    options: Option<Vec<String>>,
+    title: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    questions: Vec<AskUserQuestionCliField>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AskUserQuestionCliField {
+    id: String,
+    prompt: String,
+    kind: Option<String>,
+    required: Option<bool>,
+    allow_custom_input: Option<bool>,
+    custom_input_hint: Option<String>,
+    #[serde(default)]
+    options: Vec<AskUserQuestionCliOption>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AskUserQuestionCliOption {
+    label: String,
+    value: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    recommended: Option<bool>,
+}
+
+impl CliToolExecutor {
+    fn execute_ask_user_question(&mut self, value: serde_json::Value) -> Result<String, ToolError> {
+        {
+            use std::io::Write as _;
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open("/tmp/scode-acp-diag.log")
+            {
+                let _ = writeln!(f, "[ACP-DIAG] execute_ask_user_question invoked");
+            }
+        }
+        let input: AskUserQuestionCliInput = serde_json::from_value(value)
+            .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+
+        let Some(prompter) = self.question_prompter.as_mut() else {
+            return Err(ToolError::new(
+                "AskUserQuestion requires an interactive question prompter",
+            ));
+        };
+
+        let fields = if !input.questions.is_empty() {
+            input.questions
+                .into_iter()
+                .map(|field| {
+                    let options = field
+                        .options
+                        .into_iter()
+                        .map(|option| QuestionOption {
+                            label: option.label,
+                            value: option.value,
+                            description: option.description,
+                            recommended: option.recommended.unwrap_or(false),
+                        })
+                        .collect::<Vec<_>>();
+                    let kind = field
+                        .kind
+                        .as_deref()
+                        .and_then(QuestionKind::from_str)
+                        .unwrap_or_else(|| {
+                            if options.is_empty() {
+                                QuestionKind::Text
+                            } else {
+                                QuestionKind::SingleSelect
+                            }
+                        });
+                    QuestionField {
+                        id: field.id,
+                        prompt: field.prompt,
+                        kind,
+                        required: field.required.unwrap_or(true),
+                        allow_custom_input: field.allow_custom_input.unwrap_or(false),
+                        custom_input_hint: field.custom_input_hint,
+                        options,
+                    }
+                })
+                .collect::<Vec<_>>()
+        } else {
+            let prompt = input
+                .question
+                .map(|question| question.trim().to_string())
+                .filter(|question| !question.is_empty())
+                .ok_or_else(|| ToolError::new("question or questions is required"))?;
+            let options = input
+                .options
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|option| !option.trim().is_empty())
+                .map(|option| QuestionOption {
+                    label: option.clone(),
+                    value: option,
+                    description: None,
+                    recommended: false,
+                })
+                .collect::<Vec<_>>();
+            let kind = if options.is_empty() {
+                QuestionKind::Text
+            } else {
+                QuestionKind::SingleSelect
+            };
+            vec![QuestionField {
+                id: "q1".to_string(),
+                prompt,
+                kind,
+                required: true,
+                allow_custom_input: options.is_empty(),
+                custom_input_hint: None,
+                options,
+            }]
+        };
+
+        let request = QuestionPromptRequest {
+            title: input.title,
+            description: input.description,
+            fields,
+        };
+
+        let answers = prompter.ask(&request).map_err(ToolError::new)?;
+        serde_json::to_string_pretty(&serde_json::json!({
+            "status": "answered",
+            "title": request.title,
+            "description": request.description,
+            "questions": request.fields.iter().map(|field| serde_json::json!({
+              "id": field.id,
+              "prompt": field.prompt,
+              "kind": field.kind.as_str(),
+              "required": field.required,
+              "allowCustomInput": field.allow_custom_input,
+              "customInputHint": field.custom_input_hint,
+              "options": field.options.iter().map(|option| serde_json::json!({
+                "label": option.label,
+                "value": option.value,
+                "description": option.description,
+                "recommended": option.recommended,
+              })).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+            "answers": answers.iter().map(|answer| serde_json::json!({
+              "id": answer.id,
+              "value": answer.value,
+              "label": answer.label,
+            })).collect::<Vec<_>>(),
+        }))
+        .map_err(|error| ToolError::new(error.to_string()))
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1905,7 +1905,10 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
             runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
         })?;
-        session.runtime.tool_executor_mut().set_question_prompter(prompter);
+        session
+            .runtime
+            .tool_executor_mut()
+            .set_question_prompter(prompter);
         Ok(())
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1897,6 +1897,18 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         self.run_prompt_impl(session_id, prompt, observer, Some(prompter))
     }
 
+    fn set_question_prompter(
+        &mut self,
+        session_id: &str,
+        prompter: Box<dyn runtime::QuestionPrompter>,
+    ) -> Result<(), runtime::AcpError> {
+        let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
+            runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
+        })?;
+        session.runtime.tool_executor_mut().set_question_prompter(prompter);
+        Ok(())
+    }
+
     fn handle_slash_command(
         &mut self,
         session_id: &str,
@@ -2274,7 +2286,6 @@ impl AcpSdkDelegate {
                 return Err(runtime::AcpError::internal(user_message));
             }
         }
-
         self.inner
             .tokio_runtime
             .block_on(session.runtime.run_turn(prompt, prompter, Some(observer)))

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -5440,9 +5440,7 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
             .blocks
             .iter()
             .filter_map(|block| match block {
-                ContentBlock::Text { text } => {
-                    Some(InputContentBlock::Text { text: text.clone() })
-                }
+                ContentBlock::Text { text } => Some(InputContentBlock::Text { text: text.clone() }),
                 ContentBlock::Thinking { .. } => None,
                 ContentBlock::ToolUse {
                     id,
@@ -5488,9 +5486,10 @@ fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
         if matches!(message.role, MessageRole::Tool) {
             if let Some(last) = result.last_mut() {
                 if last.role == "user"
-                    && last.content.iter().all(|block| {
-                        matches!(block, InputContentBlock::ToolResult { .. })
-                    })
+                    && last
+                        .content
+                        .iter()
+                        .all(|block| matches!(block, InputContentBlock::ToolResult { .. }))
                 {
                     last.content.extend(content);
                     continue;
@@ -6877,10 +6876,9 @@ mod tests {
         classify_lane_failure, derive_agent_state, execute_agent_with_spawn, execute_tool,
         extract_recovery_outcome, final_assistant_text, global_cron_registry,
         maybe_commit_provenance, mvp_tool_specs, permission_mode_from_plugin,
-        persist_agent_terminal_state, push_output_block, run_task_packet, sweep_orphaned_tmp_files,
-        run_ask_user_question_v2, AgentInput, AgentJob, AskUserQuestionInput,
-        AskUserQuestionItem, AskUserQuestionOption, GlobalToolRegistry, LaneEventName,
-        LaneFailureClass,
+        persist_agent_terminal_state, push_output_block, run_ask_user_question_v2, run_task_packet,
+        sweep_orphaned_tmp_files, AgentInput, AgentJob, AskUserQuestionInput, AskUserQuestionItem,
+        AskUserQuestionOption, GlobalToolRegistry, LaneEventName, LaneFailureClass,
         SubagentToolExecutor,
     };
     use api::OutputContentBlock;

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod managed_agent;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -843,18 +844,51 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "AskUserQuestion",
-            description: "Ask the user a question and wait for their response.",
+            description: "Ask the user structured questions and wait for their response. Use this tool whenever you need user preferences, configuration values, first-run setup answers, or any other structured input. Prefer title/description/questions[] for multi-step forms; simple legacy question/options is still accepted. Do not ask numbered setup questions directly in plain assistant text when this tool is available.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
+                    "title": { "type": "string" },
+                    "description": { "type": "string" },
                     "question": { "type": "string" },
                     "options": {
                         "type": "array",
                         "items": { "type": "string" }
+                    },
+                    "questions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": { "type": "string" },
+                                "prompt": { "type": "string" },
+                                "kind": {
+                                    "type": "string",
+                                    "enum": ["single_select", "multi_select", "text", "boolean"]
+                                },
+                                "required": { "type": "boolean" },
+                                "allowCustomInput": { "type": "boolean" },
+                                "customInputHint": { "type": "string" },
+                                "options": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": { "type": "string" },
+                                            "value": { "type": "string" },
+                                            "description": { "type": "string" },
+                                            "recommended": { "type": "boolean" }
+                                        },
+                                        "required": ["label", "value"],
+                                        "additionalProperties": false
+                                    }
+                                }
+                            },
+                            "required": ["id", "prompt"],
+                            "additionalProperties": false
+                        }
                     }
-                },
-                "required": ["question"],
-                "additionalProperties": false
+                }
             }),
             required_permission: PermissionMode::ReadOnly,
         },
@@ -1442,16 +1476,25 @@ fn maybe_enforce_permission_check_with_mode(
 
 #[allow(clippy::needless_pass_by_value)]
 fn run_ask_user_question(input: AskUserQuestionInput) -> Result<String, String> {
-    use std::io::{self, BufRead, Write};
+    use std::io;
 
-    // Display the question to the user via stdout
     let stdout = io::stdout();
     let stdin = io::stdin();
     let mut out = stdout.lock();
+    let mut reader = stdin.lock();
 
-    writeln!(out, "\n[Question] {}", input.question).map_err(|e| e.to_string())?;
+    run_ask_user_question_v2(input, &mut out, &mut reader)
+}
 
-    if let Some(ref options) = input.options {
+fn prompt_user_for_answer(
+    out: &mut impl Write,
+    reader: &mut impl BufRead,
+    question: &str,
+    options: Option<&Vec<String>>,
+) -> Result<String, String> {
+    writeln!(out, "\n[Question] {question}").map_err(|e| e.to_string())?;
+
+    if let Some(options) = options {
         for (i, option) in options.iter().enumerate() {
             writeln!(out, "  {}. {}", i + 1, option).map_err(|e| e.to_string())?;
         }
@@ -1461,34 +1504,73 @@ fn run_ask_user_question(input: AskUserQuestionInput) -> Result<String, String> 
     }
     out.flush().map_err(|e| e.to_string())?;
 
-    // Read user response from stdin
     let mut response = String::new();
-    stdin
-        .lock()
-        .read_line(&mut response)
-        .map_err(|e| e.to_string())?;
+    reader.read_line(&mut response).map_err(|e| e.to_string())?;
     let response = response.trim().to_string();
 
-    // If options were provided, resolve the numeric choice
-    let answer = if let Some(ref options) = input.options {
+    if let Some(options) = options {
         if let Ok(idx) = response.parse::<usize>() {
             if idx >= 1 && idx <= options.len() {
-                options[idx - 1].clone()
-            } else {
-                response.clone()
+                return Ok(options[idx - 1].clone());
             }
-        } else {
-            response.clone()
         }
-    } else {
-        response.clone()
-    };
+    }
 
-    to_pretty_json(json!({
-        "question": input.question,
-        "answer": answer,
-        "status": "answered"
-    }))
+    Ok(response)
+}
+
+fn run_ask_user_question_v2(
+    input: AskUserQuestionInput,
+    out: &mut impl Write,
+    reader: &mut impl BufRead,
+) -> Result<String, String> {
+    let (title, description, questions) = normalize_ask_user_question_input(input)?;
+
+    if let Some(title) = &title {
+        writeln!(out, "\n[Question Set] {title}").map_err(|e| e.to_string())?;
+    }
+    if let Some(description) = &description {
+        writeln!(out, "{description}").map_err(|e| e.to_string())?;
+    }
+
+    let mut answers = Vec::with_capacity(questions.len());
+    for (index, item) in questions.iter().enumerate() {
+        let prompt = format!("{}. {}", index + 1, item.prompt);
+        let option_labels = if item.options.is_empty() {
+            None
+        } else {
+            Some(
+                item.options
+                    .iter()
+                    .map(|option| option.label.clone())
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        let answer = prompt_user_for_answer(out, reader, &prompt, option_labels.as_ref())?;
+        let matched_option = item
+            .options
+            .iter()
+            .find(|option| option.label == answer || option.value == answer);
+
+        answers.push(AskUserQuestionAnswer {
+            id: item.id.clone(),
+            value: matched_option
+                .map(|option| option.value.clone())
+                .unwrap_or_else(|| answer.clone()),
+            label: matched_option
+                .map(|option| option.label.clone())
+                .or_else(|| (!answer.is_empty()).then_some(answer)),
+        });
+    }
+
+    to_pretty_json(AskUserQuestionResult {
+        status: "answered".to_string(),
+        title,
+        description,
+        questions,
+        answers,
+    })
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -2596,10 +2678,111 @@ struct PowerShellInput {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct AskUserQuestionInput {
-    question: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    question: Option<String>,
     #[serde(default)]
     options: Option<Vec<String>>,
+    #[serde(default)]
+    questions: Vec<AskUserQuestionItem>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct AskUserQuestionItem {
+    id: String,
+    prompt: String,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    required: Option<bool>,
+    #[serde(default)]
+    allow_custom_input: Option<bool>,
+    #[serde(default)]
+    custom_input_hint: Option<String>,
+    #[serde(default)]
+    options: Vec<AskUserQuestionOption>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct AskUserQuestionOption {
+    label: String,
+    value: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    recommended: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AskUserQuestionAnswer {
+    id: String,
+    value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AskUserQuestionResult {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    questions: Vec<AskUserQuestionItem>,
+    answers: Vec<AskUserQuestionAnswer>,
+}
+
+fn normalize_ask_user_question_input(
+    input: AskUserQuestionInput,
+) -> Result<(Option<String>, Option<String>, Vec<AskUserQuestionItem>), String> {
+    if !input.questions.is_empty() {
+        return Ok((input.title, input.description, input.questions));
+    }
+
+    let question = input
+        .question
+        .map(|question| question.trim().to_string())
+        .filter(|question| !question.is_empty())
+        .ok_or_else(|| "question or questions is required".to_string())?;
+
+    let options = input
+        .options
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|option| !option.trim().is_empty())
+        .map(|option| AskUserQuestionOption {
+            label: option.clone(),
+            value: option,
+            description: None,
+            recommended: None,
+        })
+        .collect::<Vec<_>>();
+
+    Ok((
+        input.title,
+        input.description,
+        vec![AskUserQuestionItem {
+            id: "q1".to_string(),
+            prompt: question,
+            kind: Some(if options.is_empty() {
+                "text".to_string()
+            } else {
+                "single_select".to_string()
+            }),
+            required: Some(true),
+            allow_custom_input: Some(options.is_empty()),
+            custom_input_hint: None,
+            options,
+        }],
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -5247,60 +5430,79 @@ fn tool_specs_for_allowed_tools(allowed_tools: Option<&BTreeSet<String>>) -> Vec
 }
 
 fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
-    messages
-        .iter()
-        .filter_map(|message| {
-            let role = match message.role {
-                MessageRole::System | MessageRole::User | MessageRole::Tool => "user",
-                MessageRole::Assistant => "assistant",
-            };
-            let content = message
-                .blocks
-                .iter()
-                .filter_map(|block| match block {
-                    ContentBlock::Text { text } => {
-                        Some(InputContentBlock::Text { text: text.clone() })
-                    }
-                    ContentBlock::Thinking { .. } => None,
-                    ContentBlock::ToolUse {
-                        id,
-                        name,
-                        input,
-                        thought_signature,
-                    } => Some(InputContentBlock::ToolUse {
-                        id: id.clone(),
-                        name: name.clone(),
-                        input: serde_json::from_str(input)
-                            .unwrap_or_else(|_| serde_json::json!({ "raw": input })),
-                        thought_signature: thought_signature.clone(),
-                    }),
-                    ContentBlock::ToolResult {
-                        tool_use_id,
-                        output,
-                        is_error,
-                        ..
-                    } => Some(InputContentBlock::ToolResult {
-                        tool_use_id: tool_use_id.clone(),
-                        content: vec![ToolResultContentBlock::Text {
-                            text: output.clone(),
-                        }],
-                        is_error: *is_error,
-                    }),
-                    ContentBlock::Image { data, mime_type } => Some(InputContentBlock::Image {
-                        source: api::ImageSource {
-                            source_type: "base64".to_string(),
-                            media_type: mime_type.clone(),
-                            data: data.clone(),
-                        },
-                    }),
-                })
-                .collect::<Vec<_>>();
-            (!content.is_empty()).then(|| InputMessage {
-                role: role.to_string(),
-                content,
+    let mut result: Vec<InputMessage> = Vec::with_capacity(messages.len());
+    for message in messages {
+        let role = match message.role {
+            MessageRole::System | MessageRole::User | MessageRole::Tool => "user",
+            MessageRole::Assistant => "assistant",
+        };
+        let content = message
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => {
+                    Some(InputContentBlock::Text { text: text.clone() })
+                }
+                ContentBlock::Thinking { .. } => None,
+                ContentBlock::ToolUse {
+                    id,
+                    name,
+                    input,
+                    thought_signature,
+                } => Some(InputContentBlock::ToolUse {
+                    id: id.clone(),
+                    name: name.clone(),
+                    input: serde_json::from_str(input)
+                        .unwrap_or_else(|_| serde_json::json!({ "raw": input })),
+                    thought_signature: thought_signature.clone(),
+                }),
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    output,
+                    is_error,
+                    ..
+                } => Some(InputContentBlock::ToolResult {
+                    tool_use_id: tool_use_id.clone(),
+                    content: vec![ToolResultContentBlock::Text {
+                        text: output.clone(),
+                    }],
+                    is_error: *is_error,
+                }),
+                ContentBlock::Image { data, mime_type } => Some(InputContentBlock::Image {
+                    source: api::ImageSource {
+                        source_type: "base64".to_string(),
+                        media_type: mime_type.clone(),
+                        data: data.clone(),
+                    },
+                }),
             })
-        })
-        .collect()
+            .collect::<Vec<_>>();
+        if content.is_empty() {
+            continue;
+        }
+
+        // Merge consecutive Tool-role messages into the previous user-role
+        // InputMessage. Anthropic requires every `tool_use` in an assistant
+        // turn to have its matching `tool_result` in the SAME next user
+        // message; emitting one user message per tool_result breaks this.
+        if matches!(message.role, MessageRole::Tool) {
+            if let Some(last) = result.last_mut() {
+                if last.role == "user"
+                    && last.content.iter().all(|block| {
+                        matches!(block, InputContentBlock::ToolResult { .. })
+                    })
+                {
+                    last.content.extend(content);
+                    continue;
+                }
+            }
+        }
+        result.push(InputMessage {
+            role: role.to_string(),
+            content,
+        });
+    }
+    result
 }
 
 fn push_output_block(
@@ -6676,7 +6878,9 @@ mod tests {
         extract_recovery_outcome, final_assistant_text, global_cron_registry,
         maybe_commit_provenance, mvp_tool_specs, permission_mode_from_plugin,
         persist_agent_terminal_state, push_output_block, run_task_packet, sweep_orphaned_tmp_files,
-        AgentInput, AgentJob, GlobalToolRegistry, LaneEventName, LaneFailureClass,
+        run_ask_user_question_v2, AgentInput, AgentJob, AskUserQuestionInput,
+        AskUserQuestionItem, AskUserQuestionOption, GlobalToolRegistry, LaneEventName,
+        LaneFailureClass,
         SubagentToolExecutor,
     };
     use api::OutputContentBlock;
@@ -9915,6 +10119,100 @@ mod tests {
         assert!(output["sentAt"].as_str().is_some());
         assert_eq!(output["attachments"][0]["isImage"], true);
         let _ = std::fs::remove_file(attachment);
+    }
+
+    #[test]
+    fn ask_user_question_v2_returns_structured_answers() {
+        use std::io::Cursor;
+
+        let input = AskUserQuestionInput {
+            question: None,
+            options: None,
+            title: Some("Initial setup".to_string()),
+            description: Some("Please answer the following.".to_string()),
+            questions: vec![
+                AskUserQuestionItem {
+                    id: "save_scope".to_string(),
+                    prompt: "Where to save preferences?".to_string(),
+                    kind: Some("single_select".to_string()),
+                    required: Some(true),
+                    allow_custom_input: Some(false),
+                    custom_input_hint: None,
+                    options: vec![
+                        AskUserQuestionOption {
+                            label: "Project".to_string(),
+                            value: "project".to_string(),
+                            description: None,
+                            recommended: Some(true),
+                        },
+                        AskUserQuestionOption {
+                            label: "User".to_string(),
+                            value: "user".to_string(),
+                            description: None,
+                            recommended: None,
+                        },
+                    ],
+                },
+                AskUserQuestionItem {
+                    id: "default_language".to_string(),
+                    prompt: "Default language?".to_string(),
+                    kind: Some("single_select".to_string()),
+                    required: Some(true),
+                    allow_custom_input: Some(false),
+                    custom_input_hint: None,
+                    options: vec![
+                        AskUserQuestionOption {
+                            label: "zh-CN".to_string(),
+                            value: "zh-CN".to_string(),
+                            description: None,
+                            recommended: None,
+                        },
+                        AskUserQuestionOption {
+                            label: "en-US".to_string(),
+                            value: "en-US".to_string(),
+                            description: None,
+                            recommended: None,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        let mut output = Vec::new();
+        let mut input_reader = Cursor::new(b"1\n2\n".to_vec());
+        let result = run_ask_user_question_v2(input, &mut output, &mut input_reader)
+            .expect("AskUserQuestion v2 should succeed");
+        let json: serde_json::Value = serde_json::from_str(&result).expect("json");
+
+        assert_eq!(json["status"], "answered");
+        assert_eq!(json["title"], "Initial setup");
+        assert_eq!(json["questions"][0]["id"], "save_scope");
+        assert_eq!(json["answers"][0]["id"], "save_scope");
+        assert_eq!(json["answers"][0]["value"], "project");
+        assert_eq!(json["answers"][0]["label"], "Project");
+        assert_eq!(json["answers"][1]["value"], "en-US");
+        assert!(String::from_utf8(output)
+            .expect("utf8")
+            .contains("[Question Set] Initial setup"));
+    }
+
+    #[test]
+    fn ask_user_question_v2_requires_non_empty_questions() {
+        use std::io::Cursor;
+
+        let input = AskUserQuestionInput {
+            question: None,
+            options: None,
+            title: None,
+            description: None,
+            questions: vec![],
+        };
+
+        let mut output = Vec::new();
+        let mut input_reader = Cursor::new(Vec::<u8>::new());
+        let error = run_ask_user_question_v2(input, &mut output, &mut input_reader)
+            .expect_err("empty questions should fail");
+        assert!(error.contains("question or questions is required"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds structured question support for the AskUserQuestion tool in ACP protocol mode, enabling sudowork to render interactive question UI and receive user answers.

### Key Changes

- **New Types** (`permissions.rs`): Add `QuestionPrompter` trait, `QuestionField`, `QuestionOption`, `QuestionKind`, `QuestionPromptRequest`, `QuestionPromptAnswer`
- **Tool Executor** (`tool_executor.rs`): Add `question_prompter` field and `execute_ask_user_question()` for ACP mode
- **ToolSpec Upgrade** (`tools/lib.rs`): Extend AskUserQuestion schema with `title`, `description`, `questions[]` for multi-step forms
- **ACP Extension** (`acp_sdk_server.rs`): Add `_scode/ask_user_question` method and `set_question_prompter` delegate
- **Gemini Fix** (`gemini.rs`): Fix `functionResponse.name` matching to prevent empty tool result responses
- **Critical Fix**: Catch-all handler now returns `Handled::No` for Response variants to avoid overwriting real responses with `method_not_found`

### Impact

| Mode | Behavior |
|------|----------|
| Standalone CLI | No change - stdin/stdout interactive prompts |
| ACP Mode (sudowork) | New structured question UI via `QuestionPrompter` |
| Gemini | Tool results now correctly returned |

### Backward Compatibility

- Legacy `question` + `options` format still supported
- Auto-converted to `questions[]` structure internally

## Test Plan

- [x] Test AskUserQuestion in sudowork ACP mode with Claude/GPT/Gemini
- [x] Verify multi-step forms render correctly
- [x] Confirm answers are returned to LLM for continued execution
- [x] Test backward compatibility with simple question format
- [x] Verify Gemini tool results no longer produce empty responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)