### PR TITLE
feat: propagate usage cost units

### DIFF
--- a/rust/crates/api/src/prompt_cache.rs
+++ b/rust/crates/api/src/prompt_cache.rs
@@ -540,6 +540,7 @@ mod tests {
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 6_000,
                 output_tokens: 0,
+                ..Usage::default()
             },
         );
         let current = TrackedPromptState::from_usage(
@@ -549,6 +550,7 @@ mod tests {
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 1_000,
                 output_tokens: 0,
+                ..Usage::default()
             },
         );
         let event = detect_cache_break(&PromptCacheConfig::default(), Some(&previous), &current)
@@ -568,6 +570,7 @@ mod tests {
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 6_000,
                 output_tokens: 0,
+                ..Usage::default()
             },
         );
         let current = TrackedPromptState::from_usage(
@@ -577,6 +580,7 @@ mod tests {
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 1_000,
                 output_tokens: 0,
+                ..Usage::default()
             },
         );
         let event = detect_cache_break(&PromptCacheConfig::default(), Some(&previous), &current)
@@ -728,6 +732,7 @@ mod tests {
                 cache_creation_input_tokens: 5,
                 cache_read_input_tokens,
                 output_tokens,
+                ..Usage::default()
             },
             request_id: Some("req_test".to_string()),
         }

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -904,12 +904,14 @@ impl MessageStream {
                                 .client_request_id
                                 .clone()
                                 .unwrap_or_else(|| "unknown".to_string());
-                            tracer.record_usage(
+                            tracer.record_usage_with_cost(
                                 request_id,
                                 usage.input_tokens,
                                 usage.output_tokens,
                                 usage.cache_creation_input_tokens,
                                 usage.cache_read_input_tokens,
+                                usage.cost_units,
+                                usage.cost_currency.as_deref(),
                             );
                         }
                     }

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -667,6 +667,7 @@ impl StreamState {
                             as u32,
                         cache_creation_input_tokens: 0,
                         cache_read_input_tokens: 0,
+                        ..Usage::default()
                     });
                 }
                 self.stop_reason = Some(if self.tool_blocks.is_empty() {

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -912,6 +912,7 @@ impl StreamState {
                 output_tokens,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
+                ..Usage::default()
             });
         }
 

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -214,9 +214,26 @@ impl OpenAiCompatClient {
         let payload = serde_json::from_str::<ChatCompletionResponse>(&body).map_err(|error| {
             ApiError::json_deserialize(self.config.provider_name, &request.model, &body, error)
         })?;
+        let has_usage = payload.usage.is_some();
         let mut normalized = normalize_response(&request.model, payload)?;
         if normalized.request_id.is_none() {
             normalized.request_id = request_id;
+        }
+        if has_usage {
+            if let Some(tracer) = self.session_tracer() {
+                tracer.record_usage_with_cost(
+                    normalized
+                        .request_id
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    normalized.usage.input_tokens,
+                    normalized.usage.output_tokens,
+                    normalized.usage.cache_creation_input_tokens,
+                    normalized.usage.cache_read_input_tokens,
+                    normalized.usage.cost_units,
+                    normalized.usage.cost_currency.as_deref(),
+                );
+            }
         }
         Ok(normalized)
     }
@@ -236,6 +253,8 @@ impl OpenAiCompatClient {
             parser: OpenAiSseParser::with_context(self.config.provider_name, request.model.clone()),
             pending: VecDeque::new(),
             done: false,
+            usage_recorded: false,
+            session_tracer: self.session_tracer().cloned(),
             state: StreamState::new(request.model.clone()),
         })
     }
@@ -313,6 +332,8 @@ pub struct MessageStream {
     parser: OpenAiSseParser,
     pending: VecDeque<StreamEvent>,
     done: bool,
+    usage_recorded: bool,
+    session_tracer: Option<telemetry::SessionTracer>,
     state: StreamState,
 }
 
@@ -330,6 +351,7 @@ impl MessageStream {
 
             if self.done {
                 self.pending.extend(self.state.finish()?);
+                self.record_usage_once();
                 if let Some(event) = self.pending.pop_front() {
                     return Ok(Some(event));
                 }
@@ -347,6 +369,30 @@ impl MessageStream {
                 }
             }
         }
+    }
+
+    fn record_usage_once(&mut self) {
+        if self.usage_recorded {
+            return;
+        }
+        self.usage_recorded = true;
+        let Some(usage) = self.state.usage.as_ref() else {
+            return;
+        };
+        let Some(tracer) = &self.session_tracer else {
+            return;
+        };
+        tracer.record_usage_with_cost(
+            self.request_id
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cache_creation_input_tokens,
+            usage.cache_read_input_tokens,
+            usage.cost_units,
+            usage.cost_currency.as_deref(),
+        );
     }
 }
 
@@ -430,6 +476,8 @@ impl StreamState {
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: usage.prompt_tokens_details.cached_tokens,
                 output_tokens: usage.completion_tokens,
+                cost_units: usage.cost_units,
+                cost_currency: usage.cost_currency,
             });
         }
 
@@ -589,6 +637,8 @@ impl StreamState {
                     cache_creation_input_tokens: 0,
                     cache_read_input_tokens: 0,
                     output_tokens: 0,
+                    cost_units: None,
+                    cost_currency: None,
                 }),
             }));
             events.push(StreamEvent::MessageStop(MessageStopEvent {}));
@@ -618,6 +668,8 @@ impl StreamState {
                     cache_creation_input_tokens: 0,
                     cache_read_input_tokens: 0,
                     output_tokens: 0,
+                    cost_units: None,
+                    cost_currency: None,
                 },
                 request_id: None,
             },
