### PR TITLE
docs: rewrite CONTRIBUTING.md; slim CLAUDE.md to pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,95 +1,13 @@
 # CLAUDE.md
 
-Guidance for agents working in this repository.
+Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) — that is the canonical
+guide for working in this repository. Human contributors and AI
+agents follow the same rules.
 
-## Working agreement
-
-- Prefer small, reviewable changes. Group related edits in a single
-  commit; split unrelated edits across commits.
-- Shared defaults live in `.scode.json`. Machine-local overrides live in
-  `.nexus/sudocode/settings.local.json`.
-- Update existing files intentionally; edit content rather than replace
-  whole files unless the file is being restructured.
-
-## Parity work: standing rule
-
-When making a parity decision against `anthropics/claude-code`, **always**
-also check `claude-code-best/claude-code` (CCB) — the TypeScript
-behavioral reference — before settling the resolution. CHANGELOG entries
-are usually too coarse on their own; CCB converts them into readable
-source. CCB is not a cherry-pick source for our Rust tree; we read it
-for understanding only. The full triage flow, sync markers, and
-resolution taxonomy live in [`docs/parity.md`](./docs/parity.md).
-
-Every design write-up for a feature with parity intent **leads** with a
-CCB validation section: which CCB files were read, what behavior was
-confirmed, what surprises were found, and what decisions follow.
-Design write-ups live in [`ROADMAP.html`](./ROADMAP.html) under the goal
-they belong to (the `!` bash mode section under Goal 3 is the shape
-future design write-ups follow). When a plan ships or is superseded,
-remove its content from ROADMAP.html in the same PR; ROADMAP tracks the
-live state, not history.
-
-## Verification
-
-The Rust workspace lives in `rust/`. From the repo root the standard
-checks are:
-
-```bash
-cd rust
-cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
-```
-
-`scripts/fmt.sh` from the repo root wraps `cd rust && cargo fmt` and
-forwards flags.
-
-## Publishing ROADMAP.html to ShareOne (interim, manual)
-
-`ROADMAP.html` is the SSOT plan file in this repo. Mirroring it to
-ShareOne for at-a-glance external viewing is currently a manual
-maintainer action. The long-term plan — exposing
-`publish_to_shareone` as an LLM tool that any `scode` agent can call
-— is tracked as a Goal 3 candidate inside ROADMAP.html itself and
-ships when a real user asks for it.
-
-Until that tool exists, the documented manual recipes are:
-
-**Create a new share** (each run yields a fresh URL):
-
-```bash
-curl -s -X POST https://shareone.app/api/v1/pages \
-  -H "X-API-Key: $SHAREONE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"filename\":\"ROADMAP.html\",\"html_content\":$(jq -Rs . < ROADMAP.html),\"allow_comments\":true}"
-```
-
-The response includes `share_url` — that is the page to share.
-
-**Update an existing share** (stable URL — pass the `share_id` you
-got back from a prior POST):
-
-```bash
-curl -s -X PUT "https://shareone.app/api/v1/pages/<share_id>" \
-  -H "X-API-Key: $SHAREONE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"filename\":\"ROADMAP.html\",\"html_content\":$(jq -Rs . < ROADMAP.html),\"allow_comments\":true}"
-```
-
-Get a `SHAREONE_API_KEY` from <https://shareone.app>. URL stability
-across re-publishes is optional; if you only want a one-off shareable
-link, the POST form is enough.
-
-## Documentation map
-
-- [`README.md`](./README.md) — project entry, install, quick start.
-- [`ROADMAP.html`](./ROADMAP.html) — goals.
-- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contributor setup and PR
-  workflow.
-- [`docs/`](./docs/) — topic-scoped SSOTs (usage, authentication,
-  permissions, ACP, models, plugins, parity, mock harness, container).
-- [`rust/README.md`](./rust/README.md) — Cargo workspace map.
-
-When the repository workflow changes, update this file along with the
-change.
+The previous content of this file (working agreement, parity
+standing rule, verification commands, ShareOne publishing recipe,
+documentation map) has been migrated into `CONTRIBUTING.md` so the
+rules apply to every contributor by default, not just to Claude.
+This file remains as a thin pointer because Claude Code reads it on
+startup by convention; the pointer ensures the agent finds the
+canonical doc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,6 +363,42 @@ syncing your feature branch onto the latest `main` —
   repository's security contact (see `SECURITY.md` if present) or
   use GitHub's private vulnerability reporting.
 
