### PR TITLE
fix(cli): carry prompt_known_date across REPL turn rebuilds

### DIFF
--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -259,6 +259,17 @@ where
         self
     }
 
+    /// Date currently treated as "when the cached system prompt was frozen".
+    /// Exposed so the CLI can propagate this state across runtime rebuilds —
+    /// the runtime advances it after firing a date-rollover reminder, and a
+    /// rebuild that didn't carry it forward would reset the state and re-fire
+    /// the reminder (or suppress it entirely when the rebuild stamps today's
+    /// date over the original known date).
+    #[must_use]
+    pub fn prompt_known_date(&self) -> Option<&str> {
+        self.prompt_known_date.as_deref()
+    }
+
     #[must_use]
     pub fn with_max_iterations(mut self, max_iterations: usize) -> Self {
         self.max_iterations = max_iterations;
@@ -2579,6 +2590,77 @@ mod tests {
             second_turn_user_blocks.len(),
             1,
             "reminder must not repeat after rollover acknowledged"
+        );
+        assert!(matches!(
+            &second_turn_user_blocks[0],
+            ContentBlock::Text { text } if text == "second"
+        ));
+    }
+
+    #[tokio::test]
+    async fn prompt_known_date_advances_after_rollover_and_can_be_carried_over() {
+        // Models the CLI rebuild path: a fresh runtime inherits the previous
+        // runtime's `prompt_known_date()` so the rollover reminder fires
+        // exactly once per actual date change, even when the runtime is
+        // reconstructed every turn (see issue #135).
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut first = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_date("2026-05-15");
+        first.today_override = Some("2026-05-19".to_string());
+
+        first
+            .run_turn("first", None, None)
+            .await
+            .expect("first turn");
+        // Reminder fires and the runtime advances its known date to today.
+        assert_eq!(first.prompt_known_date(), Some("2026-05-19"));
+
+        let carried = first
+            .prompt_known_date()
+            .expect("known date should be set")
+            .to_string();
+
+        // Simulate `prepare_turn_runtime` rebuilding the runtime for the next
+        // turn while inheriting the advanced known date from the previous
+        // runtime.
+        let mut second = ConversationRuntime::new(
+            first.session().clone(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_date(carried);
+        second.today_override = Some("2026-05-19".to_string());
+
+        second
+            .run_turn("second", None, None)
+            .await
+            .expect("second turn");
+
+        let requests = captured.lock().expect("captured mutex");
+        let second_turn_user_blocks = requests[1]
+            .messages
+            .iter()
+            .filter(|m| m.role == MessageRole::User)
+            .last()
+            .expect("user message")
+            .blocks
+            .clone();
+        assert_eq!(
+            second_turn_user_blocks.len(),
+            1,
+            "carrying over the advanced known date must suppress a duplicate reminder"
         );
         assert!(matches!(
             &second_turn_user_blocks[0],

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1506,6 +1506,15 @@ impl BuiltRuntime {
         self
     }
 
+    fn with_session_known_date(mut self, date: impl Into<String>) -> Self {
+        let runtime = self
+            .runtime
+            .take()
+            .expect("runtime should exist before overriding session known date");
+        self.runtime = Some(runtime.with_session_known_date(date));
+        self
+    }
+
     fn shutdown_plugins(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if self.plugins_active {
             self.plugin_registry.shutdown()?;
@@ -2575,7 +2584,14 @@ impl LiveCli {
         emit_output: bool,
     ) -> Result<(BuiltRuntime, HookAbortMonitor), Box<dyn std::error::Error>> {
         let hook_abort_signal = runtime::HookAbortSignal::new();
-        let runtime = build_runtime(
+        // `build_runtime` stamps `prompt_known_date` with today's local date,
+        // which is correct only for a freshly-created runtime. The REPL
+        // rebuilds the runtime on every turn, so without carrying this date
+        // forward a long-running session that crosses midnight would have its
+        // known date silently advanced to today on every turn — suppressing
+        // the date-rollover reminder added in #128 (see issue #135).
+        let inherited_known_date = self.runtime.prompt_known_date().map(str::to_string);
+        let mut runtime = build_runtime(
             self.runtime.session().clone(),
             &self.session.id,
             RuntimeConfig {
@@ -2584,6 +2600,9 @@ impl LiveCli {
             },
         )?
         .with_hook_abort_signal(hook_abort_signal.clone());
+        if let Some(known) = inherited_known_date {
+            runtime = runtime.with_session_known_date(known);
+        }
         let hook_abort_monitor = HookAbortMonitor::spawn(hook_abort_signal);
 
         Ok((runtime, hook_abort_monitor))


### PR DESCRIPTION
Closes #135.

## Summary
- The REPL rebuilds `ConversationRuntime` on every turn via `prepare_turn_runtime`, which calls `build_runtime` - and `build_runtime` stamps `prompt_known_date` with `today_local()`. In a long-running TUI session that crosses midnight, that stamp silently advances the known date to today every turn, so the date-rollover `<system-reminder>` added in #128 never fires.
- Expose `ConversationRuntime::prompt_known_date()` and have `prepare_turn_runtime` propagate that value from the previous runtime to the newly built one. The runtime continues to advance its own known date after firing a reminder, so subsequent turns on the same day don't repeat it.

## Test plan
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Manual: keep a REPL/TUI session open across a local midnight and confirm the next turn receives a `<system-reminder>` about the date change.

Generated with [Claude Code](https://claude.ai/code)