@@ -763,6 +815,10 @@ struct OpenAiUsage {
     /// Example: `{"prompt_tokens_details": {"cached_tokens": 1234}}`
     #[serde(default)]
     prompt_tokens_details: PromptTokensDetails,
+    #[serde(default)]
+    cost_units: Option<u64>,
+    #[serde(default)]
+    cost_currency: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1351,6 +1407,11 @@ fn normalize_response(
                 .usage
                 .as_ref()
                 .map_or(0, |usage| usage.completion_tokens),
+            cost_units: response.usage.as_ref().and_then(|usage| usage.cost_units),
+            cost_currency: response
+                .usage
+                .as_ref()
+                .and_then(|usage| usage.cost_currency.clone()),
         },
         request_id: None,
     })
@@ -1661,6 +1722,86 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn non_streaming_response_preserves_cost_usage_fields() {
+        let response = super::ChatCompletionResponse {
+            id: "chatcmpl_cost".to_string(),
+            model: "sudorouter-model".to_string(),
+            choices: vec![super::ChatChoice {
+                message: super::ChatMessage {
+                    role: "assistant".to_string(),
+                    content: Some("final answer".to_string()),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: Some(super::OpenAiUsage {
+                prompt_tokens: 10,
+                completion_tokens: 4,
+                prompt_tokens_details: super::PromptTokensDetails { cached_tokens: 3 },
+                cost_units: Some(43_700),
+                cost_currency: Some("sudo_point".to_string()),
+            }),
+        };
+
+        let normalized = normalize_response("sudorouter-model", response).expect("normalized");
+
+        assert_eq!(normalized.usage.input_tokens, 10);
+        assert_eq!(normalized.usage.output_tokens, 4);
+        assert_eq!(normalized.usage.cache_read_input_tokens, 3);
+        assert_eq!(normalized.usage.cost_units, Some(43_700));
+        assert_eq!(
+            normalized.usage.cost_currency.as_deref(),
+            Some("sudo_point")
+        );
+    }
+
+    #[test]
+    fn streaming_usage_chunk_preserves_cost_usage_fields() {
+        let mut state = StreamState::new("sudorouter-model".to_string());
+        let _ = state
+            .ingest_chunk(super::ChatCompletionChunk {
+                id: "chatcmpl_stream_cost".to_string(),
+                model: Some("sudorouter-model".to_string()),
+                choices: vec![super::ChunkChoice {
+                    delta: super::ChunkDelta {
+                        content: Some("answer".to_string()),
+                        reasoning_content: None,
+                        tool_calls: Vec::new(),
+                    },
+                    finish_reason: None,
+                }],
+                usage: None,
+            })
+            .expect("text chunk");
+        let _ = state
+            .ingest_chunk(super::ChatCompletionChunk {
+                id: "chatcmpl_stream_cost".to_string(),
+                model: None,
+                choices: Vec::new(),
+                usage: Some(super::OpenAiUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 4,
+                    prompt_tokens_details: super::PromptTokensDetails { cached_tokens: 3 },
+                    cost_units: Some(43_700),
+                    cost_currency: Some("sudo_point".to_string()),
+                }),
+            })
+            .expect("usage chunk");
+        let events = state.finish().expect("finish");
+
+        let usage = events
+            .iter()
+            .find_map(|event| match event {
+                StreamEvent::MessageDelta(delta) => Some(&delta.usage),
+                _ => None,
+            })
+            .expect("message delta usage");
+        assert_eq!(usage.cost_units, Some(43_700));
+        assert_eq!(usage.cost_currency.as_deref(), Some("sudo_point"));
     }
 
     #[test]

--- a/rust/crates/api/src/sse.rs
+++ b/rust/crates/api/src/sse.rs
@@ -208,6 +208,7 @@ mod tests {
                         cache_creation_input_tokens: 0,
                         cache_read_input_tokens: 0,
                         output_tokens: 2,
+                        ..Usage::default()
                     },
                 }),
                 StreamEvent::MessageStop(crate::types::MessageStopEvent {}),

--- a/rust/crates/api/src/types.rs
+++ b/rust/crates/api/src/types.rs
@@ -1,4 +1,4 @@
-use runtime::{pricing_for_model, TokenUsage, UsageCostEstimate};
+use runtime::{parse_usage_cost_currency, pricing_for_model, TokenUsage, UsageCostEstimate};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -220,6 +220,10 @@ pub struct Usage {
     pub cache_read_input_tokens: u32,
     #[serde(default)]
     pub output_tokens: u32,
+    #[serde(default)]
+    pub cost_units: Option<u64>,
+    #[serde(default)]
+    pub cost_currency: Option<String>,
 }
 
 impl Usage {
@@ -232,12 +236,14 @@ impl Usage {
     }
 
     #[must_use]
-    pub const fn token_usage(&self) -> TokenUsage {
+    pub fn token_usage(&self) -> TokenUsage {
         TokenUsage {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             cache_creation_input_tokens: self.cache_creation_input_tokens,
             cache_read_input_tokens: self.cache_read_input_tokens,
+            cost_units: self.cost_units,
+            cost_currency: parse_usage_cost_currency(self.cost_currency.as_deref()),
         }
     }
 
@@ -313,7 +319,7 @@ pub enum StreamEvent {
 
 #[cfg(test)]
 mod tests {
-    use runtime::format_usd;
+    use runtime::{format_usd, UsageCostCurrency};
 
     use super::{MessageResponse, Usage};
 
@@ -324,6 +330,7 @@ mod tests {
             cache_creation_input_tokens: 2,
             cache_read_input_tokens: 3,
             output_tokens: 4,
+            ..Usage::default()
         };
 
         assert_eq!(usage.total_tokens(), 19);
@@ -345,6 +352,7 @@ mod tests {
                 cache_creation_input_tokens: 100_000,
                 cache_read_input_tokens: 200_000,
                 output_tokens: 500_000,
+                ..Usage::default()
             },
             request_id: None,
         };
@@ -352,5 +360,54 @@ mod tests {
         let cost = response.usage.estimated_cost_usd(&response.model);
         assert_eq!(format_usd(cost.total_cost_usd()), "$54.6750");
         assert_eq!(response.total_tokens(), 1_800_000);
+    }
+
+    #[test]
+    fn usage_deserializes_cost_fields() {
+        let usage: Usage = serde_json::from_value(serde_json::json!({
+            "input_tokens": 10,
+            "output_tokens": 4,
+            "cost_units": 43700,
+            "cost_currency": "sudo_point"
+        }))
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.cost_units, Some(43_700));
+        assert_eq!(usage.cost_currency.as_deref(), Some("sudo_point"));
+        let token_usage = usage.token_usage();
+        assert_eq!(token_usage.cost_units, Some(43_700));
+        assert_eq!(
+            token_usage.cost_currency,
+            Some(UsageCostCurrency::SudoPoint)
+        );
+    }
+
+    #[test]
+    fn usage_deserializes_missing_cost_as_none() {
+        let usage: Usage = serde_json::from_value(serde_json::json!({
+            "input_tokens": 10,
+            "output_tokens": 4
+        }))
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.cost_units, None);
+        assert_eq!(usage.cost_currency, None);
+        assert_eq!(usage.token_usage().cost_currency, None);
+    }
+
+    #[test]
+    fn usage_preserves_but_does_not_accept_unknown_currency_for_token_usage() {
+        let usage: Usage = serde_json::from_value(serde_json::json!({
+            "input_tokens": 10,
+            "output_tokens": 4,
+            "cost_units": 43700,
+            "cost_currency": "usd"
+        }))
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.cost_units, Some(43_700));
+        assert_eq!(usage.cost_currency.as_deref(), Some("usd"));
+        assert_eq!(usage.token_usage().cost_units, Some(43_700));
+        assert_eq!(usage.token_usage().cost_currency, None);
     }
 }

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -737,6 +737,7 @@ fn text_message_response(id: &str, text: &str) -> MessageResponse {
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
             output_tokens: 6,
+            ..Usage::default()
         },
         request_id: None,
     }
