### PR TITLE
fix(openai_compat): use empty string for content when tool_calls present

### DIFF
--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -1032,9 +1032,19 @@ pub fn translate_message(message: &InputMessage, model: &str) -> Vec<Value> {
         if text.is_empty() && tool_calls.is_empty() && !include_reasoning {
             Vec::new()
         } else {
+            // When tool_calls are present, use empty string instead of None for content.
+            // Some providers (e.g., Gemini via OpenAI-compatible endpoint) fail to handle
+            // content: null properly, resulting in empty SSE stream responses.
+            let content = if !text.is_empty() {
+                Some(text)
+            } else if !tool_calls.is_empty() {
+                Some(String::new())
+            } else {
+                None
+            };
             let mut msg = serde_json::json!({
                 "role": "assistant",
-                "content": (!text.is_empty()).then_some(text),
+                "content": content,
             });
             if include_reasoning {
                 msg["reasoning_content"] = json!(reasoning);

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -2535,7 +2535,11 @@ mod tests {
         let msg = &translated[0];
         assert_eq!(msg["role"], json!("assistant"));
         // Content should be empty string, not null
-        assert_eq!(msg["content"], json!(""), "content should be empty string when tool_calls present");
+        assert_eq!(
+            msg["content"],
+            json!(""),
+            "content should be empty string when tool_calls present"
+        );
         assert!(msg.get("tool_calls").is_some());
         let tool_calls = msg["tool_calls"].as_array().unwrap();
         assert_eq!(tool_calls.len(), 1);

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -2514,6 +2514,63 @@ mod tests {
         assert_eq!(super::strip_routing_prefix("kimi/kimi-k1.5"), "kimi-k1.5");
     }
 
+    #[test]
+    fn translate_message_assistant_with_tool_calls_uses_empty_string_for_content() {
+        // When assistant message has tool_calls but no text, content should be ""
+        // not null, for compatibility with providers like Gemini that fail on content: null
+        use crate::types::InputContentBlock;
+
+        let message = InputMessage {
+            role: "assistant".to_string(),
+            content: vec![InputContentBlock::ToolUse {
+                id: "call_123".to_string(),
+                name: "read_file".to_string(),
+                input: serde_json::json!({"path": "/tmp/test"}),
+                thought_signature: None,
+            }],
+        };
+
+        let translated = super::translate_message(&message, "gpt-4o");
+        assert_eq!(translated.len(), 1);
+        let msg = &translated[0];
+        assert_eq!(msg["role"], json!("assistant"));
+        // Content should be empty string, not null
+        assert_eq!(msg["content"], json!(""), "content should be empty string when tool_calls present");
+        assert!(msg.get("tool_calls").is_some());
+        let tool_calls = msg["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["id"], json!("call_123"));
+        assert_eq!(tool_calls[0]["function"]["name"], json!("read_file"));
+    }
+
+    #[test]
+    fn translate_message_assistant_with_text_and_tool_calls_preserves_text() {
+        // When assistant message has both text and tool_calls, content should be the text
+        use crate::types::InputContentBlock;
+
+        let message = InputMessage {
+            role: "assistant".to_string(),
+            content: vec![
+                InputContentBlock::Text {
+                    text: "Let me read that file".to_string(),
+                },
+                InputContentBlock::ToolUse {
+                    id: "call_456".to_string(),
+                    name: "read_file".to_string(),
+                    input: serde_json::json!({"path": "/tmp/test"}),
+                    thought_signature: None,
+                },
+            ],
+        };
+
+        let translated = super::translate_message(&message, "gemini-2.0-flash");
+        assert_eq!(translated.len(), 1);
+        let msg = &translated[0];
+        assert_eq!(msg["role"], json!("assistant"));
+        assert_eq!(msg["content"], json!("Let me read that file"));
+        assert!(msg.get("tool_calls").is_some());
+    }
+
     fn assistant_history_with_thinking_request(model: &str) -> MessageRequest {
         MessageRequest {
             model: model.to_string(),


### PR DESCRIPTION
## Summary

- When an assistant message has `tool_calls` but no text content, serialize `content` as empty string `""` instead of `null`
- Fixes "assistant stream produced no content" error for providers like Gemini that use OpenAI-compatible endpoints

## Root Cause

Some providers (e.g., Gemini via OpenAI-compatible endpoint) fail to handle `content: null` properly in assistant messages with tool_calls, resulting in empty SSE stream responses.

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test -p api --lib` passes (169 tests)
- [ ] Verify with customer's reproduction case

🤖 Generated with [Claude Code](https://claude.com/claude-code)