### PR TITLE
refactor(#4259): switch kernel dep to nexus-vfs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -34,11 +34,10 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -81,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "const-random",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -240,9 +239,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -316,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blake3"
@@ -341,6 +340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -374,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -410,9 +418,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -558,6 +566,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,7 +600,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus?rev=b3a0bdb9d#b3a0bdb9d68d382c1b193c18b34fbb28c357283d"
+source = "git+https://github.com/nexi-lab/nexus-vfs#418fec88500f974213525651e55fbd8fd9c4afaa"
 dependencies = [
  "parking_lot",
  "serde",
@@ -717,6 +751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -823,8 +866,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -860,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -877,24 +931,15 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "endian-type"
@@ -926,9 +971,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastcdc"
-version = "3.2.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
+checksum = "77af40d8a8dadb92dc178569a5f5edb5f3056e98255c2de48ab5d59a52892e0c"
 
 [[package]]
 name = "fastrand"
@@ -1197,10 +1242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1263,9 +1310,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1282,8 +1326,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -1292,6 +1334,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1322,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1366,10 +1413,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1433,7 +1489,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1666,9 +1722,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1688,18 +1744,18 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.10.0"
-source = "git+https://github.com/nexi-lab/nexus?rev=b3a0bdb9d#b3a0bdb9d68d382c1b193c18b34fbb28c357283d"
+version = "0.10.1"
+source = "git+https://github.com/nexi-lab/nexus-vfs#418fec88500f974213525651e55fbd8fd9c4afaa"
 dependencies = [
  "ahash",
  "base64",
  "blake3",
  "bloomfilter",
+ "bytes",
  "chrono",
  "contracts",
  "crc32fast",
  "dashmap",
- "encoding_rs",
  "fastcdc",
  "futures",
  "globset",
@@ -1709,7 +1765,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "parking_lot",
- "prost",
+ "prost 0.14.3",
  "protoc-bin-vendored",
  "rayon",
  "redb",
@@ -1717,13 +1773,13 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "simdutf8",
- "simsimd",
+ "smallvec",
  "string-interner",
  "tempfile",
  "tokio",
- "tonic",
- "tonic-build",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing",
  "uuid",
 ]
@@ -1747,14 +1803,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus?rev=b3a0bdb9d#b3a0bdb9d68d382c1b193c18b34fbb28c357283d"
+source = "git+https://github.com/nexi-lab/nexus-vfs#418fec88500f974213525651e55fbd8fd9c4afaa"
 dependencies = [
  "ahash",
  "base64",
  "blake3",
+ "contracts",
  "crc32fast",
  "dashmap",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "globset",
  "memchr",
  "parking_lot",
@@ -1764,12 +1821,12 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "string-interner",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
 ]
 
@@ -1781,9 +1838,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -1823,17 +1880,17 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1850,9 +1907,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -1881,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1920,12 +1977,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 name = "nexus-vfs-client"
 version = "0.1.10"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "protoc-bin-vendored",
  "serde_json",
  "tokio",
- "tonic",
- "tonic-build",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -1951,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2114,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -2141,6 +2198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
 
@@ -2288,7 +2356,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -2302,10 +2380,31 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
@@ -2325,12 +2424,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -2399,9 +2520,9 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "getopts",
@@ -2415,6 +2536,15 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
+]
 
 [[package]]
 name = "pxfm"
@@ -2450,7 +2580,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2487,7 +2617,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2574,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -2741,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -2771,7 +2901,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "telemetry",
  "tokio",
  "tower-http",
@@ -2928,15 +3058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,12 +3100,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -3035,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3103,24 +3218,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3135,7 +3249,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3146,7 +3260,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3157,9 +3282,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -3199,21 +3324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simsimd"
-version = "6.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3259,12 +3369,11 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string-interner"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+checksum = "ad3df9b59e2eded8d825c7c4363ad339a20fb6bc0b9a4778560f518f59910b15"
 dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "serde",
 ]
 
@@ -3472,6 +3581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3518,7 +3636,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3600,8 +3718,37 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.4",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -3619,10 +3766,49 @@ checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.3",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "quote",
+ "syn",
+ "tempfile",
+ "tonic-build 0.14.6",
 ]
 
 [[package]]