@@ -763,6 +764,7 @@ fn text_message_response_with_usage(
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
             output_tokens,
+            ..Usage::default()
         },
         request_id: None,
     }
@@ -812,6 +814,7 @@ fn tool_message_response_many(id: &str, tool_uses: &[ToolUseMessage<'_>]) -> Mes
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
             output_tokens: 3,
+            ..Usage::default()
         },
         request_id: None,
     }

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -19,6 +19,7 @@ use crate::permissions::{
     PermissionMode, PermissionPromptDecision, PermissionPrompter, PermissionRequest,
     QuestionPromptAnswer, QuestionPromptRequest, QuestionPrompter,
 };
+use crate::usage::UsageCostCurrency;
 use agent_client_protocol::{
     on_receive_dispatch, on_receive_notification, on_receive_request, ConnectTo, ConnectionTo,
     Dispatch, Error, Handled, JsonRpcRequest, JsonRpcResponse, Responder,
@@ -371,6 +372,8 @@ pub struct PromptUsage {
     pub cache_write_tokens: Option<u64>,
     pub context_window_tokens: Option<u64>,
     pub estimated_session_tokens: Option<u64>,
+    pub cost_units: Option<u64>,
+    pub cost_currency: Option<UsageCostCurrency>,
     /// Cumulative usage for the entire session, exposed via _meta.sudocode.cumulativeUsage
     pub cumulative_usage: Option<CumulativeUsage>,
 }
@@ -383,6 +386,73 @@ pub struct CumulativeUsage {
     pub total_tokens: u64,
     pub cached_read_tokens: Option<u64>,
     pub cached_write_tokens: Option<u64>,
+}
+
+fn sudocode_meta_from_prompt_usage(u: &PromptUsage) -> Map<String, serde_json::Value> {
+    let mut sudocode_meta = Map::new();
+    sudocode_meta.insert(
+        "contextWindowTokens".to_string(),
+        json!(u.context_window_tokens),
+    );
+    sudocode_meta.insert(
+        "estimatedSessionTokens".to_string(),
+        json!(u.estimated_session_tokens),
+    );
+    if let Some(cost_units) = u.cost_units {
+        sudocode_meta.insert("costUnits".to_string(), json!(cost_units));
+    }
+    if let Some(cost_currency) = u.cost_currency {
+        sudocode_meta.insert("costCurrency".to_string(), json!(cost_currency.as_str()));
+    }
+    if let Some(cumulative) = &u.cumulative_usage {
+        sudocode_meta.insert(
+            "cumulativeUsage".to_string(),
+            json!({
+                "inputTokens": cumulative.input_tokens,
+                "outputTokens": cumulative.output_tokens,
+                "totalTokens": cumulative.total_tokens,
+                "cachedReadTokens": cumulative.cached_read_tokens,
+                "cachedWriteTokens": cumulative.cached_write_tokens,
+            }),
+        );
+    }
+    sudocode_meta
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sudocode_meta_from_prompt_usage, CumulativeUsage, PromptUsage};
+    use crate::usage::UsageCostCurrency;
+
+    #[test]
+    fn prompt_usage_meta_includes_cost_without_standard_usage_tokens() {
+        let meta = sudocode_meta_from_prompt_usage(&PromptUsage {
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14,
+            cache_read_tokens: Some(3),
+            cache_write_tokens: Some(0),
+            context_window_tokens: Some(200_000),
+            estimated_session_tokens: Some(42),
+            cost_units: Some(43_700),
+            cost_currency: Some(UsageCostCurrency::SudoPoint),
+            cumulative_usage: Some(CumulativeUsage {
+                input_tokens: 10,
+                output_tokens: 4,
+                total_tokens: 14,
+                cached_read_tokens: Some(3),
+                cached_write_tokens: Some(0),
+            }),
+        });
+
+        assert_eq!(meta["costUnits"], serde_json::json!(43_700));
+        assert_eq!(meta["costCurrency"], serde_json::json!("sudo_point"));
+        assert!(meta.get("totalTokens").is_none());
+        assert_eq!(
+            meta["cumulativeUsage"]["totalTokens"],
+            serde_json::json!(14)
+        );
+    }
 }
 
 /// Thread-safe handle to a delegate, shared across async handlers.
