### PR TITLE
feat: optimize logging system with request tracking and trace_id pass-through

### DIFF
--- a/docs/plans/2026-05-20-log-optimization.md
+++ b/docs/plans/2026-05-20-log-optimization.md
@@ -1,0 +1,250 @@
+# 日志系统优化方案
+
+## 问题分析
+
+### 1. 重复记录问题 (严重)
+
+当前日志存在大量重复记录:
+
+| 事件类型 | 重复情况 | 根因 |
+|---------|---------|------|
+| `session_started` | 每次会话 2 条 | `record_session_started` 调用了 `sink.record()` 和 `self.record()` |
+| `request_started` + `http_request_started` | 每次请求 2 条 | 同上 |
+| `request_succeeded` + `http_request_succeeded` | 每次成功 2 条 | 同上 |
+| `request_failed` + `http_request_failed` | 每次失败 2 条 | 同上 |
+
+**代码位置**: `telemetry/src/lib.rs` 中 `SessionTracer` 的方法
+
+```rust
+// 当前实现 (有重复)
+pub fn record_http_request_started(...) {
+    self.sink.record(TelemetryEvent::HttpRequestStarted {...});  // 第1条
+    self.record("http_request_started", ...);                     // 第2条 (SessionTrace)
+}
+```
+
+### 2. 缺少 request_id 用于对账
+
+当前 `request_debug` 没有唯一的 request_id，无法与大模型提供商对账。
+
+### 3. 日志级别单一
+
+所有日志都是 `info` 级别，无法过滤:
+- `request_debug` → 应该是 `debug` 级别
+- `request_failed` → 应该是 `warn` 或 `error` 级别
+
+### 4. 缺少关键指标
+
+- 没有请求耗时 (duration_ms)
+- 没有请求/响应大小
+
+---
+
+## 优化方案
+
+### 方案 A: 消除重复记录 (推荐)
+
+**修改 `SessionTracer` 方法，只保留一条记录:**
+
+```rust
+// 优化后: 只记录一次
+pub fn record_http_request_started(...) {
+    // 只调用 sink.record，不再调用 self.record
+    self.sink.record(TelemetryEvent::HttpRequestStarted {
+        session_id: self.session_id.clone(),
+        attempt,
+        method,
+        path,
+        attributes,
+    });
+}
+```
+
+**影响**:
+- 日志量减少 ~50%
+- 不再有 `http_request_*` 和 `request_*` 两种事件名
+- 统一使用 `request_started`, `request_succeeded`, `request_failed`
+
+### 方案 B: 添加 request_id 用于对账
+
+**为每次请求生成唯一 request_id:**
+
+```rust
+use uuid::Uuid;
+
+pub fn record_http_request_debug(...) {
+    let request_id = Uuid::new_v4().to_string();  // 生成唯一 ID
+    self.sink.record(TelemetryEvent::HttpRequestDebug {
+        session_id: self.session_id.clone(),
+        request_id,  // 新增: 用于对账
+        timestamp_ms: current_timestamp_ms(),
+        url,
+        method,
+        headers,
+        body,
+    });
+}
+```
+
+**request_id 格式**: `req_` + UUID v4，例如 `req_550e8400-e29b-41d4-a716-446655440000`
+
+**用途**:
+1. 用户排查问题时可通过 request_id 定位具体请求
+2. 与大模型提供商对账时提供唯一标识
+3. 关联同一请求的 started/debug/succeeded/failed 事件
+
+### 方案 C: 添加请求耗时
+
+**在 `HttpRequestStarted` 和 `HttpRequestSucceeded` 中添加时间戳:**
+
+```rust
+HttpRequestStarted {
+    session_id: String,
+    request_id: String,  // 新增: 关联请求
+    attempt: u32,
+    method: String,
+    path: String,
+    timestamp_ms: u64,   // 新增: 请求开始时间
+    attributes: Map<String, Value>,
+}
+
+HttpRequestSucceeded {
+    session_id: String,
+    request_id: String,  // 新增: 关联请求
+    attempt: u32,
+    method: String,
+    path: String,
+    status: u16,
+    duration_ms: u64,    // 新增: 请求耗时
+    provider_request_id: Option<String>,  // 重命名: 提供商返回的 request-id
+    attributes: Map<String, Value>,
+}
+```
+
+### 方案 D: 添加日志级别
+
+**根据事件类型设置日志级别:**
+
+```rust
+fn get_log_level(event: &TelemetryEvent) -> &'static str {
+    match event {
+        TelemetryEvent::HttpRequestDebug { .. } => "debug",
+        TelemetryEvent::HttpRequestFailed { .. } => "warn",
+        TelemetryEvent::SessionEnded { .. } => "info",
+        _ => "info",
+    }
+}
+```
+
+---
+
+## 推荐实施顺序
+
+1. **方案 A** - 消除重复记录 (最大收益，减少 ~50% 日志量)
+2. **方案 B** - 添加 request_id (对账需求)
+3. **方案 C** - 添加耗时指标 (增强可观测性)
+4. **方案 D** - 添加日志级别过滤 (灵活性)
+
+---
+
+## 实施后的日志格式
+
+### request_started (请求开始)
+```json
+{
+  "timestamp": "2026-05-20T10:00:00.000+08:00",
+  "level": "info",
+  "session_id": "session-123",
+  "component": "scode",
+  "event": "request_started",
+  "attributes": {
+    "request_id": "req_550e8400-e29b-41d4-a716-446655440000",
+    "attempt": 1,
+    "method": "POST",
+    "path": "/v1/chat/completions",
+    "timestamp_ms": 1716163200000
+  }
+}
+```
+
+### request_debug (请求详情 - debug 级别)
+```json
+{
+  "timestamp": "2026-05-20T10:00:00.100+08:00",
+  "level": "debug",
+  "session_id": "session-123",
+  "component": "scode",
+  "event": "request_debug",
+  "attributes": {
+    "request_id": "req_550e8400-e29b-41d4-a716-446655440000",
+    "url": "https://api.anthropic.com/v1/messages",
+    "method": "POST",
+    "headers": {"x-api-key": "sk-ant-... (hidden)"},
+    "body": {"model": "claude-sonnet-4-6", "messages": [...]}
+  }
+}
+```
+
+### request_succeeded (请求成功)
+```json
+{
+  "timestamp": "2026-05-20T10:00:01.500+08:00",
+  "level": "info",
+  "session_id": "session-123",
+  "component": "scode",
+  "event": "request_succeeded",
+  "attributes": {
+    "request_id": "req_550e8400-e29b-41d4-a716-446655440000",
+    "attempt": 1,
+    "method": "POST",
+    "path": "/v1/chat/completions",
+    "status": 200,
+    "duration_ms": 1500,
+    "provider_request_id": "req_abc123_from_provider"
+  }
+}
+```
+
+### request_failed (请求失败 - warn 级别)
+```json
+{
+  "timestamp": "2026-05-20T10:00:02.000+08:00",
+  "level": "warn",
+  "session_id": "session-123",
+  "component": "scode",
+  "event": "request_failed",
+  "attributes": {
+    "request_id": "req_550e8400-e29b-41d4-a716-446655440000",
+    "attempt": 3,
+    "method": "POST",
+    "path": "/v1/chat/completions",
+    "error": "rate limit exceeded",
+    "retryable": true
+  }
+}
+```
+
+---
+
+## request_id 设计说明
+
+### 生成规则
+- 格式: `req_` + UUID v4
+- 示例: `req_550e8400-e29b-41d4-a716-446655440000`
+- 在请求开始时生成，贯穿整个请求生命周期
+
+### 与 provider_request_id 的区别
+
+| 字段 | 来源 | 用途 |
+|-----|------|------|
+| `request_id` | 客户端生成 | 内部追踪、用户排查问题 |
+| `provider_request_id` | 提供商返回 (响应头中的 request-id) | 与提供商对账 |
+
+### 关联查询
+
+用户可以通过 request_id 关联一次请求的所有日志:
+
+```bash
+# 查询某次请求的所有日志
+cat scode.log | jq 'select(.attributes.request_id == "req_550e8400-e29b-41d4-a716-446655440000")'
+```

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "serde_json",
  "telemetry",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/rust/crates/api/Cargo.toml
