### PR TITLE
fix: detach stdin when running PowerShell tool to prevent ACP hang

### DIFF
--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -6833,6 +6833,13 @@ fn execute_shell_command(
         .arg("-Command")
         .arg(command);
     process
+        // Detach stdin so the child never inherits the parent's stdin. In ACP
+        // stdio mode the parent's stdin is the JSON-RPC protocol stream; a child
+        // (or grandchild such as `python` spawned by `py`) that inherits it can
+        // block reading input that never arrives — and the post-kill
+        // `wait_with_output()` then hangs forever waiting on the still-open pipe,
+        // making the timeout appear ineffective.
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 


### PR DESCRIPTION
## Summary

Fixes #164. In ACP stdio mode, running a PowerShell command could completely freeze the session and the `timeout` parameter had no effect.

The foreground PowerShell path in `execute_shell_command` did not set stdin, so the spawned shell and any grandchildren (e.g. `python` launched via `py`) inherited the runtime's stdin — which in ACP mode is the JSON-RPC protocol stream. Those children could block reading input that never arrives, and the post-kill `wait_with_output()` then waited forever on the still-open pipe.

The fix sets `stdin(Stdio::null())`, matching the background path and the bash tool which already detach stdin. TUI mode was unaffected because its stdin is a terminal, not a protocol pipe.

## Test plan
- [ ] On Windows, in ACP mode, run a PowerShell command such as `py -c "import sys; print(sys.executable)"` with a timeout and confirm it returns instead of hanging
- [ ] Confirm the `timeout` parameter now terminates long-running PowerShell commands

Generated with [Claude Code](https://claude.ai/code)