### PR TITLE
fix(runtime): skip ppid<=1 check in container environments

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/runtime/src/acp_stdio_server.rs
+++ b/rust/crates/runtime/src/acp_stdio_server.rs
@@ -79,11 +79,15 @@ fn spawn_stdin_eof_watchdog() {
 /// death, so this never fires while the host is still alive.
 #[cfg(unix)]
 fn spawn_parent_exit_watchdog() {
+    use crate::sandbox::detect_container_environment;
+
     let initial_ppid = nix::unistd::getppid();
 
     // Already orphaned before we even started (parent reaped, reparented to
     // init): nothing to serve, so exit immediately.
-    if initial_ppid.as_raw() <= 1 {
+    // Skip this check in containers where ppid=1 is normal.
+    if initial_ppid.as_raw() <= 1 && !detect_container_environment().in_container {
+        eprintln!("[acp-stdio] Exiting: parent process is PID 1 (orphaned) and not running in a container");
         std::process::exit(0);
     }
 
@@ -91,6 +95,7 @@ fn spawn_parent_exit_watchdog() {
         loop {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             if nix::unistd::getppid() != initial_ppid {
+                eprintln!("[acp-stdio] Exiting: parent process changed (parent exited)");
                 std::process::exit(0);
             }
         }


### PR DESCRIPTION
In container environments, ppid=1 is normal behavior (process runs directly under PID 1). Previously, the parent exit watchdog would immediately exit when ppid<=1, preventing the server from running in containers.

Now uses detect_container_environment() to check if we're in a container before applying the orphaned process check.