### PR TITLE
fix: update download bucket from sudoclaw to sudowork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           coscmd config \
             -a "$TENCENT_SECRET_ID" \
             -s "$TENCENT_SECRET_KEY" \
-            -b sudoclaw-download-1309794936 \
+            -b sudowork-download-1309794936 \
             -e cos.accelerate.myqcloud.com
           for file in dist/scode-*.tar.gz dist/scode-*.zip; do
             [ -f "$file" ] || continue
@@ -149,4 +149,4 @@ jobs:
             coscmd upload "$file" "sudocode/release/latest/$filename"
           done
           coscmd upload dist/SHA256SUMS.txt "sudocode/release/latest/SHA256SUMS.txt"
-          echo "Done: https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/"
+          echo "Done: https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Overrides:
 **China mirror** — faster downloads for mainland China users (checksums still verified against GitHub):
 
 ```bash
-SCODE_MIRROR=https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \
+SCODE_MIRROR=https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \
   curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@
 #                       Use this to point at a mirror (e.g. Tencent COS) for
 #                       faster downloads in China. The checksum file is always
 #                       fetched from GitHub Releases for security.
-#                       Example: https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest
+#                       Example: https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest
 #   NO_COLOR            Disable ANSI color output when set.
 #
 # Flags:
@@ -89,7 +89,7 @@ ${C_BOLD}EXAMPLES${C_RESET}
     sh install.sh --prefix /usr/local
     sh install.sh --no-sudo
     # China mirror (faster in mainland China):
-    SCODE_MIRROR=https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \\
+    SCODE_MIRROR=https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \\
       curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
 EOF
 }


### PR DESCRIPTION
## Summary
- Update Tencent COS bucket name from `sudoclaw-download` to `sudowork-download`
- Update references in release workflow, README, and install script

## Test plan
- [x] Verify the new bucket URL is accessible
- [x] Test download links work correctly
- [x] Verify release workflow can upload to the new bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)