### PR TITLE
docs(parity): add claude-code-best as Tier 2 behavioral reference

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,6 +17,7 @@ on:
       - CLAUDE.md
       - CONTRIBUTING.md
       - LAST_PARITY_SYNC_COMMIT
+      - LAST_CCB_REF_VERSION
       - docs/**
       - rust/**
   pull_request:
@@ -33,6 +34,7 @@ on:
       - CLAUDE.md
       - CONTRIBUTING.md
       - LAST_PARITY_SYNC_COMMIT
+      - LAST_CCB_REF_VERSION
       - docs/**
       - rust/**
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,16 @@ Guidance for agents working in this repository.
 - Update existing files intentionally; edit content rather than replace
   whole files unless the file is being restructured.
 
+## Parity work: standing rule
+
+When making a parity decision against `anthropics/claude-code`, **always**
+also check `claude-code-best/claude-code` (CCB) — the TypeScript
+behavioral reference — before settling the resolution. CHANGELOG entries
+are usually too coarse on their own; CCB converts them into readable
+source. CCB is not a cherry-pick source for our Rust tree; we read it
+for understanding only. The full triage flow, sync markers, and
+resolution taxonomy live in [`docs/parity.md`](./docs/parity.md).
+
 ## Verification
 
 The Rust workspace lives in `rust/`. From the repo root the standard

--- a/LAST_CCB_REF_VERSION
+++ b/LAST_CCB_REF_VERSION
@@ -1,0 +1,1 @@
+91cffe16e23fc886f6860a7edfe8754d74a4abbf

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,14 +48,26 @@ Every feature gap between `scode` and `anthropics/claude-code` carries a
 written resolution — `[BUILD]` / `[CHERRY-PICK]` / `[SKIP]` / `[N/A]` /
 `[OBSERVE]` — with a one-line rationale.
 
-The reference target is `anthropics/claude-code`. Comparison runs against
-public release notes, the published npm bundle's tool and slash
-surfaces, and official documentation, anchored to a tracked sync marker.
-The mechanism is described in [`docs/parity.md`](./docs/parity.md).
+Three reference sources, with distinct roles:
 
-`ultraworkers/claw-code` is a cherry-pick source for Rust-side
-implementations of overlapping features. Their work is treated as
-optional input rather than upstream-of-truth.
+- **Source of truth** — `anthropics/claude-code` itself. The source is
+  private; the signal comes from the public CHANGELOG, the npm bundle's
+  tool and slash surfaces, and the official docs.
+- **Behavioral reference** — `claude-code-best/claude-code` (CCB), a
+  TypeScript reconstruction of Claude Code that aims for high
+  source-level fidelity. We **always** open CCB while making a parity
+  decision: it converts CHANGELOG entries into readable source so we
+  can confirm what CC actually does. We read it; we do not lift its
+  TypeScript into our Rust tree.
+- **Cherry-pick source** — `ultraworkers/claw-code`, a Rust port we can
+  lift commits from when the feature shape overlaps. Optional input,
+  not upstream-of-truth.
+
+The mechanism, the standing assumption about CCB, the mandatory
+"CHANGELOG → grep CCB → align understanding" loop, and the two sync
+markers (`LAST_PARITY_SYNC_COMMIT` for claw-code,
+`LAST_CCB_REF_VERSION` for CCB) all live in
+[`docs/parity.md`](./docs/parity.md).
 
 ### Goal 3 · Ship features real users miss
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,13 @@ the content.
 
 ## Project mechanics
 
-- [`parity.md`](./parity.md) — what claude-code parity means for `scode`
-  and how it is tracked.
+- [`parity.md`](./parity.md) — what claude-code parity means for `scode`,
+  the three reference sources we work against (anthropics/claude-code
+  as source of truth, claude-code-best/claude-code as behavioral
+  reference, ultraworkers/claw-code as optional Rust cherry-pick
+  source), the mandatory "CHANGELOG → grep CCB → align understanding"
+  loop, and the sync markers (`LAST_PARITY_SYNC_COMMIT`,
+  `LAST_CCB_REF_VERSION`).
 - [`mock-parity-harness.md`](./mock-parity-harness.md) — the
   deterministic mock backend and the harness that exercises the parity
   scenarios.

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -1,9 +1,9 @@
 # Parity
 
 This document describes how `scode` tracks feature parity with
-`anthropics/claude-code`: the scope of "parity," the comparison sources
-used, the resolution taxonomy applied to each gap, and the sync marker
-that anchors the comparison window.
+`anthropics/claude-code`: the scope of "parity," the three reference
+sources we compare against, the resolution taxonomy applied to each gap,
+and the sync markers that anchor each source to a point in time.
 
 The roadmap that owns this work is [`../ROADMAP.md`](../ROADMAP.md)
 (Goal 2).
@@ -24,10 +24,17 @@ Parity covers four dimensions, ordered by visibility to a user of
    precedence rules for `.scode.json` and related configuration
    sources.
 
-## Reference target
+## Three reference sources
 
-The reference target is `anthropics/claude-code`. The public surfaces
-used to derive the comparison are:
+We work against three sources, each with a different role. Treat them
+in this order — start with the source-of-truth signal, then verify
+against the high-fidelity reference, then look for a Rust
+implementation we can lift.
+
+### Tier 1 — source of truth: `anthropics/claude-code`
+
+The reference target. The public surfaces used to derive what we are
+tracking against are:
 
 - The published CHANGELOG entries on `anthropics/claude-code`.
 - The published `@anthropic-ai/claude-code` npm package, used to
@@ -35,13 +42,77 @@ used to derive the comparison are:
   resources.
 - The official documentation at `docs.claude.com`.
 
-## Optional cherry-pick source
+The source itself is private, so this tier gives feature-level signal,
+not commit-level.
+
+### Tier 2 — behavioral reference: `claude-code-best/claude-code`
+
+`claude-code-best/claude-code` (`CCB`) is a TypeScript reconstruction
+of Claude Code that aims for high source-level fidelity. It is
+**treated as our running approximation of what CC actually does** when
+the CHANGELOG signal alone is too coarse.
+
+**Standing assumption.** CCB is sufficiently close to upstream
+`anthropics/claude-code` that reading its source informs our
+understanding of CC's behavior. The assumption is approximate, not
+absolute — when CCB and CHANGELOG diverge, CHANGELOG wins.
+
+**Mandatory workflow.** Whenever we make a parity decision based on a
+CHANGELOG entry, we **also** open CCB and check the relevant code path.
+This applies to every entry, including the ones that look obvious — the
+nuance is usually in the path we did not anticipate.
+
+```
+CC CHANGELOG entry
+        │
+        ▼
+  grep CCB source for the feature
+        │
+        ▼
+  align understanding ── any surprise? → revisit the resolution
+        │
+        ▼
+  pick resolution tag (see "Resolution taxonomy" below)
+```
+
+**What to grep.** CCB is monorepo-shaped TypeScript:
+
+- `src/` — agent loop, REPL, tool dispatch, slash commands, system prompt.
+- `packages/` — modular components (tool implementations, MCP, hooks).
+- `docs/` — Mintlify-based feature documentation.
+
+For a CHANGELOG entry like *"added `/cd` command to move a session to a
+new working directory,"* searches that work:
+
+```bash
+# In a local CCB clone:
+grep -rn -E "/cd\\b|case 'cd'|slash.*cd" src/ packages/
+grep -rn "working directory" docs/ src/
+```
+
+**What CCB is not.** CCB is a reconstruction shipped as TypeScript and
+distributed under "for learning/research only" terms. **It is not a
+cherry-pick source for our Rust tree.** We read it for understanding;
+we do not lift TypeScript into Rust. Citations in commit messages are
+welcome ("matches the behavior in CCB `src/...`"), but the code itself
+is re-implemented in Rust from understanding.
+
+**When CCB does not help.** If CCB itself does not implement the
+feature (it lags upstream by some window), record that fact in the
+resolution: the gap stays anchored to the CC CHANGELOG entry and the
+resolution carries an `[OBSERVE]` tag pending more signal.
+
+### Tier 3 — optional cherry-pick source: `ultraworkers/claw-code`
 
 `ultraworkers/claw-code` is a Rust port of the same family. Where its
 implementation of an overlapping feature fits `scode`'s shape, the
 commit can be cherry-picked into our tree. The relationship is
 optional: `claw-code` is treated as a candidate source for Rust-side
 implementations, separate from the reference target above.
+
+Methodology for cherry-pick triage lives in
+`scripts/triage_claw_code.py` and the cycle's report in
+`docs/parity-claw-code-sync-YYYY-WW.md`.
 
 ## Resolution taxonomy
 
@@ -53,14 +124,21 @@ Every parity gap carries a one-word tag and a short rationale.
 | `[CHERRY-PICK]` | The gap will be closed by lifting a `claw-code` commit. |
 | `[SKIP]` | The gap is closed by intent: `scode` provides the capability differently, the feature is replaced upstream, or it does not apply. |
 | `[N/A]` | The gap belongs to a layer `scode` does not implement (for example, npm packaging). |
-| `[OBSERVE]` | The gap is left open while waiting on more signal — typically how `claw-code` ports the feature, or whether real users hit it. |
+| `[OBSERVE]` | The gap is left open while waiting on more signal — typically how `claw-code` ports the feature, whether CCB has implemented it yet, or whether real users hit it. |
 
-## Sync marker
+## Sync markers
 
-`LAST_PARITY_SYNC_COMMIT` at the repo root records the upstream
-reference SHA the parity table was last anchored to. The sync marker is
-mechanical state used by tooling; the gap inventory and resolutions
-live alongside their owning issues, PRs, and design notes.
+Two marker files at the repo root anchor each source to a point in
+time:
+
+| File | Source | What it records |
+|---|---|---|
+| `LAST_PARITY_SYNC_COMMIT` | `ultraworkers/claw-code` HEAD | The claw-code SHA the last cherry-pick cycle was triaged against. |
+| `LAST_CCB_REF_VERSION` | `claude-code-best/claude-code` HEAD | The CCB SHA our behavioral references currently point at. Bumped when we re-clone CCB for a new cycle. |
+
+Sync markers are mechanical state used by tooling and triage scripts;
+the gap inventory and per-feature resolutions live alongside their
+owning issues, PRs, and design notes.
 
 ## Comparison window
 
@@ -74,3 +152,13 @@ The e2e coverage half of parity (Goal 1 in
 harness described in [`mock-parity-harness.md`](./mock-parity-harness.md).
 The harness runs against the `scode` binary in a clean environment and
 covers the scode-native testable feature surface.
+
+## Quick reference: where each source enters a parity decision
+
+| Step | Source | Action |
+|---|---|---|
+| 1. Identify the gap | Tier 1 (CHANGELOG / npm / docs) | List the CHANGELOG entry or surface diff. |
+| 2. Align understanding | Tier 2 (CCB grep) | Open CCB, read the actual implementation, confirm the intent. |
+| 3. Pick the resolution | All three | Decide `[BUILD]` / `[CHERRY-PICK]` / `[SKIP]` / `[N/A]` / `[OBSERVE]`. |
+| 4. Execute | Tier 3 if `[CHERRY-PICK]`, otherwise hand-rolled | Apply the resolution. |
+| 5. Anchor | `LAST_PARITY_SYNC_COMMIT` / `LAST_CCB_REF_VERSION` | Update marker files when the cycle closes. |


### PR DESCRIPTION
## Summary

Establishes \`claude-code-best/claude-code\` (CCB) as the **Tier 2 behavioral reference** for claude-code parity work. With Anthropic's source private and CHANGELOG signal too coarse on its own, CCB is the running approximation we read to convert release notes into readable source.

## The three-tier model

| Tier | Repo | Role |
|---|---|---|
| 1 / source of truth | \`anthropics/claude-code\` | CHANGELOG, npm bundle, docs site. Feature-level signal. |
| 2 / **behavioral reference** | \`claude-code-best/claude-code\` | High-fidelity TypeScript reconstruction. Read for understanding; **not** a cherry-pick source for our Rust tree. |
| 3 / cherry-pick source | \`ultraworkers/claw-code\` | Rust port we can lift commits from. |

## The standing rule

Every parity decision touches CCB at step 2. Embedded in 6 places so a contributor hits it from any direction:

- \`docs/parity.md\` — full mechanism, mandatory workflow, grep recipes, legal posture, and a "where each source enters a parity decision" quick-reference table.
- \`ROADMAP.md\` (Goal 2) — three-source model with each role spelled out.
- \`CLAUDE.md\` — "Parity work: standing rule" section for agents doing parity work.
- \`docs/README.md\` — docs index entry expanded.
- \`LAST_CCB_REF_VERSION\` — new marker file at repo root, sits next to \`LAST_PARITY_SYNC_COMMIT\`. Initialized to \`91cffe16\` (CCB main, 2026-06-12).
- \`.github/workflows/rust-ci.yml\` — path triggers include the new marker.

## The loop

\`\`\`
CC CHANGELOG entry
        -> grep CCB source for the feature
        -> align understanding; surprise -> revisit
        -> pick a resolution tag
        -> update marker files when the cycle closes
\`\`\`

## Legal posture

CCB ships as TypeScript under "for learning/research only" terms. We **read** it; we never lift TypeScript into our Rust tree. Citations in commit messages welcome ("matches the behavior in CCB \`src/...\`"), but the code itself is re-implemented in Rust from understanding.

## Test plan

- [x] Doc renders cleanly
- [x] All cross-references resolve
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)