@@ -960,28 +1030,7 @@ pub(crate) async fn run_acp_on_transport(
                             Ok((stop_reason, prompt_usage)) => {
                                 let mut response = PromptResponse::new(stop_reason);
                                 if let Some(u) = prompt_usage {
-                                    let mut sudocode_meta = Map::new();
-                                    sudocode_meta.insert(
-                                        "contextWindowTokens".to_string(),
-                                        json!(u.context_window_tokens),
-                                    );
-                                    sudocode_meta.insert(
-                                        "estimatedSessionTokens".to_string(),
-                                        json!(u.estimated_session_tokens),
-                                    );
-                                    // Add cumulativeUsage for clients that need session totals
-                                    if let Some(cumulative) = &u.cumulative_usage {
-                                        sudocode_meta.insert(
-                                            "cumulativeUsage".to_string(),
-                                            json!({
-                                                "inputTokens": cumulative.input_tokens,
-                                                "outputTokens": cumulative.output_tokens,
-                                                "totalTokens": cumulative.total_tokens,
-                                                "cachedReadTokens": cumulative.cached_read_tokens,
-                                                "cachedWriteTokens": cumulative.cached_write_tokens,
-                                            }),
-                                        );
-                                    }
+                                    let sudocode_meta = sudocode_meta_from_prompt_usage(&u);
                                     let mut meta = Map::new();
                                     meta.insert("sudocode".to_string(), json!(sudocode_meta));
                                     response = response.usage(

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -18,7 +18,7 @@ use crate::permissions::{
 };
 use crate::prompt::SystemPrompt;
 use crate::session::{ContentBlock, ConversationMessage, Session};
-use crate::usage::{TokenUsage, UsageTracker};
+use crate::usage::{TokenUsage, UsageAggregation, UsageTracker};
 
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 100_000;
 const AUTO_COMPACTION_THRESHOLD_ENV_VAR: &str = "CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS";
@@ -1439,13 +1439,13 @@ fn build_assistant_message(
 /// Sums the token usage from all assistant messages in a turn.
 /// Each assistant message carries the usage from one model request.
 fn sum_assistant_message_usage(messages: &[ConversationMessage]) -> TokenUsage {
-    let mut total = TokenUsage::default();
+    let mut total = UsageAggregation::default();
     for message in messages {
         if let Some(usage) = message.usage {
-            total.add_assign_usage(usage);
+            total.push(usage);
         }
     }
-    total
+    total.finish()
 }
 
 fn has_pending_tool_uses(message: &ConversationMessage) -> bool {
@@ -1642,7 +1642,7 @@ mod tests {
     };
     use crate::prompt::{ProjectContext, SystemPrompt, SystemPromptBuilder};
     use crate::session::{ContentBlock, MessageRole, Session};
-    use crate::usage::TokenUsage;
+    use crate::usage::{TokenUsage, UsageCostCurrency};
     use crate::ToolError;
     use async_trait::async_trait;
     use std::fs;
@@ -1686,6 +1686,7 @@ mod tests {
                             output_tokens: 6,
                             cache_creation_input_tokens: 1,
                             cache_read_input_tokens: 2,
+                            ..TokenUsage::default()
                         }),
                         AssistantEvent::MessageStop,
                     ]))
@@ -1703,6 +1704,7 @@ mod tests {
                             output_tokens: 4,
                             cache_creation_input_tokens: 1,
                             cache_read_input_tokens: 3,
+                            ..TokenUsage::default()
                         }),
                         AssistantEvent::PromptCache(PromptCacheEvent {
                             unexpected: true,
@@ -1972,6 +1974,7 @@ mod tests {
                                 output_tokens: 0,
                                 cache_creation_input_tokens: 0,
                                 cache_read_input_tokens: 0,
+                                ..TokenUsage::default()
                             }),
                             AssistantEvent::MessageStop,
                         ]))
@@ -2706,6 +2709,7 @@ mod tests {
                     output_tokens: 7,
                     cache_creation_input_tokens: 2,
                     cache_read_input_tokens: 1,
+                    ..TokenUsage::default()
                 }),
             ));
 
@@ -2867,6 +2871,7 @@ mod tests {
                         output_tokens: 4,
                         cache_creation_input_tokens: 0,
                         cache_read_input_tokens: 0,
+                        ..TokenUsage::default()
                     }),
                     AssistantEvent::MessageStop,
                 ]))
@@ -2924,6 +2929,7 @@ mod tests {
                         output_tokens: 4,
                         cache_creation_input_tokens: 0,
                         cache_read_input_tokens: 0,
+                        ..TokenUsage::default()
                     }),
                     AssistantEvent::MessageStop,
                 ]))
@@ -3456,6 +3462,8 @@ mod tests {
                                 output_tokens: 50,
                                 cache_creation_input_tokens: 10,
                                 cache_read_input_tokens: 20,
+                                cost_units: Some(1_000),
+                                cost_currency: Some(UsageCostCurrency::SudoPoint),
                             }),
                             AssistantEvent::MessageStop,
                         ]))
@@ -3474,6 +3482,8 @@ mod tests {
                                 output_tokens: 30,
                                 cache_creation_input_tokens: 5,
                                 cache_read_input_tokens: 15,
+                                cost_units: Some(2_000),
+                                cost_currency: Some(UsageCostCurrency::SudoPoint),
                             }),
                             AssistantEvent::MessageStop,
                         ]))
@@ -3515,6 +3525,11 @@ mod tests {
             "cache_read should be 20 + 15"
         );
         assert_eq!(summary.turn_usage.total_tokens(), 430);
