### PR TITLE
ci: upload scode binaries to Tencent COS + China mirror install support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,25 @@ jobs:
             dist/scode-*
             dist/SHA256SUMS.txt
           fail_on_unmatched_files: true
+
+      - name: Upload to Tencent COS
+        if: env.TENCENT_SECRET_ID != '' && env.TENCENT_SECRET_KEY != ''
+        env:
+          TENCENT_SECRET_ID: ${{ secrets.TENCENT_SECRET_ID }}
+          TENCENT_SECRET_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          pip install coscmd --quiet
+          coscmd config \
+            -a "$TENCENT_SECRET_ID" \
+            -s "$TENCENT_SECRET_KEY" \
+            -b sudoclaw-download-1309794936 \
+            -e cos.accelerate.myqcloud.com
+          for file in dist/scode-*.tar.gz dist/scode-*.zip; do
+            [ -f "$file" ] || continue
+            filename=$(basename "$file")
+            echo "Uploading $filename"
+            coscmd upload "$file" "sudocode/release/latest/$filename"
+          done
+          coscmd upload dist/SHA256SUMS.txt "sudocode/release/latest/SHA256SUMS.txt"
+          echo "Done: https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Overrides:
 - `SCODE_INSTALL_DIR=$HOME/.local/bin sh install.sh` — explicit per-user install (no `sudo`).
 - `sh install.sh --prefix /usr/local` — explicit prefix (no `sudo`).
 
+**China mirror** — faster downloads for mainland China users (checksums still verified against GitHub):
+
+```bash
+SCODE_MIRROR=https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \
+  curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
+```
+
 Already built from source? Skip to [Quick Start](#quick-start).
 
 ## Quick Start

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,11 @@
 # Environment overrides:
 #   SCODE_VERSION       Release tag to install (e.g. v0.1.5). Default: latest.
 #   SCODE_INSTALL_DIR   Directory to install into. Overrides default resolution.
+#   SCODE_MIRROR        Base URL for archive downloads (no trailing slash).
+#                       Use this to point at a mirror (e.g. Tencent COS) for
+#                       faster downloads in China. The checksum file is always
+#                       fetched from GitHub Releases for security.
+#                       Example: https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest
 #   NO_COLOR            Disable ANSI color output when set.
 #
 # Flags:
@@ -74,6 +79,8 @@ ${C_BOLD}FLAGS${C_RESET}
 ${C_BOLD}ENVIRONMENT${C_RESET}
     SCODE_VERSION       Pin a release tag (default: latest).
     SCODE_INSTALL_DIR   Override install dir (same as --prefix). No sudo.
+    SCODE_MIRROR        Mirror base URL for archive downloads (no trailing slash).
+                        Checksums are still fetched from GitHub for security.
     NO_COLOR            Disable colored output.
 
 ${C_BOLD}EXAMPLES${C_RESET}
@@ -81,6 +88,9 @@ ${C_BOLD}EXAMPLES${C_RESET}
     SCODE_VERSION=v0.1.5 sh install.sh
     sh install.sh --prefix /usr/local
     sh install.sh --no-sudo
+    # China mirror (faster in mainland China):
+    SCODE_MIRROR=https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \\
+      curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
 EOF
 }
 
@@ -259,10 +269,17 @@ fi
 # ----- artifact selection ----------------------------------------------------
 TARGET=$(detect_target)
 ARCHIVE="scode-${TARGET}.tar.gz"
-ARCHIVE_URL="${DOWNLOAD_BASE}/${VERSION}/${ARCHIVE}"
+# Checksums always come from GitHub Releases (authoritative source).
 CHECKSUM_URL="${DOWNLOAD_BASE}/${VERSION}/${CHECKSUM_FILE}"
+# Archive may come from a mirror when SCODE_MIRROR is set.
+if [ -n "${SCODE_MIRROR:-}" ]; then
+    ARCHIVE_URL="${SCODE_MIRROR%/}/${ARCHIVE}"
+else
+    ARCHIVE_URL="${DOWNLOAD_BASE}/${VERSION}/${ARCHIVE}"
+fi
 
 info "target: ${C_BOLD}${TARGET}${C_RESET}"
+[ -n "${SCODE_MIRROR:-}" ] && info "mirror: ${C_BOLD}${SCODE_MIRROR%/}${C_RESET}"
 if [ "$INSTALL_DIR_FORCED" -eq 1 ]; then
     info "install dir: ${INSTALL_DIR}"
 else


### PR DESCRIPTION
## Summary

- **CI**: 在 `release.yml` 的 `publish-release` job 末尾加入 COS 上传 step，每次正式 tag 发布后自动把 6 个平台的 scode 二进制同步到腾讯 COS (`sudocode/release/latest/`)
- **install.sh**: 新增 `SCODE_MIRROR` 环境变量，国内用户可以指向 COS 镜像加速下载；checksum 仍然从 GitHub Releases 取，安全性不变
- **README**: 补充国内镜像一行命令说明

## COS 路径

```
https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/scode-{platform}.tar.gz
```

## 国内用户安装方式

```bash
SCODE_MIRROR=https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \
  curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
```

## Test plan

- [x] 用 `v0.1.8-rc1` tag 触发了完整 pipeline，`publish-release` 成功，6 个平台文件均已上传至 COS
- [x] `install.sh` shell syntax 验证通过 (`sh -n`)
- [ ] 合并后打正式 tag，确认 COS 文件更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)