### PR TITLE
docs(browser): update plugin SKILL.md for new browser CLI

### DIFF
--- a/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
+++ b/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
@@ -41,7 +41,7 @@ browser page discover --json
 
 # 4. Click / type
 browser click text --text "Sign in" --json
-browser type text --text "hello" --selector "#search" --json
+browser type text --text "hello" --name "Search" --json
 
 # 5. List sessions / tabs
 browser session list --json

--- a/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
+++ b/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
@@ -1,16 +1,79 @@
 ---
 name: browser
-description: "AI-native browser. Explore websites, discover page structure, take screenshots, and automate interactions."
+description: "AI-native browser. Explore websites, discover page structure, take screenshots, and automate interactions via the `browser` CLI."
 ---
 
 # Browser
 
+`browser <noun> <verb> [flags]` wraps ai-dev-browser's tools. Data goes to
+stdout, errors to stderr. Requires a Chrome/Chromium install for live browsing.
+
+## Output modes (every command)
+
+- `--json`   machine-readable JSON.
+- `--quiet`  just the primary scalar (port, url, path, count, ...).
+- `--full`   dump every field (default output is terse: ~3-4 fields/item).
+- `--no-interactive`  never prompt; missing required values error out.
+
+When stdout is not a TTY, `--json --quiet --no-interactive` are auto-enabled,
+so output is always pipe-safe and never hangs.
+
+## Discover commands
+
 ```bash
-browser --list
+browser --help                 # list nouns
+browser page --help            # list verbs under `page`
+browser page goto --help       # flags for one command
 ```
 
-Every CLI tool has an identical Python function in `ai_dev_browser.core` — explore interactively with CLI, then script with the same functions:
+## 5 most-used commands
 
-```python
-from ai_dev_browser.core import page_goto, click_by_text, page_screenshot
+```bash
+# 1. Start (or reuse) a browser — idempotent: reuses an idle Chrome by default
+browser session start --json
+browser session start --headless --json
+
+# 2. Navigate
+browser page goto --url https://example.com --json
+
+# 3. See what's interactable (returns refs for click/type by ref)
+browser page discover --json
+
+# 4. Click / type
+browser click text --text "Sign in" --json
+browser type text --text "hello" --selector "#search" --json
+
+# 5. List sessions / tabs
+browser session list --json
+browser tab list --json
 ```
+
+## Exit codes
+
+`0` ok · `2` validation · `4` not-found (element or no browser) · `5` conflict
+· `7` auth · `8` rate-limit · `9` transient (timeout, connection). Never `1`
+for everything — branch on the code.
+
+In `--json` mode an error is printed to **stderr** as:
+
+```json
+{"error": {"code": 4, "message": "...", "retryable": true, "hint": "..."}}
+```
+
+## Common error recoveries
+
+- `code 4` + "Failed to connect to Chrome" → no browser running. Run
+  `browser session start` first (retryable).
+- `code 4` + "not found" → the element isn't there. Re-run
+  `browser page discover` and use a fresh `--ref`, or widen your selector.
+- `code 9` + "timeout" → bump `--timeout`, or `browser page wait-ready`
+  before acting; then retry.
+
+## Notes
+
+- Noun-verb tree: session, page, tab, click, find, type, element, mouse,
+  cookies, storage, window, js, cdp, dialog, download, login.
+- `browser login interactive` is human-in-the-loop; it fails fast (code 7)
+  under `--no-interactive` or when stdout is not a TTY.
+- Every CLI command has an identical Python function in `ai_dev_browser.core`
+  for scripting, e.g. `from ai_dev_browser.core import page_goto, click_by_text`.


### PR DESCRIPTION
## Summary
- Rewrites the bundled `browser` plugin skill (`crates/plugins/bundled/browser/skills/browser/SKILL.md`) to document the new `browser <noun> <verb>` CLI surface: output modes (`--json/--quiet/--full/--no-interactive`), command discovery, the 5 most-used commands, distinct exit codes (2/4/5/7/8/9), and common error recoveries.
- Replaces the stale `browser --list` reference and raw `ai_dev_browser.core` import guidance, which did not reflect a real `browser` executable.

## Dependency / sequencing
This SKILL.md references the `browser` CLI introduced in **ai-dev-browser PR sudoprivacy/ai-dev-browser#5** (umbrella noun-verb CLI + console script). That CLI is **not yet merged/released** — the documented `browser ...` commands only work once #5 lands and a release ships the console script. Merge order: land ai-dev-browser#5 and cut a release, then merge this. The doc is otherwise harmless if merged earlier (it just describes the target surface).

## Test plan
- [ ] After ai-dev-browser#5 is released: `pip install -U ai-dev-browser` then verify `browser --help`, `browser session start --json`, `browser page goto --url ... --json` match the documented surface.
- [x] SKILL.md stays under the harness-playbook 100-line budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)