### PR TITLE
Improve stream error logging

### DIFF
--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -256,6 +256,8 @@ impl OpenAiCompatClient {
             usage_recorded: false,
             session_tracer: self.session_tracer().cloned(),
             state: StreamState::new(request.model.clone()),
+            chunks_read: 0,
+            sse_events_read: 0,
         })
     }
 
@@ -335,6 +337,10 @@ pub struct MessageStream {
     usage_recorded: bool,
     session_tracer: Option<telemetry::SessionTracer>,
     state: StreamState,
+    /// Number of HTTP chunks successfully read from the stream.
+    chunks_read: u64,
+    /// Number of SSE events successfully parsed from the stream.
+    sse_events_read: u64,
 }
 
 impl MessageStream {
@@ -358,14 +364,35 @@ impl MessageStream {
                 return Ok(None);
             }
 
-            match self.response.chunk().await? {
-                Some(chunk) => {
+            match self.response.chunk().await {
+                Ok(Some(chunk)) => {
+                    self.chunks_read += 1;
                     for parsed in self.parser.push(&chunk)? {
+                        self.sse_events_read += 1;
                         self.pending.extend(self.state.ingest_chunk(parsed)?);
                     }
                 }
-                None => {
+                Ok(None) => {
                     self.done = true;
+                }
+                Err(error) => {
+                    if let Some(tracer) = &self.session_tracer {
+                        let error_chain = format_error_chain(&error);
+                        tracer.record_stream_error(telemetry::StreamErrorTelemetry {
+                            request_id: self
+                                .request_id
+                                .clone()
+                                .unwrap_or_else(|| "unknown".to_string()),
+                            model: self.state.model.clone(),
+                            chunks_read: self.chunks_read,
+                            sse_events_read: self.sse_events_read,
+                            usage_seen: self.state.usage.is_some(),
+                            stream_finished: self.state.finished,
+                            error_message: error.to_string(),
+                            error_chain,
+                        });
+                    }
+                    return Err(ApiError::from(error));
                 }
             }
         }
@@ -1593,6 +1620,16 @@ fn normalize_finish_reason(value: &str) -> String {
         other => other,
     }
     .to_string()
+}
+
+fn format_error_chain(error: &dyn std::error::Error) -> String {
+    let mut chain = vec![error.to_string()];
+    let mut source = error.source();
+    while let Some(err) = source {
+        chain.push(err.to_string());
+        source = err.source();
+    }
+    chain.join(" -> ")
 }
 
 trait StringExt {

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -1019,6 +1019,41 @@ impl SessionTracer {
         attributes.insert("error_message".to_string(), Value::String(error_message));
         self.record("prompt_error", attributes);
     }
+
+    /// Record a stream error that occurred while reading the response body.
+    pub fn record_stream_error(&self, error: StreamErrorTelemetry) {
+        let mut attributes = Map::new();
+        attributes.insert("request_id".to_string(), Value::String(error.request_id));
+        attributes.insert("model".to_string(), Value::String(error.model));
+        attributes.insert("chunks_read".to_string(), Value::from(error.chunks_read));
+        attributes.insert(
+            "sse_events_read".to_string(),
+            Value::from(error.sse_events_read),
+        );
+        attributes.insert("usage_seen".to_string(), Value::Bool(error.usage_seen));
+        attributes.insert(
+            "stream_finished".to_string(),
+            Value::Bool(error.stream_finished),
+        );
+        attributes.insert(
+            "error_message".to_string(),
+            Value::String(error.error_message),
+        );
+        attributes.insert("error_chain".to_string(), Value::String(error.error_chain));
+        self.record("stream_error", attributes);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StreamErrorTelemetry {
+    pub request_id: String,
+    pub model: String,
+    pub chunks_read: u64,
+    pub sse_events_read: u64,
+    pub usage_seen: bool,
+    pub stream_finished: bool,
+    pub error_message: String,
+    pub error_chain: String,
 }
 
 /// Mask sensitive header values for debug capture logs.

--- a/scripts/analyze_scode_log.py
+++ b/scripts/analyze_scode_log.py
@@ -79,6 +79,10 @@ class SessionInfo:
     total_cache_creation_tokens: int = 0
     total_cache_read_tokens: int = 0
 
+    # Errors: prompt_error and stream_error events
+    prompt_errors: list[dict[str, Any]] = field(default_factory=list)
+    stream_errors: list[dict[str, Any]] = field(default_factory=list)
+
 
 def parse_timestamp(ts_str: str) -> datetime | None:
     """Parse ISO 8601 timestamp string."""
@@ -253,6 +257,26 @@ def analyze_log(log_path: Path) -> dict[str, SessionInfo]:
                     if header_name in headers:
                         req.provider_response_request_id = headers[header_name]
                         break
+
+            elif event == "prompt_error":
+                session.prompt_errors.append({
+                    "timestamp": timestamp,
+                    "error_type": attrs.get("error_type"),
+                    "error_message": attrs.get("error_message"),
+                })
+
+            elif event == "stream_error":
+                session.stream_errors.append({
+                    "timestamp": timestamp,
+                    "request_id": attrs.get("request_id"),
+                    "model": attrs.get("model"),
+                    "chunks_read": attrs.get("chunks_read"),
+                    "sse_events_read": attrs.get("sse_events_read"),
+                    "usage_seen": attrs.get("usage_seen"),
+                    "stream_finished": attrs.get("stream_finished"),
+                    "error_message": attrs.get("error_message"),
+                    "error_chain": attrs.get("error_chain"),
+                })
 
     return sessions
 
@@ -561,6 +585,43 @@ def print_report(sessions: dict[str, SessionInfo]) -> None:
                 if req.cache_read_input_tokens:
                     print(f"    Cache Read Tokens:         {req.cache_read_input_tokens:,}")
                 print()
+
+        # Errors section - prompt_error and stream_error
+        if session.prompt_errors or session.stream_errors:
+            print("-" * 80)
+            print("  ERRORS")
+            print("-" * 80)
+
+            if session.prompt_errors:
+                print(f"\n  Prompt Errors ({len(session.prompt_errors)}):")
+                for i, err in enumerate(session.prompt_errors, 1):
+                    ts = format_datetime(err.get("timestamp"))
+                    err_type = err.get("error_type") or "unknown"
+                    err_msg = err.get("error_message") or "N/A"
+                    print(f"    [{i}] {ts} - {err_type}: {err_msg[:200]}")
+
+            if session.stream_errors:
+                print(f"\n  Stream Errors ({len(session.stream_errors)}):")
+                for i, err in enumerate(session.stream_errors, 1):
+                    ts = format_datetime(err.get("timestamp"))
+                    req_id = err.get("request_id") or "unknown"
+                    model = err.get("model") or "unknown"
+                    chunks = err.get("chunks_read") or 0
+                    sse = err.get("sse_events_read") or 0
+                    usage_seen = err.get("usage_seen") or False
+                    finished = err.get("stream_finished") or False
+                    err_msg = err.get("error_message") or "N/A"
+                    err_chain = err.get("error_chain") or "N/A"
+                    print(f"    [{i}] {ts}")
+                    print(f"        Request ID: {req_id}")
+                    print(f"        Model: {model}")
+                    print(f"        Chunks read: {chunks}, SSE events: {sse}")
+                    print(f"        Usage seen: {usage_seen}, Stream finished: {finished}")
+                    print(f"        Error: {err_msg[:150]}")
+                    if err_chain and err_chain != err_msg:
+                        print(f"        Chain: {err_chain[:200]}")
+
+            print()
 
         # Session summary
         print("-" * 80)


### PR DESCRIPTION
## Summary
- add stream_error telemetry when OpenAI-compatible streaming response body reads fail
- include request/model, chunk and SSE event counters, usage/finish flags, and full error source chain
- teach scripts/analyze_scode_log.py to display prompt_error and stream_error events

## Behavior
- does not change request sending, retry behavior, or token/cost accounting
- stream body errors still return the original ApiError::Http path after logging

## Verification
- cargo fmt --all --check
- cargo check -p api -p telemetry
- analyze_scode_log.py smoke test with prompt_error and stream_error JSONL sample