### PR TITLE
[codex] add tool timeout and interrupt handling

### DIFF
--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -95,6 +95,7 @@ enum Scenario {
     WriteFileDenied,
     MultiToolTurnRoundtrip,
     BashStdoutRoundtrip,
+    BashInterruptLongRunning,
     BashPermissionPromptApproved,
     BashPermissionPromptDenied,
     PluginToolRoundtrip,
@@ -112,6 +113,7 @@ impl Scenario {
             "write_file_denied" => Some(Self::WriteFileDenied),
             "multi_tool_turn_roundtrip" => Some(Self::MultiToolTurnRoundtrip),
             "bash_stdout_roundtrip" => Some(Self::BashStdoutRoundtrip),
+            "bash_interrupt_long_running" => Some(Self::BashInterruptLongRunning),
             "bash_permission_prompt_approved" => Some(Self::BashPermissionPromptApproved),
             "bash_permission_prompt_denied" => Some(Self::BashPermissionPromptDenied),
             "plugin_tool_roundtrip" => Some(Self::PluginToolRoundtrip),
@@ -130,6 +132,7 @@ impl Scenario {
             Self::WriteFileDenied => "write_file_denied",
             Self::MultiToolTurnRoundtrip => "multi_tool_turn_roundtrip",
             Self::BashStdoutRoundtrip => "bash_stdout_roundtrip",
+            Self::BashInterruptLongRunning => "bash_interrupt_long_running",
             Self::BashPermissionPromptApproved => "bash_permission_prompt_approved",
             Self::BashPermissionPromptDenied => "bash_permission_prompt_denied",
             Self::PluginToolRoundtrip => "plugin_tool_roundtrip",
@@ -444,6 +447,18 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
                 &[r#"{"command":"printf 'alpha from bash'","timeout":1000}"#],
             ),
         },
+        Scenario::BashInterruptLongRunning => match latest_tool_result(request) {
+            Some((tool_output, _)) => final_text_sse(&format!(
+                "bash interrupt unexpectedly continued: {tool_output}"
+            )),
+            None => tool_use_sse(
+                "toolu_bash_interrupt",
+                "bash",
+                &[
+                    r#"{"command":"printf 'interrupt-start'; sleep 30; printf 'interrupt-done'","timeout":120000}"#,
+                ],
+            ),
+        },
         Scenario::BashPermissionPromptApproved => match latest_tool_result(request) {
             Some((tool_output, is_error)) => {
                 if is_error {
@@ -595,6 +610,21 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 json!({"command": "printf 'alpha from bash'", "timeout": 1000}),
             ),
         },
+        Scenario::BashInterruptLongRunning => match latest_tool_result(request) {
+            Some((tool_output, _)) => text_message_response(
+                "msg_bash_interrupt_unexpected_final",
+                &format!("bash interrupt unexpectedly continued: {tool_output}"),
+            ),
+            None => tool_message_response(
+                "msg_bash_interrupt_tool",
+                "toolu_bash_interrupt",
+                "bash",
+                json!({
+                    "command": "printf 'interrupt-start'; sleep 30; printf 'interrupt-done'",
+                    "timeout": 120000
+                }),
+            ),
+        },
         Scenario::BashPermissionPromptApproved => match latest_tool_result(request) {
             Some((tool_output, is_error)) => {
                 if is_error {
@@ -670,6 +700,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         Scenario::WriteFileDenied => "req_write_file_denied",
         Scenario::MultiToolTurnRoundtrip => "req_multi_tool_turn_roundtrip",
         Scenario::BashStdoutRoundtrip => "req_bash_stdout_roundtrip",
+        Scenario::BashInterruptLongRunning => "req_bash_interrupt_long_running",
         Scenario::BashPermissionPromptApproved => "req_bash_permission_prompt_approved",
         Scenario::BashPermissionPromptDenied => "req_bash_permission_prompt_denied",
         Scenario::PluginToolRoundtrip => "req_plugin_tool_roundtrip",

--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -6,14 +6,21 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command as TokioCommand;
 use tokio::runtime::Builder;
-use tokio::time::timeout;
 
+use crate::hooks::HookAbortSignal;
 use crate::lane_events::{LaneEvent, ShipMergeMethod, ShipProvenance};
 use crate::sandbox::{
     build_linux_sandbox_command, resolve_sandbox_status_for_request, FilesystemIsolationMode,
     SandboxConfig, SandboxStatus,
 };
 use crate::ConfigLoader;
+
+/// Default foreground subprocess timeout for tool-backed command execution.
+///
+/// Tool schemas still allow callers to provide a larger or smaller per-call
+/// timeout; this default prevents unbounded foreground commands from pinning a
+/// turn indefinitely when the model omits that field.
+pub const DEFAULT_TOOL_SUBPROCESS_TIMEOUT_MS: u64 = 120_000;
 
 /// Input schema for the built-in bash execution tool.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -69,6 +76,14 @@ pub struct BashCommandOutput {
 
 /// Executes a shell command with the requested sandbox settings.
 pub fn execute_bash(input: BashCommandInput) -> io::Result<BashCommandOutput> {
+    execute_bash_with_abort(input, None)
+}
+
+/// Executes a shell command and cooperates with turn cancellation.
+pub fn execute_bash_with_abort(
+    input: BashCommandInput,
+    abort_signal: Option<&HookAbortSignal>,
+) -> io::Result<BashCommandOutput> {
     let cwd = env::current_dir()?;
     let sandbox_status = sandbox_status_for_input(&input, &cwd);
 
@@ -104,11 +119,21 @@ pub fn execute_bash(input: BashCommandInput) -> io::Result<BashCommandOutput> {
     // creating a nested runtime which would panic.
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         tokio::task::block_in_place(|| {
-            handle.block_on(execute_bash_async(input, sandbox_status, cwd))
+            handle.block_on(execute_bash_async(
+                input,
+                sandbox_status,
+                cwd,
+                abort_signal.cloned(),
+            ))
         })
     } else {
         let runtime = Builder::new_current_thread().enable_all().build()?;
-        runtime.block_on(execute_bash_async(input, sandbox_status, cwd))
+        runtime.block_on(execute_bash_async(
+            input,
+            sandbox_status,
+            cwd,
+            abort_signal.cloned(),
+        ))
     }
 }
 
@@ -178,6 +203,7 @@ async fn execute_bash_async(
     input: BashCommandInput,
     sandbox_status: SandboxStatus,
     cwd: std::path::PathBuf,
+    abort_signal: Option<HookAbortSignal>,
 ) -> io::Result<BashCommandOutput> {
     // Detect and emit ship provenance for git push operations
     detect_and_emit_ship_prepared(&input.command);
@@ -185,34 +211,42 @@ async fn execute_bash_async(
     let mut command = prepare_tokio_command(&input.command, &cwd, &sandbox_status, true);
     command.stdin(Stdio::null());
 
-    let output_result = if let Some(timeout_ms) = input.timeout {
-        match timeout(Duration::from_millis(timeout_ms), command.output()).await {
-            Ok(result) => (result?, false),
-            Err(_) => {
-                return Ok(BashCommandOutput {
-                    stdout: String::new(),
-                    stderr: format!("Command exceeded timeout of {timeout_ms} ms"),
-                    raw_output_path: None,
-                    interrupted: true,
-                    is_image: None,
-                    background_task_id: None,
-                    backgrounded_by_user: None,
-                    assistant_auto_backgrounded: None,
-                    dangerously_disable_sandbox: input.dangerously_disable_sandbox,
-                    return_code_interpretation: Some(String::from("timeout")),
-                    no_output_expected: Some(true),
-                    structured_content: None,
-                    persisted_output_path: None,
-                    persisted_output_size: None,
-                    sandbox_status: Some(sandbox_status),
-                });
-            }
+    command.kill_on_drop(true);
+    let timeout_ms = input.timeout.unwrap_or(DEFAULT_TOOL_SUBPROCESS_TIMEOUT_MS);
+    let output = command.output();
+    tokio::pin!(output);
+    let timeout_sleep = tokio::time::sleep(Duration::from_millis(timeout_ms));
+    tokio::pin!(timeout_sleep);
+    let abort_wait = async {
+        if let Some(signal) = abort_signal {
+            signal.cancelled().await;
+        } else {
+            std::future::pending::<()>().await;
         }
-    } else {
-        (command.output().await?, false)
+    };
+    tokio::pin!(abort_wait);
+
+    let output = tokio::select! {
+        biased;
+        () = &mut abort_wait => {
+            return Ok(interrupted_bash_output(
+                "Command interrupted by user",
+                "interrupted",
+                input.dangerously_disable_sandbox,
+                sandbox_status,
+            ));
+        }
+        () = &mut timeout_sleep => {
+            return Ok(interrupted_bash_output(
+                &format!("Command exceeded timeout of {timeout_ms} ms"),
+                "timeout",
+                input.dangerously_disable_sandbox,
+                sandbox_status,
+            ));
+        }
+        result = &mut output => result?,
     };
 
-    let (output, interrupted) = output_result;
     let stdout = truncate_output(&String::from_utf8_lossy(&output.stdout));
     let stderr = truncate_output(&String::from_utf8_lossy(&output.stderr));
     let no_output_expected = Some(stdout.trim().is_empty() && stderr.trim().is_empty());
@@ -228,7 +262,7 @@ async fn execute_bash_async(
         stdout,
         stderr,
         raw_output_path: None,
-        interrupted,
+        interrupted: false,
         is_image: None,
         background_task_id: None,
         backgrounded_by_user: None,
@@ -241,6 +275,31 @@ async fn execute_bash_async(
         persisted_output_size: None,
         sandbox_status: Some(sandbox_status),
     })
+}
+
+fn interrupted_bash_output(
+    stderr: &str,
+    return_code_interpretation: &str,
+    dangerously_disable_sandbox: Option<bool>,
+    sandbox_status: SandboxStatus,
+) -> BashCommandOutput {
+    BashCommandOutput {
+        stdout: String::new(),
+        stderr: stderr.to_string(),
+        raw_output_path: None,
+        interrupted: true,
+        is_image: None,
+        background_task_id: None,
+        backgrounded_by_user: None,
+        assistant_auto_backgrounded: None,
+        dangerously_disable_sandbox,
+        return_code_interpretation: Some(return_code_interpretation.to_string()),
+        no_output_expected: Some(true),
+        structured_content: None,
+        persisted_output_path: None,
+        persisted_output_size: None,
+        sandbox_status: Some(sandbox_status),
+    }
 }
 
 fn sandbox_status_for_input(input: &BashCommandInput, cwd: &std::path::Path) -> SandboxStatus {
@@ -362,7 +421,8 @@ pub fn execute_bash_with_tracking(
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_bash, BashCommandInput};
+    use super::{execute_bash, execute_bash_with_abort, BashCommandInput};
+    use crate::hooks::HookAbortSignal;
     use crate::sandbox::FilesystemIsolationMode;
 
     #[test]
@@ -401,6 +461,34 @@ mod tests {
         .expect("bash command should execute");
 
         assert!(!output.sandbox_status.expect("sandbox status").enabled);
+    }
+
+    #[test]
+    fn abort_signal_interrupts_foreground_command() {
+        let abort_signal = HookAbortSignal::new();
+        abort_signal.abort();
+
+        let output = execute_bash_with_abort(
+            BashCommandInput {
+                command: String::from("sleep 5"),
+                timeout: Some(10_000),
+                description: None,
+                run_in_background: Some(false),
+                dangerously_disable_sandbox: Some(false),
+                namespace_restrictions: Some(false),
+                isolate_network: Some(false),
+                filesystem_mode: Some(FilesystemIsolationMode::WorkspaceOnly),
+                allowed_mounts: None,
+            },
+            Some(&abort_signal),
+        )
+        .expect("bash command should return interrupted output");
+
+        assert!(output.interrupted);
+        assert_eq!(
+            output.return_code_interpretation.as_deref(),
+            Some("interrupted")
+        );
     }
 }
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -101,6 +101,8 @@ pub trait RuntimeObserver {
 /// Trait implemented by tool dispatchers that execute model-requested tools.
 pub trait ToolExecutor: Send {
     fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError>;
+
+    fn set_abort_signal(&mut self, _abort_signal: HookAbortSignal) {}
 }
 
 /// Error returned when a tool invocation fails locally.
@@ -303,6 +305,8 @@ where
 
     #[must_use]
     pub fn with_hook_abort_signal(mut self, hook_abort_signal: HookAbortSignal) -> Self {
+        self.tool_executor
+            .set_abort_signal(hook_abort_signal.clone());
         self.hook_abort_signal = hook_abort_signal;
         self
     }
@@ -550,6 +554,73 @@ where
             // Log cleaned files for debugging (could be sent to observer in future)
             // Note: This is silent cleanup, no token consumption
         }
+        self.finish_current_turn_tracking();
+    }
+
+    fn finish_current_turn_tracking(&mut self) {
+        self.file_tracker.end_turn();
+        self.current_turn_id = None;
+        self.user_request_intent = None;
+    }
+
+    fn push_tool_result_message(
+        &mut self,
+        observer: &mut Option<&mut dyn RuntimeObserver>,
+        iterations: usize,
+        tool_results: &mut Vec<ConversationMessage>,
+        result_message: ConversationMessage,
+    ) -> Result<(), RuntimeError> {
+        notify_tool_result(runtime_observer_mut(observer), &result_message);
+        self.session
+            .push_message(result_message.clone())
+            .map_err(|error| RuntimeError::new(error.to_string()))?;
+        self.record_tool_finished(iterations, &result_message);
+        tool_results.push(result_message);
+        Ok(())
+    }
+
+    fn push_interrupted_tool_results(
+        &mut self,
+        observer: &mut Option<&mut dyn RuntimeObserver>,
+        iterations: usize,
+        tool_results: &mut Vec<ConversationMessage>,
+        pending_tool_uses: &[(String, String, String)],
+        start_index: usize,
+    ) -> Result<(), RuntimeError> {
+        for (tool_use_id, tool_name, _) in &pending_tool_uses[start_index..] {
+            let result_message = ConversationMessage::tool_result(
+                tool_use_id.clone(),
+                tool_name.clone(),
+                INTERRUPT_MESSAGE,
+                true,
+            );
+            self.push_tool_result_message(observer, iterations, tool_results, result_message)?;
+        }
+        Ok(())
+    }
+
+    fn cancelled_summary(
+        &mut self,
+        assistant_messages: Vec<ConversationMessage>,
+        tool_results: Vec<ConversationMessage>,
+        prompt_cache_events: Vec<PromptCacheEvent>,
+        iterations: usize,
+    ) -> TurnSummary {
+        let cleaned = self.cleanup_current_turn_drafts();
+        if !cleaned.is_empty() {
+            // Log cleaned files for debugging (could be sent to observer in future)
+            // Note: This is silent cleanup, no token consumption
+        }
+        self.finish_current_turn_tracking();
+        TurnSummary {
+            assistant_messages,
+            tool_results,
+            prompt_cache_events,
+            iterations,
+            usage: self.usage_tracker.cumulative_usage(),
+            auto_compaction: None,
+            cancelled: true,
+        }
     }
 
     #[allow(clippy::too_many_lines)]
@@ -772,8 +843,41 @@ where
                 break;
             }
 
-            for (tool_use_id, tool_name, input) in pending_tool_uses {
+            for tool_index in 0..pending_tool_uses.len() {
+                if self.hook_abort_signal.is_aborted() {
+                    self.push_interrupted_tool_results(
+                        &mut observer,
+                        iterations,
+                        &mut tool_results,
+                        &pending_tool_uses,
+                        tool_index,
+                    )?;
+                    return Ok(self.cancelled_summary(
+                        assistant_messages,
+                        tool_results,
+                        prompt_cache_events,
+                        iterations,
+                    ));
+                }
+
+                let (tool_use_id, tool_name, input) = pending_tool_uses[tool_index].clone();
                 let pre_hook_result = self.run_pre_tool_use_hook(&tool_name, &input);
+                if self.hook_abort_signal.is_aborted() {
+                    self.push_interrupted_tool_results(
+                        &mut observer,
+                        iterations,
+                        &mut tool_results,
+                        &pending_tool_uses,
+                        tool_index,
+                    )?;
+                    return Ok(self.cancelled_summary(
+                        assistant_messages,
+                        tool_results,
+                        prompt_cache_events,
+                        iterations,
+                    ));
+                }
+
                 let effective_input = pre_hook_result
                     .updated_input()
                     .map_or_else(|| input.clone(), ToOwned::to_owned);
@@ -827,6 +931,34 @@ where
                                 Ok(output) => (output, false),
                                 Err(error) => (error.to_string(), true),
                             };
+                        if self.hook_abort_signal.is_aborted() {
+                            output = merge_hook_feedback(pre_hook_result.messages(), output, true);
+                            let result_message = ConversationMessage::tool_result(
+                                tool_use_id,
+                                tool_name,
+                                output,
+                                true,
+                            );
+                            self.push_tool_result_message(
+                                &mut observer,
+                                iterations,
+                                &mut tool_results,
+                                result_message,
+                            )?;
+                            self.push_interrupted_tool_results(
+                                &mut observer,
+                                iterations,
+                                &mut tool_results,
+                                &pending_tool_uses,
+                                tool_index + 1,
+                            )?;
+                            return Ok(self.cancelled_summary(
+                                assistant_messages,
+                                tool_results,
+                                prompt_cache_events,
+                                iterations,
+                            ));
+                        }
                         output = merge_hook_feedback(pre_hook_result.messages(), output, false);
 
                         let post_hook_result = if is_error {
@@ -866,21 +998,18 @@ where
                         true,
                     ),
                 };
-                notify_tool_result(runtime_observer_mut(&mut observer), &result_message);
-                self.session
-                    .push_message(result_message.clone())
-                    .map_err(|error| RuntimeError::new(error.to_string()))?;
-                self.record_tool_finished(iterations, &result_message);
-                tool_results.push(result_message);
+                self.push_tool_result_message(
+                    &mut observer,
+                    iterations,
+                    &mut tool_results,
+                    result_message,
+                )?;
             }
         }
 
         let auto_compaction = self.maybe_auto_compact();
 
-        // End file tracking for this turn
-        self.file_tracker.end_turn();
-        self.current_turn_id = None;
-        self.user_request_intent = None;
+        self.finish_current_turn_tracking();
 
         let summary = TurnSummary {
             assistant_messages,
@@ -2037,6 +2166,84 @@ mod tests {
                 ObservedRuntimeEvent::TextDelta("The answer is 4.".to_string()),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn abort_during_tool_execution_cancels_turn_and_synthesizes_remaining_results() {
+        struct TwoToolUseApiClient {
+            calls: usize,
+        }
+
+        #[async_trait]
+        impl ApiClient for TwoToolUseApiClient {
+            async fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                self.calls += 1;
+                assert_eq!(
+                    self.calls, 1,
+                    "cancelled turn must not make a follow-up API call"
+                );
+                Ok(events_to_stream(vec![
+                    AssistantEvent::ToolUse {
+                        id: "tool-1".to_string(),
+                        name: "slow".to_string(),
+                        input: "{}".to_string(),
+                        thought_signature: None,
+                    },
+                    AssistantEvent::ToolUse {
+                        id: "tool-2".to_string(),
+                        name: "later".to_string(),
+                        input: "{}".to_string(),
+                        thought_signature: None,
+                    },
+                    AssistantEvent::MessageStop,
+                ]))
+            }
+        }
+
+        let abort_signal = crate::HookAbortSignal::new();
+        let abort_from_tool = abort_signal.clone();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            TwoToolUseApiClient { calls: 0 },
+            StaticToolExecutor::new()
+                .register("slow", move |_input| {
+                    abort_from_tool.abort();
+                    Ok("partial output".to_string())
+                })
+                .register("later", |_input| {
+                    panic!("remaining tool should be synthesized")
+                }),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_hook_abort_signal(abort_signal);
+
+        let summary = runtime
+            .run_turn("use tools", None, None)
+            .await
+            .expect("cancelled tool turn should resolve cleanly");
+
+        assert!(summary.cancelled);
+        assert_eq!(summary.tool_results.len(), 2);
+        let ContentBlock::ToolResult {
+            output, is_error, ..
+        } = &summary.tool_results[0].blocks[0]
+        else {
+            panic!("expected first tool result");
+        };
+        assert!(*is_error);
+        assert_eq!(output, "partial output");
+        let ContentBlock::ToolResult {
+            output, is_error, ..
+        } = &summary.tool_results[1].blocks[0]
+        else {
+            panic!("expected synthesized tool result");
+        };
+        assert!(*is_error);
+        assert!(output.contains("Interrupted"));
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -63,8 +63,8 @@ pub mod worker_boot;
 
 pub use acp_sdk_server::AcpError;
 pub use bash::{
-    execute_bash, execute_bash_with_tracking, BashCommandInput, BashCommandOutput,
-    BashWithTrackingResult,
+    execute_bash, execute_bash_with_abort, execute_bash_with_tracking, BashCommandInput,
+    BashCommandOutput, BashWithTrackingResult, DEFAULT_TOOL_SUBPROCESS_TIMEOUT_MS,
 };
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -46,6 +46,7 @@ pub(crate) struct CliToolExecutor {
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     spinner_pause: Option<Arc<AtomicBool>>,
     question_prompter: Option<Box<dyn QuestionPrompter>>,
+    abort_signal: Option<runtime::HookAbortSignal>,
 }
 
 impl CliToolExecutor {
@@ -63,6 +64,7 @@ impl CliToolExecutor {
             mcp_state,
             spinner_pause: None,
             question_prompter: None,
+            abort_signal: None,
         }
     }
 
@@ -189,14 +191,18 @@ impl ToolExecutor for CliToolExecutor {
             self.execute_runtime_tool(tool_name, value)
         } else {
             self.tool_registry
-                .execute(tool_name, &value)
+                .execute_with_abort(tool_name, &value, self.abort_signal.as_ref())
                 .map_err(ToolError::new)
         };
         match result {
             Ok(output) => {
                 if self.emit_output {
                     self.pause_spinner();
-                    let formatted = format_tool_result(tool_name, &output, false);
+                    let interrupted = self
+                        .abort_signal
+                        .as_ref()
+                        .is_some_and(runtime::HookAbortSignal::is_aborted);
+                    let formatted = format_tool_result(tool_name, &output, interrupted);
                     writeln!(io::stdout(), "{formatted}")
                         .and_then(|()| io::stdout().flush())
                         .map_err(|error| ToolError::new(error.to_string()))?;
@@ -216,6 +222,10 @@ impl ToolExecutor for CliToolExecutor {
                 Err(error)
             }
         }
+    }
+
+    fn set_abort_signal(&mut self, abort_signal: runtime::HookAbortSignal) {
+        self.abort_signal = Some(abort_signal);
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/tests/interrupt_e2e.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/interrupt_e2e.rs
@@ -1,0 +1,187 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use mock_anthropic_service::{MockAnthropicService, SCENARIO_PREFIX};
+use serde_json::Value;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[test]
+fn sigint_during_bash_tool_returns_interrupted_result_without_continuing_turn() {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should build");
+    let server = runtime
+        .block_on(MockAnthropicService::spawn())
+        .expect("mock service should start");
+    let base_url = server.base_url();
+
+    let workspace = unique_temp_dir("interrupt-e2e");
+    let config_home = workspace.join("config-home");
+    let home = workspace.join("home");
+    fs::create_dir_all(&workspace).expect("workspace should exist");
+    fs::create_dir_all(&config_home).expect("config home should exist");
+    fs::create_dir_all(&home).expect("home should exist");
+    write_config(&config_home, &base_url);
+
+    let prompt = format!("{SCENARIO_PREFIX}bash_interrupt_long_running");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_scode"))
+        .current_dir(&workspace)
+        .env_clear()
+        .env("SUDO_CODE_CONFIG_HOME", &config_home)
+        .env("HOME", &home)
+        .env("NO_COLOR", "1")
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        )
+        .args([
+            "--auth",
+            "api-key",
+            "--model",
+            "sonnet",
+            "--permission-mode",
+            "danger-full-access",
+            "--allowedTools",
+            "bash",
+            "--output-format",
+            "json",
+            &prompt,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("scode should launch");
+
+    wait_for_message_request(&runtime, &server, 1, Duration::from_secs(10));
+    thread::sleep(Duration::from_millis(1500));
+    send_sigint(child.id());
+
+    let status =
+        wait_for_exit(&mut child, Duration::from_secs(10)).expect("scode should exit after SIGINT");
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    child
+        .stdout
+        .take()
+        .expect("stdout should be piped")
+        .read_to_string(&mut stdout)
+        .expect("stdout should read");
+    child
+        .stderr
+        .take()
+        .expect("stderr should be piped")
+        .read_to_string(&mut stderr)
+        .expect("stderr should read");
+
+    assert!(
+        status.success(),
+        "scode should exit cleanly after interrupt\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+    );
+
+    let captured = runtime.block_on(server.captured_requests());
+    let message_request_count = captured
+        .iter()
+        .filter(|request| request.path == "/v1/messages")
+        .count();
+    assert_eq!(
+        message_request_count, 1,
+        "interrupt should cancel the turn without a follow-up model call"
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+    let tool_results = parsed["tool_results"]
+        .as_array()
+        .expect("tool_results should be an array");
+    assert_eq!(tool_results.len(), 1);
+    assert_eq!(tool_results[0]["tool_name"], "bash");
+    assert_eq!(tool_results[0]["is_error"], true);
+
+    let tool_output: Value = serde_json::from_str(
+        tool_results[0]["output"]
+            .as_str()
+            .expect("tool output should be a JSON string"),
+    )
+    .expect("bash output should parse as JSON");
+    assert_eq!(tool_output["interrupted"], true);
+    assert_eq!(tool_output["returnCodeInterpretation"], "interrupted");
+    assert_eq!(tool_output["stderr"], "Command interrupted by user");
+
+    fs::remove_dir_all(&workspace).expect("workspace cleanup should succeed");
+}
+
+fn wait_for_message_request(
+    runtime: &tokio::runtime::Runtime,
+    server: &MockAnthropicService,
+    expected: usize,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let captured = runtime.block_on(server.captured_requests());
+        let count = captured
+            .iter()
+            .filter(|request| request.path == "/v1/messages")
+            .count();
+        if count >= expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected} /v1/messages request(s); saw {count}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_exit(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(50)),
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Err(error) => panic!("failed to wait for scode: {error}"),
+        }
+    }
+}
+
+fn send_sigint(pid: u32) {
+    let status = Command::new("kill")
+        .arg("-INT")
+        .arg(pid.to_string())
+        .status()
+        .expect("kill should launch");
+    assert!(status.success(), "kill -INT should succeed");
+}
+
+fn write_config(config_home: &std::path::Path, base_url: &str) {
+    let sample = runtime::SAMPLE_SUDOCODE_JSON
+        .replace("https://api.anthropic.com", base_url)
+        .replace("<YOUR_ANTHROPIC_API_KEY>", "test-interrupt-key");
+    fs::write(config_home.join("sudocode.json"), sample).expect("sudocode.json should be written");
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_millis();
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "scode-{label}-{}-{millis}-{counter}",
+        std::process::id()
+    ))
+}

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -15,8 +15,8 @@ use api::{
 use plugins::PluginTool;
 use reqwest::blocking::Client;
 use runtime::{
-    check_freshness, dedupe_superseded_commit_events, edit_file, execute_bash, glob_search,
-    grep_search, load_system_prompt,
+    check_freshness, dedupe_superseded_commit_events, edit_file, execute_bash_with_abort,
+    glob_search, grep_search, load_system_prompt,
     lsp_client::LspRegistry,
     mcp_tool_bridge::McpToolRegistry,
     permission_enforcer::{EnforcementResult, PermissionEnforcer},
@@ -27,10 +27,10 @@ use runtime::{
     worker_boot::{WorkerReadySnapshot, WorkerRegistry, WorkerTaskReceipt},
     write_file, ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, BashCommandInput,
     BashCommandOutput, BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage,
-    ConversationRuntime, GrepSearchInput, LaneCommitProvenance, LaneEvent, LaneEventBlocker,
-    LaneEventName, LaneEventStatus, LaneFailureClass, McpDegradedReport, MessageRole,
-    PermissionMode, PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig, RuntimeError,
-    Session, StdFsBackend, SystemPrompt, TaskPacket, ToolError, ToolExecutor,
+    ConversationRuntime, GrepSearchInput, HookAbortSignal, LaneCommitProvenance, LaneEvent,
+    LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass, McpDegradedReport,
+    MessageRole, PermissionMode, PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig,
+    RuntimeError, Session, StdFsBackend, SystemPrompt, TaskPacket, ToolError, ToolExecutor,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -451,8 +451,17 @@ impl GlobalToolRegistry {
     }
 
     pub fn execute(&self, name: &str, input: &Value) -> Result<String, String> {
+        self.execute_with_abort(name, input, None)
+    }
+
+    pub fn execute_with_abort(
+        &self,
+        name: &str,
+        input: &Value,
+        abort_signal: Option<&HookAbortSignal>,
+    ) -> Result<String, String> {
         if mvp_tool_specs().iter().any(|spec| spec.name == name) {
-            return execute_tool_with_enforcer(self.enforcer.as_ref(), name, input);
+            return execute_tool_with_enforcer(self.enforcer.as_ref(), name, input, abort_signal);
         }
         self.plugin_tools
             .iter()
@@ -505,7 +514,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "command": { "type": "string" },
-                    "timeout": { "type": "integer", "minimum": 1 },
+                    "timeout": { "type": "integer", "minimum": 1, "description": "Maximum milliseconds to wait before interrupting the command (default 120000)." },
                     "description": { "type": "string" },
                     "run_in_background": { "type": "boolean" },
                     "dangerouslyDisableSandbox": { "type": "boolean" },
@@ -819,7 +828,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "properties": {
                     "code": { "type": "string" },
                     "language": { "type": "string" },
-                    "timeout_ms": { "type": "integer", "minimum": 1 }
+                    "timeout_ms": { "type": "integer", "minimum": 1, "description": "Maximum milliseconds to wait before interrupting execution (default 120000)." }
                 },
                 "required": ["code", "language"],
                 "additionalProperties": false
@@ -833,7 +842,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "command": { "type": "string" },
-                    "timeout": { "type": "integer", "minimum": 1 },
+                    "timeout": { "type": "integer", "minimum": 1, "description": "Maximum milliseconds to wait before interrupting the command (default 120000)." },
                     "description": { "type": "string" },
                     "run_in_background": { "type": "boolean" }
                 },
@@ -1338,13 +1347,22 @@ pub fn enforce_permission_check(
 }
 
 pub fn execute_tool(name: &str, input: &Value) -> Result<String, String> {
-    execute_tool_with_enforcer(None, name, input)
+    execute_tool_with_abort(name, input, None)
+}
+
+pub fn execute_tool_with_abort(
+    name: &str,
+    input: &Value,
+    abort_signal: Option<&HookAbortSignal>,
+) -> Result<String, String> {
+    execute_tool_with_enforcer(None, name, input, abort_signal)
 }
 
 fn execute_tool_with_enforcer(
     enforcer: Option<&PermissionEnforcer>,
     name: &str,
     input: &Value,
+    abort_signal: Option<&HookAbortSignal>,
 ) -> Result<String, String> {
     match name {
         "bash" => {
@@ -1352,7 +1370,7 @@ fn execute_tool_with_enforcer(
             let bash_input: BashCommandInput = from_value(input)?;
             let classified_mode = classify_bash_permission(&bash_input.command);
             maybe_enforce_permission_check_with_mode(enforcer, name, input, classified_mode)?;
-            run_bash(bash_input)
+            run_bash(bash_input, abort_signal)
         }
         "read_file" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
@@ -1381,7 +1399,7 @@ fn execute_tool_with_enforcer(
         "Agent" => from_value::<AgentInput>(input).and_then(run_agent),
         "ToolSearch" => from_value::<ToolSearchInput>(input).and_then(run_tool_search),
         "NotebookEdit" => from_value::<NotebookEditInput>(input).and_then(run_notebook_edit),
-        "Sleep" => from_value::<SleepInput>(input).and_then(run_sleep),
+        "Sleep" => from_value::<SleepInput>(input).and_then(|input| run_sleep(input, abort_signal)),
         "SendUserMessage" | "Brief" => from_value::<BriefInput>(input).and_then(run_brief),
         "Config" => from_value::<ConfigInput>(input).and_then(run_config),
         "EnterPlanMode" => from_value::<EnterPlanModeInput>(input).and_then(run_enter_plan_mode),
@@ -1389,13 +1407,13 @@ fn execute_tool_with_enforcer(
         "StructuredOutput" => {
             from_value::<StructuredOutputInput>(input).and_then(run_structured_output)
         }
-        "REPL" => from_value::<ReplInput>(input).and_then(run_repl),
+        "REPL" => from_value::<ReplInput>(input).and_then(|input| run_repl(input, abort_signal)),
         "PowerShell" => {
             // Parse input to get the command for permission classification
             let ps_input: PowerShellInput = from_value(input)?;
             let classified_mode = classify_powershell_permission(&ps_input.command);
             maybe_enforce_permission_check_with_mode(enforcer, name, input, classified_mode)?;
-            run_powershell(ps_input)
+            run_powershell(ps_input, abort_signal)
         }
         "AskUserQuestion" => {
             from_value::<AskUserQuestionInput>(input).and_then(run_ask_user_question)
@@ -2165,12 +2183,17 @@ fn has_dangerous_paths(command: &str) -> bool {
     false
 }
 
-fn run_bash(input: BashCommandInput) -> Result<String, String> {
+fn run_bash(
+    input: BashCommandInput,
+    abort_signal: Option<&HookAbortSignal>,
+) -> Result<String, String> {
     if let Some(output) = workspace_test_branch_preflight(&input.command) {
         return serde_json::to_string_pretty(&output).map_err(|error| error.to_string());
     }
-    serde_json::to_string_pretty(&execute_bash(input).map_err(|error| error.to_string())?)
-        .map_err(|error| error.to_string())
+    serde_json::to_string_pretty(
+        &execute_bash_with_abort(input, abort_signal).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())
 }
 
 fn workspace_test_branch_preflight(command: &str) -> Option<BashCommandOutput> {
@@ -2428,8 +2451,8 @@ fn run_notebook_edit(input: NotebookEditInput) -> Result<String, String> {
     to_pretty_json(execute_notebook_edit(input)?)
 }
 
-fn run_sleep(input: SleepInput) -> Result<String, String> {
-    to_pretty_json(execute_sleep(input)?)
+fn run_sleep(input: SleepInput, abort_signal: Option<&HookAbortSignal>) -> Result<String, String> {
+    to_pretty_json(execute_sleep(input, abort_signal)?)
 }
 
 fn run_brief(input: BriefInput) -> Result<String, String> {
@@ -2452,8 +2475,8 @@ fn run_structured_output(input: StructuredOutputInput) -> Result<String, String>
     to_pretty_json(execute_structured_output(input)?)
 }
 
-fn run_repl(input: ReplInput) -> Result<String, String> {
-    to_pretty_json(execute_repl(input)?)
+fn run_repl(input: ReplInput, abort_signal: Option<&HookAbortSignal>) -> Result<String, String> {
+    to_pretty_json(execute_repl(input, abort_signal)?)
 }
 
 /// Classify `PowerShell` command permission based on command type and path.
@@ -2528,8 +2551,11 @@ fn is_within_workspace(path: &str) -> bool {
     !path.starts_with("/") && !path.starts_with("\\") && !path.starts_with("..")
 }
 
-fn run_powershell(input: PowerShellInput) -> Result<String, String> {
-    to_pretty_json(execute_powershell(input).map_err(|error| error.to_string())?)
+fn run_powershell(
+    input: PowerShellInput,
+    abort_signal: Option<&HookAbortSignal>,
+) -> Result<String, String> {
+    to_pretty_json(execute_powershell(input, abort_signal).map_err(|error| error.to_string())?)
 }
 
 fn to_pretty_json<T: serde::Serialize>(value: T) -> Result<String, String> {
@@ -5455,7 +5481,7 @@ impl ToolExecutor for SubagentToolExecutor {
         }
         let value = serde_json::from_str(input)
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-        execute_tool_with_enforcer(self.enforcer.as_ref(), tool_name, &value)
+        execute_tool_with_enforcer(self.enforcer.as_ref(), tool_name, &value, None)
             .map_err(ToolError::new)
     }
 }
@@ -5999,14 +6025,25 @@ fn cell_kind(cell: &serde_json::Value) -> Option<NotebookCellType> {
 const MAX_SLEEP_DURATION_MS: u64 = 300_000;
 
 #[allow(clippy::needless_pass_by_value)]
-fn execute_sleep(input: SleepInput) -> Result<SleepOutput, String> {
+fn execute_sleep(
+    input: SleepInput,
+    abort_signal: Option<&HookAbortSignal>,
+) -> Result<SleepOutput, String> {
     if input.duration_ms > MAX_SLEEP_DURATION_MS {
         return Err(format!(
             "duration_ms {} exceeds maximum allowed sleep of {MAX_SLEEP_DURATION_MS}ms",
             input.duration_ms,
         ));
     }
-    std::thread::sleep(Duration::from_millis(input.duration_ms));
+    let started = Instant::now();
+    let duration = Duration::from_millis(input.duration_ms);
+    while started.elapsed() < duration {
+        if abort_signal.is_some_and(HookAbortSignal::is_aborted) {
+            return Err(String::from("Sleep interrupted by user"));
+        }
+        let remaining = duration.saturating_sub(started.elapsed());
+        std::thread::sleep(remaining.min(Duration::from_millis(50)));
+    }
     Ok(SleepOutput {
         duration_ms: input.duration_ms,
         message: format!("Slept for {}ms", input.duration_ms),
@@ -6261,7 +6298,10 @@ fn execute_structured_output(
     })
 }
 
-fn execute_repl(input: ReplInput) -> Result<ReplOutput, String> {
+fn execute_repl(
+    input: ReplInput,
+    abort_signal: Option<&HookAbortSignal>,
+) -> Result<ReplOutput, String> {
     if input.code.trim().is_empty() {
         return Err(String::from("code must not be empty"));
     }
@@ -6275,35 +6315,37 @@ fn execute_repl(input: ReplInput) -> Result<ReplOutput, String> {
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    let output = if let Some(timeout_ms) = input.timeout_ms {
-        let mut child = process.spawn().map_err(|error| error.to_string())?;
-        loop {
-            if child
-                .try_wait()
-                .map_err(|error| error.to_string())?
-                .is_some()
-            {
-                break child
-                    .wait_with_output()
-                    .map_err(|error| error.to_string())?;
-            }
-            if started.elapsed() >= Duration::from_millis(timeout_ms) {
-                child.kill().map_err(|error| error.to_string())?;
-                child
-                    .wait_with_output()
-                    .map_err(|error| error.to_string())?;
-                return Err(format!(
-                    "REPL execution exceeded timeout of {timeout_ms} ms"
-                ));
-            }
-            std::thread::sleep(Duration::from_millis(10));
+    let timeout_ms = input
+        .timeout_ms
+        .unwrap_or(runtime::DEFAULT_TOOL_SUBPROCESS_TIMEOUT_MS);
+    let mut child = process.spawn().map_err(|error| error.to_string())?;
+    let output = loop {
+        if abort_signal.is_some_and(HookAbortSignal::is_aborted) {
+            child.kill().map_err(|error| error.to_string())?;
+            child
+                .wait_with_output()
+                .map_err(|error| error.to_string())?;
+            return Err(String::from("REPL execution interrupted by user"));
         }
-    } else {
-        process
-            .spawn()
+        if child
+            .try_wait()
             .map_err(|error| error.to_string())?
-            .wait_with_output()
-            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            break child
+                .wait_with_output()
+                .map_err(|error| error.to_string())?;
+        }
+        if started.elapsed() >= Duration::from_millis(timeout_ms) {
+            child.kill().map_err(|error| error.to_string())?;
+            child
+                .wait_with_output()
+                .map_err(|error| error.to_string())?;
+            return Err(format!(
+                "REPL execution exceeded timeout of {timeout_ms} ms"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(10));
     };
 
     Ok(ReplOutput {
@@ -6665,7 +6707,10 @@ fn iso8601_timestamp() -> String {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn execute_powershell(input: PowerShellInput) -> std::io::Result<runtime::BashCommandOutput> {
+fn execute_powershell(
+    input: PowerShellInput,
+    abort_signal: Option<&HookAbortSignal>,
+) -> std::io::Result<runtime::BashCommandOutput> {
     let _ = &input.description;
     if let Some(output) = workspace_test_branch_preflight(&input.command) {
         return Ok(output);
@@ -6676,6 +6721,7 @@ fn execute_powershell(input: PowerShellInput) -> std::io::Result<runtime::BashCo
         &input.command,
         input.timeout,
         input.run_in_background,
+        abort_signal,
     )
 }
 
@@ -6710,6 +6756,7 @@ fn execute_shell_command(
     command: &str,
     timeout: Option<u64>,
     run_in_background: Option<bool>,
+    abort_signal: Option<&HookAbortSignal>,
 ) -> std::io::Result<runtime::BashCommandOutput> {
     if run_in_background.unwrap_or(false) {
         let child = std::process::Command::new(shell)
@@ -6750,90 +6797,93 @@ fn execute_shell_command(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    if let Some(timeout_ms) = timeout {
-        let mut child = process.spawn()?;
-        let started = Instant::now();
-        loop {
-            if let Some(status) = child.try_wait()? {
-                let output = child.wait_with_output()?;
-                return Ok(runtime::BashCommandOutput {
-                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                    stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                    raw_output_path: None,
-                    interrupted: false,
-                    is_image: None,
-                    background_task_id: None,
-                    backgrounded_by_user: None,
-                    assistant_auto_backgrounded: None,
-                    dangerously_disable_sandbox: None,
-                    return_code_interpretation: status
-                        .code()
-                        .filter(|code| *code != 0)
-                        .map(|code| format!("exit_code:{code}")),
-                    no_output_expected: Some(output.stdout.is_empty() && output.stderr.is_empty()),
-                    structured_content: None,
-                    persisted_output_path: None,
-                    persisted_output_size: None,
-                    sandbox_status: None,
-                });
-            }
-            if started.elapsed() >= Duration::from_millis(timeout_ms) {
-                let _ = child.kill();
-                let output = child.wait_with_output()?;
-                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-                let stderr = if stderr.trim().is_empty() {
-                    format!("Command exceeded timeout of {timeout_ms} ms")
-                } else {
-                    format!(
-                        "{}
-Command exceeded timeout of {timeout_ms} ms",
-                        stderr.trim_end()
-                    )
-                };
-                return Ok(runtime::BashCommandOutput {
-                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                    stderr,
-                    raw_output_path: None,
-                    interrupted: true,
-                    is_image: None,
-                    background_task_id: None,
-                    backgrounded_by_user: None,
-                    assistant_auto_backgrounded: None,
-                    dangerously_disable_sandbox: None,
-                    return_code_interpretation: Some(String::from("timeout")),
-                    no_output_expected: Some(false),
-                    structured_content: None,
-                    persisted_output_path: None,
-                    persisted_output_size: None,
-                    sandbox_status: None,
-                });
-            }
-            std::thread::sleep(Duration::from_millis(10));
+    let timeout_ms = timeout.unwrap_or(runtime::DEFAULT_TOOL_SUBPROCESS_TIMEOUT_MS);
+    let mut child = process.spawn()?;
+    let started = Instant::now();
+    loop {
+        if abort_signal.is_some_and(HookAbortSignal::is_aborted) {
+            let _ = child.kill();
+            let output = child.wait_with_output()?;
+            let stderr = append_status_line(
+                &String::from_utf8_lossy(&output.stderr),
+                "Command interrupted by user",
+            );
+            return Ok(runtime::BashCommandOutput {
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr,
+                raw_output_path: None,
+                interrupted: true,
+                is_image: None,
+                background_task_id: None,
+                backgrounded_by_user: None,
+                assistant_auto_backgrounded: None,
+                dangerously_disable_sandbox: None,
+                return_code_interpretation: Some(String::from("interrupted")),
+                no_output_expected: Some(false),
+                structured_content: None,
+                persisted_output_path: None,
+                persisted_output_size: None,
+                sandbox_status: None,
+            });
         }
+        if let Some(status) = child.try_wait()? {
+            let output = child.wait_with_output()?;
+            return Ok(runtime::BashCommandOutput {
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                raw_output_path: None,
+                interrupted: false,
+                is_image: None,
+                background_task_id: None,
+                backgrounded_by_user: None,
+                assistant_auto_backgrounded: None,
+                dangerously_disable_sandbox: None,
+                return_code_interpretation: status
+                    .code()
+                    .filter(|code| *code != 0)
+                    .map(|code| format!("exit_code:{code}")),
+                no_output_expected: Some(output.stdout.is_empty() && output.stderr.is_empty()),
+                structured_content: None,
+                persisted_output_path: None,
+                persisted_output_size: None,
+                sandbox_status: None,
+            });
+        }
+        if started.elapsed() >= Duration::from_millis(timeout_ms) {
+            let _ = child.kill();
+            let output = child.wait_with_output()?;
+            let stderr = append_status_line(
+                &String::from_utf8_lossy(&output.stderr),
+                &format!("Command exceeded timeout of {timeout_ms} ms"),
+            );
+            return Ok(runtime::BashCommandOutput {
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr,
+                raw_output_path: None,
+                interrupted: true,
+                is_image: None,
+                background_task_id: None,
+                backgrounded_by_user: None,
+                assistant_auto_backgrounded: None,
+                dangerously_disable_sandbox: None,
+                return_code_interpretation: Some(String::from("timeout")),
+                no_output_expected: Some(false),
+                structured_content: None,
+                persisted_output_path: None,
+                persisted_output_size: None,
+                sandbox_status: None,
+            });
+        }
+        std::thread::sleep(Duration::from_millis(10));
     }
+}
 
-    let output = process.output()?;
-    Ok(runtime::BashCommandOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        raw_output_path: None,
-        interrupted: false,
-        is_image: None,
-        background_task_id: None,
-        backgrounded_by_user: None,
-        assistant_auto_backgrounded: None,
-        dangerously_disable_sandbox: None,
-        return_code_interpretation: output
-            .status
-            .code()
-            .filter(|code| *code != 0)
-            .map(|code| format!("exit_code:{code}")),
-        no_output_expected: Some(output.stdout.is_empty() && output.stderr.is_empty()),
-        structured_content: None,
-        persisted_output_path: None,
-        persisted_output_size: None,
-        sandbox_status: None,
-    })
+fn append_status_line(stderr: &str, status_line: &str) -> String {
+    if stderr.trim().is_empty() {
+        status_line.to_string()
+    } else {
+        format!("{}\n{status_line}", stderr.trim_end())
+    }
 }
 
 fn resolve_cell_index(


### PR DESCRIPTION
## Summary

- add a default timeout for foreground bash-backed tool execution so omitted timeouts no longer allow unbounded hangs
- thread the turn abort signal into the CLI tool executor and interrupt-aware tool paths for bash, Sleep, REPL, and PowerShell
- cancel the current turn after user interrupt, push interrupted tool results, and avoid follow-up model calls after cancellation
- add a real `scode` E2E test that drives a long-running bash tool through the mock Anthropic service and interrupts it with SIGINT

## Validation

- `cargo fmt --check`
- `cargo test -p rusty-sudocode-cli --test interrupt_e2e -- --nocapture`
- manual E2E: real `target/debug/scode`, mock model returns `bash sleep 30`, send SIGINT; observed `interrupted: true`, `returnCodeInterpretation: "interrupted"`, and no second `/v1/messages` call
- manual E2E: real `target/debug/scode`, mock model returns `bash sleep 30` with `timeout: 700`; observed `interrupted: true` and `returnCodeInterpretation: "timeout"`
- `cargo test --workspace` was run; it hit two known flaky `mcp_stdio` tests, and both passed when rerun individually:
  - `mcp_stdio::tests::given_child_exits_after_discovery_when_calling_twice_then_second_call_succeeds_after_reset`
  - `mcp_stdio::tests::given_initialize_hangs_once_when_discover_tools_then_manager_retries_and_succeeds`

## Notes

`cargo clippy --workspace --all-targets -- -D warnings` still fails on existing lint debt outside this change. Timeout currently returns structured timeout output and lets the model continue; SIGINT/user interrupt cancels the turn.
