### PR TITLE
Preserve usage metadata across compaction

### DIFF
--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -1,4 +1,5 @@
 use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+use crate::usage::{TokenUsage, UsageAggregation};
 
 const COMPACT_CONTINUATION_PREAMBLE: &str =
     "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\n";
@@ -191,8 +192,10 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
         }
         k
     };
+    let existing_usage = session.compaction.as_ref().and_then(|value| value.usage);
     let removed = &session.messages[compacted_prefix_len..keep_from];
     let preserved = session.messages[keep_from..].to_vec();
+    let compacted_usage = aggregate_compaction_usage(existing_usage, removed);
     let summary =
         merge_compact_summaries(existing_summary.as_deref(), &summarize_messages(removed));
     let formatted_summary = format_compact_summary(&summary);
@@ -208,7 +211,7 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
 
     let mut compacted_session = session.clone();
     compacted_session.messages = compacted_messages;
-    compacted_session.record_compaction(summary.clone(), removed.len());
+    compacted_session.record_compaction_with_usage(summary.clone(), removed.len(), compacted_usage);
 
     CompactionResult {
         summary,
@@ -216,6 +219,28 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
         compacted_session,
         removed_message_count: removed.len(),
     }
+}
+
+fn aggregate_compaction_usage(
+    existing_usage: Option<TokenUsage>,
+    removed_messages: &[ConversationMessage],
+) -> Option<TokenUsage> {
+    let mut total = UsageAggregation::default();
+    let mut found = false;
+    if let Some(usage) = existing_usage {
+        total.push(usage);
+        found = true;
+    }
+    for message in removed_messages {
+        if message.role != MessageRole::Assistant {
+            continue;
+        }
+        if let Some(usage) = message.usage {
+            total.push(usage);
+            found = true;
+        }
+    }
+    found.then(|| total.finish())
 }
 
 fn compacted_summary_prefix_len(session: &Session) -> usize {
@@ -598,6 +623,7 @@ mod tests {
         get_compact_continuation_message, infer_pending_work, should_compact, CompactionConfig,
     };
     use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+    use crate::usage::{TokenUsage, UsageCostCurrency};
 
     #[test]
     fn formats_compact_summary_like_upstream() {
@@ -680,17 +706,98 @@ mod tests {
     }
 
     #[test]
+    fn compaction_records_usage_for_removed_assistant_messages() {
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("one ".repeat(200)),
+            ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "two ".repeat(200),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 10,
+                    output_tokens: 4,
+                    cache_creation_input_tokens: 1,
+                    cache_read_input_tokens: 2,
+                    cost_units: Some(100),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
+                }),
+            ),
+            ConversationMessage::user_text("three ".repeat(200)),
+            ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "four ".repeat(200),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 20,
+                    output_tokens: 6,
+                    cache_creation_input_tokens: 3,
+                    cache_read_input_tokens: 5,
+                    cost_units: Some(250),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
+                }),
+            ),
+            ConversationMessage::user_text("recent"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "kept".to_string(),
+            }]),
+        ];
+
+        let result = compact_session(
+            &session,
+            CompactionConfig {
+                preserve_recent_messages: 2,
+                max_estimated_tokens: 1,
+            },
+        );
+
+        let usage = result
+            .compacted_session
+            .compaction
+            .expect("compaction")
+            .usage
+            .expect("compacted usage");
+        assert_eq!(usage.input_tokens, 30);
+        assert_eq!(usage.output_tokens, 10);
+        assert_eq!(usage.cache_creation_input_tokens, 4);
+        assert_eq!(usage.cache_read_input_tokens, 7);
+        assert_eq!(usage.cost_units, Some(350));
+        assert_eq!(usage.cost_currency, Some(UsageCostCurrency::SudoPoint));
+        assert_eq!(result.compacted_session.messages[0].usage, None);
+    }
+
+    #[test]
     fn keeps_previous_compacted_context_when_compacting_again() {
         let mut initial_session = Session::new();
         initial_session.messages = vec![
             ConversationMessage::user_text("Investigate rust/crates/runtime/src/compact.rs"),
-            ConversationMessage::assistant(vec![ContentBlock::Text {
-                text: "I will inspect the compact flow.".to_string(),
-            }]),
+            ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "I will inspect the compact flow.".to_string(),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 10,
+                    output_tokens: 4,
+                    cache_creation_input_tokens: 1,
+                    cache_read_input_tokens: 2,
+                    cost_units: Some(100),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
+                }),
+            ),
             ConversationMessage::user_text("Also update rust/crates/runtime/src/conversation.rs"),
