### PR TITLE
[codex] fix one-shot prompt model config

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -451,7 +451,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             };
             let effective_prompt = merge_prompt_with_stdin(&prompt, stdin_context.as_deref());
             let session_start = Instant::now();
-            let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode, auth_mode)?;
+            let resolved_model = resolve_repl_model(model);
+            let mut cli = LiveCli::new(
+                resolved_model,
+                true,
+                allowed_tools,
+                permission_mode,
+                auth_mode,
+            )?;
             cli.set_reasoning_effort(reasoning_effort);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
 


### PR DESCRIPTION
## Summary

- Resolve the one-shot prompt model through runtime config before constructing `LiveCli`.
- Makes `scode --print ...` honor `settings.json` model defaults such as `auto`, matching REPL/ACP behavior.

## Root Cause

The `CliAction::Prompt` one-shot path passed the parser-provided model directly into `LiveCli::new(...)`. When no `--model` is supplied, that value is already `DEFAULT_MODEL`, so the prompt path skipped runtime config model resolution.

## Fix

Call `resolve_repl_model(model)` before constructing `LiveCli` in the prompt branch.

## Validation

- `cargo check -p rusty-sudocode-cli --quiet`
- `cargo test -p rusty-sudocode-cli resolve_repl_model --quiet`
- `cargo run -p rusty-sudocode-cli --quiet -- --allow-broad-cwd --permission-mode read-only --print 'Reply with exactly: PATCHED_AUTO_OK'`

I reran the first two commands on this branch. `cargo check` passed with existing dead-code warnings; the focused test command exited successfully with no matching tests executed.
