### PR TITLE
fix(runtime): cherry-pick pilot — close bash stdin (claw-code d07664b)

### DIFF
--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -354,20 +354,24 @@ fn prepare_tokio_command(
         prepare_sandbox_dirs(cwd);
     }
 
-    if let Some(launcher) = build_linux_sandbox_command(command, cwd, sandbox_status) {
-        let mut prepared = TokioCommand::new(launcher.program);
-        prepared.args(launcher.args);
-        prepared.current_dir(cwd);
-        prepared.envs(launcher.env);
-        return prepared;
-    }
+    let mut prepared =
+        if let Some(launcher) = build_linux_sandbox_command(command, cwd, sandbox_status) {
+            let mut cmd = TokioCommand::new(launcher.program);
+            cmd.args(launcher.args);
+            cmd.envs(launcher.env);
+            cmd
+        } else {
+            let mut cmd = TokioCommand::new("sh");
+            cmd.arg("-lc").arg(command);
+            if sandbox_status.filesystem_active {
+                cmd.env("HOME", cwd.join(".sandbox-home"));
+                cmd.env("TMPDIR", cwd.join(".sandbox-tmp"));
+            }
+            cmd
+        };
 
-    let mut prepared = TokioCommand::new("sh");
-    prepared.arg("-lc").arg(command).current_dir(cwd);
-    if sandbox_status.filesystem_active {
-        prepared.env("HOME", cwd.join(".sandbox-home"));
-        prepared.env("TMPDIR", cwd.join(".sandbox-tmp"));
-    }
+    prepared.current_dir(cwd);
+    prepared.stdin(Stdio::null());
     prepared
 }
 
@@ -488,6 +492,27 @@ mod tests {
         assert_eq!(
             output.return_code_interpretation.as_deref(),
             Some("interrupted")
+        );
+    }
+
+    #[test]
+    fn prevents_stdin_hangs_by_redirecting_to_null() {
+        let output = execute_bash(BashCommandInput {
+            command: String::from("cat"),
+            timeout: Some(2_000),
+            description: None,
+            run_in_background: Some(false),
+            dangerously_disable_sandbox: Some(true),
+            namespace_restrictions: None,
+            isolate_network: None,
+            filesystem_mode: None,
+            allowed_mounts: None,
+        })
+        .expect("bash command should execute cleanly");
+
+        assert!(
+            !output.interrupted,
+            "Command hung and was cut off by the timeout!"
         );
     }
 }


### PR DESCRIPTION
## Summary

First cherry-pick from \`ultraworkers/claw-code\` against our 2026-W24 sync window. Per the methodology in [\`docs/parity.md\`](https://github.com/sudoprivacy/sudocode/blob/main/docs/parity.md), this is a single \`[CHERRY-PICK]\` resolution closing a real runtime bug.

**Change:** Route both sandboxed and unsandboxed bash launches through one \`prepared\` \`TokioCommand\` and explicitly close stdin with \`Stdio::null()\`. Without this, child bash processes inherit the parent's stdin, which can hang interactive workflows and lets side-channel input leak into spawned commands.

**Source:** \`ultraworkers/claw-code@d07664b44cbe\` — \`fix: keep hooks clean and close bash stdin\`

**Dropped during port:**
- The original commit also restored a \`.github/hooks/pre-push\` file. We do not ship that hook, so that portion is dropped.

## Pilot lessons (for the next batch)

This pilot also surfaced the practical mechanics of cherry-picking from claw-code:

- **Direct \`git cherry-pick\` works** when the file is shared by name (\`rust/crates/runtime/src/bash.rs\`, \`rust/crates/runtime/src/file_ops.rs\`, etc.).
- **Path translation needed** for crate rename \`rusty-claude-cli\` → \`rusty-sudocode-cli\`. Conflicts show as \`modify/delete\` because git sees the old path as deleted.
- **Manual port needed** where we have extracted modules they still have inline. For example, our \`DiagnosticCheck\` lives in \`cli/doctor.rs\` while theirs is still in \`main.rs\`; their commit touching \`main.rs\` doctor code does not apply mechanically.
- **\`ROADMAP.md\` portions always dropped.** Most of their commits also update their own \`ROADMAP.md\`; we keep ours.

Triage doc with all 614 commits and per-bucket commit lists is at [\`docs/parity-claw-code-sync-2026-W24.md\`](https://github.com/sudoprivacy/sudocode/blob/main/docs/parity-claw-code-sync-2026-W24.md) (landing in PR #191).

## Test plan

- [x] Local cherry-pick + amend with provenance trailer
- [ ] CI green (cargo fmt / clippy / cargo test --workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)