@@ -3663,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3747,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -3765,9 +3951,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3813,9 +3999,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3873,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3886,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3896,9 +4082,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3906,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3919,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3962,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4467,18 +4653,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/crates/nexus-vfs-client/proto/nexus/grpc/vfs/vfs.proto
+++ b/rust/crates/nexus-vfs-client/proto/nexus/grpc/vfs/vfs.proto
@@ -1,11 +1,14 @@
 // VFS gRPC transport for REMOTE profile and federation peers.
 //
-// Phase 1 (PR #2667): Generic Call RPC — method name + JSON payload.
-// Phase 2: Typed RPCs for content ops (native bytes, no base64 overhead)
-//          + Ping health check.
+// Every syscall is a typed RPC. The generic `Call` RPC is retained only
+// for the non-syscall in-process control plane — service_* lifecycle
+// no-ops, trie_* / agent_* registry ops, and the `get_mount_points`
+// operational query. Every other method now errors with "unknown Call
+// method". Native bytes on the content / stream ops kill the prior
+// base64-in-JSON tax.
 //
-// Generic Call stays for 25+ service proxy methods and metadata ops.
-// Typed RPCs only for content-heavy operations (Read/Write/Delete).
+// Issue #1133: Unified gRPC transport.
+// Issue #1202: gRPC for REMOTE profile.
 
 syntax = "proto3";
 