+        assert_eq!(summary.turn_usage.cost_units, Some(3_000));
+        assert_eq!(
+            summary.turn_usage.cost_currency,
+            Some(UsageCostCurrency::SudoPoint)
+        );
 
         // For first turn, session_usage should equal turn_usage
         assert_eq!(
@@ -3528,5 +3543,65 @@ mod tests {
             summary.session_usage,
             "runtime cumulative usage should match session_usage"
         );
+    }
+
+    #[test]
+    fn turn_usage_omits_cost_when_any_usage_lacks_cost() {
+        let messages = vec![
+            crate::session::ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "first".to_string(),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cache_creation_input_tokens: 10,
+                    cache_read_input_tokens: 20,
+                    cost_units: Some(1_000),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
+                }),
+            ),
+            crate::session::ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "second".to_string(),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 200,
+                    output_tokens: 30,
+                    cache_creation_input_tokens: 5,
+                    cache_read_input_tokens: 15,
+                    ..TokenUsage::default()
+                }),
+            ),
+        ];
+
+        let usage = super::sum_assistant_message_usage(&messages);
+
+        assert_eq!(usage.total_tokens(), 430);
+        assert_eq!(usage.cost_units, None);
+        assert_eq!(usage.cost_currency, None);
+    }
+
+    #[test]
+    fn turn_usage_preserves_zero_cost() {
+        let messages = vec![crate::session::ConversationMessage::assistant_with_usage(
+            vec![ContentBlock::Text {
+                text: "free".to_string(),
+            }],
+            Some(TokenUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_creation_input_tokens: 10,
+                cache_read_input_tokens: 20,
+                cost_units: Some(0),
+                cost_currency: Some(UsageCostCurrency::SudoPoint),
+            }),
+        )];
+
+        let usage = super::sum_assistant_message_usage(&messages);
+
+        assert_eq!(usage.total_tokens(), 180);
+        assert_eq!(usage.cost_units, Some(0));
+        assert_eq!(usage.cost_currency, Some(UsageCostCurrency::SudoPoint));
     }
 }

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -198,7 +198,8 @@ pub use time::today_local;
 #[cfg(test)]
 pub use trust_resolver::{TrustConfig, TrustDecision, TrustEvent, TrustPolicy, TrustResolver};
 pub use usage::{
-    format_usd, pricing_for_model, ModelPricing, TokenUsage, UsageCostEstimate, UsageTracker,
+    format_usd, parse_usage_cost_currency, pricing_for_model, ModelPricing, TokenUsage,
+    UsageCostCurrency, UsageCostEstimate, UsageTracker,
 };
 pub use worker_boot::{
     Worker, WorkerEvent, WorkerEventKind, WorkerEventPayload, WorkerFailure, WorkerFailureKind,

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::fs_backend::{FsBackend, StdFsBackend};
 use crate::json::{JsonError, JsonValue};
-use crate::usage::TokenUsage;
+use crate::usage::{parse_usage_cost_currency, TokenUsage};
 
 const SESSION_VERSION: u32 = 1;
 const ROTATE_AFTER_BYTES: u64 = 256 * 1024;
@@ -1077,6 +1077,15 @@ fn usage_to_json(usage: TokenUsage) -> JsonValue {
         "cache_read_input_tokens".to_string(),
         JsonValue::Number(i64::from(usage.cache_read_input_tokens)),
     );
+    if let Some(cost_units) = usage.cost_units.and_then(|value| i64::try_from(value).ok()) {
+        object.insert("cost_units".to_string(), JsonValue::Number(cost_units));
+    }
+    if let Some(cost_currency) = usage.cost_currency {
+        object.insert(
+            "cost_currency".to_string(),
+            JsonValue::String(cost_currency.as_str().to_string()),
+        );
+    }
     JsonValue::Object(object)
 }
 
@@ -1089,7 +1098,26 @@ fn usage_from_json(value: &JsonValue) -> Result<TokenUsage, SessionError> {
         output_tokens: required_u32(object, "output_tokens")?,
         cache_creation_input_tokens: required_u32(object, "cache_creation_input_tokens")?,
         cache_read_input_tokens: required_u32(object, "cache_read_input_tokens")?,
+        cost_units: optional_u64(object, "cost_units")?,
+        cost_currency: parse_usage_cost_currency(
+            optional_string(object, "cost_currency")?.as_deref(),
+        ),
     })
+}
+
+fn optional_string(
+    object: &BTreeMap<String, JsonValue>,
+    key: &str,
+) -> Result<Option<String>, SessionError> {
+    object
+        .get(key)
+        .map(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| SessionError::Format(format!("{key} must be a string")))
+        })
+        .transpose()
 }
 
 fn required_string(
@@ -1116,6 +1144,16 @@ fn required_u64(object: &BTreeMap<String, JsonValue>, key: &str) -> Result<u64, 
         .get(key)
         .ok_or_else(|| SessionError::Format(format!("missing {key}")))?;
     required_u64_from_value(value, key)
+}
+
+fn optional_u64(
+    object: &BTreeMap<String, JsonValue>,
+    key: &str,
+) -> Result<Option<u64>, SessionError> {
+    object
+        .get(key)
+        .map(|value| required_u64_from_value(value, key))
+        .transpose()
 }
 
 fn required_u64_from_value(value: &JsonValue, key: &str) -> Result<u64, SessionError> {
@@ -1306,7 +1344,7 @@ mod tests {
         ConversationMessage, MessageRole, Session, SessionFork,
     };
     use crate::json::JsonValue;
-    use crate::usage::TokenUsage;
+    use crate::usage::{TokenUsage, UsageCostCurrency, UsageTracker};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1345,6 +1383,8 @@ mod tests {
                     output_tokens: 4,
                     cache_creation_input_tokens: 1,
                     cache_read_input_tokens: 2,
+                    cost_units: Some(43_700),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
                 }),
             ))
             .expect("assistant message should append");
@@ -1365,7 +1405,40 @@ mod tests {
             restored.messages[1].usage.expect("usage").total_tokens(),
             17
         );
