### PR TITLE
feat(api): extract OpenAI cached_tokens into cache_read_input_tokens

### DIFF
--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -428,7 +428,7 @@ impl StreamState {
             self.usage = Some(Usage {
                 input_tokens: usage.prompt_tokens,
                 cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
+                cache_read_input_tokens: usage.prompt_tokens_details.cached_tokens,
                 output_tokens: usage.completion_tokens,
             });
         }
@@ -753,12 +753,22 @@ struct ResponseToolFunction {
     arguments: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct OpenAiUsage {
     #[serde(default)]
     prompt_tokens: u32,
     #[serde(default)]
     completion_tokens: u32,
+    /// OpenAI returns cached token counts inside `prompt_tokens_details`.
+    /// Example: `{"prompt_tokens_details": {"cached_tokens": 1234}}`
+    #[serde(default)]
+    prompt_tokens_details: PromptTokensDetails,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1333,7 +1343,10 @@ fn normalize_response(
                 .as_ref()
                 .map_or(0, |usage| usage.prompt_tokens),
             cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_read_input_tokens: response
+                .usage
+                .as_ref()
+                .map_or(0, |usage| usage.prompt_tokens_details.cached_tokens),
             output_tokens: response
                 .usage
                 .as_ref()

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -1762,6 +1762,7 @@ mod tests {
                     usage: Some(super::OpenAiUsage {
                         prompt_tokens: 9,
                         completion_tokens: 0,
+                        ..Default::default()
                     }),
                 })
                 .expect("usage-only chunk"),


### PR DESCRIPTION
## Summary
- Parse OpenAI's `prompt_tokens_details.cached_tokens` field and map it to `cache_read_input_tokens` in the usage response
- Previously `cache_read_input_tokens` was always reported as 0 for OpenAI-compatible providers
- Applies to both streaming and non-streaming response paths

## Test plan
- [ ] Verify cached token counts are correctly reported for OpenAI API responses containing `prompt_tokens_details`
- [ ] Verify backward compatibility when `prompt_tokens_details` is absent (defaults to 0)
- [ ] Run `cargo test --workspace` to ensure no regressions