@@ -13,6 +16,7 @@ package nexus.grpc.vfs;
 
 service NexusVFSService {
   // Generic dispatch RPC — method name + JSON-encoded params.
+  // Server routes to the same dispatch_method() as the HTTP endpoint.
   rpc Call(CallRequest) returns (CallResponse);
 
   // Typed RPCs for content operations — native bytes, no JSON/base64.
@@ -22,58 +26,153 @@ service NexusVFSService {
 
   // Health check with server metadata.
   rpc Ping(PingRequest) returns (PingResponse);
+
+  // Vectored batch read (Issue #4058). Per-request errors are reported
+  // per-item; outer Status is reserved for transport-level failures.
+  rpc BatchRead(BatchReadRequest) returns (BatchReadResponse);
+
+  // Vectored batch write — native bytes (no base64 tax) + per-item
+  // error isolation. Replaces the generic `write_batch` Call.
+  rpc BatchWrite(BatchWriteRequest) returns (BatchWriteResponse);
+
+  // Typed metadata stat — the hottest metadata op.
+  rpc Stat(StatRequest) returns (StatResponse);
+
+  // Typed directory listing — metastore + backend merge, procfs intercepts.
+  rpc Readdir(ReaddirRequest) returns (ReaddirResponse);
+
+  // Vectored stat — single redb txn on the optimized KernelConvenience
+  // override. Per-path not-found is in-band (`found = false`).
+  rpc BatchStat(BatchStatRequest) returns (BatchStatResponse);
+
+  // Typed attribute set / inode create. Exposes the subset of the
+  // 21-param inherent sys_setattr that crosses the JSON wire today —
+  // Arc<ObjectStore>, metastore, raft_backend, read_fd/write_fd, source,
+  // and remote_metastore stay off this RPC (they need in-process refs).
+  rpc Setattr(SetattrRequest) returns (SetattrResponse);
+
+  // Typed rename / server-side copy.
+  rpc Rename(RenameRequest) returns (RenameResponse);
+  rpc Copy(CopyRequest) returns (CopyResponse);
+
+  // Typed advisory-lock acquire / release.
+  rpc Lock(LockRequest) returns (LockResponse);
+  rpc Unlock(UnlockRequest) returns (UnlockResponse);
+
+  // Typed file-event watch (blocking, inotify-shaped).
+  rpc Watch(WatchRequest) returns (WatchResponse);
+
+  // Typed xattr (extended-attribute) ops — Tier 2 KernelConvenience.
+  // Direct-metastore path, no hooks / no permission gate.
+  rpc GetXattr(GetXattrRequest) returns (GetXattrResponse);
+  rpc SetXattr(SetXattrRequest) returns (SetXattrResponse);
+  rpc GetXattrBulk(GetXattrBulkRequest) returns (GetXattrBulkResponse);
+
+  // Typed mkdir — the prior generic `sys_mkdir` Call retired.
+  rpc Mkdir(MkdirRequest) returns (MkdirResponse);
+
+  // Typed IPC pipe / stream ops. Creation goes through `Setattr` with
+  // entry_type=DT_PIPE / DT_STREAM (no separate Create*Ipc RPC needed).
+  rpc ClosePipe(IpcPathRequest) returns (IpcAck);
+  rpc HasPipe(IpcPathRequest) returns (IpcHasResponse);
+  rpc CloseAllPipes(IpcEmpty) returns (IpcAck);
+
+  rpc CloseStream(IpcPathRequest) returns (IpcAck);
+  rpc HasStream(IpcPathRequest) returns (IpcHasResponse);
+  rpc StreamWriteNowait(StreamWriteRequest) returns (StreamWriteResponse);
+  rpc StreamReadAt(StreamReadAtRequest) returns (StreamReadAtResponse);
+  rpc StreamCollectAll(IpcPathRequest) returns (StreamCollectAllResponse);
 }
 
+// --- Generic dispatch messages (Phase 1, unchanged) ---
+
 message CallRequest {
-  string method = 1;
-  bytes payload = 2;
-  string auth_token = 3;
+  string method = 1;      // "sys_read", "sys_write", "workspace_snapshot", ...
+  bytes payload = 2;      // JSON-encoded params dict (rpc_codec)
+  string auth_token = 3;  // Bearer token (same as HTTP Authorization header)
 }
 
 message CallResponse {
-  bytes payload = 1;
-  bool is_error = 2;
+  bytes payload = 1;      // JSON-encoded result or error dict
+  bool is_error = 2;      // If true, payload is JSON-RPC error dict
 }
+
+// --- Typed content messages (Phase 2) ---
 
 message ReadRequest {
   string path = 1;
   string auth_token = 2;
-  string content_id = 3;
+  string content_id = 3;   // Opaque content identifier (hash for CAS, path for PAS) — when set, server reads content directly (no metastore lookup)
+  // Pipe-/stream-read knobs — full-fidelity sys_read on the wire.
+  // Defaults give plain file-read semantics: blocking ≤5s, from offset 0.
+  uint64 timeout_ms = 4;   // 0 → non-blocking; otherwise pipe/stream block budget
+  uint64 offset = 5;       // byte offset within content (streams + range reads)
 }
 
 message ReadResponse {
-  bytes content = 1;
-  string etag = 2;
+  bytes content = 1;       // Raw file bytes — no base64
+  string content_id = 2;
   int64 size = 3;
   bool is_error = 4;
-  bytes error_payload = 5;
+  bytes error_payload = 5; // JSON error dict (same format as CallResponse)
+  uint64 gen = 6;
+  // Stream / typed-entry fields — let Python sys_read drop its Call
+  // fallback (timeout_ms/offset on the wire + these fields out).
+  int32 entry_type = 7;             // DT_* of the resolved entry
+  optional uint64 stream_next_offset = 8;  // streams: where the next read picks up
+  bool post_hook_needed = 9;        // OBSERVE chain trigger
 }
 
 message WriteRequest {
   string path = 1;
-  bytes content = 2;
+  bytes content = 2;       // Raw file bytes — no base64
   string auth_token = 3;
-  string etag = 4;
+  string content_id = 4;   // Optional: opaque content identifier for conditional write (If-Match)
 }
 
 message WriteResponse {
-  string etag = 1;
+  string content_id = 1;
   int64 size = 2;
   bool is_error = 3;
   bytes error_payload = 4;
+  uint64 gen = 5;
 }
 
 message DeleteRequest {
   string path = 1;
   string auth_token = 2;
-  bool recursive = 3;
+  bool recursive = 3;      // For rmdir
 }
 
 message DeleteResponse {
   bool success = 1;
   bool is_error = 2;
   bytes error_payload = 3;
+  // Richer per-result fields — added so the typed Delete subsumes the
+  // prior `sys_unlink` Call (callers read entry_type for the audit
+  // trail, content_id / size for metrics). Zero / empty when success=false.
+  uint32 entry_type = 4;
+  string path = 5;
+  string content_id = 6;
+  uint64 size = 7;
 }
+
+// --- Typed mkdir (replaces the `sys_mkdir` Call) ---
+
+message MkdirRequest {
+  string path = 1;
+  string auth_token = 2;
+  bool parents = 3;
+  bool exist_ok = 4;
+}
+
+message MkdirResponse {
+  bool hit = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+// --- Health check messages ---
 
 message PingRequest {
   string auth_token = 1;
@@ -83,4 +182,370 @@ message PingResponse {
   string version = 1;
   string zone_id = 2;
   int64 uptime_seconds = 3;
+}
+
+// --- Batch read (Issue #4058) ---
+
+message BatchReadRequest {
+  string auth_token = 1;
+  repeated BatchReadItemRequest items = 2;
+}
+
+message BatchReadItemRequest {
+  string path = 1;
+  uint64 offset = 2;
+  // proto3 `optional` so callers can distinguish "no length set"
+  // (read to EOF from offset) from `length = 0` (legitimate zero-byte
+  // EOF probe). Old clients that omitted `length` continue to read
+  // whole files; new clients can explicitly set 0 for an empty slice.
+  // (Named `length` rather than `len` so the generated Rust struct
+  // doesn't trip `clippy::len_without_is_empty`.)
+  optional uint64 length = 3;
+}
+
+message BatchReadResponse {
+  repeated BatchReadItemResponse results = 1;  // input order
+}
+
+message BatchReadItemResponse {
+  bytes content = 1;        // empty when is_error
+  bool is_error = 2;
+  bytes error_payload = 3;  // JSON RPC error dict (same as CallResponse)
+  string content_id = 4;
+  uint64 gen = 5;
+}
+
+// --- Batch write (typed — replaces the base64 `write_batch` Call) ---
+
+message BatchWriteRequest {
+  string auth_token = 1;
+  repeated BatchWriteItemRequest items = 2;
+}
+
+message BatchWriteItemRequest {
+  string path = 1;
+  bytes content = 2;        // Raw file bytes — no base64
+}
+
+message BatchWriteResponse {
+  repeated BatchWriteItemResponse results = 1;  // input order
+}
+
+message BatchWriteItemResponse {
+  string content_id = 1;
+  int64 size = 2;
+  uint64 gen = 3;
+  uint32 version = 4;
+  bool is_error = 5;
+  bytes error_payload = 6;  // JSON RPC error dict (same as CallResponse)
+}
+
+// --- Typed metadata stat (replaces the `sys_stat` Call) ---
+
+message StatRequest {
+  string path = 1;
+  string auth_token = 2;
+  string zone_id = 3;       // empty → caller's context zone
+}
+
+message StatResponse {
+  bool found = 1;           // false → path does not exist (not an error)
+  // Stat fields — valid only when found == true. Mirrors StatResult /
+  // the `stat_to_json` shape; the `lock` field is intentionally omitted
+  // (matches the generic Call path — include_lock is a separate query).
+  string path = 2;
+  int64 size = 3;
+  string content_id = 4;            // "" when unset
+  string mime_type = 5;
+  bool is_directory = 6;
+  int32 entry_type = 7;
+  uint32 mode = 8;
+  uint32 version = 9;
+  uint64 gen = 10;
+  string zone_id = 11;              // "" when unset
+  optional int64 created_at_ms = 12;
+  optional int64 modified_at_ms = 13;
+  string last_writer_address = 14;  // "" when unset
+  string link_target = 15;          // "" when unset
+  string owner_id = 16;             // "" when unset
+  bool is_error = 17;
+  bytes error_payload = 18;         // JSON error dict — auth failures only
+}
+
+// --- Typed directory listing (replaces the `sys_readdir` Call) ---
+
+message ReaddirRequest {
+  string path = 1;
+  string auth_token = 2;
+  string zone_id = 3;        // empty → caller's context zone
+  // `is_admin` is intentionally NOT a request field — the handler reads
+  // it from the auth-resolved OperationContext so a client can't spoof.
+}
+
+message ReaddirEntry {
+  string name = 1;           // child path (matches the inherent Vec<(String, u8)>)
+  uint32 entry_type = 2;     // DT_* code (u8 widened)
+}
+
+message ReaddirResponse {
+  repeated ReaddirEntry entries = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;   // JSON error dict — auth failures only
+}
+
+// --- Vectored stat (replaces the `stat_batch` Call) ---
+
+message BatchStatRequest {
+  string auth_token = 1;
+  string zone_id = 2;        // empty → caller's context zone
+  repeated string paths = 3;
+}
+
+// Mirrors `StatResponse`'s stat fields but without `is_error` — auth
+// failures surface as an outer tonic Status (matching BatchRead /
+// BatchWrite), and per-path not-found is in-band via `found = false`.
+message BatchStatItem {
+  bool found = 1;
+  string path = 2;
+  int64 size = 3;
+  string content_id = 4;
+  string mime_type = 5;
+  bool is_directory = 6;
+  int32 entry_type = 7;
+  uint32 mode = 8;
+  uint32 version = 9;
+  uint64 gen = 10;
+  string zone_id = 11;
+  optional int64 created_at_ms = 12;
+  optional int64 modified_at_ms = 13;
+  string last_writer_address = 14;
+  string link_target = 15;
+  string owner_id = 16;
+}
+
+message BatchStatResponse {
+  repeated BatchStatItem results = 1;  // positional — same length/order as request.paths
+}
+
+// --- Typed setattr (replaces the `sys_setattr` Call) ---
+
+message SetattrRequest {
+  string path = 1;
+  string auth_token = 2;
+  int32 entry_type = 3;             // DT_* code
+  string zone_id = 4;                // empty → ROOT_ZONE_ID
+
+  // Optional metadata fields (presence-tracked — None survives the wire).
+  optional string mime_type = 5;
+  optional string content_id = 6;
+  optional int64 modified_at_ms = 7;
+  optional int64 created_at_ms = 8;
+  optional uint64 size = 9;
+  optional uint32 version = 10;
+
+  // DT_PIPE / DT_STREAM container fields. Default-zero / empty when unused.
+  string backend_name = 11;
+  string io_profile = 12;
+  bool is_external = 13;
+  uint64 capacity = 14;
+}
+
+message SetattrResponse {
+  // Mirrors the Call response shape consumed by _SysSetAttrResult.
+  string path = 1;
+  bool created = 2;
+  int32 entry_type = 3;
+  bool is_error = 4;
+  bytes error_payload = 5;
+}
+
+// --- Typed rename (replaces the `sys_rename` Call) ---
+
+message RenameRequest {
+  string path = 1;          // old path
+  string new_path = 2;
+  string auth_token = 3;
+}
+
+message RenameResponse {
+  bool hit = 1;
+  bool success = 2;
+  bool is_directory = 3;
+  // Old metadata — surfaced for audit / post-hook context.
+  optional string old_content_id = 4;
+  optional uint64 old_size = 5;
+  optional uint32 old_version = 6;
+  optional int64 old_modified_at_ms = 7;
+  bool is_error = 8;
+  bytes error_payload = 9;
+  // post_hook_needed is omitted — always false on the gRPC architecture
+  // (no Python post-hook dispatch); _SysRenameResult defaults it.
+}
+
+// --- Typed server-side copy (replaces the `sys_copy` Call) ---
+
+message CopyRequest {
+  string src = 1;
+  string dst = 2;
+  string auth_token = 3;
+}
+
+message CopyResponse {
+  bool hit = 1;
+  string dst_path = 2;
+  optional string content_id = 3;
+  uint64 size = 4;
+  uint32 version = 5;
+  uint64 gen = 6;
+  bool is_error = 7;
+  bytes error_payload = 8;
+}
+
+// --- Typed advisory locks (replace the `sys_lock` / `sys_unlock` Calls) ---
+
+// Matches the Call wire surface: the kernel `sys_lock` hardcodes
+// Exclusive + max_holders=1 + ttl_secs=timeout_ms/1000+1 on this path,
+// so we don't expose mode / max_holders / ttl_secs on the RPC yet.
+message LockRequest {
+  string path = 1;
+  string auth_token = 2;
+  string lock_id = 3;      // empty → server generates
+  uint64 timeout_ms = 4;
+}
+
+message LockResponse {
+  bool acquired = 1;       // false → lock contention, no other error
+  string lock_id = 2;      // set when acquired
+  bool is_error = 3;
+  bytes error_payload = 4;
+}
+
+message UnlockRequest {
+  string path = 1;
+  string auth_token = 2;
+  string lock_id = 3;
+  bool force = 4;
+}
+
+message UnlockResponse {
+  bool released = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+// --- Typed file-event watch (replaces the `sys_watch` Call) ---
+
+message WatchRequest {
+  string path = 1;
+  string auth_token = 2;
+  uint64 timeout_ms = 3;
+}
+
+message WatchResponse {
+  bool matched = 1;        // false → timed out, no event
+  string path = 2;         // event path when matched
+  string event_type = 3;   // FileEventType Debug string (e.g. "FileWrite")
+  bool is_error = 4;
+  bytes error_payload = 5;
+}
+
+// --- Typed xattr ops (replace get_xattr / set_xattr / get_xattr_bulk Calls) ---
+
+message GetXattrRequest {
+  string path = 1;
+  string key = 2;
+  string auth_token = 3;
+}
+
+message GetXattrResponse {
+  bool found = 1;        // false → key not set; not an error
+  string value = 2;
+  bool is_error = 3;
+  bytes error_payload = 4;
+}
+
+message SetXattrRequest {
+  string path = 1;
+  string key = 2;
+  string value = 3;
+  string auth_token = 4;
+}
+
+message SetXattrResponse {
+  bool is_error = 1;
+  bytes error_payload = 2;
+}
+
+message GetXattrBulkRequest {
+  repeated string paths = 1;
+  string key = 2;
+  string auth_token = 3;
+}
+
+message GetXattrBulkItem {
+  string path = 1;
+  bool found = 2;        // false → key not set on this path
+  string value = 3;
+}
+
+message GetXattrBulkResponse {
+  repeated GetXattrBulkItem items = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+// --- IPC pipe / stream ops (replace the IPC Call arms) ---
+
+message IpcPathRequest {
+  string path = 1;
+  string auth_token = 2;
+}
+
+message IpcAck {
+  bool is_error = 1;
+  bytes error_payload = 2;
+}
+
+message IpcHasResponse {
+  bool present = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+message IpcEmpty {
+  string auth_token = 1;
+}
+
+message StreamWriteRequest {
+  string path = 1;
+  bytes data = 2;             // native bytes — no base64 tax
+  string auth_token = 3;
+}
+
+message StreamWriteResponse {
+  uint64 offset = 1;          // offset where the data landed
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+message StreamReadAtRequest {
+  string path = 1;
+  uint64 offset = 2;
+  bool blocking = 3;          // true → server blocks up to timeout_ms
+  uint64 timeout_ms = 4;      // only honoured when blocking == true
+  string auth_token = 5;
+}
+
+message StreamReadAtResponse {
+  bytes data = 1;
+  uint64 next_offset = 2;
+  bool eof = 3;               // non-blocking: true → no data available
+  bool is_error = 4;
+  bytes error_payload = 5;
+}
+
+message StreamCollectAllResponse {
+  bytes data = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
 }

--- a/rust/crates/nexus-vfs-client/src/lib.rs
+++ b/rust/crates/nexus-vfs-client/src/lib.rs
@@ -76,6 +76,8 @@ impl NexusVfsClient {
                                         path,
                                         auth_token,
                                         content_id: String::new(),
+                                        timeout_ms: 0,
+                                        offset: 0,
                                     })
                                     .await;
                                 let _ = resp.send(grpc_result(r, |r| {
@@ -97,7 +99,7 @@ impl NexusVfsClient {
                                         path,
                                         content,
                                         auth_token,
-                                        etag: String::new(),
+                                        content_id: String::new(),
                                     })
                                     .await;
                                 let _ = resp.send(grpc_result(r, |r| {

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -21,13 +21,9 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # stack, py-hook adapters) off in the sudocode build — sudocode does
 # not need them and they would bloat the standalone CLI.
 #
-# Cross-repo git-dep pinned to the nexus PR branch that introduced
-# the trait (PR #4026, `feat/kernel-abi-trait`). Bump the rev when
-# nexus pushes new commits to the branch; the lockstep merge order
-# is "nexus PR #4026 lands → bump rev to merged commit on develop →
-# this sudocode PR lands". Until the nexus PR lands, this pin is
-# the one stable rev both repos see.
-kernel = { git = "https://github.com/nexi-lab/nexus", rev = "b3a0bdb9d", default-features = false }
+# Points at nexus-vfs main (the kernel crate's canonical home after
+# the DRY repo extraction, #4259).
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -216,7 +216,7 @@ impl FsBackend for StdFsBackend {
 ///
 /// Forwards every operation through the [`KernelAbi`] trait so managed
 /// agents read/write the VFS trie via `sys_read` / `sys_write` /
-/// `sys_stat` / `sys_readdir_backend` instead of touching the host
+/// `sys_stat` / `sys_readdir` instead of touching the host
 /// filesystem.
 pub struct KernelFsBackend<K: KernelAbi> {
     kernel: Arc<K>,
@@ -287,20 +287,13 @@ impl<K: KernelAbi + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
 
     fn readdir(&self, path: &str) -> io::Result<Vec<FsDirEntry>> {
         let zone = &self.ctx.zone_id;
-        let entries = self.kernel.sys_readdir_backend(path, zone);
+        // sys_readdir returns Vec<(child_name, entry_type)>; DT_DIR == 1.
+        let entries = self.kernel.sys_readdir(path, zone, false);
         Ok(entries
             .into_iter()
-            .map(|child_path| {
-                let is_dir = self
-                    .kernel
-                    .sys_stat(&child_path, zone)
-                    .map_or(false, |s| s.is_directory);
-                let name = child_path
-                    .rsplit('/')
-                    .next()
-                    .unwrap_or(&child_path)
-                    .to_string();
-                FsDirEntry { name, is_dir }
+            .map(|(name, entry_type)| FsDirEntry {
+                name,
+                is_dir: entry_type == 1, // DT_DIR
             })
             .collect())
     }

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
-use kernel::kernel::{Kernel, OperationContext};
+use kernel::kernel::{Kernel, OperationContext, ReadRequest, WriteRequest};
 use runtime::spawn_task::spawn_task_echo;
 
 const DT_STREAM: i32 = 4;
@@ -42,6 +42,10 @@ fn plant_chat_stream(kernel: &Kernel, pid: &str) {
             /* write_fd */ None,
             /* mime_type */ None,
             /* modified_at_ms */ None,
+            /* content_id */ None,
+            /* size */ None,
+            /* version */ None,
+            /* created_at_ms */ None,
             /* link_target */ None,
             /* source */ None,
             /* remote_metastore */ None,
@@ -79,8 +83,15 @@ fn read_envelopes(
     let mut offset = from_offset;
     let mut out = Vec::new();
     loop {
-        match kernel.sys_read(path, ctx, 0, offset) {
-            Ok(result) => {
+        let reqs = [ReadRequest {
+            path: path.to_string(),
+            offset,
+            len: None,
+            timeout_ms: 0,
+        }];
+        let mut results = kernel.sys_read(&reqs, ctx);
+        match results.pop() {
+            Some(Ok(result)) => {
                 if let Some(bytes) = result.data.as_ref() {
                     if !bytes.is_empty() {
                         if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
@@ -94,7 +105,7 @@ fn read_envelopes(
                 }
                 offset = next;
             }
-            Err(_) => break,
+            _ => break,
         }
     }
     (out, offset)
@@ -137,8 +148,15 @@ fn echo_round_trip_through_proc_pid_chat_with_me() {
         "to": "agent-v0",
         "body": "hello",
     });
+    let write_reqs = [WriteRequest {
+        path: cwm_path.to_string(),
+        content: serde_json::to_vec(&prompt).unwrap(),
+        offset: 0,
+    }];
     kernel
-        .sys_write(cwm_path, &ctx, &serde_json::to_vec(&prompt).unwrap(), 0)
+        .sys_write(&write_reqs, &ctx)
+        .pop()
+        .expect("sys_write returned empty vec")
         .expect("user write to chat-with-me");
 
     let echo = wait_for_envelope_with_body(
@@ -201,8 +219,15 @@ fn skips_own_writes_to_avoid_echo_loop() {
         "to": "agent-loop",
         "body": "ping",
     });
+    let write_reqs = [WriteRequest {
+        path: cwm_path.to_string(),
+        content: serde_json::to_vec(&prompt).unwrap(),
+        offset: 0,
+    }];
     kernel
-        .sys_write(cwm_path, &ctx, &serde_json::to_vec(&prompt).unwrap(), 0)
+        .sys_write(&write_reqs, &ctx)
+        .pop()
+        .expect("sys_write returned empty vec")
         .unwrap();
 
     let _ = wait_for_envelope_with_body(


### PR DESCRIPTION
## Summary
- Switch `kernel` git dependency from `nexi-lab/nexus` to `nexi-lab/nexus-vfs` (DRY extraction)
- Adapt callers to nexus-vfs ABI changes: `ReadRequest` new fields, `WriteRequest.etag` -> `content_id`, `sys_readdir_backend` -> `sys_readdir`
- Sync `vfs.proto` from nexus-vfs SSOT (adds new typed RPCs: BatchRead, BatchWrite, Stat, Readdir, etc.)
- Regenerate Cargo.lock

Part of nexus-vfs repo extraction (#4259).

## Test plan
- [x] `cargo check --workspace` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)