### PR TITLE
spike #179 follow-up: hook-feedback fix, diff preview, /undo

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "serde_json",
  "syntect",
  "telemetry",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tools",

--- a/rust/SPIKE-179-s1-s2-s3.md
+++ b/rust/SPIKE-179-s1-s2-s3.md
@@ -1,0 +1,346 @@
+# Spike #179 — S1, S2, S3
+
+Investigation only. No source / `Cargo.toml` edits. All file:line citations
+verified against current `main` (worktree branch `spike/179-s1-s2-s3`).
+
+The plan being gated lives on `spike/tuie-tui-replacement`:
+`rust/TUI-ENHANCEMENT-PLAN.md` §3 (the three spike rows quoted in #179).
+
+---
+
+## S1 — Diff-aware `edit_file` display
+
+**Question.** Does `tools::EditFile`'s `ToolResult` carry a unified diff or
+pre/post file contents? Should we extend the schema or recompute the diff in
+the CLI (race risk)?
+
+### Evidence
+
+`EditFileOutput` is the JSON payload that becomes the `ToolResult.output`
+string for the `edit_file` tool:
+
+`rust/crates/runtime/src/file_ops.rs:100-119`
+```rust
+pub struct EditFileOutput {
+    pub file_path: String,
+    pub old_string: String,
+    pub new_string: String,
+    pub original_file: String,                       // FULL pre-edit content
+    pub structured_patch: Vec<StructuredPatchHunk>,  // see below
+    pub user_modified: bool,
+    pub replace_all: bool,
+    pub git_diff: Option<serde_json::Value>,         // currently always None
+}
+```
+
+`WriteFileOutput` has the parallel shape — note `original_file: Option<String>`
+(None on create) and the new content under `content: String`:
+
+`rust/crates/runtime/src/file_ops.rs:84-98`
+
+The "patch" today is **not** a real unified diff. `make_patch` emits one
+hunk whose `lines` array is every original line prefixed with `-` followed by
+every new line prefixed with `+` — no LCS, no minimization, no context:
+
+`rust/crates/runtime/src/file_ops.rs:605-621`
+```rust
+fn make_patch(original: &str, updated: &str) -> Vec<StructuredPatchHunk> {
+    let mut lines = Vec::new();
+    for line in original.lines() { lines.push(format!("-{line}")); }
+    for line in updated.lines()  { lines.push(format!("+{line}")); }
+    vec![StructuredPatchHunk {
+        old_start: 1, old_lines: original.lines().count(),
+        new_start: 1, new_lines: updated.lines().count(),
+        lines,
+    }]
+}
+```
+
+The runtime executor returns `to_pretty_json(EditFileOutput)` as the tool
+result string with no transformation:
+
+- dispatch: `rust/crates/tools/src/lib.rs:1133-1136`
+- body: `rust/crates/tools/src/lib.rs:1912-1942` (`run_edit_file`)
+- serializer: `rust/crates/tools/src/lib.rs:2099` (`to_pretty_json`)
+
+The conversation loop wraps that string into a `ConversationMessage::tool_result`
+without inspecting it (only hook feedback may be appended — see "Caveats"):
+
+`rust/crates/runtime/src/conversation.rs:953-1016`
+
+The CLI already consumes `structuredPatch` for its inline preview:
+
+- `rust/crates/rusty-sudocode-cli/src/cli/format.rs:945-963`
+  (`format_structured_patch_preview`)
+- `rust/crates/rusty-sudocode-cli/src/cli/format.rs:965-995`
+  (`format_edit_result`, called from `format_tool_result` at
+  `rust/crates/rusty-sudocode-cli/src/cli/format.rs:693`)
+
+### Answer
+
+The `ToolResult` already carries **both** pre/post content (`original_file`,
+plus `old_string` / `new_string`) and a "patch" field — but the patch is not
+a unified diff in any meaningful sense. It's a degenerate all-minus-then-
+all-plus dump. The CLI's existing preview is already running off it.
+
+**No schema change required to do diff-aware display.** Everything needed —
+`original_file`, `new_string` substitution, or the existing `structured_patch`
+hunks — is already in the result envelope. The CLI can compute a proper
+unified diff in-process from `original_file` → reconstructed updated content
+(or directly from `(old_string, new_string, replace_all)`).
+
+**No race risk** if the CLI computes diff from the in-result fields. The race
+the spike worries about — re-reading the file from disk after the edit — is
+not necessary: `original_file` is the authoritative pre-image captured *at the
+moment* of the edit. Recomputing diff from those bytes avoids any TOCTOU
+window.
+
+A schema change would only be warranted if we wanted the runtime to ship a
+ready-to-render unified diff string (saves work in every consumer, including
+ACP / JSON output). That's a quality-of-life improvement, not a correctness
+fix. Defer it.
+
+### Caveats
+
+- **Hook feedback wrapping.** When `PreToolUse` / `PostToolUse` hooks emit
+  messages, the conversation loop concatenates them onto the JSON output:
+  `rust/crates/runtime/src/conversation.rs:1530-1546`. This breaks
+  `serde_json::from_str(output)` in `format_tool_result`
+  (`rust/crates/rusty-sudocode-cli/src/cli/format.rs:687-688`), which falls
+  back to a string value, and `format_edit_result` then renders without any
+  patch preview. A diff-aware feature should parse defensively: try to
+  extract the JSON object from the prefix before any `\n\nHook feedback:`
+  marker. Same caveat applies to S3.
+- The `git_diff` field exists but is always `None` today (no producer); free
+  to repurpose if we later want runtime-supplied unified diffs.
+
+### Recommended next step
+
+Schedule TUI item #9 ("Colored `/diff`") **and** a sibling
+"diff-aware `edit_file` preview" task. Both can ship without touching the
+tool schema. Concretely:
+
+1. In `format_edit_result` / `format_write_result`, parse `original_file` +
+   reconstruct updated content, then feed both into a small unified-diff
+   helper (e.g. `similar` crate, already commonly bundled — verify if
+   already in `Cargo.lock` before adding).
+2. Strip any `\n\nHook feedback:` suffix before JSON parse so the preview
+   still works when hooks fire.
+3. Leave `EditFileOutput` / `WriteFileOutput` schemas alone.
+
+---
+
+## S2 — `/search` scope (product decision)
+
+**Question.** What does `/search` search — current session messages, all
+persisted sessions, tool output, or all? Pick before designing storage.
+
+### Evidence
+
+`/search` is **not implemented today**. The only mention is in the slash-
+command autocomplete keyword list at
+`rust/crates/rusty-sudocode-cli/src/main.rs:4538` (`"search"`). No dispatcher,
+no handler. (`format_search_start` at
+`rust/crates/rusty-sudocode-cli/src/cli/format.rs:711` is unrelated — it
+formats the spinner label for `grep_search` / `glob_search` tool starts.)
+
+Storage surface today:
+- One JSONL file per session at the path managed by `SessionStore`
+  (`rust/crates/rusty-sudocode-cli/src/cli/session.rs:32-39`); listing API at
+  `:89-108`.
+- Session file rotation at 256 KiB, keeping 3 rotated logs:
+  `rust/crates/runtime/src/session.rs:12-14`,
+  `rust/crates/runtime/src/session.rs:1227-1300`.
+- Each `ContentBlock::ToolResult` is stored verbatim as a string, including
+  full tool output:
+  `rust/crates/runtime/src/session.rs:49-54` and `:867-887`.
+
+So a search feature has, at minimum, access to:
+- in-memory current session (live);
+- every JSONL session file under the session directory;
+- the full tool-result `output` strings inside those files (no truncation
+  at the storage layer — `bash` does truncate at 16 KiB before storage at
+  `rust/crates/runtime/src/bash.rs:499-509`, but file IO results are stored
+  whole).
+
+### This is a product decision, not a technical one
+
+The scope cannot be picked from the codebase. Below are the realistic
+options for the maintainer to choose between.
+
+| Option | Indexing / storage cost | Privacy | UX sketch |
+|---|---|---|---|
+| **A. Current session, messages only** | None — linear scan of in-memory `Session.messages`. ~50 ms for any plausible session size. | Lowest. Nothing leaves the running process. | `/search foo` → list of `(turn #, role, snippet)`; <Enter> scrolls back. |
+| **B. Current session, messages + tool output** | None — same scan, just include `ContentBlock::ToolResult.output`. | Low. Same scope. Tool output may contain secrets users pasted into commands; opt-in flag advised. | Same as A. Visually mark tool-result hits distinctly. |
+| **C. All persisted sessions, messages only** | Modest. Linear scan over JSONL files in `sessions_dir()`; on cold cache, ~10 ms × number_of_files. No index needed at first; revisit at 100+ sessions. | Medium. Searches surface text from past sessions in other working directories of the same store. | `/search foo` → results grouped by session id with a recency stamp; selecting one opens a viewer or switches session. |
+| **D. All persisted sessions, everything (messages + tool output)** | Largest. Tool output can dominate file size; full-text scans become noticeable past a few MB. Eventually wants an index (sqlite FTS5 / tantivy). | Highest. Will surface bash stdout, file contents read, etc. — must consider redaction. | Same as C but flag scope filters: `/search foo --tools`, `--errors`. |
+| **E. Scoped via flags, default = A** | Same as A by default; opt-in higher cost on demand. | Same as A by default. | `/search foo` (current session) vs `/search --all foo` vs `/search --all --tools foo`. |
+
+Cross-cutting concerns regardless of scope:
+- **Rotation.** Past tool outputs may live only in `*.rot-*.jsonl` files
+  (`rust/crates/runtime/src/session.rs:1247-1252`). Option C/D must decide
+  whether to include rotated logs (yes, otherwise large-session histories
+  vanish from results without warning).
+- **Compaction.** Once `/compact` summarizes a turn, the original messages
+  are gone from the active file (see S3). Search will not find them unless
+  it also scans rotated logs.
+- **Workspace scoping.** `SessionStore::from_cwd` derives the session dir
+  from the current workspace (`rust/crates/rusty-sudocode-cli/src/cli/session.rs:36-39`),
+  so "all sessions" naturally means "all sessions in this workspace" — a
+  reasonable privacy default.
+
+### Recommended default (subject to maintainer confirmation)
+
+**E with default = A** ("current session, messages only" by default, with
+opt-in flags `--all` and `--tools`).
+
+Why this is defensible without picking the harder questions now:
+- Ships value in <½ day (linear scan over `Session.messages`).
+- Forces no storage redesign, no indexing dependency, no compaction-history
+  question.
+- Leaves the door open to C/D later by repurposing the same flag surface.
+- Matches the default scope of `grep` in most tools (the current buffer).
+- Privacy story is trivial to explain.
+
+**Do not start design work** on cross-session indexing until the maintainer
+confirms this default. C and D have very different storage shapes.
+
+### Recommended next step
+
+Open a one-paragraph design issue listing options A–E above and ask the
+maintainer to pick the default plus opt-in flags. Block any /search
+implementation work until that decision lands.
+
+---
+
+## S3 — `/undo` data round-trip
+
+**Question.** Does `write_file` / `edit_file` `ToolResult` persist the
+original file content across a session-to-disk round-trip?
+
+### Evidence
+
+The pre-image is in the tool output struct:
+
+- `EditFileOutput.original_file: String` (always present) —
+  `rust/crates/runtime/src/file_ops.rs:109-110`. Populated from
+  `fs.read_to_string(&abs_str)?` at `:292`.
+- `WriteFileOutput.original_file: Option<String>` (None when creating a new
+  file) — `rust/crates/runtime/src/file_ops.rs:94-95`. Populated at
+  `:259` (`let original_file = fs.read_to_string(&abs_str).ok();`).
+
+The runtime stores the tool output string verbatim as
+`ContentBlock::ToolResult.output`:
+
+- `rust/crates/runtime/src/conversation.rs:953-1016` — the executor's `Ok`
+  output flows into `ConversationMessage::tool_result(...)` with no field
+  inspection.
+- `rust/crates/runtime/src/session.rs:49-54` — `ToolResult.output: String`.
+
+JSONL persistence is symmetric and lossless for strings:
+
+- write side: `rust/crates/runtime/src/session.rs:867-887`
+  (`output` → `JsonValue::String(output.clone())`)
+- read side: `rust/crates/runtime/src/session.rs:924-932`
+  (`output: required_string(object, "output")?`)
+
+Files are appended per-message (`append_persisted_message` at
+`rust/crates/runtime/src/session.rs:606-623`), so a normal session round-trip
+(`push_message` → exit → `Session::load_from_path`) preserves the full
+`original_file` byte-for-byte.
+
+### Answer
+
+**Yes — for a single round-trip on the active JSONL file, the original
+content survives.** It is embedded in the pretty-printed JSON `output` of the
+tool result, stored as a `JsonValue::String`, and re-read intact.
+
+There are three real-world ways the data can become unrecoverable:
+
+1. **Session rotation.** `ROTATE_AFTER_BYTES = 256 * 1024`
+   (`rust/crates/runtime/src/session.rs:12-14`) and `MAX_ROTATED_FILES = 3`
+   (`:14`). When `save_to_path` runs, the existing file ≥ 256 KiB is renamed
+   to `*.rot-{ts}.jsonl` and a fresh snapshot is written. Older rotations
+   beyond the third are deleted (`cleanup_rotated_logs_with` at
+   `rust/crates/runtime/src/session.rs:1260-1300`). `/undo` that targets an
+   edit older than the live file + 3 rotations is gone.
+2. **Compaction.** `compact_session` keeps only `preserve_recent_messages`
+   (default 4, `rust/crates/runtime/src/compact.rs:16-22`) tail messages
+   plus a text summary. Then the CLI calls
+   `result.compacted_session.save_to_path(...)`
+   (`rust/crates/rusty-sudocode-cli/src/main.rs:986`,
+   `rust/crates/rusty-sudocode-cli/src/main.rs:2410`), which overwrites the
+   active file with the post-compaction snapshot. The pre-images of edits
+   in the discarded tail are unrecoverable unless they survived in a
+   rotated file.
+3. **Hook feedback.** When pre/post-tool-use hooks emit messages,
+   `merge_hook_feedback` appends `\n\nHook feedback:\n…` onto the output
+   string before storage (`rust/crates/runtime/src/conversation.rs:1530-1546`).
+   The bytes are still there, but a naive `serde_json::from_str(output)`
+   parse fails (the JSON object now has trailing non-JSON text). `/undo`
+   would need to slice the JSON prefix before parsing (same fix as S1).
+
+### Verification snippet (do **not** add to suite)
+
+If we want a paranoid check before /undo design starts, this is the
+minimum repro — drop into a scratch test crate:
+
+```rust
+// scratch verification — not committed
+use runtime::file_ops::{edit_file, EditFileOutput};
+use runtime::fs_backend::StdFsBackend;
+use runtime::session::{ContentBlock, ConversationMessage, Session};
+
+fn main() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), "hello world\n").unwrap();
+
+    let out = edit_file(&StdFsBackend, tmp.path().to_str().unwrap(),
+                        "hello", "goodbye", false).unwrap();
+    let json = serde_json::to_string(&out).unwrap();
+    assert!(json.contains("\"originalFile\":\"hello world\\n\""));
+
+    let mut s = Session::new();
+    s.push_message(ConversationMessage::tool_result(
+        "tool_use_id_1".into(), "edit_file".into(), json.clone(), false,
+    )).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("session.jsonl");
+    s.save_to_path(&path).unwrap();
+    let loaded = Session::load_from_path(&path).unwrap();
+
+    let blk = &loaded.messages.last().unwrap().blocks[0];
+    let ContentBlock::ToolResult { output, .. } = blk else { panic!() };
+    let back: EditFileOutput = serde_json::from_str(output).unwrap();
+    assert_eq!(back.original_file, "hello world\n");  // <-- round-trip
+}
+```
+
+### Recommended next step
+
+Treat `/undo` as viable but with **two design constraints**:
+
+1. **Per-file undo stack must be built from the live session at memory
+   time**, not from disk-reload time, because compaction and rotation can
+   erase older pre-images. The handler should walk
+   `session.messages.iter().rev()`, finding the most recent
+   `ToolResult` whose `tool_name == "edit_file"|"write_file"` and whose
+   parsed `file_path` matches, and apply its `originalFile`.
+2. **Parse defensively** — strip any `\n\nHook feedback:` suffix before
+   `serde_json::from_str`. Otherwise hooks silently disable `/undo`.
+
+If the maintainer wants /undo to survive `/compact`, that's a separate
+proposal: it requires writing pre-image snapshots into a sidecar file
+*outside* the session JSONL (or excluding edit/write tool results from
+compaction's discard set). Flag for follow-up.
+
+---
+
+## Summary table
+
+| Spike | Verdict | Schema change needed? | Next action |
+|---|---|---|---|
+| **S1** | Both pre/post content + a (degenerate) patch already in `EditFileOutput`. No race risk if CLI diffs from `original_file`. | No | Schedule diff-aware `edit_file` preview alongside #9; CLI-side only. |
+| **S2** | `/search` not implemented. Scope is a product decision. Recommended default: **current-session messages**, with `--all` / `--tools` flags. | N/A (gated on decision) | Maintainer confirms default before any storage design. |
+| **S3** | Pre-image survives a single round-trip. Compaction and rotation can erase older pre-images; hook feedback corrupts naive JSON parse. | No (unless undo must survive compaction) | Build `/undo` against in-memory session; strip hook suffix before parsing. |

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1044,6 +1044,13 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         argument_hint: None,
         resume_supported: true,
     },
+    SlashCommandSpec {
+        name: "undo",
+        aliases: &[],
+        summary: "Revert the most recent edit_file or write_file in this session",
+        argument_hint: None,
+        resume_supported: false,
+    },
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1192,6 +1199,7 @@ pub enum SlashCommand {
     History {
         count: Option<String>,
     },
+    Undo,
     Unknown(String),
 }
 
@@ -1293,6 +1301,7 @@ impl SlashCommand {
             Self::Sandbox => "/sandbox",
             Self::Mcp { .. } => "/mcp",
             Self::Export { .. } => "/export",
+            Self::Undo => "/undo",
             #[allow(unreachable_patterns)]
             _ => "/unknown",
         }
@@ -1385,6 +1394,10 @@ pub fn validate_slash_command_input(
         "diff" => {
             validate_no_args(command, &args)?;
             SlashCommand::Diff
+        }
+        "undo" => {
+            validate_no_args(command, &args)?;
+            SlashCommand::Undo
         }
         "version" => {
             validate_no_args(command, &args)?;
@@ -4468,6 +4481,7 @@ pub fn handle_slash_command(
         | SlashCommand::OutputStyle { .. }
         | SlashCommand::AddDir { .. }
         | SlashCommand::History { .. }
+        | SlashCommand::Undo
         | SlashCommand::Unknown(_) => None,
     }
 }
@@ -5051,7 +5065,7 @@ mod tests {
         assert!(help.contains("aliases: /skill"));
         assert!(!help.contains("/login"));
         assert!(!help.contains("/logout"));
-        assert_eq!(slash_command_specs().len(), 140);
+        assert_eq!(slash_command_specs().len(), 141);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1049,7 +1049,7 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         aliases: &[],
         summary: "Revert the most recent edit_file or write_file in this session",
         argument_hint: None,
-        resume_supported: false,
+        resume_supported: true,
     },
 ];
 

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -38,6 +38,7 @@ workspace = true
 futures-util = "0.3"
 mock-anthropic-service = { path = "../mock-anthropic-service" }
 serde_json.workspace = true
+tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-tungstenite = "0.29"
 

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -1082,6 +1082,13 @@ pub(crate) fn format_edit_result(icon: &str, parsed: &serde_json::Value) -> Stri
 /// Render a context-windowed diff for the first occurrence of `old_string`
 /// inside `original`. Returns `None` when we cannot locate the match (e.g.
 /// `original` was not captured, or the JSON was malformed).
+///
+/// `old_string` is treated as a substring of `original`, not necessarily
+/// line-aligned. The "affected block" is widened out to whole-line
+/// boundaries on both ends so the rendered `-`/`+` lines reflect the
+/// actual lines that changed — not just the literal `old_string` /
+/// `new_string` fragments (which would mislead the user when an edit
+/// happens mid-line).
 pub(crate) fn format_edit_diff_preview(
     original: &str,
     old_string: &str,
@@ -1090,19 +1097,35 @@ pub(crate) fn format_edit_diff_preview(
     if original.is_empty() || old_string.is_empty() {
         return None;
     }
-    let byte_offset = original.find(old_string)?;
-    let lines_before = original[..byte_offset].lines().count();
-    let pre_context_start = lines_before.saturating_sub(DIFF_PREVIEW_CONTEXT_LINES);
+    let match_start = original.find(old_string)?;
+    let match_end = match_start + old_string.len();
+
+    // Widen to whole-line boundaries.
+    let line_start = original[..match_start].rfind('\n').map_or(0, |idx| idx + 1);
+    let line_end = original[match_end..]
+        .find('\n')
+        .map_or(original.len(), |idx| match_end + idx);
+
+    let affected_old = &original[line_start..line_end];
+    let new_region = format!(
+        "{}{}{}",
+        &original[line_start..match_start],
+        new_string,
+        &original[match_end..line_end],
+    );
+
+    let old_lines: Vec<&str> = affected_old.lines().collect();
+    let new_lines: Vec<&str> = new_region.lines().collect();
+    let edit_start_line = original[..line_start].matches('\n').count() + 1;
+    let pre_context_start = edit_start_line.saturating_sub(1 + DIFF_PREVIEW_CONTEXT_LINES);
     let original_lines: Vec<&str> = original.lines().collect();
 
-    let old_lines: Vec<&str> = old_string.lines().collect();
-    let new_lines: Vec<&str> = new_string.lines().collect();
     Some(render_diff_window(
         &old_lines,
         &new_lines,
         &original_lines,
         pre_context_start,
-        lines_before + 1,
+        edit_start_line,
     ))
 }
 
@@ -1999,6 +2022,36 @@ mod tests {
     }
 
     #[test]
+    fn format_edit_diff_preview_widens_substring_match_to_whole_lines() {
+        // Regression caught during manual inspection: when `old_string` is
+        // a mid-line substring (very common — replacing a function name
+        // inside `    foo();`), the body must show the WHOLE affected line
+        // with the replacement applied in place, not just the literal
+        // fragment. Otherwise the rendered diff lies about which line is
+        // changing and the line number is off-by-one.
+        let original =
+            "fn header() {}\n\nfn caller() {\n    let x = 1;\n    old_function();\n    return x;\n}\n";
+        let preview =
+            format_edit_diff_preview(original, "old_function()", "new_function()").unwrap();
+        let plain = strip_ansi(&preview);
+        // Hunk header points at line 5 (the line containing the match),
+        // not line 6.
+        assert!(plain.contains("@@ -5,1 +5,1 @@"), "{plain}");
+        // The `-`/`+` rows show the full affected line with indentation,
+        // not the bare fragment.
+        assert!(plain.contains("-     old_function();"), "{plain}");
+        assert!(plain.contains("+     new_function();"), "{plain}");
+        // The full line must NOT also appear as a dim context row above
+        // the change.
+        let context_dup = "  \x1b[0m";
+        let _ = context_dup; // anchor for the reader; assertion below
+        assert!(
+            !plain.contains("    old_function();\n-"),
+            "affected line leaked into pre-context: {plain}"
+        );
+    }
+
+    #[test]
     fn format_edit_result_renders_replace_all_count() {
         let json = serde_json::json!({
             "filePath": "src/main.rs",
@@ -2044,5 +2097,67 @@ mod tests {
         assert!(plain.contains("(2 lines)"), "{plain}");
         assert!(!plain.contains("was"), "{plain}");
         assert!(!plain.contains("@@"), "{plain}");
+    }
+
+    /// Visual-inspection-only: print four representative tool results so the
+    /// rendered ANSI output can be eyeballed during manual verification. Run
+    /// with `cargo test -p rusty-sudocode-cli --bin scode -- \
+    /// cli::format::tests::PREVIEW_render_samples_for_manual_inspection \
+    /// --nocapture --include-ignored`. Marked `#[ignore]` so it never runs
+    /// in the default suite.
+    #[test]
+    #[ignore = "visual-inspection only; run with --include-ignored --nocapture"]
+    #[allow(non_snake_case)]
+    fn PREVIEW_render_samples_for_manual_inspection() {
+        let edit_with_context = serde_json::json!({
+            "filePath": "src/main.rs",
+            "oldString": "old_function()",
+            "newString": "new_function()",
+            "originalFile": "fn header() {}\n\nfn caller() {\n    let x = 1;\n    old_function();\n    return x;\n}\n\nfn footer() {}\n",
+            "userModified": false,
+            "replaceAll": false,
+        })
+        .to_string();
+        println!("\n=== SAMPLE 1: edit_file with surrounding context ===");
+        println!(
+            "{}",
+            format_tool_result("edit_file", &edit_with_context, false)
+        );
+
+        let edit_replace_all = serde_json::json!({
+            "filePath": "src/lib.rs",
+            "oldString": "foo",
+            "newString": "bar",
+            "originalFile": "foo one\nfoo two\nfoo three\n",
+            "userModified": false,
+            "replaceAll": true,
+        })
+        .to_string();
+        println!("\n=== SAMPLE 2: edit_file with replaceAll + occurrence count ===");
+        println!(
+            "{}",
+            format_tool_result("edit_file", &edit_replace_all, false)
+        );
+
+        let write_update = serde_json::json!({
+            "type": "update",
+            "filePath": "config.toml",
+            "content": "[server]\nport = 8080\nhost = \"0.0.0.0\"\nmax_connections = 100\n",
+            "originalFile": "[server]\nport = 3000\nhost = \"127.0.0.1\"\n",
+        })
+        .to_string();
+        println!("\n=== SAMPLE 3: write_file update with line-count delta ===");
+        println!("{}", format_tool_result("write_file", &write_update, false));
+
+        let with_hook_feedback = format!(
+            "{}\n\nHook feedback:\nrustfmt clean\nclippy clean",
+            edit_with_context
+        );
+        println!("\n=== SAMPLE 4: edit_file with hook feedback suffix (regression #1) ===");
+        println!(
+            "{}",
+            format_tool_result("edit_file", &with_hook_feedback, false)
+        );
+        println!();
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -670,13 +670,29 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
     )
 }
 
+/// Split a `ToolResult.output` string into its JSON-payload prefix and any
+/// trailing hook-feedback section that `runtime::conversation::merge_hook_feedback`
+/// may have appended. Returns `(payload, Some(feedback))` when a marker is
+/// found, or `(output, None)` otherwise.
+pub(crate) fn split_hook_feedback(output: &str) -> (&str, Option<&str>) {
+    const MARKERS: &[&str] = &["\n\nHook feedback:\n", "\n\nHook feedback (error):\n"];
+    for marker in MARKERS {
+        if let Some(idx) = output.find(marker) {
+            let (head, tail) = output.split_at(idx);
+            return (head, Some(tail.trim_start_matches('\n')));
+        }
+    }
+    (output, None)
+}
+
 pub(crate) fn format_tool_result(name: &str, output: &str, is_error: bool) -> String {
     let icon = if is_error {
         "\x1b[1;31m⏺\x1b[0m"
     } else {
         "\x1b[1;32m⏺\x1b[0m"
     };
-    if is_error {
+    let (payload, hook_feedback) = split_hook_feedback(output);
+    let base = if is_error {
         let summary = truncate_for_summary(output.trim(), 160);
         if summary.is_empty() {
             format!("{icon} \x1b[38;5;245m{name}\x1b[0m")
@@ -685,7 +701,7 @@ pub(crate) fn format_tool_result(name: &str, output: &str, is_error: bool) -> St
         }
     } else {
         let parsed: serde_json::Value =
-            serde_json::from_str(output).unwrap_or(serde_json::Value::String(output.to_string()));
+            serde_json::from_str(payload).unwrap_or(serde_json::Value::String(payload.to_string()));
         match name {
             "bash" | "Bash" => format_bash_result(icon, &parsed),
             "read_file" | "Read" => format_read_result(icon, &parsed),
@@ -695,6 +711,13 @@ pub(crate) fn format_tool_result(name: &str, output: &str, is_error: bool) -> St
             "grep_search" | "Grep" => format_grep_result(icon, &parsed),
             _ => format_generic_tool_result(icon, name, &parsed),
         }
+    };
+    match hook_feedback {
+        Some(feedback) if !is_error => {
+            let indented = feedback.replace('\n', "\n  ");
+            format!("{base}\n  \x1b[38;5;214m{indented}\x1b[0m")
+        }
+        _ => base,
     }
 }
 
@@ -926,64 +949,126 @@ pub(crate) fn language_token_from_path(path: &str) -> &str {
         .unwrap_or("")
 }
 
+/// Max number of `-`/`+` lines shown per side before the body is collapsed.
+pub(crate) const DIFF_PREVIEW_MAX_BODY_LINES: usize = 8;
+/// Lines of unchanged context shown above and below the edit window.
+pub(crate) const DIFF_PREVIEW_CONTEXT_LINES: usize = 3;
+
 pub(crate) fn format_write_result(icon: &str, parsed: &serde_json::Value) -> String {
     let path = extract_tool_path(parsed);
     let kind = parsed
         .get("type")
         .and_then(|value| value.as_str())
         .unwrap_or("write");
-    let line_count = parsed
+    let new_content = parsed
         .get("content")
         .and_then(|value| value.as_str())
-        .map_or(0, |content| content.lines().count());
-    format!(
-        "{icon} \x1b[1;32m✏️ {} {path}\x1b[0m \x1b[2m({line_count} lines)\x1b[0m",
-        if kind == "create" { "Wrote" } else { "Updated" },
-    )
+        .unwrap_or_default();
+    let new_line_count = new_content.lines().count();
+    let original = parsed.get("originalFile").and_then(|value| value.as_str());
+    let verb = if kind == "create" { "Wrote" } else { "Updated" };
+    let header = match original {
+        Some(prev) if kind != "create" => {
+            let prev_lines = prev.lines().count();
+            let delta = new_line_count.cast_signed() - prev_lines.cast_signed();
+            let delta_str = match delta.cmp(&0) {
+                std::cmp::Ordering::Greater => format!(" +{delta}"),
+                std::cmp::Ordering::Less => format!(" {delta}"),
+                std::cmp::Ordering::Equal => String::new(),
+            };
+            format!(
+                "{icon} \x1b[1;32m✏️ {verb} {path}\x1b[0m \x1b[2m({new_line_count} lines, was {prev_lines}{delta_str})\x1b[0m",
+            )
+        }
+        _ => format!(
+            "{icon} \x1b[1;32m✏️ {verb} {path}\x1b[0m \x1b[2m({new_line_count} lines)\x1b[0m",
+        ),
+    };
+    match original {
+        Some(prev) if kind != "create" => match format_full_replace_diff_preview(prev, new_content)
+        {
+            Some(preview) => {
+                let indented = preview.replace('\n', "\n  ");
+                format!("{header}\n  {indented}")
+            }
+            None => header,
+        },
+        _ => header,
+    }
 }
 
-pub(crate) fn format_structured_patch_preview(parsed: &serde_json::Value) -> Option<String> {
-    let hunks = parsed.get("structuredPatch")?.as_array()?;
-    let mut preview = Vec::new();
-    for hunk in hunks.iter().take(2) {
-        let lines = hunk.get("lines")?.as_array()?;
-        for line in lines.iter().filter_map(|value| value.as_str()).take(6) {
-            match line.chars().next() {
-                Some('+') => preview.push(format!("\x1b[38;5;70m{line}\x1b[0m")),
-                Some('-') => preview.push(format!("\x1b[38;5;203m{line}\x1b[0m")),
-                _ => preview.push(line.to_string()),
-            }
-        }
+/// Build a small context-windowed diff preview for a write_file that
+/// fully replaces an existing file. Walks the line lists from both ends
+/// to skip identical head/tail, then prints up to
+/// `DIFF_PREVIEW_MAX_BODY_LINES` of removed and added lines with a hunk
+/// header. Returns `None` when the contents are byte-identical.
+pub(crate) fn format_full_replace_diff_preview(original: &str, updated: &str) -> Option<String> {
+    if original == updated {
+        return None;
     }
-    if preview.is_empty() {
-        None
-    } else {
-        Some(preview.join("\n"))
+    let old_lines: Vec<&str> = original.lines().collect();
+    let new_lines: Vec<&str> = updated.lines().collect();
+
+    let mut head = 0;
+    while head < old_lines.len() && head < new_lines.len() && old_lines[head] == new_lines[head] {
+        head += 1;
     }
+    let mut tail = 0;
+    while tail < old_lines.len() - head
+        && tail < new_lines.len() - head
+        && old_lines[old_lines.len() - 1 - tail] == new_lines[new_lines.len() - 1 - tail]
+    {
+        tail += 1;
+    }
+
+    let old_changed = &old_lines[head..old_lines.len() - tail];
+    let new_changed = &new_lines[head..new_lines.len() - tail];
+    let edit_start_line = head + 1;
+    Some(render_diff_window(
+        old_changed,
+        new_changed,
+        &old_lines,
+        head,
+        edit_start_line,
+    ))
 }
 
 pub(crate) fn format_edit_result(icon: &str, parsed: &serde_json::Value) -> String {
     let path = extract_tool_path(parsed);
-    let suffix = if parsed
+    let replace_all = parsed
         .get("replaceAll")
         .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-    {
-        " (replace all)"
+        .unwrap_or(false);
+    let original = parsed
+        .get("originalFile")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let old_value = parsed
+        .get("oldString")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let new_value = parsed
+        .get("newString")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+
+    let occurrences = if replace_all && !old_value.is_empty() {
+        count_non_overlapping(original, old_value)
     } else {
-        ""
+        usize::from(!old_value.is_empty() && original.contains(old_value))
     };
-    let preview = format_structured_patch_preview(parsed).or_else(|| {
-        let old_value = parsed
-            .get("oldString")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default();
-        let new_value = parsed
-            .get("newString")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default();
-        format_patch_preview(old_value, new_value)
-    });
+    let suffix = if replace_all {
+        if occurrences > 1 {
+            format!(" (replace all, {occurrences} occurrences)")
+        } else {
+            " (replace all)".to_string()
+        }
+    } else {
+        String::new()
+    };
+
+    let preview = format_edit_diff_preview(original, old_value, new_value)
+        .or_else(|| format_patch_preview(old_value, new_value));
 
     match preview {
         Some(preview) => {
@@ -992,6 +1077,105 @@ pub(crate) fn format_edit_result(icon: &str, parsed: &serde_json::Value) -> Stri
         }
         None => format!("{icon} \x1b[1;33m📝 Edited {path}{suffix}\x1b[0m"),
     }
+}
+
+/// Render a context-windowed diff for the first occurrence of `old_string`
+/// inside `original`. Returns `None` when we cannot locate the match (e.g.
+/// `original` was not captured, or the JSON was malformed).
+pub(crate) fn format_edit_diff_preview(
+    original: &str,
+    old_string: &str,
+    new_string: &str,
+) -> Option<String> {
+    if original.is_empty() || old_string.is_empty() {
+        return None;
+    }
+    let byte_offset = original.find(old_string)?;
+    let lines_before = original[..byte_offset].lines().count();
+    let pre_context_start = lines_before.saturating_sub(DIFF_PREVIEW_CONTEXT_LINES);
+    let original_lines: Vec<&str> = original.lines().collect();
+
+    let old_lines: Vec<&str> = old_string.lines().collect();
+    let new_lines: Vec<&str> = new_string.lines().collect();
+    Some(render_diff_window(
+        &old_lines,
+        &new_lines,
+        &original_lines,
+        pre_context_start,
+        lines_before + 1,
+    ))
+}
+
+/// Render a single diff hunk: pre-context, `-` body, `+` body, post-context.
+/// Body lines beyond `DIFF_PREVIEW_MAX_BODY_LINES` per side are collapsed
+/// with a "…" summary line.
+fn render_diff_window(
+    old_body: &[&str],
+    new_body: &[&str],
+    original_lines: &[&str],
+    pre_context_start: usize,
+    edit_start_line_1based: usize,
+) -> String {
+    let mut out: Vec<String> = Vec::new();
+    let pre_context = &original_lines
+        [pre_context_start..pre_context_start + (edit_start_line_1based - 1 - pre_context_start)];
+    let post_context_start = pre_context_start + pre_context.len() + old_body.len();
+    let post_context_end = post_context_start
+        .saturating_add(DIFF_PREVIEW_CONTEXT_LINES)
+        .min(original_lines.len());
+    let post_context = if post_context_start <= original_lines.len() {
+        &original_lines[post_context_start..post_context_end]
+    } else {
+        &[][..]
+    };
+
+    out.push(format!(
+        "\x1b[38;5;245m@@ -{},{} +{},{} @@\x1b[0m",
+        edit_start_line_1based,
+        old_body.len(),
+        edit_start_line_1based,
+        new_body.len(),
+    ));
+    for line in pre_context {
+        out.push(format!("\x1b[2m  {line}\x1b[0m"));
+    }
+    push_body_lines(&mut out, old_body, '-', "\x1b[38;5;203m");
+    push_body_lines(&mut out, new_body, '+', "\x1b[38;5;70m");
+    for line in post_context {
+        out.push(format!("\x1b[2m  {line}\x1b[0m"));
+    }
+    out.join("\n")
+}
+
+fn push_body_lines(out: &mut Vec<String>, body: &[&str], sign: char, color: &str) {
+    let limit = DIFF_PREVIEW_MAX_BODY_LINES;
+    if body.len() <= limit {
+        for line in body {
+            out.push(format!("{color}{sign} {line}\x1b[0m"));
+        }
+    } else {
+        let head = limit.saturating_sub(1);
+        for line in &body[..head] {
+            out.push(format!("{color}{sign} {line}\x1b[0m"));
+        }
+        out.push(format!(
+            "\x1b[2m{sign} … +{} more lines\x1b[0m",
+            body.len() - head,
+        ));
+    }
+}
+
+fn count_non_overlapping(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut start = 0;
+    while let Some(idx) = haystack[start..].find(needle) {
+        count += 1;
+        start += idx + needle.len();
+    }
+    count
 }
 
 pub(crate) fn format_glob_result(icon: &str, parsed: &serde_json::Value) -> String {
@@ -1710,5 +1894,155 @@ mod tests {
         let plain = strip_ansi(&rendered);
         assert!(!plain.contains("Reason"), "{plain}");
         assert!(plain.contains("Tool      read_file"), "{plain}");
+    }
+
+    #[test]
+    fn split_hook_feedback_no_marker_returns_original() {
+        let s = "{\"filePath\":\"foo\"}";
+        let (head, tail) = split_hook_feedback(s);
+        assert_eq!(head, s);
+        assert!(tail.is_none());
+    }
+
+    #[test]
+    fn split_hook_feedback_strips_normal_marker() {
+        let s = "{\"filePath\":\"foo\"}\n\nHook feedback:\nlinted";
+        let (head, tail) = split_hook_feedback(s);
+        assert_eq!(head, "{\"filePath\":\"foo\"}");
+        assert_eq!(tail, Some("Hook feedback:\nlinted"));
+    }
+
+    #[test]
+    fn split_hook_feedback_strips_error_marker() {
+        let s = "{\"filePath\":\"foo\"}\n\nHook feedback (error):\ndenied";
+        let (head, tail) = split_hook_feedback(s);
+        assert_eq!(head, "{\"filePath\":\"foo\"}");
+        assert_eq!(tail, Some("Hook feedback (error):\ndenied"));
+    }
+
+    #[test]
+    fn format_tool_result_recovers_edit_preview_when_hook_appends_feedback() {
+        // Regression: merge_hook_feedback wraps the JSON output with
+        // "\n\nHook feedback:\n...", which used to break serde_json::from_str
+        // and silently disable the structured edit preview.
+        let edit_json = serde_json::json!({
+            "filePath": "src/main.rs",
+            "oldString": "alpha",
+            "newString": "omega",
+            "originalFile": "alpha beta\n",
+            "userModified": false,
+            "replaceAll": false,
+        })
+        .to_string();
+        let polluted = format!("{edit_json}\n\nHook feedback:\nformatter clean");
+        let rendered = format_tool_result("edit_file", &polluted, false);
+        let plain = strip_ansi(&rendered);
+        assert!(plain.contains("Edited src/main.rs"), "{plain}");
+        // Diff preview survives — the +/- lines come from oldString/newString
+        // against originalFile, which only parse if we stripped the suffix.
+        assert!(plain.contains("- alpha"), "{plain}");
+        assert!(plain.contains("+ omega"), "{plain}");
+        // Hook feedback should still be rendered, but as a separate line.
+        assert!(plain.contains("Hook feedback:"), "{plain}");
+        assert!(plain.contains("formatter clean"), "{plain}");
+    }
+
+    #[test]
+    fn format_edit_diff_preview_shows_context_around_change() {
+        let original = "line 1\nline 2\nline 3\nold line\nline 5\nline 6\nline 7\n";
+        let preview = format_edit_diff_preview(original, "old line", "new line").unwrap();
+        let plain = strip_ansi(&preview);
+        // Hunk header pointing at line 4.
+        assert!(plain.contains("@@ -4,1 +4,1 @@"), "{plain}");
+        // Three lines of pre-context.
+        assert!(plain.contains("  line 1"), "{plain}");
+        assert!(plain.contains("  line 2"), "{plain}");
+        assert!(plain.contains("  line 3"), "{plain}");
+        // The change itself.
+        assert!(plain.contains("- old line"), "{plain}");
+        assert!(plain.contains("+ new line"), "{plain}");
+        // Three lines of post-context.
+        assert!(plain.contains("  line 5"), "{plain}");
+        assert!(plain.contains("  line 6"), "{plain}");
+        assert!(plain.contains("  line 7"), "{plain}");
+    }
+
+    #[test]
+    fn format_edit_diff_preview_collapses_oversized_bodies() {
+        let original = (1..=20)
+            .map(|n| format!("old{n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let old_str = original.clone();
+        let new_str = (1..=20)
+            .map(|n| format!("new{n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let preview = format_edit_diff_preview(&original, &old_str, &new_str).unwrap();
+        let plain = strip_ansi(&preview);
+        // Body collapses at DIFF_PREVIEW_MAX_BODY_LINES (8) per side.
+        assert!(plain.contains("- old1"), "{plain}");
+        assert!(plain.contains("- old7"), "{plain}");
+        assert!(!plain.contains("- old8"), "{plain}");
+        assert!(plain.contains("- … +13 more lines"), "{plain}");
+        assert!(plain.contains("+ new1"), "{plain}");
+        assert!(plain.contains("+ … +13 more lines"), "{plain}");
+    }
+
+    #[test]
+    fn format_edit_diff_preview_returns_none_without_anchor() {
+        // Empty original / old_string means we cannot anchor the window —
+        // caller falls back to single-line summary.
+        assert!(format_edit_diff_preview("", "x", "y").is_none());
+        assert!(format_edit_diff_preview("foo", "", "y").is_none());
+        assert!(format_edit_diff_preview("foo", "not present", "y").is_none());
+    }
+
+    #[test]
+    fn format_edit_result_renders_replace_all_count() {
+        let json = serde_json::json!({
+            "filePath": "src/main.rs",
+            "oldString": "foo",
+            "newString": "bar",
+            "originalFile": "foo a\nfoo b\nfoo c\n",
+            "replaceAll": true,
+            "userModified": false,
+        });
+        let rendered = format_edit_result("⏺", &json);
+        let plain = strip_ansi(&rendered);
+        assert!(plain.contains("(replace all, 3 occurrences)"), "{plain}");
+    }
+
+    #[test]
+    fn format_write_result_shows_line_delta_on_update() {
+        let json = serde_json::json!({
+            "type": "update",
+            "filePath": "src/main.rs",
+            "content": "a\nb\nc\nd\n",
+            "originalFile": "a\nx\nc\n",
+        });
+        let rendered = format_write_result("⏺", &json);
+        let plain = strip_ansi(&rendered);
+        assert!(plain.contains("Updated src/main.rs"), "{plain}");
+        // 4 new lines, was 3, delta +1.
+        assert!(plain.contains("(4 lines, was 3 +1)"), "{plain}");
+        // Diff body should show the changed middle line.
+        assert!(plain.contains("- x"), "{plain}");
+        assert!(plain.contains("+ b"), "{plain}");
+    }
+
+    #[test]
+    fn format_write_result_create_skips_delta_and_diff() {
+        let json = serde_json::json!({
+            "type": "create",
+            "filePath": "new.txt",
+            "content": "hello\nworld\n",
+        });
+        let rendered = format_write_result("⏺", &json);
+        let plain = strip_ansi(&rendered);
+        assert!(plain.contains("Wrote new.txt"), "{plain}");
+        assert!(plain.contains("(2 lines)"), "{plain}");
+        assert!(!plain.contains("was"), "{plain}");
+        assert!(!plain.contains("@@"), "{plain}");
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/mod.rs
@@ -11,3 +11,4 @@ pub(crate) mod pager;
 pub(crate) mod session;
 pub(crate) mod status;
 pub(crate) mod tool_executor;
+pub(crate) mod undo;

--- a/rust/crates/rusty-sudocode-cli/src/cli/undo.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/undo.rs
@@ -1,0 +1,262 @@
+//! `/undo` — revert the most recent `edit_file` / `write_file` tool result
+//! recorded in the live session.
+//!
+//! Limitations baked in (see `rust/SPIKE-179-s1-s2-s3.md` §S3):
+//!
+//! - Walks `Session.messages` only — does not reach into rotated logs or
+//!   anything `/compact` has already summarized away.
+//! - Tracks already-undone tool-use ids in-memory so repeated `/undo` calls
+//!   step further back in history instead of re-undoing the same edit.
+//! - No automatic conflict check against the on-disk file: if the user
+//!   hand-edited the file between the tool call and the undo, we still
+//!   restore the recorded pre-image. Recovery is via git.
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use runtime::{ContentBlock, ConversationMessage};
+use serde_json::Value;
+
+use super::format::split_hook_feedback;
+
+/// Outcome of inspecting the live session for an undoable file mutation.
+#[derive(Debug)]
+pub(crate) struct UndoableEdit {
+    pub(crate) tool_use_id: String,
+    pub(crate) tool_name: String,
+    pub(crate) file_path: String,
+    /// `Some(content)` when the tool replaced an existing file; `None` when
+    /// `write_file` created a file that did not exist before. The latter
+    /// case undoes by deleting the file.
+    pub(crate) original_file: Option<String>,
+}
+
+/// Scan messages newest-first and return the first `edit_file` / `write_file`
+/// tool result whose `tool_use_id` is not in `already_undone`. Error results
+/// are skipped — only successful edits left a pre-image worth restoring.
+pub(crate) fn find_last_undoable_edit(
+    messages: &[ConversationMessage],
+    already_undone: &HashSet<String>,
+) -> Option<UndoableEdit> {
+    for message in messages.iter().rev() {
+        for block in message.blocks.iter().rev() {
+            let ContentBlock::ToolResult {
+                tool_use_id,
+                tool_name,
+                output,
+                is_error,
+            } = block
+            else {
+                continue;
+            };
+            if *is_error {
+                continue;
+            }
+            if !matches!(tool_name.as_str(), "edit_file" | "write_file") {
+                continue;
+            }
+            if already_undone.contains(tool_use_id) {
+                continue;
+            }
+            if let Some(edit) =
+                parse_undoable_edit(tool_use_id.as_str(), tool_name.as_str(), output)
+            {
+                return Some(edit);
+            }
+        }
+    }
+    None
+}
+
+fn parse_undoable_edit(tool_use_id: &str, tool_name: &str, output: &str) -> Option<UndoableEdit> {
+    let (payload, _) = split_hook_feedback(output);
+    let value: Value = serde_json::from_str(payload).ok()?;
+    let file_path = value
+        .get("filePath")
+        .or_else(|| value.get("file_path"))
+        .and_then(Value::as_str)?
+        .to_string();
+    let original_file = value
+        .get("originalFile")
+        .or_else(|| value.get("original_file"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    // write_file with kind=="create" emits originalFile=null. edit_file
+    // always has an originalFile (it cannot operate on a missing file).
+    Some(UndoableEdit {
+        tool_use_id: tool_use_id.to_string(),
+        tool_name: tool_name.to_string(),
+        file_path,
+        original_file,
+    })
+}
+
+/// Apply an undo to disk. Returns a one-line human-readable summary of what
+/// changed, suitable for printing back to the user.
+pub(crate) fn apply_undo(edit: &UndoableEdit) -> std::io::Result<String> {
+    let path = Path::new(&edit.file_path);
+    match edit.original_file.as_deref() {
+        Some(original) => {
+            fs::write(path, original)?;
+            Ok(format!(
+                "Restored {} ({} bytes) — undone {}",
+                edit.file_path,
+                original.len(),
+                edit.tool_name,
+            ))
+        }
+        None => {
+            if path.exists() {
+                fs::remove_file(path)?;
+                Ok(format!(
+                    "Deleted {} — undone {} (file was newly created)",
+                    edit.file_path, edit.tool_name,
+                ))
+            } else {
+                Ok(format!(
+                    "Already absent: {} — undone {} (file was newly created)",
+                    edit.file_path, edit.tool_name,
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runtime::{ContentBlock, ConversationMessage, MessageRole};
+
+    fn tool_result(id: &str, name: &str, output: String, is_error: bool) -> ConversationMessage {
+        ConversationMessage {
+            role: MessageRole::User,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                tool_name: name.to_string(),
+                output,
+                is_error,
+            }],
+            usage: None,
+            model: None,
+        }
+    }
+
+    fn edit_output(file_path: &str, original: &str) -> String {
+        serde_json::json!({
+            "filePath": file_path,
+            "oldString": "x",
+            "newString": "y",
+            "originalFile": original,
+            "userModified": false,
+            "replaceAll": false,
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn finds_most_recent_edit_in_reverse_order() {
+        let messages = vec![
+            tool_result("id1", "edit_file", edit_output("/tmp/a.txt", "v1"), false),
+            tool_result("id2", "edit_file", edit_output("/tmp/b.txt", "v2"), false),
+        ];
+        let undone = HashSet::new();
+        let edit = find_last_undoable_edit(&messages, &undone).unwrap();
+        assert_eq!(edit.tool_use_id, "id2");
+        assert_eq!(edit.file_path, "/tmp/b.txt");
+        assert_eq!(edit.original_file.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn skips_already_undone_ids() {
+        let messages = vec![
+            tool_result("id1", "edit_file", edit_output("/tmp/a.txt", "v1"), false),
+            tool_result("id2", "edit_file", edit_output("/tmp/b.txt", "v2"), false),
+        ];
+        let mut undone = HashSet::new();
+        undone.insert("id2".to_string());
+        let edit = find_last_undoable_edit(&messages, &undone).unwrap();
+        assert_eq!(edit.tool_use_id, "id1");
+    }
+
+    #[test]
+    fn skips_errored_tool_results() {
+        let messages = vec![
+            tool_result("id1", "edit_file", edit_output("/tmp/a.txt", "v1"), false),
+            tool_result(
+                "id2",
+                "edit_file",
+                "{\"error\":\"denied\"}".to_string(),
+                true,
+            ),
+        ];
+        let edit = find_last_undoable_edit(&messages, &HashSet::new()).unwrap();
+        assert_eq!(edit.tool_use_id, "id1");
+    }
+
+    #[test]
+    fn ignores_unrelated_tool_results() {
+        let messages = vec![
+            tool_result("id1", "bash", "stdout".to_string(), false),
+            tool_result("id2", "read_file", "{}".to_string(), false),
+        ];
+        assert!(find_last_undoable_edit(&messages, &HashSet::new()).is_none());
+    }
+
+    #[test]
+    fn parses_through_hook_feedback_suffix() {
+        let polluted = format!(
+            "{}\n\nHook feedback:\nlint clean",
+            edit_output("/tmp/c.txt", "old")
+        );
+        let messages = vec![tool_result("id1", "edit_file", polluted, false)];
+        let edit = find_last_undoable_edit(&messages, &HashSet::new()).unwrap();
+        assert_eq!(edit.file_path, "/tmp/c.txt");
+        assert_eq!(edit.original_file.as_deref(), Some("old"));
+    }
+
+    #[test]
+    fn write_file_create_carries_no_original_file() {
+        let create = serde_json::json!({
+            "type": "create",
+            "filePath": "/tmp/new.txt",
+            "content": "hello",
+            "originalFile": Value::Null,
+        })
+        .to_string();
+        let messages = vec![tool_result("id1", "write_file", create, false)];
+        let edit = find_last_undoable_edit(&messages, &HashSet::new()).unwrap();
+        assert!(edit.original_file.is_none());
+    }
+
+    #[test]
+    fn apply_undo_restores_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.txt");
+        fs::write(&path, "modified").unwrap();
+        let edit = UndoableEdit {
+            tool_use_id: "id1".into(),
+            tool_name: "edit_file".into(),
+            file_path: path.to_string_lossy().into_owned(),
+            original_file: Some("original".to_string()),
+        };
+        let msg = apply_undo(&edit).unwrap();
+        assert!(msg.contains("Restored"), "{msg}");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "original");
+    }
+
+    #[test]
+    fn apply_undo_deletes_newly_created_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.txt");
+        fs::write(&path, "content from write_file").unwrap();
+        let edit = UndoableEdit {
+            tool_use_id: "id1".into(),
+            tool_name: "write_file".into(),
+            file_path: path.to_string_lossy().into_owned(),
+            original_file: None,
+        };
+        let msg = apply_undo(&edit).unwrap();
+        assert!(msg.contains("Deleted"), "{msg}");
+        assert!(!path.exists());
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1331,7 +1331,8 @@ fn run_resume_command(
         | SlashCommand::Ide { .. }
         | SlashCommand::Tag { .. }
         | SlashCommand::OutputStyle { .. }
-        | SlashCommand::AddDir { .. } => Err("unsupported resumed slash command".into()),
+        | SlashCommand::AddDir { .. }
+        | SlashCommand::Undo => Err("unsupported resumed slash command".into()),
     }
 }
 
@@ -1486,6 +1487,9 @@ struct LiveCli {
     runtime: BuiltRuntime,
     session: SessionHandle,
     prompt_history: Vec<PromptHistoryEntry>,
+    /// Tool-use ids already restored by `/undo`. Used to make repeated
+    /// `/undo` calls step further back rather than re-undoing the same edit.
+    undone_tool_use_ids: std::collections::HashSet<String>,
     /// Shared tokio runtime used to drive async `run_turn` calls.
     tokio_runtime: tokio::runtime::Runtime,
 }
@@ -2526,6 +2530,7 @@ impl LiveCli {
             runtime,
             session,
             prompt_history: Vec::new(),
+            undone_tool_use_ids: std::collections::HashSet::new(),
             tokio_runtime: tokio::runtime::Runtime::new()?,
         };
         cli.persist_session()?;
@@ -2709,6 +2714,7 @@ impl LiveCli {
     fn replace_runtime(&mut self, runtime: BuiltRuntime) -> Result<(), Box<dyn std::error::Error>> {
         self.shutdown_runtime_resources()?;
         self.runtime = runtime;
+        self.undone_tool_use_ids.clear();
         Ok(())
     }
 
@@ -2974,6 +2980,10 @@ impl LiveCli {
             }
             SlashCommand::Diff => {
                 Self::print_diff()?;
+                false
+            }
+            SlashCommand::Undo => {
+                self.handle_undo();
                 false
             }
             SlashCommand::Version => {
@@ -3530,6 +3540,26 @@ impl LiveCli {
     fn print_diff() -> Result<(), Box<dyn std::error::Error>> {
         print_with_pager(&render_diff_report()?);
         Ok(())
+    }
+
+    fn handle_undo(&mut self) {
+        let messages = &self.runtime.session().messages;
+        match crate::cli::undo::find_last_undoable_edit(messages, &self.undone_tool_use_ids) {
+            None => {
+                println!(
+                    "Nothing to undo in this session. /undo only restores edit_file and write_file results recorded in the live session."
+                );
+            }
+            Some(edit) => match crate::cli::undo::apply_undo(&edit) {
+                Ok(message) => {
+                    self.undone_tool_use_ids.insert(edit.tool_use_id.clone());
+                    println!("{message}");
+                }
+                Err(error) => {
+                    eprintln!("undo failed for {}: {error}", edit.file_path);
+                }
+            },
+        }
     }
 
     fn print_version(output_format: CliOutputFormat) {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1150,6 +1150,37 @@ fn run_resume_command(
                 json: Some(json),
             })
         }
+        SlashCommand::Undo => {
+            let already_undone = std::collections::HashSet::new();
+            match crate::cli::undo::find_last_undoable_edit(&session.messages, &already_undone) {
+                None => Ok(ResumeCommandOutcome {
+                    session: session.clone(),
+                    message: Some(
+                        "Nothing to undo in this session. /undo only restores edit_file and write_file results recorded in the loaded session.".to_string(),
+                    ),
+                    json: Some(serde_json::json!({
+                        "kind": "undo",
+                        "applied": false,
+                        "reason": "no eligible tool result",
+                    })),
+                }),
+                Some(edit) => {
+                    let summary = crate::cli::undo::apply_undo(&edit)?;
+                    Ok(ResumeCommandOutcome {
+                        session: session.clone(),
+                        message: Some(summary),
+                        json: Some(serde_json::json!({
+                            "kind": "undo",
+                            "applied": true,
+                            "tool_name": edit.tool_name,
+                            "tool_use_id": edit.tool_use_id,
+                            "file_path": edit.file_path,
+                            "deleted": edit.original_file.is_none(),
+                        })),
+                    })
+                }
+            }
+        }
         SlashCommand::Version => Ok(ResumeCommandOutcome {
             session: session.clone(),
             message: Some(render_version_report()),
@@ -1331,8 +1362,7 @@ fn run_resume_command(
         | SlashCommand::Ide { .. }
         | SlashCommand::Tag { .. }
         | SlashCommand::OutputStyle { .. }
-        | SlashCommand::AddDir { .. }
-        | SlashCommand::Undo => Err("unsupported resumed slash command".into()),
+        | SlashCommand::AddDir { .. } => Err("unsupported resumed slash command".into()),
     }
 }
 
@@ -4559,7 +4589,6 @@ pub(crate) const STUB_COMMANDS: &[&str] = &[
     "terminal-setup",
     "api-key",
     "reset",
-    "undo",
     "stop",
     "retry",
     "paste",

--- a/rust/crates/rusty-sudocode-cli/tests/undo_e2e.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/undo_e2e.rs
@@ -1,0 +1,337 @@
+//! End-to-end coverage for `/undo` against the real `scode` binary using
+//! the `--resume` non-interactive path.
+//!
+//! Each test builds a session JSONL that contains the kind of
+//! `edit_file` / `write_file` tool-result envelopes the runtime would
+//! emit, drops the binary on it via `--resume <path> /undo`, then asserts
+//! the on-disk file was actually restored.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use runtime::{ContentBlock, ConversationMessage, MessageRole, Session};
+use serde_json::Value;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[test]
+fn resumed_undo_restores_file_modified_by_edit_file_tool() {
+    // given — workspace with the post-edit content on disk and a session
+    // recording the corresponding edit_file ToolResult.
+    let temp_dir = unique_temp_dir("undo-edit");
+    fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let target = temp_dir.join("file.txt");
+    let original_text = "version 1 alpha\nversion 1 beta\n";
+    let edited_text = "version 1 alpha\nversion 1 OMEGA\n";
+    fs::write(&target, edited_text).expect("seed edited file");
+
+    let edit_payload = serde_json::json!({
+        "filePath": target.to_str().expect("utf8 path"),
+        "oldString": "version 1 beta",
+        "newString": "version 1 OMEGA",
+        "originalFile": original_text,
+        "userModified": false,
+        "replaceAll": false,
+    })
+    .to_string();
+
+    let session_path = temp_dir.join("session.jsonl");
+    let mut session = workspace_session(&temp_dir).with_persistence_path(&session_path);
+    session
+        .push_user_text("apply that edit")
+        .expect("user prompt persisted");
+    session
+        .push_message(ConversationMessage {
+            role: MessageRole::Assistant,
+            blocks: vec![ContentBlock::ToolUse {
+                id: "tool-1".into(),
+                name: "edit_file".into(),
+                input: "{}".into(),
+                thought_signature: None,
+            }],
+            usage: None,
+            model: None,
+        })
+        .expect("tool_use persisted");
+    session
+        .push_message(ConversationMessage {
+            role: MessageRole::User,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: "tool-1".into(),
+                tool_name: "edit_file".into(),
+                output: edit_payload,
+                is_error: false,
+            }],
+            usage: None,
+            model: None,
+        })
+        .expect("tool_result persisted");
+
+    // when
+    let output = run_scode(
+        &temp_dir,
+        &[
+            "--resume",
+            session_path.to_str().expect("utf8 path"),
+            "/undo",
+        ],
+    );
+
+    // then
+    assert!(
+        output.status.success(),
+        "scode failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(
+        stdout.contains("Restored"),
+        "expected confirmation; stdout:\n{stdout}",
+    );
+    let on_disk = fs::read_to_string(&target).expect("target should exist");
+    assert_eq!(on_disk, original_text, "file should be reverted in place");
+}
+
+#[test]
+fn resumed_undo_deletes_file_when_write_file_originally_created_it() {
+    // given — write_file created a new file (originalFile: null). The
+    // existing on-disk content is the post-write payload. /undo should
+    // delete it.
+    let temp_dir = unique_temp_dir("undo-create");
+    fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let target = temp_dir.join("brand_new.txt");
+    fs::write(&target, "fresh content\n").expect("seed file");
+
+    let create_payload = serde_json::json!({
+        "type": "create",
+        "filePath": target.to_str().expect("utf8 path"),
+        "content": "fresh content\n",
+        "originalFile": Value::Null,
+        "structuredPatch": [],
+    })
+    .to_string();
+
+    let session_path = temp_dir.join("session.jsonl");
+    let mut session = workspace_session(&temp_dir).with_persistence_path(&session_path);
+    session
+        .push_message(ConversationMessage {
+            role: MessageRole::User,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: "tool-create-1".into(),
+                tool_name: "write_file".into(),
+                output: create_payload,
+                is_error: false,
+            }],
+            usage: None,
+            model: None,
+        })
+        .expect("tool_result persisted");
+
+    // when
+    let output = run_scode(
+        &temp_dir,
+        &[
+            "--resume",
+            session_path.to_str().expect("utf8 path"),
+            "/undo",
+        ],
+    );
+
+    // then
+    assert!(
+        output.status.success(),
+        "scode failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(
+        stdout.contains("Deleted"),
+        "expected deletion confirmation; stdout:\n{stdout}",
+    );
+    assert!(!target.exists(), "file should have been removed");
+}
+
+#[test]
+fn resumed_undo_reports_nothing_to_undo_when_session_has_no_edits() {
+    // given — session with only a user prompt; no tool results to undo.
+    let temp_dir = unique_temp_dir("undo-empty");
+    fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let session_path = temp_dir.join("session.jsonl");
+    let mut session = workspace_session(&temp_dir).with_persistence_path(&session_path);
+    session
+        .push_user_text("just chatting")
+        .expect("user prompt persisted");
+
+    // when
+    let output = run_scode(
+        &temp_dir,
+        &[
+            "--resume",
+            session_path.to_str().expect("utf8 path"),
+            "/undo",
+        ],
+    );
+
+    // then
+    assert!(
+        output.status.success(),
+        "scode failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(
+        stdout.contains("Nothing to undo"),
+        "expected friendly message; stdout:\n{stdout}",
+    );
+}
+
+#[test]
+fn resumed_undo_survives_hook_feedback_suffix_in_tool_result() {
+    // Regression: merge_hook_feedback appends a "Hook feedback:" suffix to
+    // ToolResult outputs. Naive JSON parse fails on that, which used to
+    // silently disable /undo. The split_hook_feedback helper strips the
+    // suffix before parsing.
+    let temp_dir = unique_temp_dir("undo-hook-feedback");
+    fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let target = temp_dir.join("hooked.txt");
+    let original_text = "before hook\n";
+    let edited_text = "after hook\n";
+    fs::write(&target, edited_text).expect("seed file");
+
+    let edit_json = serde_json::json!({
+        "filePath": target.to_str().expect("utf8 path"),
+        "oldString": "before hook",
+        "newString": "after hook",
+        "originalFile": original_text,
+        "userModified": false,
+        "replaceAll": false,
+    })
+    .to_string();
+    let polluted = format!("{edit_json}\n\nHook feedback:\nformatter clean");
+
+    let session_path = temp_dir.join("session.jsonl");
+    let mut session = workspace_session(&temp_dir).with_persistence_path(&session_path);
+    session
+        .push_message(ConversationMessage {
+            role: MessageRole::User,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: "tool-hook-1".into(),
+                tool_name: "edit_file".into(),
+                output: polluted,
+                is_error: false,
+            }],
+            usage: None,
+            model: None,
+        })
+        .expect("tool_result persisted");
+
+    // when
+    let output = run_scode(
+        &temp_dir,
+        &[
+            "--resume",
+            session_path.to_str().expect("utf8 path"),
+            "/undo",
+        ],
+    );
+
+    // then
+    assert!(
+        output.status.success(),
+        "scode failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(fs::read_to_string(&target).unwrap(), original_text);
+}
+
+#[test]
+fn resumed_undo_emits_structured_json_when_requested() {
+    let temp_dir = unique_temp_dir("undo-json");
+    fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let target = temp_dir.join("structured.txt");
+    let original_text = "lhs\n";
+    let edited_text = "rhs\n";
+    fs::write(&target, edited_text).expect("seed file");
+
+    let payload = serde_json::json!({
+        "filePath": target.to_str().expect("utf8 path"),
+        "oldString": "lhs",
+        "newString": "rhs",
+        "originalFile": original_text,
+        "userModified": false,
+        "replaceAll": false,
+    })
+    .to_string();
+
+    let session_path = temp_dir.join("session.jsonl");
+    let mut session = workspace_session(&temp_dir).with_persistence_path(&session_path);
+    session
+        .push_message(ConversationMessage {
+            role: MessageRole::User,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: "tool-json-1".into(),
+                tool_name: "edit_file".into(),
+                output: payload,
+                is_error: false,
+            }],
+            usage: None,
+            model: None,
+        })
+        .expect("tool_result persisted");
+
+    let output = run_scode(
+        &temp_dir,
+        &[
+            "--output-format",
+            "json",
+            "--resume",
+            session_path.to_str().expect("utf8 path"),
+            "/undo",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "scode failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let parsed: Value = serde_json::from_str(stdout.trim()).expect("json output");
+    assert_eq!(parsed["kind"], "undo");
+    assert_eq!(parsed["applied"], true);
+    assert_eq!(parsed["tool_name"], "edit_file");
+    assert_eq!(parsed["tool_use_id"], "tool-json-1");
+    assert_eq!(parsed["deleted"], false);
+    assert_eq!(parsed["file_path"], target.to_str().expect("utf8 path"));
+    assert_eq!(fs::read_to_string(&target).unwrap(), original_text);
+}
+
+fn run_scode(current_dir: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_scode"));
+    command.current_dir(current_dir).args(args);
+    command.output().expect("scode should launch")
+}
+
+fn workspace_session(root: &Path) -> Session {
+    Session::new().with_workspace_root(root.to_path_buf())
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_millis();
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "scode-{label}-{}-{millis}-{counter}",
+        std::process::id()
+    ))
+}


### PR DESCRIPTION
## Summary

Closes the three CLI-side spikes from #179 §3 (S1 / S2 / S3) and lands
the follow-up work that the findings unblocked. CLI-only — no schema
changes to `tools::EditFile` / `WriteFile` ToolResult.

- **Spike report** (`rust/SPIKE-179-s1-s2-s3.md`) — citation-driven
  answers for S1 (diff display), S2 (`/search` scope — flagged as a
  product decision, **not implemented**), S3 (`/undo` round-trip).
- **Bug fix:** `merge_hook_feedback` appends `"\n\nHook feedback:\n…"`
  to ToolResult outputs, which broke `serde_json::from_str` in
  `format_tool_result` and silently disabled the structured edit / write
  / read preview whenever any pre/post hook emitted text. New
  `split_hook_feedback` helper strips the suffix before parsing and
  renders the feedback as a trailing dim line.
- **Feature: diff-aware `edit_file` / `write_file` display.** Replaces
  the degenerate all-`-`-then-all-`+` `structuredPatch` dump with a
  proper context-windowed hunk built from `originalFile` plus
  `oldString` / `newString` (edit) or `originalFile` vs `content`
  (write). 3 lines of context, body collapses past 8 per side, mid-line
  substring matches widen out to whole-line boundaries (regression
  caught during manual visual inspection — see commit `45a8f96`).
- **Feature: `/undo` slash command.** Walks the live session
  newest-first, finds the most recent successful `edit_file` /
  `write_file` ToolResult, restores `originalFile` to disk (or deletes
  the file if `write_file` originally created it). Works in both
  interactive REPL and `--resume` non-interactive modes; emits text and
  structured JSON output.

S2 is **intentionally not implemented** — the report enumerates five
scope options for the maintainer to pick from before any storage design
starts.

## Manual verification

Both debug and release binaries hand-driven:

| Case | Result |
|---|---|
| `/undo` on `edit_file` (debug + release) | file restored; `Restored …` message |
| `/undo` on `write_file` create | file deleted; `Deleted …` message |
| `/undo` on empty session | friendly `Nothing to undo` message |
| `/undo` twice on same edit | first restores, second reports `Already absent` |
| `/undo --output-format json` | structured `{kind:"undo", applied, tool_name, …}` |
| Diff preview rendering | 4 ANSI samples eyeballed via `PREVIEW_render_samples_for_manual_inspection` — caught and fixed substring-match bug |
| Release build | `cargo build --release` clean (~5m27s) |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --workspace` (17 new unit tests + 5 new e2e tests all pass; pre-existing `mcp_stdio` test is flaky under parallel load — verified unrelated via `git stash`)
- [x] `cargo build --release`
- [x] Hand-smoked `/undo` against debug binary
- [x] Hand-smoked `/undo` against release binary
- [x] Hand-inspected ANSI output of diff preview via the `#[ignore]`'d `PREVIEW_render_samples_for_manual_inspection` test
- [ ] Reviewer to confirm S2 scope decision before any `/search` work is scheduled
- [ ] Reviewer to decide whether `/undo` should survive `/compact` — currently it does not, see SPIKE §S3 "Recommended next step"

🤖 Generated with [Claude Code](https://claude.com/claude-code)