### PR TITLE
fix(cli): remove duplicate response print in run_turn

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2666,10 +2666,6 @@ impl LiveCli {
                     )?;
                 } else {
                     spinner.clear(&mut stdout)?;
-                    let final_text = final_assistant_text(&summary);
-                    if !final_text.is_empty() {
-                        println!("{final_text}");
-                    }
                     if let Some(event) = summary.auto_compaction {
                         println!(
                             "{}",


### PR DESCRIPTION
## Summary

- Streaming already writes assistant text to stdout in real time when `emit_output: true`
- The post-turn `println!("{final_text}")` in `run_turn()` was a leftover from before live streaming existed, causing every response to appear twice
- Fix: delete the 4 redundant lines — `run_prompt_compact` and `run_prompt_json` are unaffected (they use `emit_output: false` and rely on `final_assistant_text` as their only output path)

Closes #143

## Test plan

- [ ] Run `scode "just say the word: HELLO"` — response appears exactly once
- [ ] Run `scode --compact "hello"` — still works (compact path unchanged)
- [ ] Run `scode --output json "hello"` — still works (JSON path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)