+## Publishing the roadmap to ShareOne (interim, manual)
+
+`ROADMAP.html` is the SSOT plan file. Mirroring it to ShareOne for
+at-a-glance external viewing is currently a manual maintainer step
+— both human and AI contributors can run it. The long-term plan
+exposes `publish_to_shareone` as an LLM tool that any `scode` agent
+can call, tracked as a Goal 3 candidate inside `ROADMAP.html`; it
+ships when a real user asks for it.
+
+Until that tool exists, the documented manual recipes are:
+
+**Create a new share** (each run yields a fresh URL):
+
+```bash
+curl -s -X POST https://shareone.app/api/v1/pages \
+  -H "X-API-Key: $SHAREONE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"filename\":\"ROADMAP.html\",\"html_content\":$(jq -Rs . < ROADMAP.html),\"allow_comments\":true}"
+```
+
+The response includes `share_url` — that is the page to share.
+
+**Update an existing share** (stable URL — pass the `share_id` you
+got back from a prior POST):
+
+```bash
+curl -s -X PUT "https://shareone.app/api/v1/pages/<share_id>" \
+  -H "X-API-Key: $SHAREONE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"filename\":\"ROADMAP.html\",\"html_content\":$(jq -Rs . < ROADMAP.html),\"allow_comments\":true}"
+```
+
+Get a `SHAREONE_API_KEY` from <https://shareone.app>. URL stability
+across re-publishes is optional; for a one-off shareable link the
+POST form is enough.
+
 ## License
 
 By contributing, your contributions are licensed under the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,32 @@
 # Contributing to Sudo Code
 
 Thanks for your interest in contributing to **Sudo Code** (`scode`).
