### PR TITLE
feat(acp): report context limits and bump to v0.1.8

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -35,6 +35,7 @@ use agent_client_protocol_schema::{
     ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Map};
 
 /// Error type returned by ACP agent implementations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,11 +62,15 @@ impl AcpError {
             Self::InvalidParams(msg) | Self::Internal(msg) => msg,
         };
 
+        if raw_message.contains("[context_window_exceeded]") {
+            return raw_message.clone();
+        }
+
         // Check for specific error types and provide friendly messages
         if raw_message.contains("context_window_blocked")
             || raw_message.contains("Context window blocked")
         {
-            return "图片或文本内容过大，超出了模型的处理限制。\n\n建议解决方案：\n1. 使用较小的图片（建议压缩或缩小图片尺寸）\n2. 简化输入内容\n3. 使用支持更大上下文的模型\n4. 清除对话历史后重新开始".to_string();
+            return "[context_window_exceeded][single_request_too_large] 图片或文本内容过大，超出了模型的处理限制。\n\n建议解决方案：\n1. 使用较小的图片（建议压缩或缩小图片尺寸）\n2. 简化输入内容\n3. 使用支持更大上下文的模型\n4. 清除对话历史后重新开始".to_string();
         }
 
         if raw_message.contains("authentication")
@@ -364,6 +369,8 @@ pub struct PromptUsage {
     pub total_tokens: u64,
     pub cache_read_tokens: Option<u64>,
     pub cache_write_tokens: Option<u64>,
+    pub context_window_tokens: Option<u64>,
+    pub estimated_session_tokens: Option<u64>,
 }
 
 /// Thread-safe handle to a delegate, shared across async handlers.
@@ -941,11 +948,19 @@ pub(crate) async fn run_acp_on_transport(
                             Ok((stop_reason, prompt_usage)) => {
                                 let mut response = PromptResponse::new(stop_reason);
                                 if let Some(u) = prompt_usage {
+                                    let mut meta = Map::new();
+                                    meta.insert(
+                                        "sudocode".to_string(),
+                                        json!({
+                                            "contextWindowTokens": u.context_window_tokens,
+                                            "estimatedSessionTokens": u.estimated_session_tokens,
+                                        }),
+                                    );
                                     response = response.usage(
                                         Usage::new(u.total_tokens, u.input_tokens, u.output_tokens)
                                             .cached_read_tokens(u.cache_read_tokens)
                                             .cached_write_tokens(u.cache_write_tokens),
-                                    );
+                                    ).meta(Some(meta));
                                 }
                                 responder.respond(response)?;
                             }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2290,7 +2290,7 @@ impl AcpSdkDelegate {
                 // If still over limit after compaction, return friendly error
                 if new_estimated_tokens > context_limit {
                     let user_message = format!(
-                        "对话内容过长，即使压缩后仍超出模型限制。\n\n\
+                        "[context_window_exceeded][history_context_too_large] 对话内容过长，即使压缩后仍超出模型限制。\n\n\
                         当前估算: {} tokens\n\
                         模型限制: {} tokens\n\n\
                         建议解决方案：\n\
@@ -2304,7 +2304,7 @@ impl AcpSdkDelegate {
             } else {
                 // No messages to compact, but request is too large
                 let user_message = format!(
-                    "当前请求内容过大，超出模型处理限制。\n\n\
+                    "[context_window_exceeded][single_request_too_large] 当前请求内容过大，超出模型处理限制。\n\n\
                     当前估算: {} tokens\n\
                     模型限制: {} tokens\n\n\
                     建议解决方案：\n\
@@ -2333,6 +2333,10 @@ impl AcpSdkDelegate {
             total_tokens: u64::from(usage.total_tokens()),
             cache_read_tokens: Some(u64::from(usage.cache_read_input_tokens)),
             cache_write_tokens: Some(u64::from(usage.cache_creation_input_tokens)),
+            context_window_tokens: Some(context_limit as u64),
+            estimated_session_tokens: Some(
+                estimate_session_tokens(session.runtime.session()) as u64
+            ),
         };
         // Record token usage to telemetry log
         if let Some(tracer) = session.runtime.session_tracer() {


### PR DESCRIPTION
## Summary
- Report sudocode context window tokens and estimated session tokens in ACP prompt response metadata
- Add structured error tags (`[context_window_exceeded]`, `[single_request_too_large]`, `[history_context_too_large]`) to context limit error messages for better client-side handling
- Bump workspace version from 0.1.7 to 0.1.8

## Test plan
- [ ] Verify `scode version` reports 0.1.8
- [ ] Verify ACP prompt responses include `sudocode.contextWindowTokens` and `sudocode.estimatedSessionTokens` in meta
- [ ] Verify context limit errors contain structured tags for client parsing
- [ ] Run `cargo test --workspace` to ensure no regressions