+        assert_eq!(
+            restored.messages[1].usage.expect("usage").cost_units,
+            Some(43_700)
+        );
+        assert_eq!(
+            restored.messages[1].usage.expect("usage").cost_currency,
+            Some(UsageCostCurrency::SudoPoint)
+        );
+        assert_eq!(
+            UsageTracker::from_session(&restored)
+                .cumulative_usage()
+                .cost_units,
+            Some(43_700)
+        );
         assert_eq!(restored.session_id, session.session_id);
+    }
+
+    #[test]
+    fn loads_jsonl_usage_without_cost_fields() {
+        let path = write_temp_session_file(
+            "legacy-usage",
+            concat!(
+                "{\"type\":\"session_meta\",\"version\":1,\"session_id\":\"legacy-usage\",\"created_at_ms\":1,\"updated_at_ms\":1}\n",
+                "{\"type\":\"message\",\"message\":{\"role\":\"assistant\",\"blocks\":[{\"type\":\"text\",\"text\":\"old\"}],\"usage\":{\"input_tokens\":10,\"output_tokens\":4,\"cache_creation_input_tokens\":1,\"cache_read_input_tokens\":2}}}\n"
+            ),
+        );
+
+        let restored = Session::load_from_path(&path).expect("legacy usage session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+        let usage = restored.messages[0].usage.expect("usage");
+
+        assert_eq!(usage.total_tokens(), 17);
+        assert_eq!(usage.cost_units, None);
+        assert_eq!(usage.cost_currency, None);
     }
 
     #[test]

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -33,6 +33,87 @@ pub struct TokenUsage {
     pub output_tokens: u32,
     pub cache_creation_input_tokens: u32,
     pub cache_read_input_tokens: u32,
+    pub cost_units: Option<u64>,
+    pub cost_currency: Option<UsageCostCurrency>,
+}
+
+/// Controlled set of cost currencies accepted from provider usage payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageCostCurrency {
+    SudoPoint,
+}
+
+impl UsageCostCurrency {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SudoPoint => "sudo_point",
+        }
+    }
+}
+
+#[must_use]
+pub fn parse_usage_cost_currency(value: Option<&str>) -> Option<UsageCostCurrency> {
+    match value {
+        Some("sudo_point") => Some(UsageCostCurrency::SudoPoint),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct UsageCostAggregation {
+    usage_count: usize,
+    cost_count: usize,
+    invalid_cost_count: usize,
+    cost_units_sum: u64,
+}
+
+impl UsageCostAggregation {
+    fn push(&mut self, usage: TokenUsage) {
+        self.usage_count += 1;
+        match (usage.cost_units, usage.cost_currency) {
+            (Some(units), Some(UsageCostCurrency::SudoPoint)) => {
+                self.cost_count += 1;
+                self.cost_units_sum = self.cost_units_sum.saturating_add(units);
+            }
+            (None, None) => {}
+            _ => {
+                self.invalid_cost_count += 1;
+            }
+        }
+    }
+
+    fn apply_to(self, usage: &mut TokenUsage) {
+        if self.usage_count > 0
+            && self.cost_count == self.usage_count
+            && self.invalid_cost_count == 0
+        {
+            usage.cost_units = Some(self.cost_units_sum);
+            usage.cost_currency = Some(UsageCostCurrency::SudoPoint);
+        } else {
+            usage.cost_units = None;
+            usage.cost_currency = None;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct UsageAggregation {
+    total: TokenUsage,
+    cost: UsageCostAggregation,
+}
+
+impl UsageAggregation {
+    pub(crate) fn push(&mut self, usage: TokenUsage) {
+        self.total.add_assign_token_counts(usage);
+        self.cost.push(usage);
+    }
+
+    #[must_use]
+    pub(crate) fn finish(mut self) -> TokenUsage {
+        self.cost.apply_to(&mut self.total);
+        self.total
+    }
 }
 
 /// Estimated dollar cost derived from a [`TokenUsage`] sample.
@@ -81,8 +162,13 @@ pub fn pricing_for_model(model: &str) -> Option<ModelPricing> {
 }
 
 impl TokenUsage {
-    /// Aggregates another TokenUsage into this one using saturating_add.
+    /// Aggregates another TokenUsage's token counters into this one using saturating_add.
     pub fn add_assign_usage(&mut self, other: Self) {
+        self.add_assign_token_counts(other);
+    }
+
+    /// Aggregates another TokenUsage's token counters into this one using saturating_add.
+    pub fn add_assign_token_counts(&mut self, other: Self) {
         self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
         self.cache_creation_input_tokens = self
@@ -181,6 +267,7 @@ pub fn format_usd(amount: f64) -> String {
 pub struct UsageTracker {
     latest_turn: TokenUsage,
     cumulative: TokenUsage,
+    cumulative_cost: UsageCostAggregation,
     turns: u32,
 }
 
@@ -203,11 +290,10 @@ impl UsageTracker {
 
     pub fn record(&mut self, usage: TokenUsage) {
         self.latest_turn = usage;
-        self.cumulative.input_tokens += usage.input_tokens;
-        self.cumulative.output_tokens += usage.output_tokens;
-        self.cumulative.cache_creation_input_tokens += usage.cache_creation_input_tokens;
-        self.cumulative.cache_read_input_tokens += usage.cache_read_input_tokens;
-        self.turns += 1;
+        self.cumulative.add_assign_token_counts(usage);
+        self.cumulative_cost.push(usage);
+        self.cumulative_cost.apply_to(&mut self.cumulative);
+        self.turns = self.turns.saturating_add(1);
     }
 
     #[must_use]
@@ -240,7 +326,10 @@ impl UsageTracker {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_usd, pricing_for_model, TokenUsage, UsageTracker};
+    use super::{
+        format_usd, parse_usage_cost_currency, pricing_for_model, TokenUsage, UsageCostCurrency,
+        UsageTracker,
+    };
     use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
 
     #[test]
@@ -250,12 +339,14 @@ mod tests {
             output_tokens: 2,
             cache_creation_input_tokens: 1,
             cache_read_input_tokens: 3,
+            ..TokenUsage::default()
         };
         total.add_assign_usage(TokenUsage {
             input_tokens: 20,
             output_tokens: 4,
             cache_creation_input_tokens: 2,
             cache_read_input_tokens: 6,
+            ..TokenUsage::default()
         });
 
         assert_eq!(total.input_tokens, 30);
@@ -272,12 +363,14 @@ mod tests {
             output_tokens: u32::MAX - 1,
             cache_creation_input_tokens: u32::MAX - 1,
             cache_read_input_tokens: u32::MAX - 1,
+            ..TokenUsage::default()
         };
         total.add_assign_usage(TokenUsage {
             input_tokens: 10,
             output_tokens: 10,
             cache_creation_input_tokens: 10,
             cache_read_input_tokens: 10,
+            ..TokenUsage::default()
         });
 
         // Should saturate at u32::MAX instead of wrapping
@@ -295,12 +388,16 @@ mod tests {
             output_tokens: 4,
             cache_creation_input_tokens: 2,
             cache_read_input_tokens: 1,
+            cost_units: Some(100),
+            cost_currency: Some(UsageCostCurrency::SudoPoint),
         });
         tracker.record(TokenUsage {
             input_tokens: 20,
             output_tokens: 6,
             cache_creation_input_tokens: 3,
             cache_read_input_tokens: 2,
+            cost_units: Some(200),
+            cost_currency: Some(UsageCostCurrency::SudoPoint),
         });
 
         assert_eq!(tracker.turns(), 2);
@@ -309,6 +406,64 @@ mod tests {
         assert_eq!(tracker.cumulative_usage().output_tokens, 10);
         assert_eq!(tracker.cumulative_usage().input_tokens, 30);
         assert_eq!(tracker.cumulative_usage().total_tokens(), 48);
+        assert_eq!(tracker.cumulative_usage().cost_units, Some(300));
+        assert_eq!(
+            tracker.cumulative_usage().cost_currency,
+            Some(UsageCostCurrency::SudoPoint)
+        );
+    }
+
+    #[test]
+    fn tracker_omits_cumulative_cost_after_missing_cost() {
+        let mut tracker = UsageTracker::new();
+        tracker.record(TokenUsage {
+            input_tokens: 10,
+            output_tokens: 4,
+            cache_creation_input_tokens: 2,
+            cache_read_input_tokens: 1,
+            cost_units: Some(100),
+            cost_currency: Some(UsageCostCurrency::SudoPoint),
+        });
+        tracker.record(TokenUsage {
+            input_tokens: 20,
+            output_tokens: 6,
+            cache_creation_input_tokens: 3,
+            cache_read_input_tokens: 2,
+            ..TokenUsage::default()
+        });
+
+        assert_eq!(tracker.cumulative_usage().total_tokens(), 48);
+        assert_eq!(tracker.cumulative_usage().cost_units, None);
+        assert_eq!(tracker.cumulative_usage().cost_currency, None);
+    }
+
+    #[test]
+    fn tracker_preserves_zero_cost() {
+        let mut tracker = UsageTracker::new();
+        tracker.record(TokenUsage {
+            input_tokens: 10,
+            output_tokens: 4,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            cost_units: Some(0),
+            cost_currency: Some(UsageCostCurrency::SudoPoint),
+        });
+
+        assert_eq!(tracker.cumulative_usage().cost_units, Some(0));
+        assert_eq!(
+            tracker.cumulative_usage().cost_currency,
+            Some(UsageCostCurrency::SudoPoint)
+        );
+    }
+
+    #[test]
+    fn parses_only_supported_cost_currency() {
+        assert_eq!(
+            parse_usage_cost_currency(Some("sudo_point")),
+            Some(UsageCostCurrency::SudoPoint)
+        );
+        assert_eq!(parse_usage_cost_currency(Some("usd")), None);
+        assert_eq!(parse_usage_cost_currency(None), None);
     }
 
     #[test]
@@ -318,6 +473,7 @@ mod tests {
             output_tokens: 500_000,
             cache_creation_input_tokens: 100_000,
             cache_read_input_tokens: 200_000,
+            ..TokenUsage::default()
         };
 
         let cost = usage.estimate_cost_usd();
@@ -336,6 +492,7 @@ mod tests {
             output_tokens: 500_000,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            ..TokenUsage::default()
         };
 
         let haiku = pricing_for_model("claude-haiku-4-5-20251001").expect("haiku pricing");
@@ -353,6 +510,7 @@ mod tests {
             output_tokens: 100,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            ..TokenUsage::default()
         };
         let lines = usage.summary_lines_for_model("usage", Some("custom-model"));
         assert!(lines[0].contains("pricing=estimated-default"));
@@ -371,6 +529,8 @@ mod tests {
                 output_tokens: 2,
                 cache_creation_input_tokens: 1,
                 cache_read_input_tokens: 0,
+                cost_units: Some(500),
+                cost_currency: Some(UsageCostCurrency::SudoPoint),
             }),
             model: None,
         }];

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -1453,6 +1453,7 @@ mod tests {
             output_tokens: 500,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            ..TokenUsage::default()
         };
         let rendered = format_turn_status_line_with_branch(
             "claude-opus-4-6",

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2387,6 +2387,8 @@ impl AcpSdkDelegate {
             estimated_session_tokens: Some(
                 estimate_session_tokens(session.runtime.session()) as u64
             ),
+            cost_units: u.cost_units,
+            cost_currency: u.cost_currency,
             cumulative_usage: Some(runtime::acp_sdk_server::CumulativeUsage {
                 input_tokens: u64::from(cumulative_usage.input_tokens),
                 output_tokens: u64::from(cumulative_usage.output_tokens),
@@ -2398,20 +2400,29 @@ impl AcpSdkDelegate {
         // Record token usage to telemetry log
         if let Some(tracer) = session.runtime.session_tracer() {
             // Record turn-level usage for this prompt
-            tracer.record_usage(
+            tracer.record_usage_with_cost(
                 "prompt_turn".to_string(),
                 turn_summary.turn_usage.input_tokens,
                 turn_summary.turn_usage.output_tokens,
                 turn_summary.turn_usage.cache_creation_input_tokens,
                 turn_summary.turn_usage.cache_read_input_tokens,
+                turn_summary.turn_usage.cost_units,
+                turn_summary
+                    .turn_usage
+                    .cost_currency
+                    .map(runtime::UsageCostCurrency::as_str),
             );
             // Record cumulative session usage
-            tracer.record_usage(
+            tracer.record_usage_with_cost(
                 "session_summary".to_string(),
                 cumulative_usage.input_tokens,
                 cumulative_usage.output_tokens,
                 cumulative_usage.cache_creation_input_tokens,
                 cumulative_usage.cache_read_input_tokens,
+                cumulative_usage.cost_units,
+                cumulative_usage
+                    .cost_currency
+                    .map(runtime::UsageCostCurrency::as_str),
             );
         }
         session

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -262,6 +262,10 @@ pub enum TelemetryEvent {
         output_tokens: u32,
         cache_creation_input_tokens: u32,
         cache_read_input_tokens: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cost_units: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cost_currency: Option<String>,
     },
     Analytics(AnalyticsEvent),
     SessionTrace(SessionTraceRecord),
@@ -675,6 +679,8 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
             output_tokens,
             cache_creation_input_tokens,
             cache_read_input_tokens,
+            cost_units,
+            cost_currency,
         } => {
             let mut attrs = Map::new();
             attrs.insert("request_id".to_string(), Value::String(request_id.clone()));
@@ -689,6 +695,15 @@ fn extract_event_info(event: &TelemetryEvent) -> (String, String, Map<String, Va
                 "cache_read_input_tokens".to_string(),
                 Value::from(*cache_read_input_tokens),
             );
+            if let Some(cost_units) = cost_units {
+                attrs.insert("cost_units".to_string(), Value::from(*cost_units));
+            }
+            if let Some(cost_currency) = cost_currency {
+                attrs.insert(
+                    "cost_currency".to_string(),
+                    Value::String(cost_currency.clone()),
+                );
+            }
             (session_id.clone(), "response_usage".to_string(), attrs)
         }
         TelemetryEvent::Analytics(event) => {
@@ -916,6 +931,27 @@ impl SessionTracer {
         cache_creation_input_tokens: u32,
         cache_read_input_tokens: u32,
     ) {
+        self.record_usage_with_cost(
+            request_id,
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+            None,
+            None,
+        );
+    }
+
+    pub fn record_usage_with_cost(
+        &self,
+        request_id: impl Into<String>,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_creation_input_tokens: u32,
+        cache_read_input_tokens: u32,
+        cost_units: Option<u64>,
+        cost_currency: Option<&str>,
+    ) {
         self.sink.record(TelemetryEvent::HttpResponseUsage {
             session_id: self.session_id.clone(),
             request_id: request_id.into(),
@@ -924,6 +960,8 @@ impl SessionTracer {
             output_tokens,
             cache_creation_input_tokens,
             cache_read_input_tokens,
+            cost_units,
+            cost_currency: cost_currency.map(ToOwned::to_owned),
         });
     }
 
@@ -1107,6 +1145,42 @@ mod tests {
         assert!(contents.contains("\"action\":\"turn_completed\""));
 
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn usage_log_entry_includes_cost_fields() {
+        let sink = Arc::new(MemoryTelemetrySink::default());
+        let tracer = SessionTracer::new("session-123", sink);
+
+        tracer.record_usage_with_cost(
+            "req-usage",
+            500,
+            200,
+            0,
+            100,
+            Some(43_700),
+            Some("sudo_point"),
+        );
+
+        let event = TelemetryEvent::HttpResponseUsage {
+            session_id: "session-123".to_string(),
+            request_id: "req-usage".to_string(),
+            timestamp_ms: 2000,
+            input_tokens: 500,
+            output_tokens: 200,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 100,
+            cost_units: Some(43_700),
+            cost_currency: Some("sudo_point".to_string()),
+        };
+        let entry = format_log_entry(&event);
+
+        assert_eq!(entry["event"], Value::String("response_usage".to_string()));
+        assert_eq!(entry["attributes"]["cost_units"], Value::from(43_700));
+        assert_eq!(
+            entry["attributes"]["cost_currency"],
+            Value::String("sudo_point".to_string())
+        );
     }
 
     #[test]

--- a/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
+++ b/rust/crates/telemetry/tests/sudoclaw_sink_integration.rs
@@ -103,6 +103,8 @@ fn multiple_events_in_sequence() {
         output_tokens: 200,
         cache_creation_input_tokens: 0,
         cache_read_input_tokens: 100,
+        cost_units: Some(43_700),
+        cost_currency: Some("sudo_point".to_string()),
     });
 
     sink.record(TelemetryEvent::SessionEnded {
@@ -145,6 +147,15 @@ fn multiple_events_in_sequence() {
             "response_usage",
             "session_ended"
         ]
+    );
+    let response_usage: serde_json::Value = serde_json::from_str(lines[3]).unwrap();
+    assert_eq!(
+        response_usage["attributes"]["cost_units"],
+        serde_json::json!(43_700)
+    );
+    assert_eq!(
+        response_usage["attributes"]["cost_currency"],
+        serde_json::json!("sudo_point")
     );
 
     let _ = std::fs::remove_file(path);


### PR DESCRIPTION
## Summary
- parse usage cost_units/cost_currency from OpenAI-compatible responses
- aggregate per-turn and session cost only when all usage entries have valid sudo_point cost
- persist cost in session JSONL and expose it through ACP _meta.sudocode
- include cost fields in response_usage and prompt/session usage logs

## Tests
- cargo fmt
- cargo test -p api usage
- cargo test -p runtime usage
- cargo test -p runtime session
- cargo test -p runtime conversation
- cargo test -p telemetry usage
- cargo test -p telemetry
- cargo test -p rusty-sudocode-cli