### PR TITLE
fix(acp): report per-turn prompt usage

### DIFF
--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -371,6 +371,18 @@ pub struct PromptUsage {
     pub cache_write_tokens: Option<u64>,
     pub context_window_tokens: Option<u64>,
     pub estimated_session_tokens: Option<u64>,
+    /// Cumulative usage for the entire session, exposed via _meta.sudocode.cumulativeUsage
+    pub cumulative_usage: Option<CumulativeUsage>,
+}
+
+/// Cumulative token usage for the entire session.
+#[derive(Debug, Clone, Default)]
+pub struct CumulativeUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub cached_read_tokens: Option<u64>,
+    pub cached_write_tokens: Option<u64>,
 }
 
 /// Thread-safe handle to a delegate, shared across async handlers.
@@ -948,14 +960,30 @@ pub(crate) async fn run_acp_on_transport(
                             Ok((stop_reason, prompt_usage)) => {
                                 let mut response = PromptResponse::new(stop_reason);
                                 if let Some(u) = prompt_usage {
-                                    let mut meta = Map::new();
-                                    meta.insert(
-                                        "sudocode".to_string(),
-                                        json!({
-                                            "contextWindowTokens": u.context_window_tokens,
-                                            "estimatedSessionTokens": u.estimated_session_tokens,
-                                        }),
+                                    let mut sudocode_meta = Map::new();
+                                    sudocode_meta.insert(
+                                        "contextWindowTokens".to_string(),
+                                        json!(u.context_window_tokens),
                                     );
+                                    sudocode_meta.insert(
+                                        "estimatedSessionTokens".to_string(),
+                                        json!(u.estimated_session_tokens),
+                                    );
+                                    // Add cumulativeUsage for clients that need session totals
+                                    if let Some(cumulative) = &u.cumulative_usage {
+                                        sudocode_meta.insert(
+                                            "cumulativeUsage".to_string(),
+                                            json!({
+                                                "inputTokens": cumulative.input_tokens,
+                                                "outputTokens": cumulative.output_tokens,
+                                                "totalTokens": cumulative.total_tokens,
+                                                "cachedReadTokens": cumulative.cached_read_tokens,
+                                                "cachedWriteTokens": cumulative.cached_write_tokens,
+                                            }),
+                                        );
+                                    }
+                                    let mut meta = Map::new();
+                                    meta.insert("sudocode".to_string(), json!(sudocode_meta));
                                     response = response.usage(
                                         Usage::new(u.total_tokens, u.input_tokens, u.output_tokens)
                                             .cached_read_tokens(u.cache_read_tokens)

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -203,6 +203,18 @@ impl UsageTracker {
         self.latest_turn
     }
 
+    /// Returns the usage for the turn that just completed, if any was recorded.
+    /// Pass the turn count before the operation to detect if new usage was recorded.
+    /// This prevents returning stale usage from previous turns.
+    #[must_use]
+    pub fn turn_usage_if_recorded(&self, turns_before: u32) -> Option<TokenUsage> {
+        if self.turns > turns_before {
+            Some(self.latest_turn)
+        } else {
+            None
+        }
+    }
+
     #[must_use]
     pub fn cumulative_usage(&self) -> TokenUsage {
         self.cumulative

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2359,36 +2359,47 @@ impl AcpSdkDelegate {
                 return Err(runtime::AcpError::internal(user_message));
             }
         }
+        // Track turn count before run_turn to detect if usage was recorded
+        let turns_before = session.runtime.usage().turns();
         self.inner
             .tokio_runtime
             .block_on(session.runtime.run_turn(prompt, prompter, Some(observer)))
             .map_err(|e| {
-                // Record error to telemetry log if available
                 if let Some(tracer) = session.runtime.session_tracer() {
                     tracer.record_prompt_error("runtime_error", e.to_string());
                 }
                 runtime::AcpError::internal(e.to_string())
             })?;
-        let usage = UsageTracker::from_session(session.runtime.session()).cumulative_usage();
-        let prompt_usage = runtime::acp_sdk_server::PromptUsage {
-            input_tokens: u64::from(usage.input_tokens),
-            output_tokens: u64::from(usage.output_tokens),
-            total_tokens: u64::from(usage.total_tokens()),
-            cache_read_tokens: Some(u64::from(usage.cache_read_input_tokens)),
-            cache_write_tokens: Some(u64::from(usage.cache_creation_input_tokens)),
+        // Get per-turn usage (only if this turn actually recorded usage)
+        let per_turn_usage = session.runtime.usage().turn_usage_if_recorded(turns_before);
+        let cumulative_usage = session.runtime.usage().cumulative_usage();
+        // Build PromptUsage if we have per-turn data, otherwise return None for usage
+        let prompt_usage = per_turn_usage.map(|u| runtime::acp_sdk_server::PromptUsage {
+            input_tokens: u64::from(u.input_tokens),
+            output_tokens: u64::from(u.output_tokens),
+            total_tokens: u64::from(u.total_tokens()),
+            cache_read_tokens: Some(u64::from(u.cache_read_input_tokens)),
+            cache_write_tokens: Some(u64::from(u.cache_creation_input_tokens)),
             context_window_tokens: Some(context_limit as u64),
             estimated_session_tokens: Some(
                 estimate_session_tokens(session.runtime.session()) as u64
             ),
-        };
-        // Record token usage to telemetry log
+            cumulative_usage: Some(runtime::acp_sdk_server::CumulativeUsage {
+                input_tokens: u64::from(cumulative_usage.input_tokens),
+                output_tokens: u64::from(cumulative_usage.output_tokens),
+                total_tokens: u64::from(cumulative_usage.total_tokens()),
+                cached_read_tokens: Some(u64::from(cumulative_usage.cache_read_input_tokens)),
+                cached_write_tokens: Some(u64::from(cumulative_usage.cache_creation_input_tokens)),
+            }),
+        });
+        // Record cumulative token usage to telemetry log
         if let Some(tracer) = session.runtime.session_tracer() {
             tracer.record_usage(
                 "session_summary".to_string(),
-                usage.input_tokens,
-                usage.output_tokens,
-                usage.cache_creation_input_tokens,
-                usage.cache_read_input_tokens,
+                cumulative_usage.input_tokens,
+                cumulative_usage.output_tokens,
+                cumulative_usage.cache_creation_input_tokens,
+                cumulative_usage.cache_read_input_tokens,
             );
         }
         session
@@ -2398,7 +2409,7 @@ impl AcpSdkDelegate {
             .map_err(|e| runtime::AcpError::internal(format!("failed to persist session: {e}")))?;
         Ok((
             runtime::acp_sdk_server::AcpStopReason::EndTurn,
-            Some(prompt_usage),
+            prompt_usage,
         ))
     }
 }

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -503,6 +503,116 @@ async fn scenario_slash_command_model(client: &mut AcpTestClient, session_id: &s
     );
 }
 
+/// Test that prompt usage returns per-turn (not cumulative) values.
+/// Uses a fresh session to avoid interference from other scenarios.
+async fn scenario_session_prompt_per_turn_usage(
+    client: &mut AcpTestClient,
+    workspace: &TestWorkspace,
+) {
+    // Create a fresh session for this test to avoid accumulated usage from other scenarios
+    let session_id = scenario_session_new(client, &workspace.root).await;
+
+    // First prompt
+    let prompt_text1 = format!("{SCENARIO_PREFIX}streaming_text");
+    let (_notifs1, resp1) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": prompt_text1 }]
+            }),
+        )
+        .await;
+
+    let result1 = &resp1["result"];
+    let usage1 = result1
+        .get("usage")
+        .expect("first prompt should have usage");
+    let first_turn_total = usage1["totalTokens"]
+        .as_u64()
+        .expect("first turn should have totalTokens");
+    assert!(first_turn_total > 0, "first turn totalTokens should be > 0");
+
+    // Check _meta.sudocode.cumulativeUsage exists for first prompt
+    let meta1 = result1
+        .get("_meta")
+        .expect("first prompt should have _meta");
+    let sudocode1 = meta1.get("sudocode").expect("_meta should have sudocode");
+    assert!(
+        sudocode1.get("cumulativeUsage").is_some(),
+        "_meta.sudocode should have cumulativeUsage"
+    );
+    let cumulative1 = &sudocode1["cumulativeUsage"];
+    let cumulative_total1 = cumulative1["totalTokens"]
+        .as_u64()
+        .expect("cumulativeUsage should have totalTokens");
+
+    // Second prompt in the same session
+    let prompt_text2 = format!("{SCENARIO_PREFIX}streaming_text");
+    let (_notifs2, resp2) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": prompt_text2 }]
+            }),
+        )
+        .await;
+
+    let result2 = &resp2["result"];
+    let usage2 = result2
+        .get("usage")
+        .expect("second prompt should have usage");
+    let second_turn_total = usage2["totalTokens"]
+        .as_u64()
+        .expect("second turn should have totalTokens");
+    assert!(
+        second_turn_total > 0,
+        "second turn totalTokens should be > 0"
+    );
+
+    // Check _meta.sudocode.cumulativeUsage for second prompt
+    let meta2 = result2
+        .get("_meta")
+        .expect("second prompt should have _meta");
+    let sudocode2 = meta2.get("sudocode").expect("_meta should have sudocode");
+    let cumulative2 = sudocode2
+        .get("cumulativeUsage")
+        .expect("should have cumulativeUsage");
+    let cumulative_total2 = cumulative2["totalTokens"]
+        .as_u64()
+        .expect("cumulativeUsage should have totalTokens");
+
+    // Key assertions:
+    // 1. usage.totalTokens should be per-turn (NOT cumulative)
+    //    So second_turn_total should NOT be the sum of both turns
+    assert!(
+        second_turn_total < cumulative_total2,
+        "second turn usage ({}) should be per-turn (less than cumulative {})",
+        second_turn_total,
+        cumulative_total2
+    );
+
+    // 2. cumulative total should be greater than first turn (because it includes both turns)
+    assert!(
+        cumulative_total2 > cumulative_total1,
+        "cumulative total after second turn ({}) should be greater than after first turn ({})",
+        cumulative_total2,
+        cumulative_total1
+    );
+
+    // 3. cumulative should be at least the sum of per-turn values
+    let sum_of_turns = first_turn_total + second_turn_total;
+    assert!(
+        cumulative_total2 >= sum_of_turns,
+        "cumulative ({}) should be at least the sum of per-turn values ({} + {} = {})",
+        cumulative_total2,
+        first_turn_total,
+        second_turn_total,
+        sum_of_turns
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Scenario runner
 // ---------------------------------------------------------------------------
@@ -515,6 +625,8 @@ async fn run_all_scenarios(client: &mut AcpTestClient, workspace: &TestWorkspace
     scenario_session_load_not_supported(client).await;
     scenario_unknown_method(client).await;
     scenario_slash_command_model(client, &session_id).await;
+    // Run per-turn usage test last with a fresh session
+    scenario_session_prompt_per_turn_usage(client, workspace).await;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- report ACP PromptResponse.usage as per-turn usage instead of session cumulative usage
- expose session cumulative usage under _meta.sudocode.cumulativeUsage for clients that need totals
- add ACP integration coverage for multi-turn usage behavior

## Verification
- cargo fmt --check
- cargo test -p runtime --lib -- usage
- cargo test -p rusty-sudocode-cli --test acp_integration -- acp_ws_integration
- manual Sudowork E2E with two scode turns: first turn displayed 9.9K tokens; second turn displayed 15K tokens instead of cumulative ~25K

Note: a full acp_integration run was previously passing, then one rerun hit a transient WebSocket connection reset; rerunning acp_ws_integration passed.