### PR TITLE
fix(cli): enable Windows ANSI/VT processing before any output

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -233,7 +233,33 @@ type RuntimePluginStateBuildOutput = (
     Vec<RuntimeToolDefinition>,
 );
 
+/// Enable ANSI/VT escape-sequence processing on the Windows console.
+///
+/// Much of the CLI emits raw ANSI escapes via `println!`/`write!` (banner,
+/// status bar, tool output, separators, etc.) instead of routing every byte
+/// through crossterm. On Windows the console has virtual-terminal processing
+/// disabled by default, so those escapes render as literal garbage (e.g.
+/// `[2m`, `[38;5;245m`, `[0m`). crossterm only flips the VT flag on its first
+/// command execution — which, via `Spinner::start()`, happens deep inside
+/// `run_turn`, long after the banner and other early output have already been
+/// written with raw escapes. Calling this at the very top of `main` triggers
+/// crossterm's `enable_vt_processing()` up front so all subsequent raw escapes
+/// are interpreted correctly. No-op on non-Windows platforms.
+#[cfg(windows)]
+fn enable_windows_ansi_support() {
+    // Side effect: on first call this enables ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    // on the current stdout console handle. We ignore the returned support flag.
+    let _ = crossterm::ansi_support::supports_ansi();
+}
+
+#[cfg(not(windows))]
+fn enable_windows_ansi_support() {}
+
 fn main() {
+    // Must run before any output so early raw ANSI escapes render correctly on
+    // the Windows console (see `enable_windows_ansi_support`).
+    enable_windows_ansi_support();
+
     if let Err(error) = run() {
         let message = error.to_string();
         // When --output-format json is active, emit errors as JSON so downstream


### PR DESCRIPTION
## 问题

在某些 Windows 终端上，CLI 的彩色/字体不显示，并出现乱码（例如 `[2m`、`[38;5;245m`、`[0m` 被当作普通字符打印）。

根因：CLI 大量使用 `println!`/`write!` 直接向 stdout 输出原始 ANSI 转义序列（banner、状态栏、工具输出、分隔线、错误信息等，共 63 处），绕过了 crossterm。Windows 控制台默认**禁用**虚拟终端（VT）处理，因此这些转义序列被原样渲染成乱码。

crossterm 会在其**第一次命令执行**时自动开启 Windows VT 处理，但那要等到 `run_turn` 深处的 `Spinner::start()` 才发生 —— 此时 banner 和其他早期输出早已以原始转义码写出。

## 修复

在 `main()` 最顶部、任何输出之前调用 crossterm 的 `ansi_support::supports_ansi()`，它会触发 `enable_vt_processing()`，通过 Console API 设置 `ENABLE_VIRTUAL_TERMINAL_PROCESSING`。这样后续所有原始转义码都能被正确解释。

- 不使用 `unsafe`（workspace 设有 `unsafe_code = "forbid"`），复用 crossterm 的安全封装。
- `ansi_support` 模块在 crossterm 中是 `#[cfg(windows)]`，因此调用按平台 gate；非 Windows 平台为 no-op。
- 最小化、定向修复：63 处原始转义点仍走原路径，但 VT 提前开启后均可正确渲染。

## 验证

- `cargo build -p rusty-sudocode-cli` 通过（exit 0）。
- `cargo fmt -p rusty-sudocode-cli -- --check` 通过。
- 受影响机器上手动验证：运行 CLI，banner 显示颜色而非 `[...m` 乱码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)