### PR TITLE
refactor: rename COS bucket from sudowork-download to sudowork-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           coscmd config \
             -a "$TENCENT_SECRET_ID" \
             -s "$TENCENT_SECRET_KEY" \
-            -b sudowork-download-1309794936 \
+            -b sudowork-release-1309794936 \
             -e cos.accelerate.myqcloud.com
           for file in dist/scode-*.tar.gz dist/scode-*.zip; do
             [ -f "$file" ] || continue
@@ -149,4 +149,4 @@ jobs:
             coscmd upload "$file" "sudocode/release/latest/$filename"
           done
           coscmd upload dist/SHA256SUMS.txt "sudocode/release/latest/SHA256SUMS.txt"
-          echo "Done: https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/"
+          echo "Done: https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/"


### PR DESCRIPTION
## Summary
- Update Tencent COS bucket name from `sudowork-download-1309794936` to `sudowork-release-1309794936`
- Reflects the bucket renaming in the release workflow

## Test plan
- [ ] Verify the new bucket name matches the actual Tencent COS bucket
- [ ] Next release will publish to the correct bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)