-This document explains how to set up a local checkout, run the required
-checks, and submit a pull request that lands smoothly.
+
+This document is the canonical guide for working in this repo —
+prerequisites, the design rules every PR is judged against, the
+required checks, and the commit/PR workflow. **Human contributors
+and AI agents follow the same rules in here.** Read it once before
+your first contribution.
+
+> **Before you write code, read [`README.md`](./README.md) and
+> [`ROADMAP.html`](./ROADMAP.html).** Sudo Code has a small but
+> bright-line set of design rules; PRs that contradict them are
+> declined regardless of code quality. The fast summary lives in
+> [Design principles you must respect](#design-principles-you-must-respect)
+> below; the full statement is in `ROADMAP.html`.
 
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Design principles you must respect](#design-principles-you-must-respect)
+- [Test policy](#test-policy)
+- [Parity work — standing rule](#parity-work--standing-rule)
 - [Project Layout](#project-layout)
 - [Prerequisites](#prerequisites)
 - [Building](#building)
 - [Required checks](#required-checks)
-- [Optional / targeted checks](#optional--targeted-checks)
 - [Running the CLI locally](#running-the-cli-locally)
 - [Working on a single crate](#working-on-a-single-crate)
-- [Mock parity harness](#mock-parity-harness)
 - [Commit style](#commit-style)
 - [Pull request guidelines](#pull-request-guidelines)
 - [Reporting bugs & requesting features](#reporting-bugs--requesting-features)
@@ -26,6 +38,119 @@ Be respectful, be concise, and assume good faith. Disagree about code,
 not people. Maintainers may close or lock conversations that turn
 personal or off-topic.
 
+## Design principles you must respect
+
+These are bright-line rules. PRs that introduce any of the items
+below will be asked to remove them or are closed. Reopening any rule
+requires a separate `ROADMAP.html` edit before the code lands — not
+the code first.
+
+**Hard NOs (the ones contributors trip on most):**
+
+- **No `ratatui`, no alternate-screen mode, no `--tui` flag.**
+  sudocode is inline-only by rule. Even a feature-flagged
+  `ratatui` dependency is rejected — its presence in `Cargo.lock`
+  is the slippery slope toward an alternate-screen path that
+  breaks scrollback, attach/detach, and pipe composition. (See
+  ROADMAP § Goal 3 → "No alternate-screen / full-screen TUI mode
+  — by rule".)
+
+- **No unit tests.** PTY (pty-expect) is the only required test
+  layer; integration is an optional debug accelerator; unit tests
+  are forbidden by rule. See [Test policy](#test-policy) below for
+  the rationale. (See ROADMAP § Goal 1 → "Test layer policy".)
+
+- **No in-CLI multi-agent dashboard.** sudocode is an agent unit,
+  not a hub. Multi-agent orchestration UI belongs in sudowork /
+  hydra / your tmux — not inside scode. (See ROADMAP § Goal 4.)
+
+- **No CLA, no copyright assignment, no closed-source escape
+  hatch.** Contributors retain their copyright; their code is
+  MIT-licensed and that is the whole arrangement.
+
+- **No "users might misclick" as a reason to hide a feature.**
+  Either ship it or don't. Hiding correct behavior behind a config
+  flag because the 99% might fumble = treating us like the 99%.
+  We are not them.
+
+- **No silent / forced updates.** Semver. Breaking change = major
+  bump + release notes. You pin a version, that version stays.
+
+- **No telemetry by default.** Opt-in is explicit; never buried.
+
+The full 11 Always / 10 Never list lives in [`README.md` § Design
+principles](./README.md#design-principles). When in doubt, read
+that section before opening the PR.
+
+## Test policy
+
+sudocode is deliberately opinionated about what to test and how.
+
+| Layer | Status | When to write |
+|---|---|---|
+| **PTY (`pty-expect`)** | **Required CI gate**; the only layer counting toward the 90% e2e coverage metric | Every user-facing feature |
+| Integration (mock harness) | Optional — debug accelerator, not a CI gate | When a PTY failure's blast radius is wide enough that shrinking bisection distance is worth the file |
+| **Unit** | **Forbidden by rule** | Don't. PRs adding unit tests will be asked to remove them. |
+
+**Why no unit tests.** Empirically, in a year of agent-driven
+development on this codebase, unit tests have not caught a real bug.
+Real bugs surface in the e2e harness or in human use of the product.
+Unit tests here have functioned as pure restatements of the
+implementation — they co-vary with every refactor without paying for
+themselves in caught bugs. The PTY layer plus structured-log trace
+quality is our substitute for fine-grained failure attribution.
+
+**Reopening this rule** requires a concrete bug a unit test would
+have caught and a PTY scenario would not, plus a `ROADMAP.html` edit
+to change the rule before the unit test lands.
+
+(See `ROADMAP.html` § Goal 1 → "Test layer policy" for the long form.)
+
+### Running tests
+
+```bash
+cd rust/
+cargo test --workspace                     # all tests (PTY tests included)
+cargo test -p runtime                      # one crate
+cargo test -p runtime -- session_resume    # one test by name
+```
+
+PTY tests live in `crates/rusty-sudocode-cli/tests/pty/`. They use
+the `sudoprivacy/pty-expect` crate and run as part of
+`cargo test --workspace` on Linux and macOS. Windows runtime
+support is deferred to `pty-expect` v0.2; on Windows CI the PTY
+tests compile but skip-execute for now.
+
+### Mock parity harness — optional
+
+The deterministic mock at `mock-anthropic-service` and the harness
+at [`rust/scripts/run_mock_parity_harness.sh`](./rust/scripts/run_mock_parity_harness.sh)
+remain available for debug-bisection of complex agent-loop
+failures. **Not a required pre-PR check.** Reach for it when a PTY
+failure's root cause sits behind transport / runtime / API surface
+noise and you want to shrink the search. The reference doc is at
+[`docs/mock-parity-harness.md`](./docs/mock-parity-harness.md).
+
+## Parity work — standing rule
+
+When making a parity decision against `anthropics/claude-code`,
+**always** also check `claude-code-best/claude-code` (CCB) — the
+TypeScript behavioral reference — before settling the resolution.
+CHANGELOG entries are usually too coarse on their own; CCB
+converts them into readable source. CCB is **not** a cherry-pick
+source for our Rust tree; we read it for understanding only. The
+full triage flow, sync markers, and resolution taxonomy live in
+[`docs/parity.md`](./docs/parity.md).
+
+Every design write-up for a feature with parity intent **leads**
+with a CCB validation section: which CCB files were read, what
+behavior was confirmed, what surprises were found, and what
+decisions follow. Design write-ups live in
+[`ROADMAP.html`](./ROADMAP.html) under the goal they belong to.
+When a plan ships or is superseded, remove its content from
+`ROADMAP.html` in the same PR; ROADMAP tracks the live state, not
+history.
+
 ## Project Layout
 
 The repository is a Cargo workspace rooted at
@@ -33,6 +158,11 @@ The repository is a Cargo workspace rooted at
 `scripts/`) is documentation or tooling around that workspace. The
 crate map and per-crate responsibilities live in
 [`rust/README.md`](./rust/README.md).
+
+Working defaults live in `.scode.json` (committed). Machine-local
+overrides live in `.nexus/sudocode/settings.local.json` (gitignored).
+Prefer editing existing files intentionally over replacing them
+wholesale — small, reviewable diffs land faster than large rewrites.
 
 All `cargo` commands in this guide assume your working directory is
 `rust/` unless stated otherwise.
@@ -42,8 +172,8 @@ All `cargo` commands in this guide assume your working directory is
 - **Rust (stable)** — install via [rustup](https://rustup.rs). The
   workspace pins `edition = "2021"` and tracks the current stable
   toolchain used by CI.
-- **`rustfmt`** and **`clippy`** components (installed by default with
-  `rustup`; otherwise `rustup component add rustfmt clippy`).
+- **`rustfmt`** and **`clippy`** components (installed by default
+  with `rustup`; otherwise `rustup component add rustfmt clippy`).
 - A POSIX-like shell for the helper scripts under `scripts/` and
   `rust/scripts/`.
 - (Optional) `python3` if you plan to run
@@ -70,8 +200,7 @@ the PR description first.
 
 ## Required checks
 
-CI runs three gating jobs against the `rust/` workspace. Run them
-locally before pushing.
+CI gates these on every PR. Run them locally before pushing:
 
 ```bash
 cd rust/
@@ -87,20 +216,21 @@ cargo test --workspace
 ./scripts/fmt.sh --check   # CI-equivalent check
 ```
 
-The workspace enables `clippy::all` and `clippy::pedantic` at `warn`
-level. A few pedantic lints are allowed globally
+The workspace enables `clippy::all` and `clippy::pedantic` at
+`warn` level. A few pedantic lints are allowed globally
 (`module_name_repetitions`, `missing_panics_doc`,
 `missing_errors_doc`); see `[workspace.lints.clippy]` in
-`rust/Cargo.toml`. Prefer fixing the lint over `#[allow(...)]`. Allow
-attributes should be scoped tightly and explained in a comment.
+`rust/Cargo.toml`. Prefer fixing the lint over `#[allow(...)]`.
+Allow attributes should be scoped tightly and explained in a
+comment.
 
-Tests run on a clean machine with no network access and no API
-credentials. Tests that need network or a live API gate behind
-`#[ignore]` or a dedicated `--test` integration target (see
-`rusty-sudocode-cli/tests/acp_live_smoke.rs` for the live-API smoke
-pattern, which CI only runs on `main`).
+`cargo test --workspace` runs PTY tests as part of the regular
+suite (not behind `#[ignore]`). Tests that need network or a live
+API gate behind `#[ignore]` or a dedicated `--test` integration
+target (see `rusty-sudocode-cli/tests/acp_live_smoke.rs` for the
+live-API smoke pattern, which CI only runs on `main`).
 
-## Optional / targeted checks
+### Targeted commands
 
 ```bash
 # A single crate's tests
@@ -135,39 +265,34 @@ relevant) `README.md`. When adding a new crate:
 2. Inherit shared metadata from the workspace where possible:
    ```toml
    [package]
-   name    = "<name>"
+   name              = "<name>"
    version.workspace = true
    edition.workspace = true
    license.workspace = true
    ```
-3. Add it to `rust/Cargo.toml` workspace dependencies if other crates
-   will consume it.
+3. Add it to `rust/Cargo.toml` workspace dependencies if other
+   crates will consume it.
 4. Run the [Required checks](#required-checks) before committing.
-
-## Mock parity harness
-
-The deterministic Anthropic-compatible mock service ships as the
-`mock-anthropic-service` crate. The harness lives at
-[`rust/scripts/run_mock_parity_harness.sh`](./rust/scripts/run_mock_parity_harness.sh).
-
-```bash
-cd rust/
-./scripts/run_mock_parity_harness.sh
-```
-
-Changes to `runtime/`, `tools/`, `api/`, or
-`rust/mock_parity_scenarios.json` run the harness locally and mention
-the result in the PR description. The full reference is at
-[`docs/mock-parity-harness.md`](./docs/mock-parity-harness.md).
 
 ## Commit style
 
-- Short, imperative subject: `Add ACP session.close support`.
-- One logical change per commit where practical. Reviewers split mixed
-  commits.
-- Reference issues in the body, not the subject: `Fixes #123` on its
-  own line at the bottom.
-- Commits omit generated artifacts (`target/`, IDE folders, `.DS_Store`).
+- **Many small commits, all on one PR.** Each commit is one logical
+  change with a clear subject. Ten focused commits beat one monster
+  commit — easier to review, easier to revert, easier for an AI
+  agent or human to read a year later.
+- Short, imperative subject:
+  `runtime: parse session.close in resume mode`.
+- One logical change per commit. Reviewers split mixed commits.
+- Reference issues in the body, not the subject: `Fixes #123` on
+  its own line at the bottom.
+- **No squash.** We use `--merge` (not `--squash`) when landing PRs
+  so feature-branch history reaches `main` intact. Squashing has
+  historically lost attribution across our multi-agent workflow.
+- Commits omit generated artifacts (`target/`, IDE folders,
+  `.DS_Store`).
+- **No AI signatures** (`Co-Authored-By: <AI tool>`,
+  "Generated with …", any AI footer). They pollute `git log`
+  without adding signal.
 
 ## Pull request guidelines
 
@@ -177,11 +302,21 @@ Before opening a PR:
 - [ ] `cargo fmt --all --check` passes.
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings` is clean.
 - [ ] `cargo test --workspace` passes locally.
+- [ ] The change does **not** add unit tests (see
+      [Test policy](#test-policy)).
+- [ ] The change does **not** introduce `ratatui`, alternate-screen
+      mode, a `--tui` flag, or any in-CLI multi-agent UI (see
+      [Design principles](#design-principles-you-must-respect)).
+- [ ] If the change is parity work, the PR description leads with a
+      CCB validation section (see
+      [Parity work — standing rule](#parity-work--standing-rule)).
 - [ ] If the change touches user-facing surfaces, the relevant
       `docs/*.md` SSOT is updated.
-- [ ] If the change touches the agent loop, tools, or API surface, the
-      mock parity harness still passes.
-- [ ] Commits are reasonably squashed and carry meaningful messages.
+- [ ] If the change touches the agent loop, tools, or API surface,
+      the mock parity harness still passes (run it locally and
+      mention the result in the PR description).
+- [ ] Commits are small and focused; no squashing in the local
+      history.
 
 When opening the PR:
 
@@ -190,12 +325,13 @@ When opening the PR:
   in each section.
 - **Title:** short, imperative, optionally prefixed with the affected
   area (`runtime:`, `cli:`, `docs:`).
-- **Summary:** explain *why* the change is needed, not just *what* it
-  does. Link the issue it closes.
+- **Summary:** explain *why* the change is needed, not just *what*
+  it does. Link the issue it closes.
 - **Testing:** list the exact commands run (`cargo test -p runtime`,
-  `./scripts/run_mock_parity_harness.sh`, manual REPL run, etc.).
-- **Scope:** keep PRs focused. Bug fixes and unrelated refactors land
-  in separate PRs.
+  PTY scenario name, `./scripts/run_mock_parity_harness.sh` if
+  invoked, manual REPL run, etc.).
+- **Scope:** keep PRs focused on one repo area at a time. Bug fixes
+  and unrelated refactors land in separate PRs.
 - **Draft early:** open the PR as a draft for directional feedback
   before polishing.
 
@@ -203,27 +339,42 @@ Reviewers may push small fixups directly to your branch (formatting,
 typos) unless the PR description opts out. Larger changes go through
 review comments.
 
-Once approved, a maintainer merges — usually as a squash commit.
-Force-pushing after a review has started goes through a request.
+Once approved, a maintainer merges with **`--merge`** (not squash)
+to preserve the feature-branch commit history. The "Block Merge
+Commits in PR" CI check requires you to **rebase** (not merge) when
+syncing your feature branch onto the latest `main` —
+`git rebase main` + `git push --force-with-lease` is the safe form.
 
 ## Reporting bugs & requesting features
 
 - **Bugs:** use the
   [bug report template](./.github/ISSUE_TEMPLATE/bug_report.md).
-  Include `scode --version`, the exact command run, the auth mode, and
-  the full error output.
+  Include `scode --version`, the exact command run, the auth mode,
+  and the full error output. If the bug touches a design principle
+  (see above), call that out explicitly — it helps triage.
 - **Features:** use the
   [feature request template](./.github/ISSUE_TEMPLATE/feature_request.md).
-  Describe the user-visible behavior and the motivating use case before
-  jumping to implementation ideas.
-- **Security issues:** email the maintainers listed in the repository's
-  security contact (see `SECURITY.md` if present) or use GitHub's
-  private vulnerability reporting.
+  Describe the user-visible behavior and the motivating use case
+  before jumping to implementation ideas. If your feature request
+  contradicts a Design principle (e.g. proposes a `--tui` flag,
+  proposes unit tests for a new module), the request will be closed
+  without code review.
+- **Security issues:** email the maintainers listed in the
+  repository's security contact (see `SECURITY.md` if present) or
+  use GitHub's private vulnerability reporting.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed
-under the [MIT License](./LICENSE.md) that covers this project.
+By contributing, your contributions are licensed under the
+[MIT License](./LICENSE.md) that covers this project.
+
+**No CLA. No copyright assignment.** You keep your copyright; we
+receive a permissive license. That is the whole arrangement — no
+contributor agreement to sign, no maintainer-administered waiver,
+no future ability for the maintainers to re-license your code
+without your consent. This is a deliberate "Always" principle of
+sudocode — see
+[`README.md` § Design principles](./README.md#design-principles).
 
 ---
 


### PR DESCRIPTION
## Summary

Aligns `CONTRIBUTING.md` with the design principles and test policy
that landed in PR #198 (README + ROADMAP rewrite), and consolidates
shared working rules out of `CLAUDE.md` so contributors (human and
AI) share one canonical guide.

## What changed

**`CONTRIBUTING.md` — rewrite**

- Top warning: read `README.md` + `ROADMAP.html` before
  contributing — PRs that contradict bright-line rules are declined
  regardless of code quality.
- New section: **Design principles you must respect** — fast-summary
  of the seven hard NOs (no `ratatui` / `--tui` / alternate-screen,
  no unit tests, no in-CLI multi-agent dashboard, no CLA, no
  "misclick" justification, no silent updates, no telemetry by
  default). Links to README § Design principles for the full 11+10.
- New section: **Test policy** — three-row layer table (PTY
  required, integration optional, unit forbidden) with the empirical
  rationale and the reopen procedure. Mock parity harness demoted to
  optional debug accelerator.
- New section: **Parity work — standing rule** — CCB validation
  flow + design-write-up-leads-with-CCB-section moved from
  `CLAUDE.md`.
- Reworked **Commit style**: many small focused commits, no squash,
  no AI signatures.
- Reworked **PR guidelines**: explicit checklist items for the
  bright-line rules; removed "usually as a squash commit".
- **License** section clarifies "no CLA, no copyright assignment,
  no future re-license" as a deliberate Always principle.
- New section: **Publishing the roadmap to ShareOne** — moved from
  `CLAUDE.md` because any contributor may need to mirror the
  roadmap, not just Claude.

**`CLAUDE.md` — slimmed to a 6-line pointer**

- All shared rules migrated to `CONTRIBUTING.md`.
- File kept as a thin pointer because Claude Code reads `CLAUDE.md`
  on startup by convention; the pointer guarantees the agent finds
  the canonical doc.

## Test plan

- [x] Doc-only change; no Rust compile / test impact expected.
- [ ] Doc source-of-truth CI check passes (no forbidden patterns).
- [ ] CI fmt / clippy / test / bench-compile pass on the branch
  (none of these read CONTRIBUTING or CLAUDE).
- [ ] Manual: links in CONTRIBUTING resolve correctly (README,
  ROADMAP anchors, docs/parity.md, docs/mock-parity-harness.md).