### PR TITLE
fix(plugins): address 8 production bugs surfaced by PR 155 e2e

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -2294,7 +2294,9 @@ pub fn handle_plugins_slash_command(
             Ok(PluginsCommandResult {
                 message: format!(
                     "Plugins\n  Result           enabled {}\n  Name             {}\n  Version          {}\n  Status           enabled",
-                    plugin.metadata.id, plugin.metadata.name, plugin.metadata.version
+                    plugin.metadata.id,
+                    plugin_display_label(&plugin),
+                    plugin.metadata.version
                 ),
                 reload_runtime: true,
             })
@@ -2311,7 +2313,9 @@ pub fn handle_plugins_slash_command(
             Ok(PluginsCommandResult {
                 message: format!(
                     "Plugins\n  Result           disabled {}\n  Name             {}\n  Version          {}\n  Status           disabled",
-                    plugin.metadata.id, plugin.metadata.name, plugin.metadata.version
+                    plugin.metadata.id,
+                    plugin_display_label(&plugin),
+                    plugin.metadata.version
                 ),
                 reload_runtime: true,
             })
@@ -2444,16 +2448,73 @@ pub fn handle_mcp_slash_command(
     args: Option<&str>,
     cwd: &Path,
 ) -> Result<String, runtime::ConfigError> {
+    handle_mcp_slash_command_with_plugins(args, cwd, None)
+}
+
+pub fn handle_mcp_slash_command_with_plugins(
+    args: Option<&str>,
+    cwd: &Path,
+    plugin_load_outcome: Option<&PluginLoadOutcome>,
+) -> Result<String, runtime::ConfigError> {
     let loader = ConfigLoader::default_for(cwd);
-    render_mcp_report_for(&loader, cwd, args)
+    render_mcp_report_for(&loader, cwd, args, plugin_load_outcome)
 }
 
 pub fn handle_mcp_slash_command_json(
     args: Option<&str>,
     cwd: &Path,
 ) -> Result<Value, runtime::ConfigError> {
+    handle_mcp_slash_command_json_with_plugins(args, cwd, None)
+}
+
+pub fn handle_mcp_slash_command_json_with_plugins(
+    args: Option<&str>,
+    cwd: &Path,
+    plugin_load_outcome: Option<&PluginLoadOutcome>,
+) -> Result<Value, runtime::ConfigError> {
     let loader = ConfigLoader::default_for(cwd);
-    render_mcp_report_json_for(&loader, cwd, args)
+    render_mcp_report_json_for(&loader, cwd, args, plugin_load_outcome)
+}
+
+/// Merge plugin-provided MCP servers (from each enabled plugin's `.mcp.json`)
+/// into the runtime-config servers, returning the merged map plus a provenance
+/// map keyed by server name. User/global runtime servers always win on name
+/// collision (matches `cli::mcp::merged_mcp_servers`). Plugin servers also
+/// carry their plugin id so `scode mcp` can attribute them to a SudoCode
+/// plugin in both text and JSON output.
+fn merge_plugin_mcp_servers(
+    runtime_servers: &BTreeMap<String, ScopedMcpServerConfig>,
+    plugin_load_outcome: Option<&PluginLoadOutcome>,
+) -> (
+    BTreeMap<String, ScopedMcpServerConfig>,
+    BTreeMap<String, String>,
+) {
+    let mut servers = runtime_servers.clone();
+    let mut provenance: BTreeMap<String, String> = BTreeMap::new();
+    let Some(outcome) = plugin_load_outcome else {
+        return (servers, provenance);
+    };
+    for plugin in &outcome.loaded_plugins {
+        if !plugin.summary.enabled {
+            continue;
+        }
+        for path in &plugin.mcp_config_paths {
+            // Silently skip plugin MCP files that fail to parse so the rest of
+            // the report still renders; the runtime path surfaces the failure
+            // separately when it actually tries to spawn the server.
+            let Ok(plugin_servers) = runtime::load_plugin_mcp_servers(path) else {
+                continue;
+            };
+            for (server_name, server_config) in plugin_servers {
+                if !servers.contains_key(&server_name) {
+                    provenance
+                        .insert(server_name.clone(), plugin.capability_summary.plugin_id.clone());
+                    servers.insert(server_name, server_config);
+                }
+            }
+        }
+    }
+    (servers, provenance)
 }
 
 pub fn handle_skills_slash_command(args: Option<&str>, cwd: &Path) -> std::io::Result<String> {
@@ -2678,6 +2739,7 @@ fn render_mcp_report_for(
     loader: &ConfigLoader,
     cwd: &Path,
     args: Option<&str>,
+    plugin_load_outcome: Option<&PluginLoadOutcome>,
 ) -> Result<String, runtime::ConfigError> {
     if let Some(args) = normalize_optional_args(args) {
         if let Some(help_path) = help_path_from_args(args) {
@@ -2695,15 +2757,26 @@ fn render_mcp_report_for(
             // as #143 for `status`). Text mode prepends a "Config load error"
             // block before the MCP list; the list falls back to empty.
             match loader.load() {
-                Ok(runtime_config) => Ok(render_mcp_summary_report(
-                    cwd,
-                    runtime_config.mcp().servers(),
-                )),
+                Ok(runtime_config) => {
+                    let (servers, provenance) = merge_plugin_mcp_servers(
+                        runtime_config.mcp().servers(),
+                        plugin_load_outcome,
+                    );
+                    Ok(render_mcp_summary_report(cwd, &servers, &provenance))
+                }
                 Err(err) => {
                     let empty = std::collections::BTreeMap::new();
+                    let empty_prov = std::collections::BTreeMap::new();
+                    let (servers, provenance) =
+                        merge_plugin_mcp_servers(&empty, plugin_load_outcome);
+                    let prov = if provenance.is_empty() {
+                        empty_prov
+                    } else {
+                        provenance
+                    };
                     Ok(format!(
                         "Config load error\n  Status           fail\n  Summary          runtime config failed to load; reporting partial MCP view\n  Details          {err}\n  Hint             `scode doctor` classifies config parse errors; fix the listed field and rerun\n\n{}",
-                        render_mcp_summary_report(cwd, &empty)
+                        render_mcp_summary_report(cwd, &servers, &prov)
                     ))
                 }
             }
@@ -2723,11 +2796,18 @@ fn render_mcp_report_for(
             // the specific server lookup can't succeed, so report the parse
             // error with context.
             match loader.load() {
-                Ok(runtime_config) => Ok(render_mcp_server_report(
-                    cwd,
-                    server_name,
-                    runtime_config.mcp().get(server_name),
-                )),
+                Ok(runtime_config) => {
+                    let (servers, provenance) = merge_plugin_mcp_servers(
+                        runtime_config.mcp().servers(),
+                        plugin_load_outcome,
+                    );
+                    Ok(render_mcp_server_report(
+                        cwd,
+                        server_name,
+                        servers.get(server_name),
+                        provenance.get(server_name).map(String::as_str),
+                    ))
+                }
                 Err(err) => Ok(format!(
                     "Config load error\n  Status           fail\n  Summary          runtime config failed to load; cannot resolve `{server_name}`\n  Details          {err}\n  Hint             `scode doctor` classifies config parse errors; fix the listed field and rerun"
                 )),
@@ -2742,6 +2822,7 @@ fn render_mcp_report_json_for(
     loader: &ConfigLoader,
     cwd: &Path,
     args: Option<&str>,
+    plugin_load_outcome: Option<&PluginLoadOutcome>,
 ) -> Result<Value, runtime::ConfigError> {
     if let Some(args) = normalize_optional_args(args) {
         if let Some(help_path) = help_path_from_args(args) {
@@ -2761,8 +2842,12 @@ fn render_mcp_report_json_for(
             // runs, the existing serializer adds `status: "ok"` below.
             match loader.load() {
                 Ok(runtime_config) => {
+                    let (servers, provenance) = merge_plugin_mcp_servers(
+                        runtime_config.mcp().servers(),
+                        plugin_load_outcome,
+                    );
                     let mut value =
-                        render_mcp_summary_report_json(cwd, runtime_config.mcp().servers());
+                        render_mcp_summary_report_json(cwd, &servers, &provenance);
                     if let Some(map) = value.as_object_mut() {
                         map.insert("status".to_string(), Value::String("ok".to_string()));
                         map.insert("config_load_error".to_string(), Value::Null);
@@ -2771,7 +2856,10 @@ fn render_mcp_report_json_for(
                 }
                 Err(err) => {
                     let empty = std::collections::BTreeMap::new();
-                    let mut value = render_mcp_summary_report_json(cwd, &empty);
+                    let (servers, provenance) =
+                        merge_plugin_mcp_servers(&empty, plugin_load_outcome);
+                    let mut value =
+                        render_mcp_summary_report_json(cwd, &servers, &provenance);
                     if let Some(map) = value.as_object_mut() {
                         map.insert("status".to_string(), Value::String("degraded".to_string()));
                         map.insert(
@@ -2797,10 +2885,15 @@ fn render_mcp_report_json_for(
             // #144: same degradation pattern for show action.
             match loader.load() {
                 Ok(runtime_config) => {
+                    let (servers, provenance) = merge_plugin_mcp_servers(
+                        runtime_config.mcp().servers(),
+                        plugin_load_outcome,
+                    );
                     let mut value = render_mcp_server_report_json(
                         cwd,
                         server_name,
-                        runtime_config.mcp().get(server_name),
+                        servers.get(server_name),
+                        provenance.get(server_name).map(String::as_str),
                     );
                     if let Some(map) = value.as_object_mut() {
                         map.insert("status".to_string(), Value::String("ok".to_string()));
@@ -2837,11 +2930,24 @@ pub fn render_plugins_report(plugins: &[PluginSummary]) -> String {
         };
         lines.push(format!(
             "  {name:<20} v{version:<10} {enabled}",
-            name = plugin.metadata.name,
+            name = plugin_display_label(plugin),
             version = plugin.metadata.version,
         ));
     }
     lines.join("\n")
+}
+
+/// User-facing label for a plugin: prefer `interface.display_name` from the v2
+/// manifest, fall back to the raw `name`. The CLI uses this everywhere a human
+/// will read it (`scode plugins`, install/enable/disable reports). The system
+/// prompt deliberately does NOT use this — that channel stays anonymized for
+/// prompt-injection safety.
+fn plugin_display_label(plugin: &PluginSummary) -> &str {
+    plugin
+        .metadata
+        .display_name
+        .as_deref()
+        .unwrap_or(plugin.metadata.name.as_str())
 }
 
 #[must_use]
@@ -2863,7 +2969,7 @@ pub fn render_plugins_report_with_failures(
             };
             lines.push(format!(
                 "  {name:<20} v{version:<10} {enabled}",
-                name = plugin.metadata.name,
+                name = plugin_display_label(plugin),
                 version = plugin.metadata.version,
             ));
         }
@@ -2887,7 +2993,7 @@ pub fn render_plugins_report_with_failures(
 }
 
 fn render_plugin_install_report(plugin_id: &str, plugin: Option<&PluginSummary>) -> String {
-    let name = plugin.map_or(plugin_id, |plugin| plugin.metadata.name.as_str());
+    let name = plugin.map_or(plugin_id, plugin_display_label);
     let version = plugin.map_or("unknown", |plugin| plugin.metadata.version.as_str());
     let enabled = plugin.is_some_and(|plugin| plugin.enabled);
     format!(
@@ -3763,6 +3869,7 @@ fn render_skill_install_report_json(skill: &InstalledSkill) -> Value {
 fn render_mcp_summary_report(
     cwd: &Path,
     servers: &BTreeMap<String, ScopedMcpServerConfig>,
+    plugin_provenance: &BTreeMap<String, String>,
 ) -> String {
     let mut lines = vec![
         "MCP".to_string(),
@@ -3776,8 +3883,12 @@ fn render_mcp_summary_report(
 
     lines.push(String::new());
     for (name, server) in servers {
+        let provenance = plugin_provenance
+            .get(name)
+            .map(|plugin_id| format!("  [SudoCode plugin {plugin_id}]"))
+            .unwrap_or_default();
         lines.push(format!(
-            "  {name:<16} {transport:<13} {scope:<7} {summary}",
+            "  {name:<16} {transport:<13} {scope:<7} {summary}{provenance}",
             transport = mcp_transport_label(&server.config),
             scope = config_source_label(server.scope),
             summary = mcp_server_summary(&server.config)
@@ -3790,6 +3901,7 @@ fn render_mcp_summary_report(
 fn render_mcp_summary_report_json(
     cwd: &Path,
     servers: &BTreeMap<String, ScopedMcpServerConfig>,
+    plugin_provenance: &BTreeMap<String, String>,
 ) -> Value {
     json!({
         "kind": "mcp",
@@ -3798,7 +3910,18 @@ fn render_mcp_summary_report_json(
         "configured_servers": servers.len(),
         "servers": servers
             .iter()
-            .map(|(name, server)| mcp_server_json(name, server))
+            .map(|(name, server)| {
+                let mut value = mcp_server_json(name, server);
+                if let (Some(map), Some(plugin_id)) =
+                    (value.as_object_mut(), plugin_provenance.get(name))
+                {
+                    map.insert(
+                        "plugin_source".to_string(),
+                        Value::String(plugin_id.clone()),
+                    );
+                }
+                value
+            })
             .collect::<Vec<_>>(),
     })
 }
@@ -3807,6 +3930,7 @@ fn render_mcp_server_report(
     cwd: &Path,
     server_name: &str,
     server: Option<&ScopedMcpServerConfig>,
+    plugin_source: Option<&str>,
 ) -> String {
     let Some(server) = server else {
         return format!(
@@ -3825,6 +3949,9 @@ fn render_mcp_server_report(
             mcp_transport_label(&server.config)
         ),
     ];
+    if let Some(plugin_id) = plugin_source {
+        lines.push(format!("  SudoCode plugin   {plugin_id}"));
+    }
 
     match &server.config {
         McpServerConfig::Stdio(config) => {
@@ -3886,15 +4013,25 @@ fn render_mcp_server_report_json(
     cwd: &Path,
     server_name: &str,
     server: Option<&ScopedMcpServerConfig>,
+    plugin_source: Option<&str>,
 ) -> Value {
     match server {
-        Some(server) => json!({
-            "kind": "mcp",
-            "action": "show",
-            "working_directory": cwd.display().to_string(),
-            "found": true,
-            "server": mcp_server_json(server_name, server),
-        }),
+        Some(server) => {
+            let mut server_value = mcp_server_json(server_name, server);
+            if let (Some(map), Some(plugin_id)) = (server_value.as_object_mut(), plugin_source) {
+                map.insert(
+                    "plugin_source".to_string(),
+                    Value::String(plugin_id.to_string()),
+                );
+            }
+            json!({
+                "kind": "mcp",
+                "action": "show",
+                "working_directory": cwd.display().to_string(),
+                "found": true,
+                "server": server_value,
+            })
+        }
         None => json!({
             "kind": "mcp",
             "action": "show",
@@ -4455,6 +4592,7 @@ mod tests {
             source: "external".to_string(),
             default_enabled: true,
             root: path.parent().map(PathBuf::from),
+            display_name: None,
         };
         PluginLoadOutcome {
             loaded_plugins: vec![LoadedPlugin {
@@ -5145,7 +5283,8 @@ mod tests {
                     source: "demo".to_string(),
                     default_enabled: false,
                     root: None,
-                },
+                    display_name: None,
+            },
                 enabled: true,
             },
             PluginSummary {
@@ -5158,7 +5297,8 @@ mod tests {
                     source: "sample".to_string(),
                     default_enabled: false,
                     root: None,
-                },
+                    display_name: None,
+            },
                 enabled: false,
             },
         ]);
@@ -5184,7 +5324,8 @@ mod tests {
                     source: "demo".to_string(),
                     default_enabled: false,
                     root: None,
-                },
+                    display_name: None,
+            },
                 enabled: true,
             }],
             &[PluginLoadFailure::new(
@@ -5700,7 +5841,7 @@ mod tests {
         .expect("write local settings");
 
         let loader = ConfigLoader::new(&workspace, &config_home);
-        let list = super::render_mcp_report_for(&loader, &workspace, None)
+        let list = super::render_mcp_report_for(&loader, &workspace, None, None)
             .expect("mcp list report should render");
         assert!(list.contains("Configured servers 2"));
         assert!(list.contains("alpha"));
@@ -5712,7 +5853,7 @@ mod tests {
         assert!(list.contains("local"));
         assert!(list.contains("wss://remote.example/mcp"));
 
-        let show = super::render_mcp_report_for(&loader, &workspace, Some("show alpha"))
+        let show = super::render_mcp_report_for(&loader, &workspace, Some("show alpha"), None)
             .expect("mcp show report should render");
         assert!(show.contains("Name              alpha"));
         assert!(show.contains("Command           uvx"));
@@ -5720,12 +5861,12 @@ mod tests {
         assert!(show.contains("Env keys          ALPHA_TOKEN"));
         assert!(show.contains("Tool timeout      1200 ms"));
 
-        let remote = super::render_mcp_report_for(&loader, &workspace, Some("show remote"))
+        let remote = super::render_mcp_report_for(&loader, &workspace, Some("show remote"), None)
             .expect("mcp show remote report should render");
         assert!(remote.contains("Transport         ws"));
         assert!(remote.contains("URL               wss://remote.example/mcp"));
 
-        let missing = super::render_mcp_report_for(&loader, &workspace, Some("show missing"))
+        let missing = super::render_mcp_report_for(&loader, &workspace, Some("show missing"), None)
             .expect("missing report should render");
         assert!(missing.contains("server `missing` is not configured"));
 
@@ -5785,7 +5926,7 @@ mod tests {
 
         let loader = ConfigLoader::new(&workspace, &config_home);
         let list =
-            render_mcp_report_json_for(&loader, &workspace, None).expect("mcp list json render");
+            render_mcp_report_json_for(&loader, &workspace, None, None).expect("mcp list json render");
         assert_eq!(list["kind"], "mcp");
         assert_eq!(list["action"], "list");
         assert_eq!(list["configured_servers"], 2);
@@ -5800,7 +5941,7 @@ mod tests {
             "wss://remote.example/mcp"
         );
 
-        let show = render_mcp_report_json_for(&loader, &workspace, Some("show alpha"))
+        let show = render_mcp_report_json_for(&loader, &workspace, Some("show alpha"), None)
             .expect("mcp show json render");
         assert_eq!(show["action"], "show");
         assert_eq!(show["found"], true);
@@ -5808,13 +5949,13 @@ mod tests {
         assert_eq!(show["server"]["details"]["env_keys"][0], "ALPHA_TOKEN");
         assert_eq!(show["server"]["details"]["tool_call_timeout_ms"], 1200);
 
-        let missing = render_mcp_report_json_for(&loader, &workspace, Some("show missing"))
+        let missing = render_mcp_report_json_for(&loader, &workspace, Some("show missing"), None)
             .expect("mcp missing json render");
         assert_eq!(missing["found"], false);
         assert_eq!(missing["server_name"], "missing");
 
         let help =
-            render_mcp_report_json_for(&loader, &workspace, Some("help")).expect("mcp help json");
+            render_mcp_report_json_for(&loader, &workspace, Some("help"), None).expect("mcp help json");
         assert_eq!(help["action"], "help");
         assert_eq!(help["usage"]["sources"][0], ".nexus/sudocode/settings.json");
 
@@ -5850,7 +5991,7 @@ mod tests {
 
         let loader = ConfigLoader::new(&workspace, &config_home);
         // list action: must return Ok (not Err) with degraded envelope.
-        let list = render_mcp_report_json_for(&loader, &workspace, None)
+        let list = render_mcp_report_json_for(&loader, &workspace, None, None)
             .expect("mcp list should not hard-fail on config parse errors (#144)");
         assert_eq!(list["kind"], "mcp");
         assert_eq!(list["action"], "list");
@@ -5870,7 +6011,7 @@ mod tests {
         assert!(list["servers"].as_array().unwrap().is_empty());
 
         // show action: should also degrade (not hard-fail).
-        let show = render_mcp_report_json_for(&loader, &workspace, Some("show everything"))
+        let show = render_mcp_report_json_for(&loader, &workspace, Some("show everything"), None)
             .expect("mcp show should not hard-fail on config parse errors (#144)");
         assert_eq!(show["kind"], "mcp");
         assert_eq!(show["action"], "show");
@@ -5885,7 +6026,7 @@ mod tests {
         let clean_ws = temp_dir("mcp-degrades-144-clean");
         fs::create_dir_all(&clean_ws).expect("clean ws");
         let clean_loader = ConfigLoader::new(&clean_ws, &config_home);
-        let clean_list = render_mcp_report_json_for(&clean_loader, &clean_ws, None)
+        let clean_list = render_mcp_report_json_for(&clean_loader, &clean_ws, None, None)
             .expect("clean mcp list should succeed");
         assert_eq!(
             clean_list["status"].as_str(),

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -2507,8 +2507,10 @@ fn merge_plugin_mcp_servers(
             };
             for (server_name, server_config) in plugin_servers {
                 if !servers.contains_key(&server_name) {
-                    provenance
-                        .insert(server_name.clone(), plugin.capability_summary.plugin_id.clone());
+                    provenance.insert(
+                        server_name.clone(),
+                        plugin.capability_summary.plugin_id.clone(),
+                    );
                     servers.insert(server_name, server_config);
                 }
             }
@@ -2846,8 +2848,7 @@ fn render_mcp_report_json_for(
                         runtime_config.mcp().servers(),
                         plugin_load_outcome,
                     );
-                    let mut value =
-                        render_mcp_summary_report_json(cwd, &servers, &provenance);
+                    let mut value = render_mcp_summary_report_json(cwd, &servers, &provenance);
                     if let Some(map) = value.as_object_mut() {
                         map.insert("status".to_string(), Value::String("ok".to_string()));
                         map.insert("config_load_error".to_string(), Value::Null);
@@ -2858,8 +2859,7 @@ fn render_mcp_report_json_for(
                     let empty = std::collections::BTreeMap::new();
                     let (servers, provenance) =
                         merge_plugin_mcp_servers(&empty, plugin_load_outcome);
-                    let mut value =
-                        render_mcp_summary_report_json(cwd, &servers, &provenance);
+                    let mut value = render_mcp_summary_report_json(cwd, &servers, &provenance);
                     if let Some(map) = value.as_object_mut() {
                         map.insert("status".to_string(), Value::String("degraded".to_string()));
                         map.insert(
@@ -5284,7 +5284,7 @@ mod tests {
                     default_enabled: false,
                     root: None,
                     display_name: None,
-            },
+                },
                 enabled: true,
             },
             PluginSummary {
@@ -5298,7 +5298,7 @@ mod tests {
                     default_enabled: false,
                     root: None,
                     display_name: None,
-            },
+                },
                 enabled: false,
             },
         ]);
@@ -5325,7 +5325,7 @@ mod tests {
                     default_enabled: false,
                     root: None,
                     display_name: None,
-            },
+                },
                 enabled: true,
             }],
             &[PluginLoadFailure::new(
@@ -5925,8 +5925,8 @@ mod tests {
         .expect("write local settings");
 
         let loader = ConfigLoader::new(&workspace, &config_home);
-        let list =
-            render_mcp_report_json_for(&loader, &workspace, None, None).expect("mcp list json render");
+        let list = render_mcp_report_json_for(&loader, &workspace, None, None)
+            .expect("mcp list json render");
         assert_eq!(list["kind"], "mcp");
         assert_eq!(list["action"], "list");
         assert_eq!(list["configured_servers"], 2);
@@ -5954,8 +5954,8 @@ mod tests {
         assert_eq!(missing["found"], false);
         assert_eq!(missing["server_name"], "missing");
 
-        let help =
-            render_mcp_report_json_for(&loader, &workspace, Some("help"), None).expect("mcp help json");
+        let help = render_mcp_report_json_for(&loader, &workspace, Some("help"), None)
+            .expect("mcp help json");
         assert_eq!(help["action"], "help");
         assert_eq!(help["usage"]["sources"][0], ".nexus/sudocode/settings.json");
 

--- a/rust/crates/plugins/src/lib.rs
+++ b/rust/crates/plugins/src/lib.rs
@@ -2669,7 +2669,7 @@ fn resolve_hook_entry(root: &Path, entry: &str) -> String {
     if is_literal_command(entry) {
         entry.to_string()
     } else {
-        normalize_path_components(root.join(entry))
+        normalize_path_components(&root.join(entry))
             .display()
             .to_string()
     }
@@ -2679,7 +2679,7 @@ fn resolve_hook_entry(root: &Path, entry: &str) -> String {
 /// relative entry like `./scripts/block.sh`, so the resolved path renders as
 /// `<root>/scripts/block.sh` instead of `<root>/./scripts/block.sh`. Keeps
 /// `..` and absolute prefixes intact — only collapses literal `.` segments.
-fn normalize_path_components(path: PathBuf) -> PathBuf {
+fn normalize_path_components(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
     for component in path.components() {
         match component {
@@ -3943,8 +3943,7 @@ mod tests {
 
         let mut reloaded_config = PluginManagerConfig::new(&config_home);
         reloaded_config.bundled_root = Some(bundled_root.clone());
-        reloaded_config.enabled_plugins =
-            load_structured_enabled_plugins(&manager.settings_path());
+        reloaded_config.enabled_plugins = load_structured_enabled_plugins(&manager.settings_path());
         let reloaded_manager = PluginManager::new(reloaded_config);
         let reloaded = reloaded_manager
             .list_installed_plugins()
@@ -3978,8 +3977,7 @@ mod tests {
 
         let mut reloaded_config = PluginManagerConfig::new(&config_home);
         reloaded_config.bundled_root = Some(bundled_root.clone());
-        reloaded_config.enabled_plugins =
-            load_structured_enabled_plugins(&manager.settings_path());
+        reloaded_config.enabled_plugins = load_structured_enabled_plugins(&manager.settings_path());
         let reloaded_manager = PluginManager::new(reloaded_config);
         let reloaded = reloaded_manager
             .list_installed_plugins()
@@ -5205,7 +5203,7 @@ mod tests {
                         default_enabled: true,
                         root: None,
                         display_name: None,
-            },
+                    },
                     enabled: self.enabled,
                 },
                 root: None,

--- a/rust/crates/plugins/src/lib.rs
+++ b/rust/crates/plugins/src/lib.rs
@@ -226,6 +226,10 @@ pub struct PluginMetadata {
     pub source: String,
     pub default_enabled: bool,
     pub root: Option<PathBuf>,
+    /// User-friendly name from manifest `interface.display_name`, when present.
+    /// `scode plugins` shows this in preference to `name` so v2 plugins can
+    /// surface a friendlier label without changing their package id.
+    pub display_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -2014,20 +2018,21 @@ impl PluginManager {
     ) -> Result<(), PluginError> {
         update_settings_json(&self.settings_path(), |root| {
             if let Some(value) = enabled {
-                if root
+                let has_structured = root
                     .get("plugins")
                     .and_then(Value::as_object)
                     .and_then(|plugins| plugins.get("enabled"))
-                    .is_some()
-                {
+                    .is_some();
+                let has_legacy_only = !has_structured && root.get("enabledPlugins").is_some();
+                if has_legacy_only {
+                    let enabled_plugins = ensure_object(root, "enabledPlugins");
+                    enabled_plugins.insert(plugin_id.to_string(), Value::Bool(value));
+                } else {
                     let plugins = ensure_object(root, "plugins");
                     let enabled_plugins = ensure_object(plugins, "enabled");
                     let mut entry = Map::new();
                     entry.insert("enabled".to_string(), Value::Bool(value));
                     enabled_plugins.insert(plugin_id.to_string(), Value::Object(entry));
-                } else {
-                    let enabled_plugins = ensure_object(root, "enabledPlugins");
-                    enabled_plugins.insert(plugin_id.to_string(), Value::Bool(value));
                 }
             } else {
                 if let Some(enabled_plugins) = root
@@ -2081,6 +2086,7 @@ pub fn builtin_plugins() -> Vec<PluginDefinition> {
             source: BUILTIN_MARKETPLACE.to_string(),
             default_enabled: false,
             root: None,
+            display_name: None,
         },
         hooks: PluginHooks::default(),
         lifecycle: PluginLifecycle::default(),
@@ -2096,6 +2102,11 @@ fn load_plugin_definition(
     marketplace: &str,
 ) -> Result<PluginDefinition, PluginError> {
     let manifest = load_plugin_from_directory(root)?;
+    let display_name = manifest
+        .capabilities
+        .interface
+        .as_ref()
+        .and_then(|interface| interface.display_name.clone());
     let metadata = PluginMetadata {
         id: plugin_id(&manifest.name, marketplace),
         name: manifest.name,
@@ -2105,6 +2116,7 @@ fn load_plugin_definition(
         source,
         default_enabled: manifest.default_enabled,
         root: Some(root.to_path_buf()),
+        display_name,
     };
     let hooks = resolve_hooks(root, &manifest.hooks);
     let lifecycle = resolve_lifecycle(root, &manifest.lifecycle);
@@ -2154,12 +2166,25 @@ fn load_manifest_from_path(
             manifest_path.display()
         ))
     })?;
-    let raw_json: Value = serde_json::from_str(&contents)?;
+    // Surface manifest parse errors with the file path so the user knows
+    // *which* file is broken — bare `error: key must be a string at line 1
+    // column 3` from `scode plugins install <dir>` was untraceable otherwise.
+    let raw_json: Value = serde_json::from_str(&contents).map_err(|error| {
+        PluginError::InvalidManifest(format!(
+            "failed to parse plugin manifest at `{}`: {error}",
+            manifest_path.display()
+        ))
+    })?;
     let compatibility_errors = detect_claude_code_manifest_contract_gaps(&raw_json);
     if !compatibility_errors.is_empty() {
         return Err(PluginError::ManifestValidation(compatibility_errors));
     }
-    let raw_manifest: RawPluginManifest = serde_json::from_value(raw_json)?;
+    let raw_manifest: RawPluginManifest = serde_json::from_value(raw_json).map_err(|error| {
+        PluginError::InvalidManifest(format!(
+            "invalid plugin manifest at `{}`: {error}",
+            manifest_path.display()
+        ))
+    })?;
     build_plugin_manifest(root, raw_manifest)
 }
 
@@ -2644,7 +2669,28 @@ fn resolve_hook_entry(root: &Path, entry: &str) -> String {
     if is_literal_command(entry) {
         entry.to_string()
     } else {
-        root.join(entry).display().to_string()
+        normalize_path_components(root.join(entry))
+            .display()
+            .to_string()
+    }
+}
+
+/// Strip `Component::CurDir` (`.`) segments produced by joining `root` with a
+/// relative entry like `./scripts/block.sh`, so the resolved path renders as
+/// `<root>/scripts/block.sh` instead of `<root>/./scripts/block.sh`. Keeps
+/// `..` and absolute prefixes intact — only collapses literal `.` segments.
+fn normalize_path_components(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
     }
 }
 
@@ -3577,6 +3623,56 @@ mod tests {
     }
 
     #[test]
+    fn write_enabled_state_defaults_to_structured_on_empty_settings() {
+        let _guard = env_guard();
+        let config_home = temp_dir("empty-settings-structured-default");
+        let manager = PluginManager::new(PluginManagerConfig::new(&config_home));
+        // No settings file exists — first write should produce the new structured shape.
+        manager
+            .write_enabled_state("demo@external", Some(true))
+            .expect("first enable on empty settings should succeed");
+        assert_eq!(
+            load_structured_enabled_plugins(&manager.settings_path()).get("demo@external"),
+            Some(&true),
+            "first enable must write structured `plugins.enabled` form"
+        );
+        assert!(
+            load_enabled_plugins(&manager.settings_path()).is_empty(),
+            "first enable must not write deprecated `enabledPlugins`"
+        );
+        let _ = fs::remove_dir_all(config_home);
+    }
+
+    #[test]
+    fn write_enabled_state_preserves_legacy_plugin_config() {
+        let _guard = env_guard();
+        let config_home = temp_dir("legacy-only-preserved");
+        let manager = PluginManager::new(PluginManagerConfig::new(&config_home));
+        write_file(
+            manager.settings_path().as_path(),
+            r#"{
+  "enabledPlugins": {
+    "demo@external": true
+  }
+}"#,
+        );
+        // When only the legacy schema is present, writing should preserve it
+        // (don't proactively migrate — that would invalidate user expectations).
+        manager
+            .write_enabled_state("demo@external", Some(false))
+            .expect("disable should update legacy state");
+        assert_eq!(
+            load_enabled_plugins(&manager.settings_path()).get("demo@external"),
+            Some(&false)
+        );
+        assert!(
+            load_structured_enabled_plugins(&manager.settings_path()).is_empty(),
+            "do not auto-migrate legacy-only settings"
+        );
+        let _ = fs::remove_dir_all(config_home);
+    }
+
+    #[test]
     fn write_enabled_state_updates_existing_structured_plugin_config() {
         let _guard = env_guard();
         let config_home = temp_dir("structured-enabled-state");
@@ -3841,13 +3937,14 @@ mod tests {
             .enable("starter@bundled")
             .expect("enable bundled plugin should succeed");
         assert_eq!(
-            load_enabled_plugins(&manager.settings_path()).get("starter@bundled"),
+            load_structured_enabled_plugins(&manager.settings_path()).get("starter@bundled"),
             Some(&true)
         );
 
         let mut reloaded_config = PluginManagerConfig::new(&config_home);
         reloaded_config.bundled_root = Some(bundled_root.clone());
-        reloaded_config.enabled_plugins = load_enabled_plugins(&manager.settings_path());
+        reloaded_config.enabled_plugins =
+            load_structured_enabled_plugins(&manager.settings_path());
         let reloaded_manager = PluginManager::new(reloaded_config);
         let reloaded = reloaded_manager
             .list_installed_plugins()
@@ -3875,13 +3972,14 @@ mod tests {
             .disable("starter@bundled")
             .expect("disable bundled plugin should succeed");
         assert_eq!(
-            load_enabled_plugins(&manager.settings_path()).get("starter@bundled"),
+            load_structured_enabled_plugins(&manager.settings_path()).get("starter@bundled"),
             Some(&false)
         );
 
         let mut reloaded_config = PluginManagerConfig::new(&config_home);
         reloaded_config.bundled_root = Some(bundled_root.clone());
-        reloaded_config.enabled_plugins = load_enabled_plugins(&manager.settings_path());
+        reloaded_config.enabled_plugins =
+            load_structured_enabled_plugins(&manager.settings_path());
         let reloaded_manager = PluginManager::new(reloaded_config);
         let reloaded = reloaded_manager
             .list_installed_plugins()
@@ -5106,7 +5204,8 @@ mod tests {
                         source: source.clone(),
                         default_enabled: true,
                         root: None,
-                    },
+                        display_name: None,
+            },
                     enabled: self.enabled,
                 },
                 root: None,

--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -42,16 +42,41 @@ pub enum HookProgressEvent {
         event: HookEvent,
         tool_name: String,
         command: String,
+        /// Plugin id when this hook was contributed by a SudoCode plugin, so
+        /// the CLI can attribute live progress to the originating plugin.
+        plugin_source: Option<String>,
     },
+    /// Hook ran and let the tool through. Carries `plugin_source` for symmetric
+    /// attribution with `Denied` / `Failed`.
     Completed {
         event: HookEvent,
         tool_name: String,
         command: String,
+        plugin_source: Option<String>,
+    },
+    /// Hook returned exit-code 2 (deny). The CLI surfaces this distinct from
+    /// `Completed` so users see *why* a tool was blocked — including the
+    /// owning plugin id when it came from a SudoCode plugin.
+    Denied {
+        event: HookEvent,
+        tool_name: String,
+        command: String,
+        plugin_source: Option<String>,
+    },
+    /// Hook crashed / exited non-zero non-2 / failed to start. Distinct from
+    /// `Denied` because the policy did not run cleanly — the tool wasn't
+    /// blocked on the *intent* of the hook, the hook itself broke.
+    Failed {
+        event: HookEvent,
+        tool_name: String,
+        command: String,
+        plugin_source: Option<String>,
     },
     Cancelled {
         event: HookEvent,
         tool_name: String,
         command: String,
+        plugin_source: Option<String>,
     },
 }
 
@@ -373,11 +398,13 @@ impl HookRunner {
 
         for command in commands {
             let hook_source = config.hook_source(event.as_str(), command);
+            let plugin_source = hook_source.map(str::to_string);
             if let Some(reporter) = reporter.as_deref_mut() {
                 reporter.on_event(&HookProgressEvent::Started {
                     event,
                     tool_name: tool_name.to_string(),
                     command: command.clone(),
+                    plugin_source: plugin_source.clone(),
                 });
             }
 
@@ -398,16 +425,18 @@ impl HookRunner {
                             event,
                             tool_name: tool_name.to_string(),
                             command: command.clone(),
+                            plugin_source: plugin_source.clone(),
                         });
                     }
                     merge_parsed_hook_output(&mut result, parsed);
                 }
                 HookCommandOutcome::Deny { parsed } => {
                     if let Some(reporter) = reporter.as_deref_mut() {
-                        reporter.on_event(&HookProgressEvent::Completed {
+                        reporter.on_event(&HookProgressEvent::Denied {
                             event,
                             tool_name: tool_name.to_string(),
                             command: command.clone(),
+                            plugin_source: plugin_source.clone(),
                         });
                     }
                     merge_parsed_hook_output(&mut result, parsed);
@@ -416,10 +445,11 @@ impl HookRunner {
                 }
                 HookCommandOutcome::Failed { parsed } => {
                     if let Some(reporter) = reporter.as_deref_mut() {
-                        reporter.on_event(&HookProgressEvent::Completed {
+                        reporter.on_event(&HookProgressEvent::Failed {
                             event,
                             tool_name: tool_name.to_string(),
                             command: command.clone(),
+                            plugin_source: plugin_source.clone(),
                         });
                     }
                     merge_parsed_hook_output(&mut result, parsed);
@@ -432,6 +462,7 @@ impl HookRunner {
                             event,
                             tool_name: tool_name.to_string(),
                             command: command.clone(),
+                            plugin_source: plugin_source.clone(),
                         });
                     }
                     result.cancelled = true;
@@ -992,6 +1023,70 @@ mod tests {
         let message = &result.messages()[0];
         assert!(message.contains("SudoCode plugin"));
         assert!(message.contains("guard-plugin@external"));
+    }
+
+    #[test]
+    fn plugin_hook_progress_events_carry_plugin_source_on_deny() {
+        // Regression for Bug #8: the CLI hook progress channel must surface
+        // the SudoCode plugin id so the terminal UI can distinguish a plugin
+        // denial from a user-configured-hook denial.
+        let runner = HookRunner::new(RuntimeHookConfig::new_with_sources(
+            vec![(shell_snippet("exit 2"), "guard-plugin@external".to_string())],
+            Vec::new(),
+            Vec::new(),
+        ));
+        let mut reporter = RecordingReporter { events: Vec::new() };
+
+        let result = runner.run_pre_tool_use_with_context(
+            "Bash",
+            r#"{"command":"pwd"}"#,
+            None,
+            Some(&mut reporter),
+        );
+
+        assert!(result.is_denied());
+        let denied = reporter
+            .events
+            .iter()
+            .find(|event| matches!(event, HookProgressEvent::Denied { .. }))
+            .expect("denied event must be emitted");
+        match denied {
+            HookProgressEvent::Denied { plugin_source, .. } => {
+                assert_eq!(plugin_source.as_deref(), Some("guard-plugin@external"));
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_hook_progress_events_have_no_plugin_source() {
+        // Configured-by-user hooks (no PluginHookEntry) must NOT spoof a
+        // plugin attribution.
+        let runner = HookRunner::new(RuntimeHookConfig::new(
+            vec![shell_snippet("exit 2")],
+            Vec::new(),
+            Vec::new(),
+        ));
+        let mut reporter = RecordingReporter { events: Vec::new() };
+
+        let _ = runner.run_pre_tool_use_with_context(
+            "Bash",
+            r#"{"command":"pwd"}"#,
+            None,
+            Some(&mut reporter),
+        );
+
+        let denied = reporter
+            .events
+            .iter()
+            .find(|event| matches!(event, HookProgressEvent::Denied { .. }))
+            .expect("denied event must be emitted");
+        match denied {
+            HookProgressEvent::Denied { plugin_source, .. } => {
+                assert_eq!(plugin_source.as_deref(), None);
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/crates/runtime/src/mcp_stdio.rs
+++ b/rust/crates/runtime/src/mcp_stdio.rs
@@ -279,6 +279,12 @@ pub enum McpServerManagerError {
     UnknownServer {
         server_name: String,
     },
+    /// Sticky terminal failure after exceeding the spawn-attempt limit.
+    /// Prevents a broken plugin MCP server from being re-forked indefinitely.
+    PermanentlyFailed {
+        server_name: String,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for McpServerManagerError {
@@ -322,6 +328,10 @@ impl std::fmt::Display for McpServerManagerError {
                 write!(f, "unknown MCP tool `{qualified_name}`")
             }
             Self::UnknownServer { server_name } => write!(f, "unknown MCP server `{server_name}`"),
+            Self::PermanentlyFailed {
+                server_name,
+                reason,
+            } => write!(f, "MCP server `{server_name}` permanently disabled: {reason}"),
         }
     }
 }
@@ -335,7 +345,8 @@ impl std::error::Error for McpServerManagerError {
             | Self::InvalidResponse { .. }
             | Self::Timeout { .. }
             | Self::UnknownTool { .. }
-            | Self::UnknownServer { .. } => None,
+            | Self::UnknownServer { .. }
+            | Self::PermanentlyFailed { .. } => None,
         }
     }
 }
@@ -356,6 +367,10 @@ impl McpServerManagerError {
             | Self::Timeout { method, .. } => lifecycle_phase_for_method(method),
             Self::UnknownTool { .. } => McpLifecyclePhase::ToolDiscovery,
             Self::UnknownServer { .. } => McpLifecyclePhase::ServerRegistration,
+            // Permanent failure is the sticky version of "couldn't make it
+            // past initialize" — preserve InitializeHandshake so downstream
+            // surfaces (degraded report, doctor) don't misclassify it.
+            Self::PermanentlyFailed { .. } => McpLifecyclePhase::InitializeHandshake,
         }
     }
 
@@ -425,6 +440,17 @@ impl McpServerManagerError {
             Self::UnknownServer { server_name } => {
                 BTreeMap::from([("server".to_string(), server_name.clone())])
             }
+            Self::PermanentlyFailed {
+                server_name,
+                reason,
+            } => BTreeMap::from([
+                ("server".to_string(), server_name.clone()),
+                ("reason".to_string(), reason.clone()),
+                // Track the lifecycle method this failure aborted, matching
+                // other variants. PermanentlyFailed always trips in the
+                // spawn → initialize handshake window.
+                ("method".to_string(), "initialize".to_string()),
+            ]),
         }
     }
 }
@@ -459,11 +485,23 @@ struct ToolRoute {
     raw_name: String,
 }
 
+/// Maximum number of spawn+initialize attempts to make against a single MCP
+/// server within one McpServerManager lifetime. Exceeding this trips a sticky
+/// `permanent_failure` so a broken plugin MCP server cannot loop-fork.
+const MCP_SPAWN_ATTEMPT_LIMIT: u32 = 2;
+
 #[derive(Debug)]
 struct ManagedMcpServer {
     bootstrap: McpClientBootstrap,
     process: Option<McpStdioProcess>,
     initialized: bool,
+    /// Total spawn attempts (including retries) made against this server.
+    /// Capped at MCP_SPAWN_ATTEMPT_LIMIT to short-circuit the spawn loop.
+    spawn_attempts: u32,
+    /// Sticky terminal failure that disables further spawn attempts and is
+    /// returned verbatim on every future request. Set once spawn_attempts
+    /// reaches the cap.
+    permanent_failure: Option<String>,
 }
 
 impl ManagedMcpServer {
@@ -472,6 +510,8 @@ impl ManagedMcpServer {
             bootstrap,
             process: None,
             initialized: false,
+            spawn_attempts: 0,
+            permanent_failure: None,
         }
     }
 }
@@ -1048,6 +1088,19 @@ impl McpServerManager {
         &mut self,
         server_name: &str,
     ) -> Result<(), McpServerManagerError> {
+        // Sticky terminal failure short-circuits before any work — prevents
+        // the spawn loop from repeatedly fork()ing a broken plugin server.
+        if let Some(reason) = self
+            .servers
+            .get(server_name)
+            .and_then(|server| server.permanent_failure.clone())
+        {
+            return Err(McpServerManagerError::PermanentlyFailed {
+                server_name: server_name.to_string(),
+                reason,
+            });
+        }
+
         if self.server_process_exited(server_name)? {
             self.reset_server(server_name).await?;
         }
@@ -1063,7 +1116,25 @@ impl McpServerManager {
                 })?;
 
             if needs_spawn {
+                let attempt_count = self
+                    .servers
+                    .get(server_name)
+                    .map(|server| server.spawn_attempts)
+                    .unwrap_or(0);
+                if attempt_count >= MCP_SPAWN_ATTEMPT_LIMIT {
+                    let reason = format!(
+                        "MCP server `{server_name}` exceeded {MCP_SPAWN_ATTEMPT_LIMIT} initialize attempts; refusing to retry spawn"
+                    );
+                    if let Some(server) = self.servers.get_mut(server_name) {
+                        server.permanent_failure = Some(reason.clone());
+                    }
+                    return Err(McpServerManagerError::PermanentlyFailed {
+                        server_name: server_name.to_string(),
+                        reason,
+                    });
+                }
                 let server = self.server_mut(server_name)?;
+                server.spawn_attempts = server.spawn_attempts.saturating_add(1);
                 server.process = Some(spawn_mcp_stdio_process(&server.bootstrap)?);
                 server.initialized = false;
             }
@@ -1410,6 +1481,7 @@ fn default_initialize_params() -> McpInitializeParams {
 
 #[cfg(test)]
 mod tests {
+    use super::MCP_SPAWN_ATTEMPT_LIMIT;
     use std::collections::BTreeMap;
     use std::fs;
     use std::io::ErrorKind;
@@ -2778,6 +2850,89 @@ mod tests {
             manager.shutdown().await.expect("shutdown");
             cleanup_script(&script_path);
             cleanup_script(&broken_script_path);
+        });
+    }
+
+    fn write_instant_exit_script(counter_path: &Path) -> PathBuf {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("temp dir");
+        let script_path = root.join("instant-exit.sh");
+        let script = format!(
+            "#!/bin/sh\n# Append spawn marker so the test can count invocations.\necho spawn >> {counter}\nexit 0\n",
+            counter = counter_path.display(),
+        );
+        fs::write(&script_path, script).expect("write script");
+        let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod");
+        script_path
+    }
+
+    /// Reproduces the production e2e finding: a plugin MCP server that exits
+    /// immediately after spawn used to trigger 4–8 fork()s during initial
+    /// discovery. With MCP_SPAWN_ATTEMPT_LIMIT in place, spawn must be capped
+    /// at 2, and a follow-up tool call must short-circuit to PermanentlyFailed.
+    #[test]
+    fn manager_caps_spawn_attempts_when_server_exits_immediately() {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async {
+            let root = temp_dir();
+            fs::create_dir_all(&root).expect("counter dir");
+            let counter_path = root.join("spawn-count.txt");
+            let script_path = write_instant_exit_script(&counter_path);
+            let servers = BTreeMap::from([(
+                "broken".to_string(),
+                ScopedMcpServerConfig {
+                    scope: ConfigSource::Local,
+                    config: McpServerConfig::Stdio(McpStdioServerConfig {
+                        command: script_path.display().to_string(),
+                        args: Vec::new(),
+                        env: BTreeMap::new(),
+                        current_dir: None,
+                        tool_call_timeout_ms: None,
+                    }),
+                },
+            )]);
+            let mut manager = McpServerManager::from_servers(&servers);
+
+            // First discovery exhausts the spawn cap.
+            let report = manager.discover_tools_best_effort().await;
+            assert!(report.tools.is_empty());
+            assert_eq!(report.failed_servers.len(), 1);
+
+            let initial_spawn_count = fs::read_to_string(&counter_path)
+                .unwrap_or_default()
+                .lines()
+                .count();
+            assert!(
+                initial_spawn_count <= usize::try_from(MCP_SPAWN_ATTEMPT_LIMIT)
+                    .expect("attempt limit fits usize"),
+                "spawn attempts must be capped to {MCP_SPAWN_ATTEMPT_LIMIT}, got {initial_spawn_count}"
+            );
+
+            // A follow-up tool call must NOT trigger any additional fork()s —
+            // the sticky permanent_failure must short-circuit before spawn.
+            let call = manager
+                .call_tool(&mcp_tool_name("broken", "anything"), None)
+                .await;
+            assert!(
+                call.is_err(),
+                "call on permanently-failed server must error"
+            );
+            let post_call_spawn_count = fs::read_to_string(&counter_path)
+                .unwrap_or_default()
+                .lines()
+                .count();
+            assert_eq!(
+                post_call_spawn_count, initial_spawn_count,
+                "no extra spawns after the cap is reached"
+            );
+
+            manager.shutdown().await.expect("shutdown");
+            cleanup_script(&script_path);
         });
     }
 

--- a/rust/crates/runtime/src/mcp_stdio.rs
+++ b/rust/crates/runtime/src/mcp_stdio.rs
@@ -331,7 +331,10 @@ impl std::fmt::Display for McpServerManagerError {
             Self::PermanentlyFailed {
                 server_name,
                 reason,
-            } => write!(f, "MCP server `{server_name}` permanently disabled: {reason}"),
+            } => write!(
+                f,
+                "MCP server `{server_name}` permanently disabled: {reason}"
+            ),
         }
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/mcp.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/mcp.rs
@@ -381,6 +381,7 @@ mod tests {
             source: "external".to_string(),
             default_enabled: true,
             root: path.parent().map(PathBuf::from),
+            display_name: None,
         };
         LoadedPlugin {
             summary: PluginSummary {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -89,8 +89,7 @@ use cli::tool_executor::{permission_policy, CliToolExecutor};
 use commands::{
     classify_skills_slash_command, handle_agents_slash_command, handle_agents_slash_command_json,
     handle_mcp_slash_command_json_with_plugins, handle_mcp_slash_command_with_plugins,
-    handle_plugins_slash_command,
-    handle_skills_slash_command, handle_skills_slash_command_json,
+    handle_plugins_slash_command, handle_skills_slash_command, handle_skills_slash_command_json,
     handle_skills_slash_command_json_with_plugins, handle_skills_slash_command_with_plugins,
     render_slash_command_help, render_slash_command_help_filtered, resolve_skill_invocation,
     resolve_skill_invocation_with_plugins, resume_supported_slash_commands, slash_command_specs,
@@ -3448,8 +3447,7 @@ impl LiveCli {
                                         "name".to_string(),
                                         Value::String(plugin.metadata.name.clone()),
                                     );
-                                    if let Some(display_name) = &plugin.metadata.display_name
-                                    {
+                                    if let Some(display_name) = &plugin.metadata.display_name {
                                         entry.insert(
                                             "display_name".to_string(),
                                             Value::String(display_name.clone()),
@@ -3471,10 +3469,8 @@ impl LiveCli {
                                         "source".to_string(),
                                         Value::String(plugin.metadata.source.clone()),
                                     );
-                                    entry.insert(
-                                        "enabled".to_string(),
-                                        Value::Bool(plugin.enabled),
-                                    );
+                                    entry
+                                        .insert("enabled".to_string(), Value::Bool(plugin.enabled));
                                     if let Some(root) = &plugin.metadata.root {
                                         entry.insert(
                                             "root".to_string(),

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -88,7 +88,8 @@ use cli::status::{
 use cli::tool_executor::{permission_policy, CliToolExecutor};
 use commands::{
     classify_skills_slash_command, handle_agents_slash_command, handle_agents_slash_command_json,
-    handle_mcp_slash_command, handle_mcp_slash_command_json, handle_plugins_slash_command,
+    handle_mcp_slash_command_json_with_plugins, handle_mcp_slash_command_with_plugins,
+    handle_plugins_slash_command,
     handle_skills_slash_command, handle_skills_slash_command_json,
     handle_skills_slash_command_json_with_plugins, handle_skills_slash_command_with_plugins,
     render_slash_command_help, render_slash_command_help_filtered, resolve_skill_invocation,
@@ -1107,10 +1108,19 @@ fn run_resume_command(
                 (Some(action), Some(target)) => Some(format!("{action} {target}")),
                 (None, Some(target)) => Some(target.to_string()),
             };
+            let plugin_load_outcome = plugin_load_outcome_for_cwd(&cwd).ok();
             Ok(ResumeCommandOutcome {
                 session: session.clone(),
-                message: Some(handle_mcp_slash_command(args.as_deref(), &cwd)?),
-                json: Some(handle_mcp_slash_command_json(args.as_deref(), &cwd)?),
+                message: Some(handle_mcp_slash_command_with_plugins(
+                    args.as_deref(),
+                    &cwd,
+                    plugin_load_outcome.as_ref(),
+                )?),
+                json: Some(handle_mcp_slash_command_json_with_plugins(
+                    args.as_deref(),
+                    &cwd,
+                    plugin_load_outcome.as_ref(),
+                )?),
             })
         }
         SlashCommand::Memory => Ok(ResumeCommandOutcome {
@@ -3353,10 +3363,22 @@ impl LiveCli {
             return run_mcp_serve();
         }
         let cwd = env::current_dir()?;
+        // Include plugin-provided MCP servers so `scode mcp` matches what the
+        // runtime actually wires up. Plugin discovery may fail (e.g. malformed
+        // installed.json) — degrade to runtime-only view instead of erroring,
+        // matching the contract of the underlying handlers.
+        let plugin_load_outcome = plugin_load_outcome_for_cwd(&cwd).ok();
         match output_format {
-            CliOutputFormat::Text => println!("{}", handle_mcp_slash_command(args, &cwd)?),
+            CliOutputFormat::Text => println!(
+                "{}",
+                handle_mcp_slash_command_with_plugins(args, &cwd, plugin_load_outcome.as_ref())?
+            ),
             CliOutputFormat::Json => {
-                let value = handle_mcp_slash_command_json(args, &cwd)?;
+                let value = handle_mcp_slash_command_json_with_plugins(
+                    args,
+                    &cwd,
+                    plugin_load_outcome.as_ref(),
+                )?;
                 // Propagate ok:false → non-zero exit so automation callers
                 // can rely on exit code instead of inspecting the envelope.
                 let is_error = value.get("ok").and_then(|v| v.as_bool()) == Some(false);
@@ -3404,16 +3426,79 @@ impl LiveCli {
         let result = handle_plugins_slash_command(action, target, &mut manager, &cwd)?;
         match output_format {
             CliOutputFormat::Text => println!("{}", result.message),
-            CliOutputFormat::Json => println!(
-                "{}",
-                serde_json::to_string_pretty(&json!({
+            CliOutputFormat::Json => {
+                // For list-style actions, emit a structured `plugins` array
+                // alongside the rendered text so scripts/CI can consume the
+                // data without re-parsing the text payload.
+                let action_name = action.unwrap_or("list");
+                let plugins_array = matches!(action_name, "list").then(|| {
+                    manager
+                        .list_installed_plugins()
+                        .ok()
+                        .map(|plugins| {
+                            plugins
+                                .iter()
+                                .map(|plugin| {
+                                    let mut entry = serde_json::Map::new();
+                                    entry.insert(
+                                        "id".to_string(),
+                                        Value::String(plugin.metadata.id.clone()),
+                                    );
+                                    entry.insert(
+                                        "name".to_string(),
+                                        Value::String(plugin.metadata.name.clone()),
+                                    );
+                                    if let Some(display_name) = &plugin.metadata.display_name
+                                    {
+                                        entry.insert(
+                                            "display_name".to_string(),
+                                            Value::String(display_name.clone()),
+                                        );
+                                    }
+                                    entry.insert(
+                                        "version".to_string(),
+                                        Value::String(plugin.metadata.version.clone()),
+                                    );
+                                    entry.insert(
+                                        "description".to_string(),
+                                        Value::String(plugin.metadata.description.clone()),
+                                    );
+                                    entry.insert(
+                                        "kind".to_string(),
+                                        Value::String(plugin.metadata.kind.to_string()),
+                                    );
+                                    entry.insert(
+                                        "source".to_string(),
+                                        Value::String(plugin.metadata.source.clone()),
+                                    );
+                                    entry.insert(
+                                        "enabled".to_string(),
+                                        Value::Bool(plugin.enabled),
+                                    );
+                                    if let Some(root) = &plugin.metadata.root {
+                                        entry.insert(
+                                            "root".to_string(),
+                                            Value::String(root.display().to_string()),
+                                        );
+                                    }
+                                    Value::Object(entry)
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                });
+                let mut envelope = json!({
                     "kind": "plugin",
-                    "action": action.unwrap_or("list"),
+                    "action": action_name,
                     "target": target,
                     "message": result.message,
                     "reload_runtime": result.reload_runtime,
-                }))?
-            ),
+                });
+                if let Some(array) = plugins_array {
+                    envelope["plugins"] = Value::Array(array);
+                }
+                println!("{}", serde_json::to_string_pretty(&envelope)?);
+            }
         }
         Ok(())
     }
@@ -4203,30 +4288,64 @@ struct CliHookProgressReporter;
 
 impl runtime::HookProgressReporter for CliHookProgressReporter {
     fn on_event(&mut self, event: &runtime::HookProgressEvent) {
+        // Format SudoCode plugin attribution once; each outcome line includes
+        // it so the user sees *who* ran the hook in addition to *what* happened.
+        fn attribution(plugin_source: Option<&str>) -> String {
+            match plugin_source {
+                Some(plugin_id) => format!(" (SudoCode plugin {plugin_id})"),
+                None => String::new(),
+            }
+        }
         match event {
             runtime::HookProgressEvent::Started {
                 event,
                 tool_name,
                 command,
+                plugin_source,
             } => eprintln!(
-                "[hook {event_name}] {tool_name}: {command}",
-                event_name = event.as_str()
+                "[hook {event_name}] {tool_name}: {command}{attr}",
+                event_name = event.as_str(),
+                attr = attribution(plugin_source.as_deref())
             ),
             runtime::HookProgressEvent::Completed {
                 event,
                 tool_name,
                 command,
+                plugin_source,
             } => eprintln!(
-                "[hook done {event_name}] {tool_name}: {command}",
-                event_name = event.as_str()
+                "[hook done {event_name}] {tool_name}: {command}{attr}",
+                event_name = event.as_str(),
+                attr = attribution(plugin_source.as_deref())
+            ),
+            runtime::HookProgressEvent::Denied {
+                event,
+                tool_name,
+                command,
+                plugin_source,
+            } => eprintln!(
+                "[hook DENIED {event_name}] {tool_name}: {command}{attr}",
+                event_name = event.as_str(),
+                attr = attribution(plugin_source.as_deref())
+            ),
+            runtime::HookProgressEvent::Failed {
+                event,
+                tool_name,
+                command,
+                plugin_source,
+            } => eprintln!(
+                "[hook FAILED {event_name}] {tool_name}: {command}{attr}",
+                event_name = event.as_str(),
+                attr = attribution(plugin_source.as_deref())
             ),
             runtime::HookProgressEvent::Cancelled {
                 event,
                 tool_name,
                 command,
+                plugin_source,
             } => eprintln!(
-                "[hook cancelled {event_name}] {tool_name}: {command}",
-                event_name = event.as_str()
+                "[hook cancelled {event_name}] {tool_name}: {command}{attr}",
+                event_name = event.as_str(),
+                attr = attribution(plugin_source.as_deref())
             ),
         }
     }

--- a/rust/crates/rusty-sudocode-cli/tests/plugin_prompt_injection.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/plugin_prompt_injection.rs
@@ -20,6 +20,7 @@ fn make_loaded_plugin(id: &str, name: &str, desc: &str, enabled: bool) -> Loaded
                 source: source.clone(),
                 default_enabled: true,
                 root: None,
+                display_name: None,
             },
             enabled,
         },


### PR DESCRIPTION
## Summary

Follow-up to #155. PR 155's骨架功能在单测层面通过，但首次实机 e2e（装一个含 manifest v2 / .mcp.json / hook 的本地 plugin → 跑 `scode plugins`、`scode mcp`、`scode --auth api-key prompt`）暴露出 8 个生产 bug。这个 PR 修这 8 个并把行为反向锁到单测里。

详细 e2e findings 见随附讨论；下面是修复矩阵。

## Fixes

| # | Bug | Fix |
|---|---|---|
| 1 | `scode plugins install` 在空 `settings.json` 上默认写 legacy `enabledPlugins`，之后每次 scode 调用都触发自己的 deprecation 警告 | `write_enabled_state` 默认写新格式 `plugins.enabled.<id>.{enabled: bool}`；已存在的 legacy schema 才保留 |
| 2 | `scode mcp` 和 `scode mcp show <name>` 看不到 plugin 提供的 MCP server | 新 `handle_mcp_slash_command{_json,}_with_plugins`，接 `PluginLoadOutcome`；text/JSON/show 三个 surface 都暴露 `plugin_source` |
| 3 | `interface.display_name` 解析了但所有 user-facing 渲染都用 raw name | `PluginMetadata` 新增 `display_name: Option<String>`；`scode plugins` / install / enable / disable 报告优先使用。**system-prompt 段保持匿名化**（防注入设计不变）|
| 4 | `scode plugins install <bad-dir>` 错误信息只有 `error: key must be a string at line 1 column 3`，不说哪个文件 | `load_manifest_from_path` 包装 `failed to parse plugin manifest at \`<path>\`` |
| 5 | `scode plugins --output-format json` 返回的是文本套了 JSON 壳，没有结构化字段 | envelope 加 `plugins[]` 数组（id/name/display_name/version/description/kind/source/enabled/root）|
| 6 | 一个写错的 plugin MCP server（如 exit-0 immediately）会触发 8 次 spawn 1 秒内 — 没有 backoff 也没有放弃逻辑 | `MCP_SPAWN_ATTEMPT_LIMIT = 2` 硬 cap + sticky `PermanentlyFailed` 状态短路后续调用 |
| 8 | CLI hook UI 只显示 `[hook PreToolUse]` / `[hook done PreToolUse]`，区分不出 allow/deny/fail，也看不到是哪个 plugin 拦的 | `HookProgressEvent` 拆出 `Denied` / `Failed` 变体，全部携带 `plugin_source: Option<String>`；CLI 渲染 `[hook DENIED PreToolUse] ... (SudoCode plugin <id>)` |
| 9 | 安装后 hook 路径含字面 `./` 段：`installed/<plugin>/./scripts/block.sh` | `resolve_hook_entry` 走新 `normalize_path_components` 跳过 `Component::CurDir` |

**Out of scope**：原 e2e 还发现 Bug #7（scode 在上游 502 / 错误模型 id 时静默挂起）。属于 auth/network 错误 surface 而非 plugin 系统，已另起追踪。

## Test plan

- [x] `cargo test -p plugins --lib`（94/94 pass，新增 2 个关于 write_enabled_state 默认行为的测试）
- [x] `cargo test -p commands --lib`（56/56 pass，MCP renderer 签名变更后的回归测试）
- [x] `cargo test -p runtime --lib`（525/525 pass，新增 1 个 spawn cap 测试 + 2 个 hook progress event 测试）
- [x] `cargo test -p rusty-sudocode-cli --tests`（所有集成 suite pass）
- [x] `cargo build -p rusty-sudocode-cli`（clean）
- [x] E2E 重跑每个 bug 的复现路径（隔离 HOME + demo plugin fixture），所有 bug 行为按预期修复

## Notable design notes

- **Bug #6 spawn cap 是 per-manager 范围**：每个 `McpServerManager` 实例独立维护 `spawn_attempts` 计数，超过 cap 设 sticky `permanent_failure`。LiveCli 多 turn 重建 runtime 时每个新 manager 重新计 cap — 总 spawn 数仍是 `O(turns)` 而非 `O(turns × inner_retries)`，但已经不是 fork-bomb 风险。如需更严格的进程级 cap，可在跟进 PR 加上。

- **Bug #8 plugin_source 走 tool_result + progress 两条通道**：模型从 tool_result 看到 `SudoCode plugin demo@external PreToolUse hook denied tool Bash`（PR 155 原本就有），CLI 用户从 `HookProgressEvent::Denied` 的 `plugin_source` 字段独立看到归属。两条通道互不依赖。

- **Bug #1 legacy 兼容策略**：只在 user 已经手写过 `enabledPlugins` 时保留它，避免重写用户配置；这条 explicit by tests `write_enabled_state_preserves_legacy_plugin_config` 和 `write_enabled_state_defaults_to_structured_on_empty_settings`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)