-            ConversationMessage::assistant(vec![ContentBlock::Text {
-                text: "Next: preserve prior summary context during auto compact.".to_string(),
-            }]),
+            ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "Next: preserve prior summary context during auto compact.".to_string(),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 20,
+                    output_tokens: 6,
+                    cache_creation_input_tokens: 3,
+                    cache_read_input_tokens: 5,
+                    cost_units: Some(250),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
+                }),
+            ),
         ];
         let config = CompactionConfig {
             preserve_recent_messages: 2,
@@ -701,12 +808,23 @@ mod tests {
         let mut follow_up_messages = first.compacted_session.messages.clone();
         follow_up_messages.extend([
             ConversationMessage::user_text("Please add regression tests for compaction."),
-            ConversationMessage::assistant(vec![ContentBlock::Text {
-                text: "Working on regression coverage now.".to_string(),
-            }]),
+            ConversationMessage::assistant_with_usage(
+                vec![ContentBlock::Text {
+                    text: "Working on regression coverage now.".to_string(),
+                }],
+                Some(TokenUsage {
+                    input_tokens: 30,
+                    output_tokens: 8,
+                    cache_creation_input_tokens: 4,
+                    cache_read_input_tokens: 7,
+                    cost_units: Some(400),
+                    cost_currency: Some(UsageCostCurrency::SudoPoint),
+                }),
+            ),
         ]);
 
         let mut second_session = Session::new();
+        second_session.compaction = first.compacted_session.compaction.clone();
         second_session.messages = follow_up_messages;
         let second = compact_session(&second_session, config);
 
@@ -732,6 +850,17 @@ mod tests {
             &second.compacted_session.messages[1].blocks[0],
             ContentBlock::Text { text } if text.contains("Please add regression tests for compaction.")
         ));
+        let usage = second
+            .compacted_session
+            .compaction
+            .expect("second compaction")
+            .usage
+            .expect("merged compaction usage");
+        assert_eq!(usage.input_tokens, 30);
+        assert_eq!(usage.output_tokens, 10);
+        assert_eq!(usage.cache_creation_input_tokens, 4);
+        assert_eq!(usage.cache_read_input_tokens, 7);
+        assert_eq!(usage.cost_units, Some(350));
     }
 
     #[test]

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -70,6 +70,7 @@ pub struct SessionCompaction {
     pub count: u32,
     pub removed_message_count: usize,
     pub summary: String,
+    pub usage: Option<TokenUsage>,
 }
 
 /// Provenance recorded when a session is forked from another session.
@@ -312,12 +313,22 @@ impl Session {
     }
 
     pub fn record_compaction(&mut self, summary: impl Into<String>, removed_message_count: usize) {
+        self.record_compaction_with_usage(summary, removed_message_count, None);
+    }
+
+    pub fn record_compaction_with_usage(
+        &mut self,
+        summary: impl Into<String>,
+        removed_message_count: usize,
+        usage: Option<TokenUsage>,
+    ) {
         self.touch();
         let count = self.compaction.as_ref().map_or(1, |value| value.count + 1);
         self.compaction = Some(SessionCompaction {
             count,
             removed_message_count,
             summary: summary.into(),
+            usage,
         });
     }
 
@@ -955,6 +966,9 @@ impl SessionCompaction {
             "summary".to_string(),
             JsonValue::String(self.summary.clone()),
         );
+        if let Some(usage) = self.usage {
+            object.insert("usage".to_string(), usage_to_json(usage));
+        }
         Ok(JsonValue::Object(object))
     }
 
@@ -979,6 +993,9 @@ impl SessionCompaction {
             "summary".to_string(),
             JsonValue::String(self.summary.clone()),
         );
+        if let Some(usage) = self.usage {
+            object.insert("usage".to_string(), usage_to_json(usage));
+        }
         Ok(JsonValue::Object(object))
     }
 
@@ -990,6 +1007,7 @@ impl SessionCompaction {
             count: required_u32(object, "count")?,
             removed_message_count: required_usize(object, "removed_message_count")?,
             summary: required_string(object, "summary")?,
+            usage: object.get("usage").map(usage_from_json).transpose()?,
         })
     }
 }
