### PR TITLE
feat(subagent): subagent registry and dispatch stub

### DIFF
--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -51,6 +51,7 @@ pub mod spawn_task;
 mod sse;
 pub mod stale_base;
 pub mod stale_branch;
+pub mod subagent;
 pub mod summary_compression;
 pub mod task_packet;
 pub mod task_registry;

--- a/rust/crates/runtime/src/subagent/dispatch.rs
+++ b/rust/crates/runtime/src/subagent/dispatch.rs
@@ -1,0 +1,122 @@
+//! Subagent dispatch — validation stub.
+//!
+//! Spawning a real child runtime (its own Tokio task, model client, and
+//! tool-surface enforcement) is deferred to a follow-up PR. For now,
+//! `dispatch` validates the request against the registry and reports
+//! whether the subagent *would* be spawned.
+
+use super::registry::SubagentRegistry;
+
+/// Request to dispatch work to a subagent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentRequest {
+    /// Name of a registered [`super::SubagentType`].
+    pub subagent_type: String,
+    /// Short (≤5 words) human-readable description used in UI and logs.
+    pub description: String,
+    /// Full task brief handed to the subagent.
+    pub prompt: String,
+}
+
+/// Outcome of a dispatch attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchStatus {
+    /// Request passed registry validation — a real runtime would spawn here.
+    Validated,
+    /// Request rejected before any work was attempted (e.g. unknown type).
+    Rejected(String),
+    /// Subagent ran and produced a result. Reserved for the post-stub
+    /// implementation; the current dispatcher never returns this variant.
+    Completed,
+    /// Subagent began running and failed. Reserved for the post-stub
+    /// implementation; the current dispatcher never returns this variant.
+    Failed(String),
+}
+
+/// Structured response from [`SubagentRegistry::dispatch`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentResponse {
+    pub status: DispatchStatus,
+    /// Populated when `status == Completed`. Always `None` from the stub.
+    pub result: Option<String>,
+    /// Human-readable message describing what happened.
+    pub message: String,
+}
+
+impl SubagentRegistry {
+    /// Validate `req` against the registry. Real execution is deferred —
+    /// see the module docs for scope.
+    // TODO(post-PR): wire up actual sub-runtime execution (separate Tokio
+    // task, separate model client, separate tool surface enforcement).
+    #[must_use]
+    pub fn dispatch(&self, req: SubagentRequest) -> SubagentResponse {
+        let Some(sa) = self.get(&req.subagent_type) else {
+            let message = format!("unknown subagent type: {}", req.subagent_type);
+            return SubagentResponse {
+                status: DispatchStatus::Rejected(message.clone()),
+                result: None,
+                message,
+            };
+        };
+
+        let tool_summary = match &sa.tools_allowed {
+            super::registry::ToolFilter::All => "all tools allowed".to_string(),
+            super::registry::ToolFilter::Allow(list) => {
+                format!("allowed tools: {}", list.join(", "))
+            }
+            super::registry::ToolFilter::Deny(list) => format!("denied tools: {}", list.join(", ")),
+        };
+
+        SubagentResponse {
+            status: DispatchStatus::Validated,
+            result: None,
+            message: format!(
+                "validated dispatch to `{}` ({}); {}",
+                sa.name, req.description, tool_summary
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::registry::{SubagentRegistry, SubagentType, ToolFilter};
+    use super::*;
+
+    fn req(kind: &str) -> SubagentRequest {
+        SubagentRequest {
+            subagent_type: kind.into(),
+            description: "find auth code".into(),
+            prompt: "Locate the authentication entry point.".into(),
+        }
+    }
+
+    #[test]
+    fn dispatch_unknown_is_rejected() {
+        let reg = SubagentRegistry::builtin();
+        let resp = reg.dispatch(req("does-not-exist"));
+        assert!(matches!(resp.status, DispatchStatus::Rejected(_)));
+        assert!(resp.result.is_none());
+    }
+
+    #[test]
+    fn dispatch_known_is_validated() {
+        let reg = SubagentRegistry::builtin();
+        let resp = reg.dispatch(req("explore"));
+        assert_eq!(resp.status, DispatchStatus::Validated);
+        assert!(resp.message.contains("explore"));
+        assert!(resp.result.is_none());
+    }
+
+    #[test]
+    fn dispatch_message_reflects_tool_filter() {
+        let mut reg = SubagentRegistry::empty();
+        reg.register(SubagentType::new(
+            "narrow",
+            "narrow agent",
+            ToolFilter::Allow(vec!["Read".into()]),
+        ));
+        let resp = reg.dispatch(req("narrow"));
+        assert!(resp.message.contains("Read"));
+    }
+}

--- a/rust/crates/runtime/src/subagent/mod.rs
+++ b/rust/crates/runtime/src/subagent/mod.rs
@@ -1,0 +1,124 @@
+//! Subagent infrastructure for the runtime.
+//!
+//! Owns the catalog of subagent types ([`SubagentRegistry`]) and the dispatch
+//! entry point that validates [`SubagentRequest`]s against that catalog.
+//! Actual sub-runtime execution is deferred (see [`dispatch`]).
+//!
+//! The prompt section advertising available subagents is injected via
+//! [`append_to_builder`] so callers can attach the section to an existing
+//! `SystemPromptBuilder` without taking a hard dependency on its internals.
+
+mod dispatch;
+mod registry;
+
+pub use dispatch::{DispatchStatus, SubagentRequest, SubagentResponse};
+pub use registry::{SubagentRegistry, SubagentType, ToolFilter};
+
+use crate::prompt::SystemPromptBuilder;
+
+/// Append the subagent-catalog section to `builder` if the registry is
+/// non-empty. Returns the builder unchanged when there are no subagents.
+#[must_use]
+pub fn append_to_builder(
+    builder: SystemPromptBuilder,
+    registry: &SubagentRegistry,
+) -> SystemPromptBuilder {
+    if registry.list().is_empty() {
+        return builder;
+    }
+    builder.append_section(registry.render_for_prompt())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_registry_has_expected_types() {
+        let reg = SubagentRegistry::builtin();
+
+        let explore = reg.get("explore").expect("explore registered");
+        match &explore.tools_allowed {
+            ToolFilter::Allow(list) => {
+                assert!(list.contains(&"Read".to_string()));
+                assert!(list.contains(&"Grep".to_string()));
+                assert!(list.contains(&"Glob".to_string()));
+                assert!(!list.contains(&"Edit".to_string()));
+                assert!(!list.contains(&"Write".to_string()));
+                assert!(!list.contains(&"Bash".to_string()));
+            }
+            other => panic!("explore should be Allow(...), got {other:?}"),
+        }
+
+        let general = reg
+            .get("general-purpose")
+            .expect("general-purpose registered");
+        assert!(matches!(general.tools_allowed, ToolFilter::All));
+
+        let plan = reg.get("plan").expect("plan registered");
+        assert!(!plan.tools_allowed.allows("Edit"));
+        assert!(!plan.tools_allowed.allows("Write"));
+        assert!(plan.tools_allowed.allows("Read"));
+
+        let reviewer = reg.get("code-reviewer").expect("code-reviewer registered");
+        assert!(!reviewer.tools_allowed.allows("Edit"));
+        assert!(!reviewer.tools_allowed.allows("Write"));
+        assert!(reviewer.tools_allowed.allows("Read"));
+    }
+
+    #[test]
+    fn test_dispatch_validates_unknown_type() {
+        let reg = SubagentRegistry::builtin();
+        let resp = reg.dispatch(SubagentRequest {
+            subagent_type: "no-such-agent".into(),
+            description: "x".into(),
+            prompt: "y".into(),
+        });
+        match resp.status {
+            DispatchStatus::Rejected(reason) => {
+                assert!(reason.contains("no-such-agent"));
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_validates_known_type() {
+        let reg = SubagentRegistry::builtin();
+        let resp = reg.dispatch(SubagentRequest {
+            subagent_type: "explore".into(),
+            description: "find login".into(),
+            prompt: "Locate the login handler.".into(),
+        });
+        assert_eq!(resp.status, DispatchStatus::Validated);
+    }
+
+    #[test]
+    fn test_render_for_prompt_contains_all_builtins() {
+        let rendered = SubagentRegistry::builtin().render_for_prompt();
+        assert!(rendered.contains("# Subagents"));
+        assert!(rendered.contains("explore"));
+        assert!(rendered.contains("general-purpose"));
+        assert!(rendered.contains("plan"));
+        assert!(rendered.contains("code-reviewer"));
+    }
+
+    #[test]
+    fn test_append_to_builder_injects_section() {
+        let reg = SubagentRegistry::builtin();
+        let builder = append_to_builder(SystemPromptBuilder::new(), &reg);
+        let rendered = builder.build().render();
+        assert!(rendered.contains("# Subagents"));
+        assert!(rendered.contains("explore"));
+    }
+
+    #[test]
+    fn test_append_to_builder_skips_when_empty() {
+        let reg = SubagentRegistry::empty();
+        let rendered_with = append_to_builder(SystemPromptBuilder::new(), &reg)
+            .build()
+            .render();
+        let rendered_without = SystemPromptBuilder::new().build().render();
+        assert_eq!(rendered_with, rendered_without);
+    }
+}

--- a/rust/crates/runtime/src/subagent/registry.rs
+++ b/rust/crates/runtime/src/subagent/registry.rs
@@ -1,0 +1,195 @@
+//! Subagent type registry.
+//!
+//! A [`SubagentRegistry`] holds the catalog of available subagent types — each
+//! described by a name, a human-readable purpose, and a [`ToolFilter`] that
+//! constrains which tools the subagent is allowed to use. The registry is the
+//! single source of truth that the prompt-injection helper and the dispatch
+//! stub both consult.
+
+/// Tool surface a subagent is permitted to use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolFilter {
+    /// Subagent inherits the full host tool set.
+    All,
+    /// Subagent may only use the listed tools.
+    Allow(Vec<String>),
+    /// Subagent may use everything except the listed tools.
+    Deny(Vec<String>),
+}
+
+impl ToolFilter {
+    /// Returns `true` iff `tool` is allowed by this filter.
+    #[must_use]
+    pub fn allows(&self, tool: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Allow(list) => list.iter().any(|t| t == tool),
+            Self::Deny(list) => list.iter().all(|t| t != tool),
+        }
+    }
+}
+
+/// A single subagent type definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentType {
+    pub name: String,
+    pub description: String,
+    pub tools_allowed: ToolFilter,
+}
+
+impl SubagentType {
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        tools_allowed: ToolFilter,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            tools_allowed,
+        }
+    }
+}
+
+/// Catalog of subagent types available to the runtime.
+#[derive(Debug, Clone, Default)]
+pub struct SubagentRegistry {
+    types: Vec<SubagentType>,
+}
+
+impl SubagentRegistry {
+    /// Empty registry. Useful for tests and for callers that want to
+    /// opt out of the built-in subagent set.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self { types: Vec::new() }
+    }
+
+    /// Registry pre-populated with the standard built-in subagent set:
+    /// `explore`, `general-purpose`, `plan`, `code-reviewer`.
+    #[must_use]
+    pub fn builtin() -> Self {
+        let mut registry = Self::empty();
+        registry.register(SubagentType::new(
+            "explore",
+            "Fast read-only search agent for locating code.",
+            ToolFilter::Allow(vec![
+                "Read".to_string(),
+                "Grep".to_string(),
+                "Glob".to_string(),
+            ]),
+        ));
+        registry.register(SubagentType::new(
+            "general-purpose",
+            "Multi-step research and execution agent.",
+            ToolFilter::All,
+        ));
+        registry.register(SubagentType::new(
+            "plan",
+            "Software architect for designing implementation plans.",
+            ToolFilter::Deny(vec![
+                "Edit".to_string(),
+                "Write".to_string(),
+                "NotebookEdit".to_string(),
+            ]),
+        ));
+        registry.register(SubagentType::new(
+            "code-reviewer",
+            "Reviews diffs for correctness.",
+            ToolFilter::Deny(vec![
+                "Edit".to_string(),
+                "Write".to_string(),
+                "NotebookEdit".to_string(),
+            ]),
+        ));
+        registry
+    }
+
+    /// Add or replace a subagent type. Replacement is by `name`.
+    pub fn register(&mut self, sa: SubagentType) {
+        if let Some(slot) = self.types.iter_mut().find(|t| t.name == sa.name) {
+            *slot = sa;
+        } else {
+            self.types.push(sa);
+        }
+    }
+
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&SubagentType> {
+        self.types.iter().find(|t| t.name == name)
+    }
+
+    #[must_use]
+    pub fn list(&self) -> &[SubagentType] {
+        &self.types
+    }
+
+    /// Render the prompt section describing available subagents. Returns an
+    /// empty string when the registry is empty so callers can skip injection.
+    #[must_use]
+    pub fn render_for_prompt(&self) -> String {
+        if self.types.is_empty() {
+            return String::new();
+        }
+
+        let mut out = String::from("# Subagents\n\n");
+        out.push_str(
+            "You can delegate work to specialized subagents via the `dispatch_subagent` tool.\n\n",
+        );
+        out.push_str("Available subagent types:\n");
+        for sa in &self.types {
+            let tools = match &sa.tools_allowed {
+                ToolFilter::All => "all".to_string(),
+                ToolFilter::Allow(list) => list.join(", "),
+                ToolFilter::Deny(list) => format!("all except {}", list.join(", ")),
+            };
+            out.push_str(&format!(
+                "- {}: {} Tools: {}.\n",
+                sa.name, sa.description, tools
+            ));
+        }
+        out.push('\n');
+        out.push_str("When to use a subagent:\n");
+        out.push_str("- Broad codebase exploration (>3 queries) → `explore`\n");
+        out.push_str("- Multi-step independent research → `general-purpose`\n");
+        out.push_str("- Design before implementation → `plan`\n");
+        out.push_str("- Verify diff correctness → `code-reviewer`\n\n");
+        out.push_str("Do NOT duplicate work a subagent is already doing.");
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_filter_all_allows_anything() {
+        assert!(ToolFilter::All.allows("Edit"));
+        assert!(ToolFilter::All.allows("anything"));
+    }
+
+    #[test]
+    fn tool_filter_allow_is_exact() {
+        let f = ToolFilter::Allow(vec!["Read".into(), "Grep".into()]);
+        assert!(f.allows("Read"));
+        assert!(!f.allows("Edit"));
+    }
+
+    #[test]
+    fn tool_filter_deny_is_exact() {
+        let f = ToolFilter::Deny(vec!["Edit".into()]);
+        assert!(f.allows("Read"));
+        assert!(!f.allows("Edit"));
+    }
+
+    #[test]
+    fn register_replaces_by_name() {
+        let mut reg = SubagentRegistry::empty();
+        reg.register(SubagentType::new("x", "v1", ToolFilter::All));
+        reg.register(SubagentType::new("x", "v2", ToolFilter::All));
+        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.get("x").unwrap().description, "v2");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `crates/runtime/src/subagent/` with `SubagentRegistry`, `SubagentType`, `ToolFilter`, and a validation-only `dispatch()` stub. Actual sub-runtime spawning (separate Tokio task + model client + tool-surface enforcement) is deferred and marked `TODO(post-PR)`.
- Built-ins registered out of the box: `explore` (read-only Read/Grep/Glob), `general-purpose` (all tools), `plan` and `code-reviewer` (read-only — deny Edit/Write/NotebookEdit).
- Inject the catalog into the system prompt via `subagent::append_to_builder`, which uses the existing `SystemPromptBuilder::append_section` hook — no changes to the builder struct.

## Notes
- One new `pub mod subagent;` line added to `crates/runtime/src/lib.rs`, alphabetically placed between `stale_branch` and `summary_compression`.
- No new `Cargo.toml` deps, no `Cargo.lock` churn.
- Module is isolated to `subagent/`; does not touch sibling memory/skill paths reserved for other workers.

## Test plan
- [x] `cargo build -p runtime`
- [x] `cargo test -p runtime subagent` (13 tests pass — 5 module tests + 8 unit tests)
- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (only pre-existing warnings outside this module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)