+++ b/rust/crates/api/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
 telemetry = { path = "../telemetry" }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -203,34 +203,36 @@ impl ProviderClient {
     pub async fn send_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageResponse, ApiError> {
         match self {
-            Self::Anthropic(client) => client.send_message(request).await,
-            Self::Xai(client) | Self::OpenAi(client) => client.send_message(request).await,
-            Self::Codex(client) => client.send_message(request).await,
-            Self::Gemini(client) => client.send_message(request).await,
+            Self::Anthropic(client) => client.send_message(request, trace_id).await,
+            Self::Xai(client) | Self::OpenAi(client) => client.send_message(request, trace_id).await,
+            Self::Codex(client) => client.send_message(request, trace_id).await,
+            Self::Gemini(client) => client.send_message(request, trace_id).await,
         }
     }
 
     pub async fn stream_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         match self {
             Self::Anthropic(client) => client
-                .stream_message(request)
+                .stream_message(request, trace_id)
                 .await
                 .map(MessageStream::Anthropic),
             Self::Xai(client) | Self::OpenAi(client) => client
-                .stream_message(request)
+                .stream_message(request, trace_id)
                 .await
                 .map(MessageStream::OpenAiCompat),
             Self::Codex(client) => client
-                .stream_message(request)
+                .stream_message(request, trace_id)
                 .await
                 .map(MessageStream::Codex),
             Self::Gemini(client) => client
-                .stream_message(request)
+                .stream_message(request, trace_id)
                 .await
                 .map(MessageStream::Gemini),
         }

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -207,7 +207,9 @@ impl ProviderClient {
     ) -> Result<MessageResponse, ApiError> {
         match self {
             Self::Anthropic(client) => client.send_message(request, trace_id).await,
-            Self::Xai(client) | Self::OpenAi(client) => client.send_message(request, trace_id).await,
+            Self::Xai(client) | Self::OpenAi(client) => {
+                client.send_message(request, trace_id).await
+            }
             Self::Codex(client) => client.send_message(request, trace_id).await,
             Self::Gemini(client) => client.send_message(request, trace_id).await,
         }

--- a/rust/crates/api/src/http_transport.rs
+++ b/rust/crates/api/src/http_transport.rs
@@ -15,6 +15,25 @@ use crate::http_client::build_http_client_or_default;
 
 const REQUEST_ID_HEADER: &str = "request-id";
 const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+const ONEAPI_REQUEST_ID_HEADER: &str = "x-oneapi-request-id";
+
+/// Result of a successful HTTP request with tracking information.
+pub struct HttpRequestResult {
+    /// The HTTP response.
+    pub response: reqwest::Response,
+    /// Client-generated unique request ID for tracking.
+    pub request_id: String,
+}
+
+/// Returns the current timestamp in milliseconds since Unix epoch.
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
 
 // ---------------------------------------------------------------------------
 // RetryPolicy
@@ -110,6 +129,7 @@ impl HttpTransport {
     ///
     /// `check_response` is provider-specific error parsing (non-2xx → `ApiError`).
     /// The transport uses `error.is_retryable()` to decide whether to retry.
+    /// Returns `HttpRequestResult` with the response and client-generated `request_id`.
     pub async fn send_json<F, Fut>(
         &self,
         url: &str,
@@ -117,7 +137,7 @@ impl HttpTransport {
         body: &Value,
         retry_policy: &RetryPolicy,
         check_response: F,
-    ) -> Result<reqwest::Response, ApiError>
+    ) -> Result<HttpRequestResult, ApiError>
     where
         F: Fn(reqwest::Response) -> Fut,
         Fut: Future<Output = Result<reqwest::Response, ApiError>>,
@@ -126,18 +146,28 @@ impl HttpTransport {
         let mut attempts = 0u32;
         let mut last_error: Option<ApiError>;
 
+        // Generate a unique request_id for this entire request lifecycle (including retries)
+        let request_id = format!("req_{}", uuid::Uuid::new_v4());
+
         loop {
             attempts += 1;
+            let start_timestamp_ms = current_timestamp_ms();
 
             // Log started.
             if let Some(tracer) = &self.session_tracer {
-                tracer.record_http_request_started(attempts, "POST", &path, Map::new());
+                tracer.record_http_request_started(
+                    &request_id,
+                    attempts,
+                    "POST",
+                    &path,
+                    Map::new(),
+                );
             }
 
             // Log debug (every attempt — matches existing Anthropic behavior).
             if let Some(tracer) = &self.session_tracer {
                 let masked = telemetry::mask_sensitive_headers(headers);
-                tracer.record_http_request_debug(url, "POST", masked, body.clone());
+                tracer.record_http_request_debug(&request_id, url, "POST", masked, body.clone());
             }
 
             // Build and send request.
@@ -150,37 +180,69 @@ impl HttpTransport {
             };
 
             match send_result {
-                Ok(response) => match check_response(response).await {
-                    Ok(response) => {
-                        if let Some(tracer) = &self.session_tracer {
-                            tracer.record_http_request_succeeded(
-                                attempts,
-                                "POST",
-                                &path,
-                                response.status().as_u16(),
-                                request_id_from_headers(response.headers()),
-                                Map::new(),
-                            );
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    let response_headers = mask_response_headers(response.headers());
+
+                    // Check if this is a streaming response (content-type: text/event-stream)
+                    let is_streaming = response_headers
+                        .get("content-type")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.contains("text/event-stream"))
+                        .unwrap_or(false);
+
+                    match check_response(response).await {
+                        Ok(response) => {
+                            // Log response debug after successful check
+                            // For streaming responses, body is consumed via SSE events
+                            if let Some(tracer) = &self.session_tracer {
+                                tracer.record_http_response_debug(
+                                    &request_id,
+                                    status,
+                                    response_headers,
+                                    if is_streaming {
+                                        serde_json::json!({"streaming": true, "note": "Response body consumed via SSE events"})
+                                    } else {
+                                        Value::Null
+                                    },
+                                );
+                            }
+
+                            if let Some(tracer) = &self.session_tracer {
+                                tracer.record_http_request_succeeded(
+                                    &request_id,
+                                    attempts,
+                                    "POST",
+                                    &path,
+                                    status,
+                                    start_timestamp_ms,
+                                    request_id_from_headers(response.headers()),
+                                    Map::new(),
+                                );
+                            }
+                            return Ok(HttpRequestResult {
+                                response,
+                                request_id,
+                            });
                         }
-                        return Ok(response);
+                        Err(error)
+                            if error.is_retryable() && attempts <= retry_policy.max_retries + 1 =>
+                        {
+                            self.record_failure(&request_id, attempts, &path, &error, start_timestamp_ms);
+                            last_error = Some(error);
+                        }
+                        Err(error) => {
+                            self.record_failure(&request_id, attempts, &path, &error, start_timestamp_ms);
+                            return Err(error);
+                        }
                     }
-                    Err(error)
-                        if error.is_retryable() && attempts <= retry_policy.max_retries + 1 =>
-                    {
-                        self.record_failure(attempts, &path, &error);
-                        last_error = Some(error);
-                    }
-                    Err(error) => {
-                        self.record_failure(attempts, &path, &error);
-                        return Err(error);
-                    }
-                },
+                }
                 Err(error) if error.is_retryable() && attempts <= retry_policy.max_retries + 1 => {
-                    self.record_failure(attempts, &path, &error);
+                    self.record_failure(&request_id, attempts, &path, &error, start_timestamp_ms);
                     last_error = Some(error);
                 }
                 Err(error) => {
-                    self.record_failure(attempts, &path, &error);
+                    self.record_failure(&request_id, attempts, &path, &error, start_timestamp_ms);
                     return Err(error);
                 }
             }
@@ -198,14 +260,23 @@ impl HttpTransport {
         })
     }
 
-    fn record_failure(&self, attempt: u32, path: &str, error: &ApiError) {
+    fn record_failure(
+        &self,
+        request_id: &str,
+        attempt: u32,
+        path: &str,
+        error: &ApiError,
+        start_timestamp_ms: u64,
+    ) {
         if let Some(tracer) = &self.session_tracer {
             tracer.record_http_request_failed(
+                request_id,
                 attempt,
                 "POST",
                 path,
                 error.to_string(),
                 error.is_retryable(),
+                start_timestamp_ms,
                 Map::new(),
             );
         }
@@ -215,6 +286,24 @@ impl HttpTransport {
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+/// Mask sensitive response header values for debug capture logs.
+fn mask_response_headers(headers: &reqwest::header::HeaderMap) -> Map<String, Value> {
+    let mut map = Map::new();
+    for (key, value) in headers {
+        let key_str = key.to_string();
+        let value_str = value.to_str().unwrap_or("").to_string();
+        // Mask sensitive headers
+        let lower = key_str.to_ascii_lowercase();
+        let masked = if lower == "set-cookie" || lower.contains("auth") {
+            "... (hidden)".to_string()
+        } else {
+            value_str
+        };
+        map.insert(key_str, Value::String(masked));
+    }
+    map
+}
 
 /// Extract the URL path for logging
 /// (e.g., `"https://api.anthropic.com/v1/messages"` → `"/v1/messages"`).
@@ -230,11 +319,16 @@ fn extract_path(url: &str) -> String {
     url.to_string()
 }
 
-/// Extract request ID from response headers (`request-id` or `x-request-id`).
+/// Extract request ID from response headers.
+/// Checks multiple header names in order of preference:
+/// 1. `request-id` (Anthropic standard)
+/// 2. `x-request-id` (Common alternative)
+/// 3. `x-oneapi-request-id` (OneAPI gateways)
 pub fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {
     headers
         .get(REQUEST_ID_HEADER)
         .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .or_else(|| headers.get(ONEAPI_REQUEST_ID_HEADER))
         .and_then(|value| value.to_str().ok())
         .map(ToOwned::to_owned)
 }

--- a/rust/crates/api/src/http_transport.rs
+++ b/rust/crates/api/src/http_transport.rs
@@ -176,8 +176,17 @@ impl HttpTransport {
             // Include X-Request-ID in the logged headers for visibility.
             if let Some(tracer) = &self.session_tracer {
                 let mut logged_headers = telemetry::mask_sensitive_headers(headers);
-                logged_headers.insert("X-Request-ID".to_string(), Value::String(request_id.clone()));
-                tracer.record_http_request_debug(&request_id, url, "POST", logged_headers, body.clone());
+                logged_headers.insert(
+                    "X-Request-ID".to_string(),
+                    Value::String(request_id.clone()),
+                );
+                tracer.record_http_request_debug(
+                    &request_id,
+                    url,
+                    "POST",
+                    logged_headers,
+                    body.clone(),
+                );
             }
 
             // Build and send request.
@@ -190,7 +199,10 @@ impl HttpTransport {
                 builder = builder.header("X-Request-ID", &request_id);
                 // Debug: print when trace_id is provided (from external source)
                 if trace_id.is_some() {
-                    eprintln!("[TRACE-ID] Sending request with X-Request-ID: {}", request_id);
+                    eprintln!(
+                        "[TRACE-ID] Sending request with X-Request-ID: {}",
+                        request_id
+                    );
                 }
                 builder.json(body).send().await.map_err(ApiError::from)
             };
@@ -244,11 +256,23 @@ impl HttpTransport {
                         Err(error)
                             if error.is_retryable() && attempts <= retry_policy.max_retries + 1 =>
                         {
-                            self.record_failure(&request_id, attempts, &path, &error, start_timestamp_ms);
+                            self.record_failure(
+                                &request_id,
+                                attempts,
+                                &path,
+                                &error,
+                                start_timestamp_ms,
+                            );
                             last_error = Some(error);
                         }
                         Err(error) => {
-                            self.record_failure(&request_id, attempts, &path, &error, start_timestamp_ms);
+                            self.record_failure(
+                                &request_id,
+                                attempts,
+                                &path,
+                                &error,
+                                start_timestamp_ms,
+                            );
                             return Err(error);
                         }
                     }

--- a/rust/crates/api/src/http_transport.rs
+++ b/rust/crates/api/src/http_transport.rs
@@ -130,6 +130,11 @@ impl HttpTransport {
     /// `check_response` is provider-specific error parsing (non-2xx → `ApiError`).
     /// The transport uses `error.is_retryable()` to decide whether to retry.
     /// Returns `HttpRequestResult` with the response and client-generated `request_id`.
+    ///
+    /// # Arguments
+    /// * `trace_id` - Optional external trace ID for request tracking. If provided,
+    ///   it will be used as the `request_id` and sent as `X-Request-ID` header.
+    ///   This enables end-to-end tracing from SudoWork to SudoRouter.
     pub async fn send_json<F, Fut>(
         &self,
         url: &str,
@@ -137,6 +142,7 @@ impl HttpTransport {
         body: &Value,
         retry_policy: &RetryPolicy,
         check_response: F,
+        trace_id: Option<&str>,
     ) -> Result<HttpRequestResult, ApiError>
     where
         F: Fn(reqwest::Response) -> Fut,
@@ -146,8 +152,10 @@ impl HttpTransport {
         let mut attempts = 0u32;
         let mut last_error: Option<ApiError>;
 
-        // Generate a unique request_id for this entire request lifecycle (including retries)
-        let request_id = format!("req_{}", uuid::Uuid::new_v4());
+        // Use external trace_id if provided, otherwise generate a new request_id
+        let request_id = trace_id
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("req_{}", uuid::Uuid::new_v4()));
 
         loop {
             attempts += 1;
@@ -165,9 +173,11 @@ impl HttpTransport {
             }
 
             // Log debug (every attempt — matches existing Anthropic behavior).
+            // Include X-Request-ID in the logged headers for visibility.
             if let Some(tracer) = &self.session_tracer {
-                let masked = telemetry::mask_sensitive_headers(headers);
-                tracer.record_http_request_debug(&request_id, url, "POST", masked, body.clone());
+                let mut logged_headers = telemetry::mask_sensitive_headers(headers);
+                logged_headers.insert("X-Request-ID".to_string(), Value::String(request_id.clone()));
+                tracer.record_http_request_debug(&request_id, url, "POST", logged_headers, body.clone());
             }
 
             // Build and send request.
@@ -175,6 +185,12 @@ impl HttpTransport {
                 let mut builder = self.inner.post(url);
                 for (name, value) in headers {
                     builder = builder.header(name.as_str(), value.as_str());
+                }
+                // Add X-Request-ID header for end-to-end tracing
+                builder = builder.header("X-Request-ID", &request_id);
+                // Debug: print when trace_id is provided (from external source)
+                if trace_id.is_some() {
+                    eprintln!("[TRACE-ID] Sending request with X-Request-ID: {}", request_id);
                 }
                 builder.json(body).send().await.map_err(ApiError::from)
             };

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -16,7 +16,7 @@ pub use error::ApiError;
 pub use http_client::{
     build_http_client, build_http_client_or_default, build_http_client_with, ProxyConfig,
 };
-pub use http_transport::{request_id_from_headers, HttpTransport, RetryPolicy};
+pub use http_transport::{request_id_from_headers, HttpRequestResult, HttpTransport, RetryPolicy};
 pub use prompt_cache::{
     CacheBreakEvent, PromptCache, PromptCacheConfig, PromptCachePaths, PromptCacheRecord,
     PromptCacheStats,

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -313,9 +313,9 @@ impl AnthropicClient {
 
         self.preflight_message_request(&request).await?;
 
-        let http_response = self.send_request(&request).await?;
-        let request_id = request_id_from_headers(http_response.headers());
-        let body = http_response.text().await.map_err(ApiError::from)?;
+        let result = self.send_request(&request).await?;
+        let request_id = request_id_from_headers(result.response.headers());
+        let body = result.response.text().await.map_err(ApiError::from)?;
         let mut response = serde_json::from_str::<MessageResponse>(&body).map_err(|error| {
             ApiError::json_deserialize("Anthropic", &request.model, &body, error)
         })?;
@@ -355,10 +355,11 @@ impl AnthropicClient {
         request: &MessageRequest,
     ) -> Result<MessageStream, ApiError> {
         self.preflight_message_request(request).await?;
-        let response = self.send_request(&request.clone().with_streaming()).await?;
+        let result = self.send_request(&request.clone().with_streaming()).await?;
         Ok(MessageStream {
-            request_id: request_id_from_headers(response.headers()),
-            response,
+            request_id: request_id_from_headers(result.response.headers()),
+            client_request_id: Some(result.request_id),
+            response: result.response,
             parser: SseParser::new().with_context("Anthropic", request.model.clone()),
             pending: VecDeque::new(),
             done: false,
@@ -414,7 +415,7 @@ impl AnthropicClient {
     }
 
     /// Build URL, headers, body and send through `HttpTransport` with retries.
-    async fn send_request(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
+    async fn send_request(&self, request: &MessageRequest) -> Result<crate::HttpRequestResult, ApiError> {
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut body);
@@ -814,7 +815,10 @@ impl Provider for AnthropicClient {
 
 #[derive(Debug)]
 pub struct MessageStream {
+    /// Provider-returned request ID (from response header).
     request_id: Option<String>,
+    /// Client-generated request ID for tracking.
+    client_request_id: Option<String>,
     response: reqwest::Response,
     parser: SseParser,
     pending: VecDeque<StreamEvent>,
@@ -876,7 +880,11 @@ impl MessageStream {
                                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(record);
                         }
                         if let Some(tracer) = &self.session_tracer {
+                            // Use client_request_id if available, otherwise generate a fallback
+                            let request_id = self.client_request_id.clone()
+                                .unwrap_or_else(|| "unknown".to_string());
                             tracer.record_usage(
+                                request_id,
                                 usage.input_tokens,
                                 usage.output_tokens,
                                 usage.cache_creation_input_tokens,

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -299,6 +299,7 @@ impl AnthropicClient {
     pub async fn send_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageResponse, ApiError> {
         let request = MessageRequest {
             stream: false,
@@ -313,7 +314,7 @@ impl AnthropicClient {
 
         self.preflight_message_request(&request).await?;
 
-        let result = self.send_request(&request).await?;
+        let result = self.send_request(&request, trace_id).await?;
         let request_id = request_id_from_headers(result.response.headers());
         let body = result.response.text().await.map_err(ApiError::from)?;
         let mut response = serde_json::from_str::<MessageResponse>(&body).map_err(|error| {
@@ -353,9 +354,10 @@ impl AnthropicClient {
     pub async fn stream_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         self.preflight_message_request(request).await?;
-        let result = self.send_request(&request.clone().with_streaming()).await?;
+        let result = self.send_request(&request.clone().with_streaming(), trace_id).await?;
         Ok(MessageStream {
             request_id: request_id_from_headers(result.response.headers()),
             client_request_id: Some(result.request_id),
@@ -415,7 +417,11 @@ impl AnthropicClient {
     }
 
     /// Build URL, headers, body and send through `HttpTransport` with retries.
-    async fn send_request(&self, request: &MessageRequest) -> Result<crate::HttpRequestResult, ApiError> {
+    async fn send_request(
+        &self,
+        request: &MessageRequest,
+        trace_id: Option<&str>,
+    ) -> Result<crate::HttpRequestResult, ApiError> {
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut body = self.request_profile.render_json_body(request)?;
         strip_unsupported_beta_body_fields(&mut body);
@@ -433,7 +439,7 @@ impl AnthropicClient {
         headers.extend(self.request_profile.header_pairs());
 
         self.http
-            .send_json(&url, &headers, &body, &self.retry_policy, expect_success)
+            .send_json(&url, &headers, &body, &self.retry_policy, expect_success, trace_id)
             .await
             .map_err(|e| enrich_bearer_auth_error(e, &self.auth))
     }
@@ -801,15 +807,17 @@ impl Provider for AnthropicClient {
     fn send_message<'a>(
         &'a self,
         request: &'a MessageRequest,
+        trace_id: Option<&'a str>,
     ) -> ProviderFuture<'a, MessageResponse> {
-        Box::pin(async move { self.send_message(request).await })
+        Box::pin(async move { self.send_message(request, trace_id).await })
     }
 
     fn stream_message<'a>(
         &'a self,
         request: &'a MessageRequest,
+        trace_id: Option<&'a str>,
     ) -> ProviderFuture<'a, Self::Stream> {
-        Box::pin(async move { self.stream_message(request).await })
+        Box::pin(async move { self.stream_message(request, trace_id).await })
     }
 }
 

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -357,7 +357,9 @@ impl AnthropicClient {
         trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         self.preflight_message_request(request).await?;
-        let result = self.send_request(&request.clone().with_streaming(), trace_id).await?;
+        let result = self
+            .send_request(&request.clone().with_streaming(), trace_id)
+            .await?;
         Ok(MessageStream {
             request_id: request_id_from_headers(result.response.headers()),
             client_request_id: Some(result.request_id),
@@ -439,7 +441,14 @@ impl AnthropicClient {
         headers.extend(self.request_profile.header_pairs());
 
         self.http
-            .send_json(&url, &headers, &body, &self.retry_policy, expect_success, trace_id)
+            .send_json(
+                &url,
+                &headers,
+                &body,
+                &self.retry_policy,
+                expect_success,
+                trace_id,
+            )
             .await
             .map_err(|e| enrich_bearer_auth_error(e, &self.auth))
     }
@@ -889,7 +898,9 @@ impl MessageStream {
                         }
                         if let Some(tracer) = &self.session_tracer {
                             // Use client_request_id if available, otherwise generate a fallback
-                            let request_id = self.client_request_id.clone()
+                            let request_id = self
+                                .client_request_id
+                                .clone()
                                 .unwrap_or_else(|| "unknown".to_string());
                             tracer.record_usage(
                                 request_id,

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -138,16 +138,18 @@ impl CodexClient {
     pub async fn send_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageResponse, ApiError> {
         // Codex subscription requires streaming; collect the stream into a
         // single response.
-        let mut stream = self.stream_message(request).await?;
+        let mut stream = self.stream_message(request, trace_id).await?;
         collect_stream(&mut stream, request).await
     }
 
     pub async fn stream_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         preflight_message_request(request)?;
 
@@ -172,7 +174,7 @@ impl CodexClient {
             .http
             .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
                 check_codex_response(response)
-            })
+            }, trace_id)
             .await?;
 
         Ok(MessageStream {

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -172,9 +172,14 @@ impl CodexClient {
 
         let result = self
             .http
-            .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
-                check_codex_response(response)
-            }, trace_id)
+            .send_json(
+                &url,
+                &headers,
+                &payload,
+                &self.retry_policy,
+                |response| check_codex_response(response),
+                trace_id,
+            )
             .await?;
 
         Ok(MessageStream {

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -168,7 +168,7 @@ impl CodexClient {
             ("originator".to_string(), "codex_cli_rs".to_string()),
         ];
 
-        let response = self
+        let result = self
             .http
             .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
                 check_codex_response(response)
@@ -176,7 +176,7 @@ impl CodexClient {
             .await?;
 
         Ok(MessageStream {
-            response,
+            response: result.response,
             parser: SseParser::new(),
             pending: VecDeque::new(),
             done: false,

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -335,7 +335,7 @@ impl GeminiClient {
             headers.push(("authorization".to_string(), format!("Bearer {token}")));
         }
 
-        let response = self
+        let result = self
             .http
             .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
                 check_gemini_response(response)
@@ -343,7 +343,7 @@ impl GeminiClient {
             .await?;
 
         Ok(MessageStream {
-            response,
+            response: result.response,
             parser: SseParser::new(),
             pending: VecDeque::new(),
             done: false,

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -289,14 +289,16 @@ impl GeminiClient {
     pub async fn send_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageResponse, ApiError> {
-        let mut stream = self.stream_message(request).await?;
+        let mut stream = self.stream_message(request, trace_id).await?;
         collect_stream(&mut stream, request).await
     }
 
     pub async fn stream_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         preflight_message_request(request)?;
 
@@ -339,7 +341,7 @@ impl GeminiClient {
             .http
             .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
                 check_gemini_response(response)
-            })
+            }, trace_id)
             .await?;
 
         Ok(MessageStream {

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -339,9 +339,14 @@ impl GeminiClient {
 
         let result = self
             .http
-            .send_json(&url, &headers, &payload, &self.retry_policy, |response| {
-                check_gemini_response(response)
-            }, trace_id)
+            .send_json(
+                &url,
+                &headers,
+                &payload,
+                &self.retry_policy,
+                |response| check_gemini_response(response),
+                trace_id,
+            )
             .await?;
 
         Ok(MessageStream {

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -66,11 +66,13 @@ pub trait Provider {
     fn send_message<'a>(
         &'a self,
         request: &'a MessageRequest,
+        trace_id: Option<&'a str>,
     ) -> ProviderFuture<'a, MessageResponse>;
 
     fn stream_message<'a>(
         &'a self,
         request: &'a MessageRequest,
+        trace_id: Option<&'a str>,
     ) -> ProviderFuture<'a, Self::Stream>;
 }
 

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -251,6 +251,7 @@ impl OpenAiCompatClient {
         self.http
             .send_json(&url, &headers, &body, &self.retry_policy, expect_success)
             .await
+            .map(|result| result.response)
     }
 }
 

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -165,13 +165,14 @@ impl OpenAiCompatClient {
     pub async fn send_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageResponse, ApiError> {
         let request = MessageRequest {
             stream: false,
             ..request.clone()
         };
         preflight_message_request(&request)?;
-        let response = self.send_request(&request).await?;
+        let response = self.send_request(&request, trace_id).await?;
         let request_id = request_id_from_headers(response.headers());
         let body = response.text().await.map_err(ApiError::from)?;
         // Some backends return {"error":{"message":"...","type":"...","code":...}}
@@ -220,9 +221,10 @@ impl OpenAiCompatClient {
     pub async fn stream_message(
         &self,
         request: &MessageRequest,
+        trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         preflight_message_request(request)?;
-        let response = self.send_request(&request.clone().with_streaming()).await?;
+        let response = self.send_request(&request.clone().with_streaming(), trace_id).await?;
         Ok(MessageStream {
             request_id: request_id_from_headers(response.headers()),
             response,
@@ -234,7 +236,7 @@ impl OpenAiCompatClient {
     }
 
     /// Build URL, headers, body and send through `HttpTransport` with retries.
-    async fn send_request(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
+    async fn send_request(&self, request: &MessageRequest, trace_id: Option<&str>) -> Result<reqwest::Response, ApiError> {
         check_request_body_size(request, self.config())?;
 
         let url = chat_completions_endpoint(&self.base_url);
@@ -249,7 +251,7 @@ impl OpenAiCompatClient {
         ];
 
         self.http
-            .send_json(&url, &headers, &body, &self.retry_policy, expect_success)
+            .send_json(&url, &headers, &body, &self.retry_policy, expect_success, trace_id)
             .await
             .map(|result| result.response)
     }
@@ -274,15 +276,17 @@ impl Provider for OpenAiCompatClient {
     fn send_message<'a>(
         &'a self,
         request: &'a MessageRequest,
+        trace_id: Option<&'a str>,
     ) -> ProviderFuture<'a, MessageResponse> {
-        Box::pin(async move { self.send_message(request).await })
+        Box::pin(async move { self.send_message(request, trace_id).await })
     }
 
     fn stream_message<'a>(
         &'a self,
         request: &'a MessageRequest,
+        trace_id: Option<&'a str>,
     ) -> ProviderFuture<'a, Self::Stream> {
-        Box::pin(async move { self.stream_message(request).await })
+        Box::pin(async move { self.stream_message(request, trace_id).await })
     }
 }
 

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -224,7 +224,9 @@ impl OpenAiCompatClient {
         trace_id: Option<&str>,
     ) -> Result<MessageStream, ApiError> {
         preflight_message_request(request)?;
-        let response = self.send_request(&request.clone().with_streaming(), trace_id).await?;
+        let response = self
+            .send_request(&request.clone().with_streaming(), trace_id)
+            .await?;
         Ok(MessageStream {
             request_id: request_id_from_headers(response.headers()),
             response,
@@ -236,7 +238,11 @@ impl OpenAiCompatClient {
     }
 
     /// Build URL, headers, body and send through `HttpTransport` with retries.
-    async fn send_request(&self, request: &MessageRequest, trace_id: Option<&str>) -> Result<reqwest::Response, ApiError> {
+    async fn send_request(
+        &self,
+        request: &MessageRequest,
+        trace_id: Option<&str>,
+    ) -> Result<reqwest::Response, ApiError> {
         check_request_body_size(request, self.config())?;
 
         let url = chat_completions_endpoint(&self.base_url);
@@ -251,7 +257,14 @@ impl OpenAiCompatClient {
         ];
 
         self.http
-            .send_json(&url, &headers, &body, &self.retry_policy, expect_success, trace_id)
+            .send_json(
+                &url,
+                &headers,
+                &body,
+                &self.retry_policy,
+                expect_success,
+                trace_id,
+            )
             .await
             .map(|result| result.response)
     }

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -202,8 +202,8 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
 
     let events = sink.events();
     // After optimization: no more duplicate SessionTrace records
-    // Events: HttpRequestStarted, HttpRequestDebug, HttpRequestSucceeded, Analytics
-    assert_eq!(events.len(), 4);
+    // Events: HttpRequestStarted, HttpRequestDebug, HttpResponseDebug, HttpRequestSucceeded, Analytics
+    assert_eq!(events.len(), 5);
     assert!(matches!(
         &events[0],
         TelemetryEvent::HttpRequestStarted {
@@ -226,6 +226,15 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
     ));
     assert!(matches!(
         &events[2],
+        TelemetryEvent::HttpResponseDebug {
+            session_id,
+            request_id,
+            status: 200,
+            ..
+        } if session_id == "session-telemetry" && request_id.starts_with("req_")
+    ));
+    assert!(matches!(
+        &events[3],
         TelemetryEvent::HttpRequestSucceeded {
             request_id,
             provider_request_id,
@@ -234,7 +243,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
         } if request_id.starts_with("req_") && provider_request_id.as_deref() == Some("req_profile_123")
     ));
     assert!(matches!(
-        &events[3],
+        &events[4],
         TelemetryEvent::Analytics(event)
             if event.namespace == "api"
                 && event.action == "message_usage"

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -48,7 +48,7 @@ async fn send_message_posts_json_and_parses_response() {
         .with_auth_token(Some("proxy-token".to_string()))
         .with_base_url(server.base_url());
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("request should succeed");
 
@@ -114,21 +114,24 @@ async fn send_message_blocks_oversized_requests_before_the_http_call() {
 
     let client = AnthropicClient::new("test-key").with_base_url(server.base_url());
     let error = client
-        .send_message(&MessageRequest {
-            model: "claude-sonnet-4-6".to_string(),
-            max_tokens: 64_000,
-            messages: vec![InputMessage {
-                role: "user".to_string(),
-                content: vec![InputContentBlock::Text {
-                    text: "x".repeat(600_000),
+        .send_message(
+            &MessageRequest {
+                model: "claude-sonnet-4-6".to_string(),
+                max_tokens: 64_000,
+                messages: vec![InputMessage {
+                    role: "user".to_string(),
+                    content: vec![InputContentBlock::Text {
+                        text: "x".repeat(600_000),
+                    }],
                 }],
-            }],
-            system: Some("Keep the answer short.".to_string()),
-            tools: None,
-            tool_choice: None,
-            stream: false,
-            ..Default::default()
-        })
+                system: Some("Keep the answer short.".to_string()),
+                tools: None,
+                tool_choice: None,
+                stream: false,
+                ..Default::default()
+            },
+            None,
+        )
         .await
         .expect_err("oversized request should fail local context-window preflight");
 
@@ -173,7 +176,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
         .with_session_tracer(SessionTracer::new("session-telemetry", sink.clone()));
 
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("request should succeed");
 
@@ -263,7 +266,7 @@ async fn send_message_parses_prompt_cache_token_usage_from_response() {
 
     let client = AnthropicClient::new("test-key").with_base_url(server.base_url());
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("request should succeed");
 
@@ -298,7 +301,7 @@ async fn given_empty_usage_object_when_send_message_parses_response_then_usage_d
 
     // when
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("response with empty usage object should still parse");
 
@@ -356,7 +359,7 @@ async fn stream_message_parses_sse_events_with_tool_use() {
         .with_base_url(server.base_url())
         .with_prompt_cache(PromptCache::new("stream-session"));
     let mut stream = client
-        .stream_message(&sample_request(false))
+        .stream_message(&sample_request(false), None)
         .await
         .expect("stream should start");
 
@@ -449,7 +452,7 @@ async fn retries_retryable_failures_before_succeeding() {
         .with_retry_policy(2, Duration::from_millis(1), Duration::from_millis(2));
 
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("retry should eventually succeed");
 
@@ -481,7 +484,7 @@ async fn provider_client_dispatches_anthropic_requests() {
         .expect("anthropic provider client should be constructed");
 
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("provider-dispatched request should succeed");
 
@@ -521,7 +524,7 @@ async fn surfaces_retry_exhaustion_for_persistent_retryable_errors() {
         .with_retry_policy(1, Duration::from_millis(1), Duration::from_millis(2));
 
     let error = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect_err("persistent 503 should fail");
 
@@ -590,7 +593,7 @@ async fn retries_multiple_retryable_failures_with_exponential_backoff_and_jitter
     let started_at = std::time::Instant::now();
 
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("8-retry policy should absorb 5 retryable failures");
 
@@ -639,11 +642,11 @@ async fn send_message_reuses_recent_completion_cache_entries() {
         .with_prompt_cache(PromptCache::new("integration-session"));
 
     let first = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("first request should succeed");
     let second = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("second request should reuse cache");
 
@@ -703,11 +706,11 @@ async fn send_message_tracks_unexpected_prompt_cache_breaks() {
         }));
 
     client
-        .send_message(&request)
+        .send_message(&request, None)
         .await
         .expect("first response should succeed");
     client
-        .send_message(&request)
+        .send_message(&request, None)
         .await
         .expect("second response should succeed");
 
@@ -729,19 +732,22 @@ async fn send_message_tracks_unexpected_prompt_cache_breaks() {
 async fn live_stream_smoke_test() {
     let client = ApiClient::from_env().expect("ANTHROPIC_API_KEY must be set");
     let mut stream = client
-        .stream_message(&MessageRequest {
-            model: std::env::var("ANTHROPIC_MODEL")
-                .unwrap_or_else(|_| "claude-3-7-sonnet-latest".to_string()),
-            max_tokens: 32,
-            messages: vec![InputMessage::user_text(
-                "Reply with exactly: hello from rust",
-            )],
-            system: None,
-            tools: None,
-            tool_choice: None,
-            stream: false,
-            ..Default::default()
-        })
+        .stream_message(
+            &MessageRequest {
+                model: std::env::var("ANTHROPIC_MODEL")
+                    .unwrap_or_else(|_| "claude-3-7-sonnet-latest".to_string()),
+                max_tokens: 32,
+                messages: vec![InputMessage::user_text(
+                    "Reply with exactly: hello from rust",
+                )],
+                system: None,
+                tools: None,
+                tool_choice: None,
+                stream: false,
+                ..Default::default()
+            },
+            None,
+        )
         .await
         .expect("live stream should start");
 

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -198,53 +198,45 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
     );
 
     let events = sink.events();
-    assert_eq!(events.len(), 7);
+    // After optimization: no more duplicate SessionTrace records
+    // Events: HttpRequestStarted, HttpRequestDebug, HttpRequestSucceeded, Analytics
+    assert_eq!(events.len(), 4);
     assert!(matches!(
         &events[0],
         TelemetryEvent::HttpRequestStarted {
             session_id,
+            request_id,
             attempt: 1,
             method,
             path,
             ..
-        } if session_id == "session-telemetry" && method == "POST" && path == "/v1/messages"
+        } if session_id == "session-telemetry" && request_id.starts_with("req_") && method == "POST" && path == "/v1/messages"
     ));
     assert!(matches!(
         &events[1],
-        TelemetryEvent::SessionTrace(trace) if trace.name == "http_request_started"
-    ));
-    assert!(matches!(
-        &events[2],
         TelemetryEvent::HttpRequestDebug {
+            request_id,
             method,
             url,
             ..
-        } if method == "POST" && url.contains("/v1/messages")
+        } if request_id.starts_with("req_") && method == "POST" && url.contains("/v1/messages")
+    ));
+    assert!(matches!(
+        &events[2],
+        TelemetryEvent::HttpRequestSucceeded {
+            request_id,
+            provider_request_id,
+            status: 200,
+            ..
+        } if request_id.starts_with("req_") && provider_request_id.as_deref() == Some("req_profile_123")
     ));
     assert!(matches!(
         &events[3],
-        TelemetryEvent::HttpRequestSucceeded {
-            request_id,
-            status: 200,
-            ..
-        } if request_id.as_deref() == Some("req_profile_123")
-    ));
-    assert!(matches!(
-        &events[4],
-        TelemetryEvent::SessionTrace(trace) if trace.name == "http_request_succeeded"
-    ));
-    assert!(matches!(
-        &events[5],
         TelemetryEvent::Analytics(event)
             if event.namespace == "api"
                 && event.action == "message_usage"
-                && event.properties.get("request_id") == Some(&json!("req_profile_123"))
                 && event.properties.get("total_tokens") == Some(&json!(7))
                 && event.properties.get("estimated_cost_usd") == Some(&json!("$0.0001"))
-    ));
-    assert!(matches!(
-        &events[6],
-        TelemetryEvent::SessionTrace(trace) if trace.name == "analytics"
     ));
 }
 

--- a/rust/crates/api/tests/openai_compat_integration.rs
+++ b/rust/crates/api/tests/openai_compat_integration.rs
@@ -35,7 +35,7 @@ async fn send_message_uses_openai_compatible_endpoint_and_auth() {
     let client = OpenAiCompatClient::new("xai-test-key", OpenAiCompatConfig::xai())
         .with_base_url(server.base_url());
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("request should succeed");
 
@@ -73,21 +73,24 @@ async fn send_message_blocks_oversized_xai_requests_before_the_http_call() {
     let client = OpenAiCompatClient::new("xai-test-key", OpenAiCompatConfig::xai())
         .with_base_url(server.base_url());
     let error = client
-        .send_message(&MessageRequest {
-            model: "grok-3".to_string(),
-            max_tokens: 64_000,
-            messages: vec![InputMessage {
-                role: "user".to_string(),
-                content: vec![InputContentBlock::Text {
-                    text: "x".repeat(300_000),
+        .send_message(
+            &MessageRequest {
+                model: "grok-3".to_string(),
+                max_tokens: 64_000,
+                messages: vec![InputMessage {
+                    role: "user".to_string(),
+                    content: vec![InputContentBlock::Text {
+                        text: "x".repeat(300_000),
+                    }],
                 }],
-            }],
-            system: Some("Keep the answer short.".to_string()),
-            tools: None,
-            tool_choice: None,
-            stream: false,
-            ..Default::default()
-        })
+                system: Some("Keep the answer short.".to_string()),
+                tools: None,
+                tool_choice: None,
+                stream: false,
+                ..Default::default()
+            },
+            None,
+        )
         .await
         .expect_err("oversized request should fail local context-window preflight");
 
@@ -122,7 +125,7 @@ async fn send_message_accepts_full_chat_completions_endpoint_override() {
     let client = OpenAiCompatClient::new("xai-test-key", OpenAiCompatConfig::xai())
         .with_base_url(endpoint_url);
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("request should succeed");
 
@@ -156,7 +159,7 @@ async fn stream_message_normalizes_text_and_multiple_tool_calls() {
     let client = OpenAiCompatClient::new("xai-test-key", OpenAiCompatConfig::xai())
         .with_base_url(server.base_url());
     let mut stream = client
-        .stream_message(&sample_request(false))
+        .stream_message(&sample_request(false), None)
         .await
         .expect("stream should start");
 
@@ -255,7 +258,7 @@ async fn openai_streaming_requests_opt_into_usage_chunks() {
     let client = OpenAiCompatClient::new("openai-test-key", OpenAiCompatConfig::openai())
         .with_base_url(server.base_url());
     let mut stream = client
-        .stream_message(&sample_request(false))
+        .stream_message(&sample_request(false), None)
         .await
         .expect("stream should start");
 
@@ -331,7 +334,7 @@ async fn provider_client_dispatches_xai_requests() {
     assert!(matches!(client, ProviderClient::Xai(_)));
 
     let response = client
-        .send_message(&sample_request(false))
+        .send_message(&sample_request(false), None)
         .await
         .expect("provider-dispatched request should succeed");
 

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -165,6 +165,7 @@ pub trait SdkAcpDelegate: Send + 'static {
         session_id: &str,
         prompt: String,
         observer: &mut SdkSessionObserver,
+        trace_id: Option<&str>,
     ) -> Result<(StopReason, Option<PromptUsage>), AcpError>;
 
     /// Run a prompt with permission prompting bridged to the ACP client.
@@ -174,6 +175,7 @@ pub trait SdkAcpDelegate: Send + 'static {
         prompt: String,
         observer: &mut SdkSessionObserver,
         prompter: &mut dyn PermissionPrompter,
+        trace_id: Option<&str>,
     ) -> Result<(StopReason, Option<PromptUsage>), AcpError>;
 
     /// Install a question prompter for AskUserQuestion tool execution within a session.
@@ -667,6 +669,11 @@ pub(crate) async fn run_acp_on_transport(
                         return Ok(());
                     }
 
+                    // Extract traceId from _meta if present
+                    let trace_id = req.meta.as_ref().and_then(|m| {
+                        m.get("traceId").and_then(|v| v.as_str().map(String::from))
+                    });
+
                     let d = Arc::clone(&delegate);
                     let sid = req.session_id.to_string();
                     let cx_inner = cx.clone();
@@ -691,6 +698,7 @@ pub(crate) async fn run_acp_on_transport(
                         let sid_for_perm = sid.clone();
                         let images_for_blocking = images.clone();
                         let prompt_text_for_blocking = prompt_text.clone();
+                        let trace_id_for_blocking = trace_id.clone();
                         let blocking_handle = tokio::task::spawn_blocking(move || {
                             let mut observer = SdkSessionObserver::new(&sid_for_blocking, notif_tx);
                             let mut bridge = AcpPermissionBridge { tx: bridge_tx };
@@ -737,6 +745,7 @@ pub(crate) async fn run_acp_on_transport(
                                     prompt_text_for_blocking,
                                     &mut observer,
                                     &mut bridge,
+                                    trace_id_for_blocking.as_deref(),
                                 )
                             };
                             // Return the Result instead of unwrapping, so we can handle errors

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -31,6 +31,9 @@ const INTERRUPT_MESSAGE: &str = "Interrupted · What should Sudo Code do instead
 pub struct ApiRequest {
     pub system_prompt: SystemPrompt,
     pub messages: Vec<ConversationMessage>,
+    /// Optional trace ID for end-to-end request tracking.
+    /// Passed through to the HTTP layer as X-Request-ID header.
+    pub trace_id: Option<String>,
 }
 
 /// Streamed events emitted while processing a single assistant turn.
@@ -199,6 +202,8 @@ pub struct ConversationRuntime<C, T> {
     current_turn_id: Option<String>,
     /// User request intent for the current turn.
     user_request_intent: Option<crate::file_intent::UserRequestIntent>,
+    /// Trace ID for the current request (passed from ACP _meta.traceId).
+    trace_id: Option<String>,
 }
 
 impl<C, T> ConversationRuntime<C, T>
@@ -258,6 +263,7 @@ where
             file_tracker: crate::file_tracker::TurnFileTracker::new(workspace_root),
             current_turn_id: None,
             user_request_intent: None,
+            trace_id: None,
         }
     }
 
@@ -314,6 +320,19 @@ where
     pub fn with_session_tracer(mut self, session_tracer: SessionTracer) -> Self {
         self.session_tracer = Some(session_tracer);
         self
+    }
+
+    /// Set the trace ID for the next request.
+    /// This is called before run_turn to pass the traceId from ACP _meta.
+    #[must_use]
+    pub fn with_trace_id(mut self, trace_id: impl Into<String>) -> Self {
+        self.trace_id = Some(trace_id.into());
+        self
+    }
+
+    /// Set the trace ID in-place (non-builder pattern).
+    pub fn set_trace_id(&mut self, trace_id: impl Into<String>) {
+        self.trace_id = Some(trace_id.into());
     }
 
     fn run_pre_tool_use_hook(&mut self, tool_name: &str, input: &str) -> HookRunResult {
@@ -630,6 +649,7 @@ where
             let request = ApiRequest {
                 system_prompt: self.system_prompt.clone(),
                 messages: self.session.messages.clone(),
+                trace_id: self.trace_id.clone(),
             };
             let mut stream = match self.api_client.stream(request).await {
                 Ok(stream) => stream,

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -138,6 +138,7 @@ impl ApiClient for AnthropicRuntimeClient {
             system_dynamic: Some(request.system_prompt.dynamic_text()),
             breakpoint_last_message: true,
         });
+        let trace_id = request.trace_id.as_deref();
         let message_request = MessageRequest {
             model: self.model.clone(),
             max_tokens: max_tokens_for_model(&self.model),
@@ -161,7 +162,7 @@ impl ApiClient for AnthropicRuntimeClient {
 
         for attempt in 1..=max_attempts {
             let result = self
-                .try_start_stream(&message_request, is_post_tool && attempt == 1)
+                .try_start_stream(&message_request, is_post_tool && attempt == 1, trace_id)
                 .await;
             match result {
                 Ok(stream) => return Ok(stream),
@@ -346,10 +347,11 @@ impl AnthropicRuntimeClient {
         &mut self,
         message_request: &MessageRequest,
         apply_stall_timeout: bool,
+        trace_id: Option<&str>,
     ) -> Result<AssistantEventStream, RuntimeError> {
         let provider_stream =
             self.client
-                .stream_message(message_request)
+                .stream_message(message_request, trace_id)
                 .await
                 .map_err(|error| {
                     RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
@@ -436,7 +438,7 @@ impl AnthropicRuntimeClient {
                         if state.buffer.is_empty() && !state.saw_stop {
                             if let Some(fallback_request) = state.fallback_request.take() {
                                 let response =
-                                    state.client.send_message(&fallback_request).await.map_err(
+                                    state.client.send_message(&fallback_request, None).await.map_err(
                                         |error| {
                                             RuntimeError::new(format_user_visible_api_error(
                                                 &state.session_id,

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -349,13 +349,13 @@ impl AnthropicRuntimeClient {
         apply_stall_timeout: bool,
         trace_id: Option<&str>,
     ) -> Result<AssistantEventStream, RuntimeError> {
-        let provider_stream =
-            self.client
-                .stream_message(message_request, trace_id)
-                .await
-                .map_err(|error| {
-                    RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-                })?;
+        let provider_stream = self
+            .client
+            .stream_message(message_request, trace_id)
+            .await
+            .map_err(|error| {
+                RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
+            })?;
 
         let state = CliStreamState {
             provider_stream,
@@ -437,15 +437,16 @@ impl AnthropicRuntimeClient {
                         // non-streaming request.
                         if state.buffer.is_empty() && !state.saw_stop {
                             if let Some(fallback_request) = state.fallback_request.take() {
-                                let response =
-                                    state.client.send_message(&fallback_request, None).await.map_err(
-                                        |error| {
-                                            RuntimeError::new(format_user_visible_api_error(
-                                                &state.session_id,
-                                                &error,
-                                            ))
-                                        },
-                                    )?;
+                                let response = state
+                                    .client
+                                    .send_message(&fallback_request, None)
+                                    .await
+                                    .map_err(|error| {
+                                        RuntimeError::new(format_user_visible_api_error(
+                                            &state.session_id,
+                                            &error,
+                                        ))
+                                    })?;
                                 // response_to_events does sync I/O (no await),
                                 // so the dyn Write borrow is safe here.
                                 let mut stdout = io::stdout();

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -454,6 +454,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let total_turns = cli.runtime.usage().turns();
             if let Some(tracer) = cli.session_tracer() {
                 tracer.record_usage(
+                    "session_summary".to_string(),
                     usage.input_tokens,
                     usage.output_tokens,
                     usage.cache_creation_input_tokens,
@@ -1426,6 +1427,7 @@ fn run_repl(
     let total_turns = cli.runtime.usage().turns();
     if let Some(tracer) = cli.session_tracer() {
         tracer.record_usage(
+            "session_summary".to_string(),
             usage.input_tokens,
             usage.output_tokens,
             usage.cache_creation_input_tokens,
@@ -2040,6 +2042,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             let total_turns = session.runtime.usage().turns();
             if let Some(tracer) = session.runtime.session_tracer() {
                 tracer.record_usage(
+                    "session_summary".to_string(),
                     usage.input_tokens,
                     usage.output_tokens,
                     usage.cache_creation_input_tokens,
@@ -2319,6 +2322,7 @@ impl AcpSdkDelegate {
         // Record token usage to telemetry log
         if let Some(tracer) = session.runtime.session_tracer() {
             tracer.record_usage(
+                "session_summary".to_string(),
                 usage.input_tokens,
                 usage.output_tokens,
                 usage.cache_creation_input_tokens,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1517,6 +1517,13 @@ impl BuiltRuntime {
         self
     }
 
+    /// Set the trace ID for the next request.
+    fn set_trace_id(&mut self, trace_id: impl Into<String>) {
+        if let Some(ref mut runtime) = self.runtime {
+            runtime.set_trace_id(trace_id);
+        }
+    }
+
     fn shutdown_plugins(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if self.plugins_active {
             self.plugin_registry.shutdown()?;
@@ -1882,6 +1889,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         session_id: &str,
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
+        trace_id: Option<&str>,
     ) -> Result<
         (
             runtime::acp_sdk_server::AcpStopReason,
@@ -1889,7 +1897,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         ),
         runtime::AcpError,
     > {
-        self.run_prompt_impl(session_id, prompt, observer, None)
+        self.run_prompt_impl(session_id, prompt, observer, None, trace_id)
     }
 
     fn run_prompt_with_prompter(
@@ -1898,6 +1906,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
         prompter: &mut dyn runtime::PermissionPrompter,
+        trace_id: Option<&str>,
     ) -> Result<
         (
             runtime::acp_sdk_server::AcpStopReason,
@@ -1905,7 +1914,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         ),
         runtime::AcpError,
     > {
-        self.run_prompt_impl(session_id, prompt, observer, Some(prompter))
+        self.run_prompt_impl(session_id, prompt, observer, Some(prompter), trace_id)
     }
 
     fn set_question_prompter(
@@ -2189,6 +2198,7 @@ impl AcpSdkDelegate {
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
         prompter: Option<&mut dyn runtime::PermissionPrompter>,
+        trace_id: Option<&str>,
     ) -> Result<
         (
             runtime::acp_sdk_server::AcpStopReason,
@@ -2204,6 +2214,11 @@ impl AcpSdkDelegate {
         let _guard = ScopedCurrentDir::change_to(&session.cwd).map_err(|e| {
             runtime::AcpError::internal(format!("failed to enter session cwd: {e}"))
         })?;
+
+        // Set trace_id on the runtime if provided
+        if let Some(tid) = trace_id {
+            session.runtime.set_trace_id(tid);
+        }
 
         // Pre-send token estimation and auto-compact logic
         let model = session

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -585,11 +585,20 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
             attrs.insert("method".to_string(), Value::String(method.clone()));
             attrs.insert("path".to_string(), Value::String(path.clone()));
             attrs.insert("status".to_string(), Value::from(*status));
-            attrs.insert("start_timestamp_ms".to_string(), Value::from(*start_timestamp_ms));
-            attrs.insert("end_timestamp_ms".to_string(), Value::from(*end_timestamp_ms));
+            attrs.insert(
+                "start_timestamp_ms".to_string(),
+                Value::from(*start_timestamp_ms),
+            );
+            attrs.insert(
+                "end_timestamp_ms".to_string(),
+                Value::from(*end_timestamp_ms),
+            );
             attrs.insert("duration_ms".to_string(), Value::from(*duration_ms));
             if let Some(rid) = provider_request_id {
-                attrs.insert("provider_request_id".to_string(), Value::String(rid.clone()));
+                attrs.insert(
+                    "provider_request_id".to_string(),
+                    Value::String(rid.clone()),
+                );
             }
             (session_id.clone(), "request_succeeded".to_string(), attrs)
         }
@@ -613,8 +622,14 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
             attrs.insert("path".to_string(), Value::String(path.clone()));
             attrs.insert("error".to_string(), Value::String(error.clone()));
             attrs.insert("retryable".to_string(), Value::Bool(*retryable));
-            attrs.insert("start_timestamp_ms".to_string(), Value::from(*start_timestamp_ms));
-            attrs.insert("end_timestamp_ms".to_string(), Value::from(*end_timestamp_ms));
+            attrs.insert(
+                "start_timestamp_ms".to_string(),
+                Value::from(*start_timestamp_ms),
+            );
+            attrs.insert(
+                "end_timestamp_ms".to_string(),
+                Value::from(*end_timestamp_ms),
+            );
             attrs.insert("duration_ms".to_string(), Value::from(*duration_ms));
             (session_id.clone(), "request_failed".to_string(), attrs)
         }
@@ -1055,13 +1070,7 @@ mod tests {
         let sink = Arc::new(MemoryTelemetrySink::default());
         let tracer = SessionTracer::new("session-123", sink.clone());
 
-        tracer.record_http_request_started(
-            "req_test-123",
-            1,
-            "POST",
-            "/v1/messages",
-            Map::new(),
-        );
+        tracer.record_http_request_started("req_test-123", 1, "POST", "/v1/messages", Map::new());
         tracer.record_analytics(
             AnalyticsEvent::new("cli", "prompt_sent")
                 .with_property("model", Value::String("claude-opus".to_string())),

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -181,35 +181,57 @@ pub struct SessionTraceRecord {
 pub enum TelemetryEvent {
     HttpRequestStarted {
         session_id: String,
+        /// Unique request ID for tracking and reconciliation with LLM providers.
+        request_id: String,
         attempt: u32,
         method: String,
         path: String,
+        timestamp_ms: u64,
         #[serde(default, skip_serializing_if = "Map::is_empty")]
         attributes: Map<String, Value>,
     },
     HttpRequestSucceeded {
         session_id: String,
+        /// Unique request ID for tracking and reconciliation with LLM providers.
+        request_id: String,
         attempt: u32,
         method: String,
         path: String,
         status: u16,
+        /// Timestamp when the request started (for duration calculation).
+        start_timestamp_ms: u64,
+        /// Timestamp when the request completed.
+        end_timestamp_ms: u64,
+        /// Request duration in milliseconds.
+        duration_ms: u64,
+        /// Request ID returned by the LLM provider (for reconciliation).
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        request_id: Option<String>,
+        provider_request_id: Option<String>,
         #[serde(default, skip_serializing_if = "Map::is_empty")]
         attributes: Map<String, Value>,
     },
     HttpRequestFailed {
         session_id: String,
+        /// Unique request ID for tracking and reconciliation with LLM providers.
+        request_id: String,
         attempt: u32,
         method: String,
         path: String,
         error: String,
         retryable: bool,
+        /// Timestamp when the request started.
+        start_timestamp_ms: u64,
+        /// Timestamp when the request failed.
+        end_timestamp_ms: u64,
+        /// Request duration in milliseconds.
+        duration_ms: u64,
         #[serde(default, skip_serializing_if = "Map::is_empty")]
         attributes: Map<String, Value>,
     },
     HttpRequestDebug {
         session_id: String,
+        /// Unique request ID for tracking and reconciliation with LLM providers.
+        request_id: String,
         timestamp_ms: u64,
         url: String,
         method: String,
@@ -217,9 +239,24 @@ pub enum TelemetryEvent {
         headers: Map<String, Value>,
         body: Value,
     },
+    /// Response content for debugging and troubleshooting.
+    HttpResponseDebug {
+        session_id: String,
+        /// Unique request ID for tracking and reconciliation with LLM providers.
+        request_id: String,
+        timestamp_ms: u64,
+        status: u16,
+        /// Response headers from the LLM provider.
+        #[serde(default, skip_serializing_if = "Map::is_empty")]
+        headers: Map<String, Value>,
+        /// Response body (may be truncated for very large responses).
+        body: Value,
+    },
     /// Token usage snapshot emitted after a streaming response completes.
     HttpResponseUsage {
         session_id: String,
+        /// Unique request ID for tracking this usage.
+        request_id: String,
         timestamp_ms: u64,
         input_tokens: u32,
         output_tokens: u32,
@@ -486,7 +523,15 @@ fn format_log_entry(event: &TelemetryEvent) -> Map<String, Value> {
     let mut entry = Map::new();
 
     entry.insert("timestamp".to_string(), Value::String(format_timestamp()));
-    entry.insert("level".to_string(), Value::String("info".to_string()));
+
+    // Set log level based on event type
+    let level = match event {
+        TelemetryEvent::HttpRequestDebug { .. } => "debug",
+        TelemetryEvent::HttpResponseDebug { .. } => "debug",
+        TelemetryEvent::HttpRequestFailed { .. } => "warn",
+        _ => "info",
+    };
+    entry.insert("level".to_string(), Value::String(level.to_string()));
 
     let (session_id, event_name, attributes) = extract_event_info(event);
 
@@ -506,55 +551,76 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
     match event {
         TelemetryEvent::HttpRequestStarted {
             session_id,
+            request_id,
             attempt,
             method,
             path,
+            timestamp_ms,
             attributes,
         } => {
             let mut attrs = attributes.clone();
+            attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
             attrs.insert("attempt".to_string(), Value::from(*attempt));
             attrs.insert("method".to_string(), Value::String(method.clone()));
             attrs.insert("path".to_string(), Value::String(path.clone()));
+            attrs.insert("timestamp_ms".to_string(), Value::from(*timestamp_ms));
             (session_id.clone(), "request_started".to_string(), attrs)
         }
         TelemetryEvent::HttpRequestSucceeded {
             session_id,
+            request_id,
             attempt,
             method,
             path,
             status,
-            request_id,
+            start_timestamp_ms,
+            end_timestamp_ms,
+            duration_ms,
+            provider_request_id,
             attributes,
         } => {
             let mut attrs = attributes.clone();
+            attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
             attrs.insert("attempt".to_string(), Value::from(*attempt));
             attrs.insert("method".to_string(), Value::String(method.clone()));
             attrs.insert("path".to_string(), Value::String(path.clone()));
             attrs.insert("status".to_string(), Value::from(*status));
-            if let Some(rid) = request_id {
-                attrs.insert("request_id".to_string(), Value::String(rid.clone()));
+            attrs.insert("start_timestamp_ms".to_string(), Value::from(*start_timestamp_ms));
+            attrs.insert("end_timestamp_ms".to_string(), Value::from(*end_timestamp_ms));
+            attrs.insert("duration_ms".to_string(), Value::from(*duration_ms));
+            if let Some(rid) = provider_request_id {
+                attrs.insert("provider_request_id".to_string(), Value::String(rid.clone()));
             }
             (session_id.clone(), "request_succeeded".to_string(), attrs)
         }
         TelemetryEvent::HttpRequestFailed {
             session_id,
+            request_id,
             attempt,
             method,
             path,
             error,
             retryable,
+            start_timestamp_ms,
+            end_timestamp_ms,
+            duration_ms,
             attributes,
         } => {
             let mut attrs = attributes.clone();
+            attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
             attrs.insert("attempt".to_string(), Value::from(*attempt));
             attrs.insert("method".to_string(), Value::String(method.clone()));
             attrs.insert("path".to_string(), Value::String(path.clone()));
             attrs.insert("error".to_string(), Value::String(error.clone()));
             attrs.insert("retryable".to_string(), Value::Bool(*retryable));
+            attrs.insert("start_timestamp_ms".to_string(), Value::from(*start_timestamp_ms));
+            attrs.insert("end_timestamp_ms".to_string(), Value::from(*end_timestamp_ms));
+            attrs.insert("duration_ms".to_string(), Value::from(*duration_ms));
             (session_id.clone(), "request_failed".to_string(), attrs)
         }
         TelemetryEvent::HttpRequestDebug {
             session_id,
+            request_id,
             timestamp_ms,
             url,
             method,
@@ -562,6 +628,7 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
             body,
         } => {
             let mut attrs = Map::new();
+            attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
             attrs.insert("timestamp_ms".to_string(), Value::from(*timestamp_ms));
             attrs.insert("url".to_string(), Value::String(url.clone()));
             attrs.insert("method".to_string(), Value::String(method.clone()));
@@ -569,8 +636,25 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
             attrs.insert("body".to_string(), body.clone());
             (session_id.clone(), "request_debug".to_string(), attrs)
         }
+        TelemetryEvent::HttpResponseDebug {
+            session_id,
+            request_id,
+            timestamp_ms,
+            status,
+            headers,
+            body,
+        } => {
+            let mut attrs = Map::new();
+            attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
+            attrs.insert("timestamp_ms".to_string(), Value::from(*timestamp_ms));
+            attrs.insert("status".to_string(), Value::from(*status));
+            attrs.insert("headers".to_string(), Value::Object(headers.clone()));
+            attrs.insert("body".to_string(), body.clone());
+            (session_id.clone(), "response_debug".to_string(), attrs)
+        }
         TelemetryEvent::HttpResponseUsage {
             session_id,
+            request_id,
             timestamp_ms,
             input_tokens,
             output_tokens,
@@ -578,6 +662,7 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
             cache_read_input_tokens,
         } => {
             let mut attrs = Map::new();
+            attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
             attrs.insert("timestamp_ms".to_string(), Value::from(*timestamp_ms));
             attrs.insert("input_tokens".to_string(), Value::from(*input_tokens));
             attrs.insert("output_tokens".to_string(), Value::from(*output_tokens));
@@ -694,90 +779,94 @@ impl SessionTracer {
 
     pub fn record_http_request_started(
         &self,
+        request_id: impl Into<String>,
         attempt: u32,
         method: impl Into<String>,
         path: impl Into<String>,
         attributes: Map<String, Value>,
     ) {
-        let method = method.into();
-        let path = path.into();
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::HttpRequestStarted {
             session_id: self.session_id.clone(),
+            request_id: request_id.into(),
             attempt,
-            method: method.clone(),
-            path: path.clone(),
-            attributes: attributes.clone(),
+            method: method.into(),
+            path: path.into(),
+            timestamp_ms: current_timestamp_ms(),
+            attributes,
         });
-        self.record(
-            "http_request_started",
-            merge_trace_fields(method, path, attempt, attributes),
-        );
     }
 
     pub fn record_http_request_succeeded(
         &self,
+        request_id: impl Into<String>,
         attempt: u32,
         method: impl Into<String>,
         path: impl Into<String>,
         status: u16,
-        request_id: Option<String>,
+        start_timestamp_ms: u64,
+        provider_request_id: Option<String>,
         attributes: Map<String, Value>,
     ) {
-        let method = method.into();
-        let path = path.into();
+        let end_timestamp_ms = current_timestamp_ms();
+        let duration_ms = end_timestamp_ms.saturating_sub(start_timestamp_ms);
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::HttpRequestSucceeded {
             session_id: self.session_id.clone(),
+            request_id: request_id.into(),
             attempt,
-            method: method.clone(),
-            path: path.clone(),
+            method: method.into(),
+            path: path.into(),
             status,
-            request_id: request_id.clone(),
-            attributes: attributes.clone(),
+            start_timestamp_ms,
+            end_timestamp_ms,
+            duration_ms,
+            provider_request_id,
+            attributes,
         });
-        let mut trace_attributes = merge_trace_fields(method, path, attempt, attributes);
-        trace_attributes.insert("status".to_string(), Value::from(status));
-        if let Some(request_id) = request_id {
-            trace_attributes.insert("request_id".to_string(), Value::String(request_id));
-        }
-        self.record("http_request_succeeded", trace_attributes);
     }
 
     pub fn record_http_request_failed(
         &self,
+        request_id: impl Into<String>,
         attempt: u32,
         method: impl Into<String>,
         path: impl Into<String>,
         error: impl Into<String>,
         retryable: bool,
+        start_timestamp_ms: u64,
         attributes: Map<String, Value>,
     ) {
-        let method = method.into();
-        let path = path.into();
-        let error = error.into();
+        let end_timestamp_ms = current_timestamp_ms();
+        let duration_ms = end_timestamp_ms.saturating_sub(start_timestamp_ms);
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::HttpRequestFailed {
             session_id: self.session_id.clone(),
+            request_id: request_id.into(),
             attempt,
-            method: method.clone(),
-            path: path.clone(),
-            error: error.clone(),
+            method: method.into(),
+            path: path.into(),
+            error: error.into(),
             retryable,
-            attributes: attributes.clone(),
+            start_timestamp_ms,
+            end_timestamp_ms,
+            duration_ms,
+            attributes,
         });
-        let mut trace_attributes = merge_trace_fields(method, path, attempt, attributes);
-        trace_attributes.insert("error".to_string(), Value::String(error));
-        trace_attributes.insert("retryable".to_string(), Value::Bool(retryable));
-        self.record("http_request_failed", trace_attributes);
     }
 
     pub fn record_http_request_debug(
         &self,
+        request_id: impl Into<String>,
         url: impl Into<String>,
         method: impl Into<String>,
         headers: Map<String, Value>,
         body: Value,
     ) {
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::HttpRequestDebug {
             session_id: self.session_id.clone(),
+            request_id: request_id.into(),
             timestamp_ms: current_timestamp_ms(),
             url: url.into(),
             method: method.into(),
@@ -786,8 +875,27 @@ impl SessionTracer {
         });
     }
 
+    pub fn record_http_response_debug(
+        &self,
+        request_id: impl Into<String>,
+        status: u16,
+        headers: Map<String, Value>,
+        body: Value,
+    ) {
+        // Only record once - no duplicate SessionTrace
+        self.sink.record(TelemetryEvent::HttpResponseDebug {
+            session_id: self.session_id.clone(),
+            request_id: request_id.into(),
+            timestamp_ms: current_timestamp_ms(),
+            status,
+            headers,
+            body,
+        });
+    }
+
     pub fn record_usage(
         &self,
+        request_id: impl Into<String>,
         input_tokens: u32,
         output_tokens: u32,
         cache_creation_input_tokens: u32,
@@ -795,6 +903,7 @@ impl SessionTracer {
     ) {
         self.sink.record(TelemetryEvent::HttpResponseUsage {
             session_id: self.session_id.clone(),
+            request_id: request_id.into(),
             timestamp_ms: current_timestamp_ms(),
             input_tokens,
             output_tokens,
@@ -804,14 +913,8 @@ impl SessionTracer {
     }
 
     pub fn record_analytics(&self, event: AnalyticsEvent) {
-        let mut attributes = event.properties.clone();
-        attributes.insert(
-            "namespace".to_string(),
-            Value::String(event.namespace.clone()),
-        );
-        attributes.insert("action".to_string(), Value::String(event.action.clone()));
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::Analytics(event));
-        self.record("analytics", attributes);
     }
 
     pub fn record_session_started(
@@ -821,24 +924,15 @@ impl SessionTracer {
         mode: impl Into<String>,
         model: impl Into<String>,
     ) {
-        let version = version.into();
-        let cwd = cwd.into();
-        let mode = mode.into();
-        let model = model.into();
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::SessionStarted {
             session_id: self.session_id.clone(),
             timestamp_ms: current_timestamp_ms(),
-            version: version.clone(),
-            cwd: cwd.clone(),
-            mode: mode.clone(),
-            model: model.clone(),
+            version: version.into(),
+            cwd: cwd.into(),
+            mode: mode.into(),
+            model: model.into(),
         });
-        let mut attributes = Map::new();
-        attributes.insert("version".to_string(), Value::String(version));
-        attributes.insert("cwd".to_string(), Value::String(cwd));
-        attributes.insert("mode".to_string(), Value::String(mode));
-        attributes.insert("model".to_string(), Value::String(model));
-        self.record("session_started", attributes);
     }
 
     pub fn record_session_ended(
@@ -848,6 +942,7 @@ impl SessionTracer {
         total_output_tokens: u64,
         duration_ms: u64,
     ) {
+        // Only record once - no duplicate SessionTrace
         self.sink.record(TelemetryEvent::SessionEnded {
             session_id: self.session_id.clone(),
             timestamp_ms: current_timestamp_ms(),
@@ -856,18 +951,6 @@ impl SessionTracer {
             total_output_tokens,
             duration_ms,
         });
-        let mut attributes = Map::new();
-        attributes.insert("total_turns".to_string(), Value::from(total_turns));
-        attributes.insert(
-            "total_input_tokens".to_string(),
-            Value::from(total_input_tokens),
-        );
-        attributes.insert(
-            "total_output_tokens".to_string(),
-            Value::from(total_output_tokens),
-        );
-        attributes.insert("duration_ms".to_string(), Value::from(duration_ms));
-        self.record("session_ended", attributes);
     }
 
     /// Record a prompt error that occurred during a turn.
@@ -910,18 +993,6 @@ fn mask_credential_value(value: &str) -> String {
     }
     let visible = &trimmed[..trimmed.len().min(10)];
     format!("{visible}... (hidden)")
-}
-
-fn merge_trace_fields(
-    method: String,
-    path: String,
-    attempt: u32,
-    mut attributes: Map<String, Value>,
-) -> Map<String, Value> {
-    attributes.insert("method".to_string(), Value::String(method));
-    attributes.insert("path".to_string(), Value::String(path));
-    attributes.insert("attempt".to_string(), Value::from(attempt));
-    attributes
 }
 
 fn current_timestamp_ms() -> u64 {
@@ -980,38 +1051,36 @@ mod tests {
     }
 
     #[test]
-    fn session_tracer_records_structured_events_and_trace_sequence() {
+    fn session_tracer_records_structured_events() {
         let sink = Arc::new(MemoryTelemetrySink::default());
         let tracer = SessionTracer::new("session-123", sink.clone());
 
-        tracer.record_http_request_started(1, "POST", "/v1/messages", Map::new());
+        tracer.record_http_request_started(
+            "req_test-123",
+            1,
+            "POST",
+            "/v1/messages",
+            Map::new(),
+        );
         tracer.record_analytics(
             AnalyticsEvent::new("cli", "prompt_sent")
                 .with_property("model", Value::String("claude-opus".to_string())),
         );
 
         let events = sink.events();
+        // No more duplicate SessionTrace records - only one event per call
         assert!(matches!(
             &events[0],
             TelemetryEvent::HttpRequestStarted {
                 session_id,
+                request_id,
                 attempt: 1,
                 method,
                 path,
                 ..
-            } if session_id == "session-123" && method == "POST" && path == "/v1/messages"
+            } if session_id == "session-123" && request_id == "req_test-123" && method == "POST" && path == "/v1/messages"
         ));
-        assert!(matches!(
-            &events[1],
-            TelemetryEvent::SessionTrace(SessionTraceRecord { sequence: 0, name, .. })
-            if name == "http_request_started"
-        ));
-        assert!(matches!(&events[2], TelemetryEvent::Analytics(_)));
-        assert!(matches!(
-            &events[3],
-            TelemetryEvent::SessionTrace(SessionTraceRecord { sequence: 1, name, .. })
-            if name == "analytics"
-        ));
+        assert!(matches!(&events[1], TelemetryEvent::Analytics(_)));
     }
 
     #[test]
@@ -1085,9 +1154,11 @@ mod tests {
     fn format_log_entry_produces_valid_json() {
         let event = TelemetryEvent::HttpRequestStarted {
             session_id: "session-123".to_string(),
+            request_id: "req_test-123".to_string(),
             attempt: 1,
             method: "POST".to_string(),
             path: "/v1/messages".to_string(),
+            timestamp_ms: 1234567890,
             attributes: Map::new(),
         };
 
@@ -1099,5 +1170,6 @@ mod tests {
         assert_eq!(parsed["session_id"], "session-123");
         assert_eq!(parsed["event"], "request_started");
         assert_eq!(parsed["component"], "scode");
+        assert_eq!(parsed["attributes"]["request_id"], "req_test-123");
     }
 }

--- a/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
+++ b/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
@@ -73,24 +73,31 @@ fn multiple_events_in_sequence() {
 
     sink.record(TelemetryEvent::HttpRequestStarted {
         session_id: "trace-test".to_string(),
+        request_id: "req_test-001".to_string(),
         attempt: 1,
         method: "POST".to_string(),
         path: "/v1/messages".to_string(),
+        timestamp_ms: 1500,
         attributes: serde_json::Map::new(),
     });
 
     sink.record(TelemetryEvent::HttpRequestSucceeded {
         session_id: "trace-test".to_string(),
+        request_id: "req_test-001".to_string(),
         attempt: 1,
         method: "POST".to_string(),
         path: "/v1/messages".to_string(),
         status: 200,
-        request_id: Some("req-123".to_string()),
+        start_timestamp_ms: 1500,
+        end_timestamp_ms: 2000,
+        duration_ms: 500,
+        provider_request_id: Some("req-123".to_string()),
         attributes: serde_json::Map::new(),
     });
 
     sink.record(TelemetryEvent::HttpResponseUsage {
         session_id: "trace-test".to_string(),
+        request_id: "req_test-001".to_string(),
         timestamp_ms: 2000,
         input_tokens: 500,
         output_tokens: 200,

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -5337,7 +5337,7 @@ async fn stream_with_provider(
     client: &ProviderClient,
     message_request: &MessageRequest,
 ) -> Result<Vec<AssistantEvent>, ApiError> {
-    let mut stream = client.stream_message(message_request).await?;
+    let mut stream = client.stream_message(message_request, None).await?;
     let mut events = Vec::new();
     let mut pending_tools: BTreeMap<u32, (String, String, String, Option<String>)> =
         BTreeMap::new();
@@ -5417,7 +5417,7 @@ async fn stream_with_provider(
         .send_message(&MessageRequest {
             stream: false,
             ..message_request.clone()
-        })
+        }, None)
         .await?;
     let mut events = response_to_events(response);
     push_prompt_cache_record(client, &mut events);

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -5414,10 +5414,13 @@ async fn stream_with_provider(
     }
 
     let response = client
-        .send_message(&MessageRequest {
-            stream: false,
-            ..message_request.clone()
-        }, None)
+        .send_message(
+            &MessageRequest {
+                stream: false,
+                ..message_request.clone()
+            },
+            None,
+        )
         .await?;
     let mut events = response_to_events(response);
     push_prompt_cache_record(client, &mut events);

--- a/scripts/analyze_scode_log.py
+++ b/scripts/analyze_scode_log.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""
+Scode Log Analyzer
+
+Analyzes scode.log files and generates formatted reports organized by:
+- Session (chronological order)
+- Each request within a session (with unique request_id)
+- Request details: status, body, response, tokens
+- Session summary with total token consumption
+
+Usage:
+    python analyze_scode_log.py [log_file_path]
+
+Default log path: ~/.nexus/logs/scode.log
+"""
+
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class RequestInfo:
+    """Information about a single request."""
+
+    request_id: str
+    started_at: datetime | None = None
+    succeeded_at: datetime | None = None
+    failed_at: datetime | None = None
+    status: int | None = None
+    duration_ms: int | None = None
+    attempt: int = 1
+    error: str | None = None
+    retryable: bool = False
+    provider_request_id: str | None = None
+
+    # Request details
+    url: str | None = None
+    method: str | None = None
+    path: str | None = None
+    headers: dict = field(default_factory=dict)
+    body: dict | None = None
+
+    # Response details
+    response_headers: dict = field(default_factory=dict)
+    response_body: dict | None = None
+    # Provider request ID from response headers (e.g., x-oneapi-request-id, request-id)
+    provider_response_request_id: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+@dataclass
+class SessionInfo:
+    """Information about a session."""
+
+    session_id: str
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    version: str | None = None
+    cwd: str | None = None
+    mode: str | None = None
+    model: str | None = None
+    total_turns: int = 0
+    duration_ms: int = 0
+
+    # Requests indexed by request_id
+    requests: dict[str, RequestInfo] = field(default_factory=dict)
+
+    # Token totals
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
+
+
+def parse_timestamp(ts_str: str) -> datetime | None:
+    """Parse ISO 8601 timestamp string."""
+    if not ts_str:
+        return None
+    try:
+        # Handle format: 2026-05-20T10:00:00.000+08:00
+        dt = datetime.fromisoformat(ts_str)
+        # Convert to UTC and make naive for comparison
+        if dt.tzinfo is not None:
+            dt = dt.replace(tzinfo=None)
+        return dt
+    except ValueError:
+        return None
+
+
+def parse_log_entry(line: str) -> dict[str, Any] | None:
+    """Parse a single log line as JSON."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+
+def analyze_log(log_path: Path) -> dict[str, SessionInfo]:
+    """Analyze log file and return sessions with their requests."""
+
+    sessions: dict[str, SessionInfo] = {}
+
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            entry = parse_log_entry(line)
+            if not entry:
+                continue
+
+            session_id = entry.get("session_id", "")
+            event = entry.get("event", "")
+            attrs = entry.get("attributes", {})
+            timestamp = parse_timestamp(entry.get("timestamp", ""))
+
+            if not session_id:
+                continue
+
+            # Get or create session
+            if session_id not in sessions:
+                sessions[session_id] = SessionInfo(session_id=session_id)
+
+            session = sessions[session_id]
+
+            if event == "session_started":
+                session.started_at = timestamp
+                session.version = attrs.get("version")
+                session.cwd = attrs.get("cwd")
+                session.mode = attrs.get("mode")
+                session.model = attrs.get("model")
+
+            elif event == "session_ended":
+                session.ended_at = timestamp
+                session.total_turns = attrs.get("total_turns", 0)
+                session.total_input_tokens = attrs.get("total_input_tokens", 0)
+                session.total_output_tokens = attrs.get("total_output_tokens", 0)
+                session.duration_ms = attrs.get("duration_ms", 0)
+
+            elif event == "request_started":
+                request_id = attrs.get("request_id", "")
+                if not request_id:
+                    # Generate a synthetic request_id for old log format
+                    request_id = f"legacy_{session_id}_{timestamp.isoformat() if timestamp else 'unknown'}"
+
+                if request_id not in session.requests:
+                    session.requests[request_id] = RequestInfo(request_id=request_id)
+
+                req = session.requests[request_id]
+                req.started_at = timestamp
+                req.attempt = attrs.get("attempt", 1)
+                req.method = attrs.get("method")
+                req.path = attrs.get("path")
+
+            elif event == "request_debug":
+                request_id = attrs.get("request_id", "")
+                if not request_id:
+                    # Skip debug events without request_id (old format)
+                    continue
+
+                if request_id not in session.requests:
+                    session.requests[request_id] = RequestInfo(request_id=request_id)
+
+                req = session.requests[request_id]
+                req.url = attrs.get("url")
+                req.method = attrs.get("method")
+                req.headers = attrs.get("headers", {})
+                req.body = attrs.get("body")
+
+            elif event == "request_succeeded":
+                request_id = attrs.get("request_id", "")
+                if not request_id:
+                    # Generate a synthetic request_id for old log format
+                    request_id = f"legacy_{session_id}_{timestamp.isoformat() if timestamp else 'unknown'}"
+
+                if request_id not in session.requests:
+                    session.requests[request_id] = RequestInfo(request_id=request_id)
+
+                req = session.requests[request_id]
+                req.succeeded_at = timestamp
+                req.status = attrs.get("status")
+                req.duration_ms = attrs.get("duration_ms")
+                req.attempt = attrs.get("attempt", 1)
+                req.provider_request_id = attrs.get("provider_request_id")
+
+            elif event == "request_failed":
+                request_id = attrs.get("request_id", "")
+                if not request_id:
+                    # Generate a synthetic request_id for old log format
+                    request_id = f"legacy_{session_id}_{timestamp.isoformat() if timestamp else 'unknown'}"
+
+                if request_id not in session.requests:
+                    session.requests[request_id] = RequestInfo(request_id=request_id)
+
+                req = session.requests[request_id]
+                req.failed_at = timestamp
+                req.error = attrs.get("error")
+                req.retryable = attrs.get("retryable", False)
+                req.duration_ms = attrs.get("duration_ms")
+                req.attempt = attrs.get("attempt", 1)
+
+            elif event == "response_usage":
+                request_id = attrs.get("request_id", "")
+                input_tokens = attrs.get("input_tokens", 0)
+                output_tokens = attrs.get("output_tokens", 0)
+                cache_creation_input_tokens = attrs.get("cache_creation_input_tokens", 0)
+                cache_read_input_tokens = attrs.get("cache_read_input_tokens", 0)
+
+                # If request_id is a specific request, update that request
+                if request_id and request_id in session.requests:
+                    req = session.requests[request_id]
+                    req.input_tokens = input_tokens
+                    req.output_tokens = output_tokens
+                    req.cache_creation_input_tokens = cache_creation_input_tokens
+                    req.cache_read_input_tokens = cache_read_input_tokens
+
+                # Always update session totals
+                session.total_input_tokens += input_tokens
+                session.total_output_tokens += output_tokens
+                session.total_cache_creation_tokens += cache_creation_input_tokens
+                session.total_cache_read_tokens += cache_read_input_tokens
+
+            elif event == "response_debug":
+                request_id = attrs.get("request_id", "")
+                if not request_id:
+                    continue
+
+                if request_id not in session.requests:
+                    session.requests[request_id] = RequestInfo(request_id=request_id)
+
+                req = session.requests[request_id]
+                req.status = attrs.get("status")
+                req.response_headers = attrs.get("headers", {})
+                req.response_body = attrs.get("body")
+
+                # Extract provider request ID from response headers
+                # Common header names: x-oneapi-request-id, x-request-id, request-id
+                headers = req.response_headers
+                for header_name in [
+                    "x-oneapi-request-id",
+                    "x-request-id",
+                    "request-id",
+                    "cf-ray",  # Cloudflare
+                ]:
+                    if header_name in headers:
+                        req.provider_response_request_id = headers[header_name]
+                        break
+
+    return sessions
+
+
+def format_datetime(dt: datetime | None) -> str:
+    """Format datetime for display."""
+    if not dt:
+        return "N/A"
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def format_duration(ms: int | None) -> str:
+    """Format duration in milliseconds to human readable."""
+    if ms is None:
+        return "N/A"
+    if ms < 1000:
+        return f"{ms}ms"
+    seconds = ms / 1000
+    if seconds < 60:
+        return f"{seconds:.2f}s"
+    minutes = seconds / 60
+    return f"{minutes:.2f}m"
+
+
+def truncate_text(text: str, max_len: int = 200) -> str:
+    """Truncate text with ellipsis."""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
+
+
+def format_body(body: dict | None, indent: int = 4) -> str:
+    """Format request body for display."""
+    if not body:
+        return "N/A"
+
+    # Create a summary version
+    result = []
+
+    # Model
+    if "model" in body:
+        result.append(f"Model: {body['model']}")
+
+    # Max tokens
+    if "max_tokens" in body:
+        result.append(f"Max Tokens: {body['max_tokens']}")
+
+    # Messages count
+    if "messages" in body:
+        messages = body["messages"]
+        result.append(f"Messages: {len(messages)} message(s)")
+
+        # Separate messages by role for better readability
+        user_messages = []
+        assistant_messages = []
+        system_messages = []
+        other_messages = []
+
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            if role == "user":
+                user_messages.append(msg)
+            elif role == "assistant":
+                assistant_messages.append(msg)
+            elif role == "system":
+                system_messages.append(msg)
+            else:
+                other_messages.append(msg)
+
+        # Show user messages prominently
+        if user_messages:
+            result.append("")
+            result.append("  USER REQUESTS:")
+            for i, msg in enumerate(user_messages, 1):
+                content = msg.get("content", "")
+                content_preview = format_message_content(content, 200)
+                result.append(f"    [{i}] {content_preview}")
+
+        # Show assistant messages
+        if assistant_messages:
+            result.append("")
+            result.append(f"  ASSISTANT RESPONSES: {len(assistant_messages)} message(s)")
+            for i, msg in enumerate(assistant_messages[:3], 1):  # Show first 3
+                content = msg.get("content", "")
+                content_preview = format_message_content(content, 150)
+                result.append(f"    [{i}] {content_preview}")
+            if len(assistant_messages) > 3:
+                result.append(f"    ... and {len(assistant_messages) - 3} more")
+
+        # Show system messages
+        if system_messages:
+            result.append("")
+            result.append(f"  SYSTEM MESSAGES: {len(system_messages)} message(s)")
+            for i, msg in enumerate(system_messages[:2], 1):  # Show first 2
+                content = msg.get("content", "")
+                content_preview = format_message_content(content, 100)
+                result.append(f"    [{i}] {content_preview}")
+            if len(system_messages) > 2:
+                result.append(f"    ... and {len(system_messages) - 2} more")
+
+        # Show other messages (tool_use, tool_result, etc.)
+        if other_messages:
+            result.append("")
+            result.append(f"  OTHER MESSAGES: {len(other_messages)} message(s)")
+            for i, msg in enumerate(other_messages[:3], 1):
+                role = msg.get("role", "unknown")
+                content = msg.get("content", "")
+                content_preview = format_message_content(content, 100)
+                result.append(f"    [{i}] {role}: {content_preview}")
+            if len(other_messages) > 3:
+                result.append(f"    ... and {len(other_messages) - 3} more")
+
+    # Tools
+    if "tools" in body:
+        tools = body["tools"]
+        result.append(f"Tools: {len(tools)} tool(s) available")
+
+    # System prompt info
+    if "system" in body:
+        system = body["system"]
+        if isinstance(system, str):
+            result.append(f"System: {truncate_text(system[:100], 100)}")
+        elif isinstance(system, list):
+            result.append(f"System: {len(system)} part(s)")
+
+    return "\n".join(" " * indent + line for line in result)
+
+
+def format_message_content(content, max_len: int = 100) -> str:
+    """Format message content for display."""
+    if isinstance(content, str):
+        # Clean up the content
+        cleaned = content.replace("\n", " ").strip()
+        # Remove system-reminder tags for cleaner display
+        if "<system-reminder>" in cleaned:
+            # Just show that it contains system-reminder
+            return truncate_text(cleaned[:max_len], max_len)
+        return truncate_text(cleaned, max_len)
+    elif isinstance(content, list):
+        # Handle multi-part content
+        parts = []
+        for part in content[:3]:
+            if isinstance(part, dict):
+                part_type = part.get("type", "unknown")
+                if part_type == "text":
+                    text = part.get("text", "")
+                    parts.append(truncate_text(text[:50], 50))
+                elif part_type == "image":
+                    parts.append("[image]")
+                elif part_type == "tool_use":
+                    parts.append(f"[tool:{part.get('name', 'unknown')}]")
+                else:
+                    parts.append(f"[{part_type}]")
+            else:
+                parts.append(str(part)[:50])
+        return ", ".join(parts)
+    else:
+        return truncate_text(str(content), max_len)
+
+
+def format_response_body(body: dict | None, indent: int = 4) -> str:
+    """Format response body for display."""
+    if not body:
+        return "N/A"
+
+    result = []
+
+    # Message ID
+    if "id" in body:
+        result.append(f"Message ID: {body['id']}")
+
+    # Model
+    if "model" in body:
+        result.append(f"Model: {body['model']}")
+
+    # Stop reason
+    if "stop_reason" in body:
+        result.append(f"Stop Reason: {body['stop_reason']}")
+
+    # Content
+    if "content" in body:
+        content = body["content"]
+        if isinstance(content, list):
+            result.append(f"Content: {len(content)} block(s)")
+            for i, block in enumerate(content[:5]):  # Show first 5 blocks
+                block_type = block.get("type", "unknown")
+                if block_type == "text":
+                    text = block.get("text", "")
+                    result.append(f"  [{i+1}] text: {truncate_text(text[:100], 100)}")
+                elif block_type == "tool_use":
+                    result.append(f"  [{i+1}] tool_use: {block.get('name', 'unknown')}")
+                else:
+                    result.append(f"  [{i+1}] {block_type}")
+            if len(content) > 5:
+                result.append(f"  ... and {len(content) - 5} more block(s)")
+        else:
+            result.append(f"Content: {truncate_text(str(content)[:100], 100)}")
+
+    # Usage
+    if "usage" in body:
+        usage = body["usage"]
+        result.append("Usage:")
+        result.append(f"  Input Tokens: {usage.get('input_tokens', 'N/A')}")
+        result.append(f"  Output Tokens: {usage.get('output_tokens', 'N/A')}")
+        if "cache_creation_input_tokens" in usage:
+            result.append(f"  Cache Creation: {usage['cache_creation_input_tokens']}")
+        if "cache_read_input_tokens" in usage:
+            result.append(f"  Cache Read: {usage['cache_read_input_tokens']}")
+
+    return "\n".join(" " * indent + line for line in result)
+
+
+def print_report(sessions: dict[str, SessionInfo]) -> None:
+    """Print formatted report."""
+
+    print("=" * 80)
+    print("SCODE LOG ANALYSIS REPORT")
+    print("=" * 80)
+    print()
+
+    # Sort sessions by start time
+    sorted_sessions = sorted(
+        sessions.values(),
+        key=lambda s: s.started_at or datetime.min,
+    )
+
+    for session in sorted_sessions:
+        print("-" * 80)
+        print(f"SESSION: {session.session_id}")
+        print("-" * 80)
+        print(f"  Started:    {format_datetime(session.started_at)}")
+        print(f"  Ended:      {format_datetime(session.ended_at)}")
+        print(f"  Version:    {session.version or 'N/A'}")
+        print(f"  Mode:       {session.mode or 'N/A'}")
+        print(f"  Model:      {session.model or 'N/A'}")
+        print(f"  Working Dir: {session.cwd or 'N/A'}")
+        print(f"  Duration:   {format_duration(session.duration_ms)}")
+        print(f"  Total Turns: {session.total_turns}")
+        print()
+
+        # Sort requests by start time
+        sorted_requests = sorted(
+            session.requests.values(),
+            key=lambda r: r.started_at or datetime.min,
+        )
+
+        for i, req in enumerate(sorted_requests, 1):
+            print(f"  {'=' * 70}")
+            print(f"  REQUEST #{i}: {req.request_id}")
+            print(f"  {'=' * 70}")
+            print()
+
+            # Status
+            if req.status:
+                status_emoji = "✅" if req.status == 200 else "❌"
+                print(f"  Status: {status_emoji} {req.status}")
+            elif req.error:
+                print(f"  Status: ❌ FAILED")
+            else:
+                print(f"  Status: ⏳ In Progress")
+
+            print(f"  Attempt:    {req.attempt}")
+            print(f"  Method:     {req.method or 'N/A'}")
+            print(f"  Path:       {req.path or 'N/A'}")
+            print(f"  Started:    {format_datetime(req.started_at)}")
+
+            if req.succeeded_at:
+                print(f"  Succeeded:  {format_datetime(req.succeeded_at)}")
+            if req.failed_at:
+                print(f"  Failed:     {format_datetime(req.failed_at)}")
+
+            print(f"  Duration:   {format_duration(req.duration_ms)}")
+
+            # Request IDs for tracking and reconciliation
+            print(f"  Client Request ID: {req.request_id}")
+            if req.provider_request_id:
+                print(f"  Provider Request ID (header): {req.provider_request_id}")
+            if req.provider_response_request_id:
+                print(f"  Provider Request ID (response): {req.provider_response_request_id}")
+
+            if req.error:
+                print(f"  Error:      {req.error}")
+                print(f"  Retryable:  {'Yes' if req.retryable else 'No'}")
+
+            print()
+
+            # Request body
+            if req.body:
+                print("  Request Body:")
+                print(format_body(req.body))
+                print()
+
+            # Response body
+            if req.response_body:
+                print("  Response Body:")
+                print(format_response_body(req.response_body))
+                print()
+
+            # Token usage
+            if req.input_tokens or req.output_tokens:
+                print("  Token Usage:")
+                print(f"    Input Tokens:              {req.input_tokens:,}")
+                print(f"    Output Tokens:             {req.output_tokens:,}")
+                if req.cache_creation_input_tokens:
+                    print(f"    Cache Creation Tokens:     {req.cache_creation_input_tokens:,}")
+                if req.cache_read_input_tokens:
+                    print(f"    Cache Read Tokens:         {req.cache_read_input_tokens:,}")
+                print()
+
+        # Session summary
+        print("-" * 80)
+        print("  SESSION SUMMARY")
+        print("-" * 80)
+        print(f"  Total Requests:        {len(session.requests)}")
+
+        # Count successful/failed
+        successful = sum(1 for r in session.requests.values() if r.status == 200)
+        failed = sum(1 for r in session.requests.values() if r.error)
+        print(f"  Successful Requests:   {successful}")
+        print(f"  Failed Requests:       {failed}")
+
+        print()
+        print("  Token Consumption:")
+        print(f"    Total Input Tokens:          {session.total_input_tokens:,}")
+        print(f"    Total Output Tokens:         {session.total_output_tokens:,}")
+        if session.total_cache_creation_tokens:
+            print(f"    Total Cache Creation Tokens: {session.total_cache_creation_tokens:,}")
+        if session.total_cache_read_tokens:
+            print(f"    Total Cache Read Tokens:     {session.total_cache_read_tokens:,}")
+
+        total_tokens = (
+            session.total_input_tokens
+            + session.total_output_tokens
+            + session.total_cache_creation_tokens
+            + session.total_cache_read_tokens
+        )
+        print(f"    ─────────────────────────────────────")
+        print(f"    Grand Total:                 {total_tokens:,}")
+
+        print()
+
+    # Final summary
+    print("=" * 80)
+    print("OVERALL SUMMARY")
+    print("=" * 80)
+    print(f"  Total Sessions:     {len(sessions)}")
+
+    total_requests = sum(len(s.requests) for s in sessions.values())
+    print(f"  Total Requests:     {total_requests}")
+
+    grand_input = sum(s.total_input_tokens for s in sessions.values())
+    grand_output = sum(s.total_output_tokens for s in sessions.values())
+    grand_cache_creation = sum(s.total_cache_creation_tokens for s in sessions.values())
+    grand_cache_read = sum(s.total_cache_read_tokens for s in sessions.values())
+
+    print()
+    print("  Total Token Consumption (All Sessions):")
+    print(f"    Input Tokens:          {grand_input:,}")
+    print(f"    Output Tokens:         {grand_output:,}")
+    print(f"    Cache Creation Tokens: {grand_cache_creation:,}")
+    print(f"    Cache Read Tokens:     {grand_cache_read:,}")
+    print(f"    ─────────────────────────────────────")
+    print(f"    Grand Total:           {grand_input + grand_output + grand_cache_creation + grand_cache_read:,}")
+    print()
+
+
+def main() -> None:
+    """Main entry point."""
+    if len(sys.argv) > 1:
+        log_path = Path(sys.argv[1])
+    else:
+        # Default path
+        log_path = Path.home() / ".nexus" / "logs" / "scode.log"
+
+    if not log_path.exists():
+        print(f"Error: Log file not found: {log_path}")
+        sys.exit(1)
+
+    print(f"Analyzing log file: {log_path}")
+    print()
+
+    sessions = analyze_log(log_path)
+
+    if not sessions:
+        print("No sessions found in log file.")
+        sys.exit(0)
+
+    print_report(sessions)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR introduces comprehensive logging optimizations for the SudoCode telemetry system, enabling end-to-end request tracking and improved troubleshooting capabilities.

### Key Changes

**1. Request Tracking with Unique `request_id`**
- Each HTTP request lifecycle now has a unique `request_id` for tracking and reconciliation with LLM providers
- `HttpRequestResult` struct returns both response and client-generated `request_id`
- Provider request ID extraction from response headers (`request-id`, `x-request-id`, `x-oneapi-request-id`)

**2. Trace ID Pass-Through (End-to-End Tracing)**
- `trace_id` parameter added to `send_json` and provider methods
- Enables request tracking from SudoWork → SudoRouter → SudoCode
- `X-Request-ID` header sent with each request for cross-system correlation

**3. Response Logging**
- New `HttpResponseDebug` event for response logging
- Streaming response detection with appropriate placeholder
- Response headers masking for sensitive data

**4. Duration Tracking**
- Added `duration_ms`, `start_timestamp_ms`, `end_timestamp_ms` fields
- Request timing from start to completion

**5. Log Level Support**
- Debug level for detailed request/response logs
- Info level for lifecycle events (started, succeeded, failed)
- Warn level for failures

**6. Duplicate Log Elimination**
- Removed redundant `SessionTrace` calls in `SessionTracer` methods
- ~50% reduction in duplicate log records

### Files Modified

- `rust/crates/telemetry/src/lib.rs` - Core telemetry events with `request_id`, duration, log levels
- `rust/crates/api/src/http_transport.rs` - `HttpRequestResult`, `request_id_from_headers`, `trace_id` support
- `rust/crates/api/src/providers/*.rs` - Updated to use `HttpRequestResult` and pass `trace_id`
- `rust/crates/runtime/src/conversation.rs` - `trace_id` extraction from ACP metadata
- `rust/crates/runtime/src/acp_sdk_server.rs` - `trace_id` pass-through support
- `scripts/analyze_scode_log.py` - Python script for log analysis by session/request

### New Tools

**Log Analysis Script** (`scripts/analyze_scode_log.py`)
- Organizes logs by session → request level
- Shows request details, response info, token consumption
- Categorizes messages by role (USER REQUESTS, ASSISTANT RESPONSES, SYSTEM MESSAGES, OTHER MESSAGES)
- Extracts provider request ID from response headers
- Session summary with total token consumption

## Test plan

- [x] Compile and run scode binary
- [x] Verify log output format with unique `request_id`
- [x] Verify response logging for streaming responses
- [x] Verify provider request ID extraction (`x-oneapi-request-id`)
- [x] Run Python analysis script on generated logs
- [x] Verify token consumption tracking
- [x] Run `cargo test --workspace` - all tests pass
- [x] Run `cargo clippy --workspace --all-targets -- -D warnings` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)