@@ -1498,7 +1516,18 @@ mod tests {
         session
             .push_user_text("before")
             .expect("message should append");
-        session.record_compaction("summarized earlier work", 4);
+        session.record_compaction_with_usage(
+            "summarized earlier work",
+            4,
+            Some(TokenUsage {
+                input_tokens: 10,
+                output_tokens: 4,
+                cache_creation_input_tokens: 1,
+                cache_read_input_tokens: 2,
+                cost_units: Some(43_700),
+                cost_currency: Some(UsageCostCurrency::SudoPoint),
+            }),
+        );
         session.save_to_path(&path).expect("session should save");
 
         let restored = Session::load_from_path(&path).expect("session should load");
@@ -1508,6 +1537,31 @@ mod tests {
         assert_eq!(compaction.count, 1);
         assert_eq!(compaction.removed_message_count, 4);
         assert!(compaction.summary.contains("summarized"));
+        let usage = compaction.usage.expect("compaction usage");
+        assert_eq!(usage.total_tokens(), 17);
+        assert_eq!(usage.cost_units, Some(43_700));
+        assert_eq!(usage.cost_currency, Some(UsageCostCurrency::SudoPoint));
+    }
+
+    #[test]
+    fn loads_legacy_compaction_without_usage() {
+        let path = write_temp_session_file(
+            "legacy-compaction",
+            concat!(
+                "{\"type\":\"session_meta\",\"version\":1,\"session_id\":\"legacy-compaction\",\"created_at_ms\":1,\"updated_at_ms\":1}\n",
+                "{\"type\":\"compaction\",\"count\":1,\"removed_message_count\":4,\"summary\":\"summarized earlier work\"}\n",
+                "{\"type\":\"message\",\"message\":{\"role\":\"user\",\"blocks\":[{\"type\":\"text\",\"text\":\"after\"}]}}\n"
+            ),
+        );
+
+        let restored =
+            Session::load_from_path(&path).expect("legacy compaction session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        let compaction = restored.compaction.expect("compaction metadata");
+        assert_eq!(compaction.count, 1);
+        assert_eq!(compaction.removed_message_count, 4);
+        assert_eq!(compaction.usage, None);
     }
 
     #[test]

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -280,6 +280,9 @@ impl UsageTracker {
     #[must_use]
     pub fn from_session(session: &Session) -> Self {
         let mut tracker = Self::new();
+        if let Some(usage) = session.compaction.as_ref().and_then(|value| value.usage) {
+            tracker.record(usage);
+        }
         for message in &session.messages {
             if let Some(usage) = message.usage {
                 tracker.record(usage);
@@ -330,7 +333,9 @@ mod tests {
         format_usd, parse_usage_cost_currency, pricing_for_model, TokenUsage, UsageCostCurrency,
         UsageTracker,
     };
-    use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
+    use crate::session::{
+        ContentBlock, ConversationMessage, MessageRole, Session, SessionCompaction,
+    };
 
     #[test]
     fn adds_token_usage_fields() {
@@ -538,5 +543,50 @@ mod tests {
         let tracker = UsageTracker::from_session(&session);
         assert_eq!(tracker.turns(), 1);
         assert_eq!(tracker.cumulative_usage().total_tokens(), 8);
+    }
+
+    #[test]
+    fn reconstructs_usage_from_compaction_and_session_messages() {
+        let mut session = Session::new();
+        session.compaction = Some(SessionCompaction {
+            count: 1,
+            removed_message_count: 2,
+            summary: "summarized earlier work".to_string(),
+            usage: Some(TokenUsage {
+                input_tokens: 10,
+                output_tokens: 4,
+                cache_creation_input_tokens: 1,
+                cache_read_input_tokens: 2,
+                cost_units: Some(100),
+                cost_currency: Some(UsageCostCurrency::SudoPoint),
+            }),
+        });
+        session.messages = vec![ConversationMessage {
+            role: MessageRole::Assistant,
+            blocks: vec![ContentBlock::Text {
+                text: "done".to_string(),
+            }],
+            usage: Some(TokenUsage {
+                input_tokens: 5,
+                output_tokens: 2,
+                cache_creation_input_tokens: 1,
+                cache_read_input_tokens: 0,
+                cost_units: Some(50),
+                cost_currency: Some(UsageCostCurrency::SudoPoint),
+            }),
+            model: None,
+        }];
+
+        let tracker = UsageTracker::from_session(&session);
+        assert_eq!(tracker.turns(), 2);
+        assert_eq!(tracker.current_turn_usage().total_tokens(), 8);
+        assert_eq!(tracker.cumulative_usage().input_tokens, 15);
+        assert_eq!(tracker.cumulative_usage().output_tokens, 6);
+        assert_eq!(tracker.cumulative_usage().total_tokens(), 25);
+        assert_eq!(tracker.cumulative_usage().cost_units, Some(150));
+        assert_eq!(
+            tracker.cumulative_usage().cost_currency,
+            Some(UsageCostCurrency::SudoPoint)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- persist aggregated assistant usage on session compaction metadata
- merge previously compacted usage when compacting multiple times
- include compacted usage when reconstructing cumulative session usage

## Tests
- cargo test -p runtime compaction -- --nocapture
- cargo test -p runtime reconstructs_usage_from_compaction_and_session_messages -- --nocapture

Note: full cargo test -p runtime was also attempted earlier and hit an unrelated existing hooks assertion failure: hooks::tests::malformed_nonempty_hook_output_reports_explicit_diagnostic_with_previews.