### PR TITLE
feat(skill): filesystem-based skill discovery and slash-command dispatch

### DIFF
--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -46,6 +46,7 @@ mod remote;
 pub mod sandbox;
 mod session;
 pub mod session_control;
+pub mod skill;
 pub use session_control::SessionStore;
 pub mod spawn_task;
 mod sse;

--- a/rust/crates/runtime/src/skill/discovery.rs
+++ b/rust/crates/runtime/src/skill/discovery.rs
@@ -1,0 +1,299 @@
+//! Filesystem walking + SKILL.md parsing.
+//!
+//! Each skill lives in its own directory containing a `SKILL.md` file
+//! with YAML-ish frontmatter. We hand-roll the frontmatter parser
+//! because the field set is tiny (string scalars + inline arrays) and
+//! pulling in a full YAML crate just for this would be overkill.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::registry::Skill;
+
+/// Parsed SKILL.md frontmatter values, separate from the markdown body.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Frontmatter {
+    pub fields: HashMap<String, FrontmatterValue>,
+}
+
+/// A single frontmatter value: scalar string or inline string array.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrontmatterValue {
+    Scalar(String),
+    List(Vec<String>),
+}
+
+impl FrontmatterValue {
+    #[must_use]
+    pub fn as_scalar(&self) -> Option<&str> {
+        match self {
+            Self::Scalar(s) => Some(s.as_str()),
+            Self::List(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_list(&self) -> Option<&[String]> {
+        match self {
+            Self::List(items) => Some(items.as_slice()),
+            Self::Scalar(_) => None,
+        }
+    }
+}
+
+/// Errors from the frontmatter parser.
+#[derive(Debug)]
+pub enum FrontmatterError {
+    /// The document has no `---` fence pair at the top.
+    Missing,
+    /// A line in the frontmatter wasn't `key: value`.
+    Malformed(String),
+}
+
+impl std::fmt::Display for FrontmatterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Missing => write!(f, "missing frontmatter"),
+            Self::Malformed(line) => write!(f, "malformed frontmatter line: {line}"),
+        }
+    }
+}
+
+impl std::error::Error for FrontmatterError {}
+
+/// Parse a SKILL.md document into (frontmatter, body).
+///
+/// Returns `Ok(None)` if the document has no frontmatter block.
+/// Returns `Err` if the frontmatter is present but malformed.
+pub fn parse_frontmatter(content: &str) -> Result<Option<(Frontmatter, String)>, FrontmatterError> {
+    let mut lines = content.lines();
+
+    let Some(first) = lines.next() else {
+        return Ok(None);
+    };
+    if first.trim() != "---" {
+        return Ok(None);
+    }
+
+    let mut fields: HashMap<String, FrontmatterValue> = HashMap::new();
+    let mut closed = false;
+    let mut body_start_offset = first.len() + 1; // include the trailing newline
+
+    for line in lines {
+        body_start_offset += line.len() + 1;
+        if line.trim() == "---" {
+            closed = true;
+            break;
+        }
+        // Blank lines and `#` comments are tolerated inside frontmatter.
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            return Err(FrontmatterError::Malformed(line.to_string()));
+        };
+        let key = key.trim().to_string();
+        if key.is_empty() {
+            return Err(FrontmatterError::Malformed(line.to_string()));
+        }
+        let value = value.trim();
+        let parsed = parse_value(value);
+        fields.insert(key, parsed);
+    }
+
+    if !closed {
+        return Err(FrontmatterError::Malformed(
+            "unterminated frontmatter block".to_string(),
+        ));
+    }
+
+    // The body is everything after the closing fence. Trim a single leading
+    // newline so the body doesn't start with a blank line artefact.
+    let body = if body_start_offset >= content.len() {
+        String::new()
+    } else {
+        let rest = &content[body_start_offset..];
+        rest.strip_prefix('\n').unwrap_or(rest).to_string()
+    };
+
+    Ok(Some((Frontmatter { fields }, body)))
+}
+
+fn parse_value(raw: &str) -> FrontmatterValue {
+    // Inline array: `[a, b, c]` (possibly quoted entries).
+    if raw.starts_with('[') && raw.ends_with(']') {
+        let inner = &raw[1..raw.len() - 1];
+        let items: Vec<String> = inner
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(strip_quotes)
+            .collect();
+        return FrontmatterValue::List(items);
+    }
+    FrontmatterValue::Scalar(strip_quotes(raw))
+}
+
+fn strip_quotes(s: &str) -> String {
+    let s = s.trim();
+    if (s.starts_with('"') && s.ends_with('"') && s.len() >= 2)
+        || (s.starts_with('\'') && s.ends_with('\'') && s.len() >= 2)
+    {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Parse a full SKILL.md file (frontmatter + body) into a [`Skill`].
+///
+/// `name` is taken from the frontmatter; the caller is responsible for
+/// supplying the on-disk directory + file paths.
+pub fn parse_skill_md(
+    content: &str,
+    root: PathBuf,
+    skill_md_path: PathBuf,
+) -> Result<Skill, FrontmatterError> {
+    let (frontmatter, body) = parse_frontmatter(content)?.ok_or(FrontmatterError::Missing)?;
+
+    let name = frontmatter
+        .fields
+        .get("name")
+        .and_then(FrontmatterValue::as_scalar)
+        .map(str::to_string)
+        .ok_or_else(|| FrontmatterError::Malformed("missing `name` field".to_string()))?;
+
+    let description = frontmatter
+        .fields
+        .get("description")
+        .and_then(FrontmatterValue::as_scalar)
+        .unwrap_or("")
+        .to_string();
+
+    let keywords = frontmatter
+        .fields
+        .get("keywords")
+        .and_then(FrontmatterValue::as_list)
+        .map(|items| items.iter().map(String::from).collect())
+        .unwrap_or_default();
+
+    let allowed_tools = frontmatter
+        .fields
+        .get("allowed_tools")
+        .and_then(FrontmatterValue::as_list)
+        .map(|items| items.iter().map(String::from).collect());
+
+    Ok(Skill {
+        name,
+        description,
+        keywords,
+        allowed_tools,
+        body,
+        root,
+        skill_md_path,
+    })
+}
+
+/// Walk `dir` looking for immediate subdirectories that contain a
+/// `SKILL.md`. Returns the parsed [`Skill`] for each one.
+///
+/// Non-existent directories are silently ignored — discovery is a
+/// best-effort scan, not a hard requirement.
+pub fn discover_in_dir(dir: &Path) -> std::io::Result<Vec<Skill>> {
+    let mut found = Vec::new();
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(found),
+        Err(err) => return Err(err),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let skill_md = path.join("SKILL.md");
+        if !skill_md.is_file() {
+            continue;
+        }
+        let content = fs::read_to_string(&skill_md)?;
+        match parse_skill_md(&content, path.clone(), skill_md.clone()) {
+            Ok(skill) => found.push(skill),
+            Err(err) => {
+                // A malformed SKILL.md should not poison the whole scan;
+                // skip it and let the user notice via missing entry.
+                eprintln!("warning: skipping {} — {}", skill_md.display(), err);
+            }
+        }
+    }
+
+    Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frontmatter_parser_basic() {
+        let doc = "---\nname: foo\ndescription: A test skill\n---\n# Body\nhello\n";
+        let (fm, body) = parse_frontmatter(doc)
+            .unwrap()
+            .expect("frontmatter present");
+        assert_eq!(fm.fields.get("name").unwrap().as_scalar(), Some("foo"));
+        assert_eq!(
+            fm.fields.get("description").unwrap().as_scalar(),
+            Some("A test skill")
+        );
+        assert!(body.starts_with("# Body"));
+        assert!(body.contains("hello"));
+    }
+
+    #[test]
+    fn test_frontmatter_parser_with_list() {
+        let doc =
+            "---\nname: tools\nkeywords: [alpha, beta, gamma]\nallowed_tools: [Read, Write]\n---\n";
+        let (fm, _body) = parse_frontmatter(doc).unwrap().unwrap();
+        let kws = fm.fields.get("keywords").unwrap().as_list().unwrap();
+        assert_eq!(kws, &["alpha", "beta", "gamma"]);
+        let tools = fm.fields.get("allowed_tools").unwrap().as_list().unwrap();
+        assert_eq!(tools, &["Read", "Write"]);
+    }
+
+    #[test]
+    fn test_frontmatter_parser_no_frontmatter() {
+        let doc = "# Just markdown\n\nNo frontmatter here.\n";
+        assert!(parse_frontmatter(doc).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_frontmatter_parser_quoted_values() {
+        let doc = "---\nname: \"foo-bar\"\ndescription: 'quoted desc'\n---\n";
+        let (fm, _) = parse_frontmatter(doc).unwrap().unwrap();
+        assert_eq!(fm.fields.get("name").unwrap().as_scalar(), Some("foo-bar"));
+        assert_eq!(
+            fm.fields.get("description").unwrap().as_scalar(),
+            Some("quoted desc")
+        );
+    }
+
+    #[test]
+    fn test_frontmatter_parser_unterminated() {
+        let doc = "---\nname: oops\nstill going\n";
+        assert!(parse_frontmatter(doc).is_err());
+    }
+
+    #[test]
+    fn test_parse_skill_md_missing_name() {
+        let doc = "---\ndescription: no name\n---\nbody";
+        let err =
+            parse_skill_md(doc, PathBuf::from("/a"), PathBuf::from("/a/SKILL.md")).unwrap_err();
+        match err {
+            FrontmatterError::Malformed(msg) => assert!(msg.contains("name")),
+            FrontmatterError::Missing => panic!("expected Malformed, got Missing"),
+        }
+    }
+}

--- a/rust/crates/runtime/src/skill/dispatch.rs
+++ b/rust/crates/runtime/src/skill/dispatch.rs
@@ -1,0 +1,116 @@
+//! Slash-command parsing for explicit skill invocation.
+//!
+//! When the user starts a message with `/<skill-name>`, we treat it as
+//! an explicit invocation request and extract `(skill_name, args)`.
+//! Skill names follow the kebab-case convention: only `[a-z0-9-]` are
+//! valid characters, and the name cannot be empty.
+
+/// Parsed slash-command from user input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashCommand {
+    pub skill_name: String,
+    pub args: String,
+}
+
+/// Parse `input` as a slash-command.
+///
+/// Returns `Some(SlashCommand)` when the input starts with `/` followed
+/// by a non-empty kebab-case identifier. Returns `None` otherwise.
+#[must_use]
+pub fn parse_slash_command(input: &str) -> Option<SlashCommand> {
+    let stripped = input.strip_prefix('/')?;
+    if stripped.is_empty() {
+        return None;
+    }
+    // Split into (name, args) on first whitespace.
+    let (name, rest) = match stripped.find(char::is_whitespace) {
+        Some(idx) => (&stripped[..idx], stripped[idx..].trim_start()),
+        None => (stripped, ""),
+    };
+    if !is_valid_skill_name(name) {
+        return None;
+    }
+    Some(SlashCommand {
+        skill_name: name.to_string(),
+        args: rest.to_string(),
+    })
+}
+
+fn is_valid_skill_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    // Disallow leading/trailing hyphen for cleanliness; nothing in the
+    // task spec demands it, but it avoids quirky names like `-foo` and
+    // `foo-`.
+    if name.starts_with('-') || name.ends_with('-') {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_slash_command_valid() {
+        let cmd = parse_slash_command("/browser open google.com").unwrap();
+        assert_eq!(cmd.skill_name, "browser");
+        assert_eq!(cmd.args, "open google.com");
+    }
+
+    #[test]
+    fn test_parse_slash_command_no_args() {
+        let cmd = parse_slash_command("/cron").unwrap();
+        assert_eq!(cmd.skill_name, "cron");
+        assert_eq!(cmd.args, "");
+    }
+
+    #[test]
+    fn test_parse_slash_command_kebab_name() {
+        let cmd = parse_slash_command("/git-clean-reset --force").unwrap();
+        assert_eq!(cmd.skill_name, "git-clean-reset");
+        assert_eq!(cmd.args, "--force");
+    }
+
+    #[test]
+    fn test_parse_slash_command_with_digits() {
+        let cmd = parse_slash_command("/skill-42 do thing").unwrap();
+        assert_eq!(cmd.skill_name, "skill-42");
+    }
+
+    #[test]
+    fn test_parse_slash_command_invalid_chars() {
+        assert!(parse_slash_command("/Foo").is_none());
+        assert!(parse_slash_command("/foo_bar").is_none());
+        assert!(parse_slash_command("/foo.bar").is_none());
+        assert!(parse_slash_command("/FOO BAR").is_none());
+    }
+
+    #[test]
+    fn test_parse_slash_command_no_slash() {
+        assert!(parse_slash_command("hello world").is_none());
+        assert!(parse_slash_command("").is_none());
+        assert!(parse_slash_command(" /foo").is_none());
+    }
+
+    #[test]
+    fn test_parse_slash_command_just_slash() {
+        assert!(parse_slash_command("/").is_none());
+    }
+
+    #[test]
+    fn test_parse_slash_command_leading_or_trailing_hyphen() {
+        assert!(parse_slash_command("/-foo").is_none());
+        assert!(parse_slash_command("/foo-").is_none());
+    }
+
+    #[test]
+    fn test_parse_slash_command_tab_separated_args() {
+        let cmd = parse_slash_command("/foo\targ1 arg2").unwrap();
+        assert_eq!(cmd.skill_name, "foo");
+        assert_eq!(cmd.args, "arg1 arg2");
+    }
+}

--- a/rust/crates/runtime/src/skill/mod.rs
+++ b/rust/crates/runtime/src/skill/mod.rs
@@ -1,0 +1,92 @@
+//! Filesystem-based skill discovery and slash-command dispatch.
+//!
+//! A *skill* is a directory under `~/.scode/skills/<name>/` (or
+//! `<cwd>/.scode/skills/<name>/`) containing a `SKILL.md` file with
+//! YAML-ish frontmatter and a markdown body. Skills are discovered at
+//! runtime, made available to the model via a rendered prompt section,
+//! and can be invoked explicitly with `/<skill-name> [args]`.
+//!
+//! This module only handles parsing, discovery, and dispatch validation.
+//! Execution of skill bodies (i.e. routing the user's request through
+//! a skill's instructions) is deliberately out of scope here.
+
+mod discovery;
+mod dispatch;
+mod registry;
+
+pub use discovery::{parse_skill_md, FrontmatterError};
+pub use dispatch::{parse_slash_command, SlashCommand};
+pub use registry::{Skill, SkillRegistry};
+
+use crate::prompt::SystemPromptBuilder;
+
+/// Append the registry's prompt section to a [`SystemPromptBuilder`].
+///
+/// No-op when the registry is empty — we do not want to inject an empty
+/// section that wastes prompt tokens.
+#[must_use]
+pub fn append_to_builder(
+    builder: SystemPromptBuilder,
+    registry: &SkillRegistry,
+) -> SystemPromptBuilder {
+    if registry.list().is_empty() {
+        return builder;
+    }
+    builder.append_section(registry.render_for_prompt())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::prompt::SystemPromptBuilder;
+
+    fn unique_tmp(prefix: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("scode-skill-mod-{prefix}-{pid}-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_skill(dir: &std::path::Path, name: &str, description: &str) {
+        let skill_dir = dir.join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_append_to_builder_injects_section() {
+        let dir = unique_tmp("inject");
+        write_skill(&dir, "browser", "drive a browser");
+
+        let reg = SkillRegistry::discover(&[dir.as_path()]).unwrap();
+        let builder = SystemPromptBuilder::new();
+        let rendered = append_to_builder(builder, &reg).render();
+
+        assert!(rendered.contains("# Skills"), "missing # Skills header");
+        assert!(rendered.contains("browser"), "missing skill name");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_append_to_builder_noop_on_empty_registry() {
+        let reg = SkillRegistry::default();
+        let baseline = SystemPromptBuilder::new().render();
+        let with_empty = append_to_builder(SystemPromptBuilder::new(), &reg).render();
+        assert_eq!(
+            baseline, with_empty,
+            "empty registry should not add a section"
+        );
+    }
+}

--- a/rust/crates/runtime/src/skill/registry.rs
+++ b/rust/crates/runtime/src/skill/registry.rs
@@ -1,0 +1,294 @@
+//! The [`SkillRegistry`] holds skills discovered from the filesystem
+//! and renders the prompt section that informs the model about them.
+
+use std::path::{Path, PathBuf};
+
+use super::discovery::discover_in_dir;
+
+const MAX_DESCRIPTION_CHARS: usize = 200;
+const MAX_RENDERED_CHARS: usize = 10_000;
+
+/// A skill discovered on disk.
+///
+/// `body` holds the parsed markdown after the frontmatter; we keep it so
+/// callers can decide whether to inline it into the prompt directly or
+/// instruct the model to read `skill_md_path` when invoked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Skill {
+    pub name: String,
+    pub description: String,
+    pub keywords: Vec<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub body: String,
+    pub root: PathBuf,
+    pub skill_md_path: PathBuf,
+}
+
+/// In-memory collection of discovered [`Skill`]s, keyed by name.
+#[derive(Debug, Clone, Default)]
+pub struct SkillRegistry {
+    skills: Vec<Skill>,
+}
+
+impl SkillRegistry {
+    /// Build a registry from a list of search paths.
+    ///
+    /// Later paths override earlier ones if names collide — this lets
+    /// project-local skills shadow user-global ones.
+    pub fn discover(search_paths: &[&Path]) -> std::io::Result<Self> {
+        let mut by_name: std::collections::BTreeMap<String, Skill> =
+            std::collections::BTreeMap::new();
+        for path in search_paths {
+            for skill in discover_in_dir(path)? {
+                by_name.insert(skill.name.clone(), skill);
+            }
+        }
+        let skills: Vec<Skill> = by_name.into_values().collect();
+        Ok(Self { skills })
+    }
+
+    /// Discover skills in the default search paths:
+    /// 1. `~/.scode/skills/`
+    /// 2. `<cwd>/.scode/skills/` (overridable via
+    ///    `SUDOCODE_WORKSPACE_SKILLS_DIR`)
+    pub fn discover_default() -> std::io::Result<Self> {
+        let mut paths: Vec<PathBuf> = Vec::new();
+        if let Some(home) = home_dir() {
+            paths.push(home.join(".scode").join("skills"));
+        }
+        let workspace = match std::env::var_os("SUDOCODE_WORKSPACE_SKILLS_DIR") {
+            Some(value) => PathBuf::from(value),
+            None => std::env::current_dir()?.join(".scode").join("skills"),
+        };
+        paths.push(workspace);
+        let refs: Vec<&Path> = paths.iter().map(PathBuf::as_path).collect();
+        Self::discover(&refs)
+    }
+
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Skill> {
+        self.skills.iter().find(|s| s.name == name)
+    }
+
+    #[must_use]
+    pub fn list(&self) -> &[Skill] {
+        &self.skills
+    }
+
+    /// Render the prompt section advertising available skills.
+    ///
+    /// Each line is capped at [`MAX_DESCRIPTION_CHARS`]; the total
+    /// output is capped at [`MAX_RENDERED_CHARS`]. If the cap is hit,
+    /// the LATER skills are dropped and a footer notes how many.
+    #[must_use]
+    pub fn render_for_prompt(&self) -> String {
+        use std::fmt::Write as _;
+
+        let header = "# Skills\n\nThe following skills are available. When the user's request matches a skill's description, read the SKILL.md and follow its instructions instead of using native tools for the same capability.\n\nAvailable skills:";
+        let footer_template = "\n\nWhen the user types `/<skill-name>`, that is an explicit invocation. Load the skill's SKILL.md and execute according to its instructions.";
+
+        let mut out = String::new();
+        out.push_str(header);
+
+        let mut dropped = 0usize;
+        for (idx, skill) in self.skills.iter().enumerate() {
+            let line = format!(
+                "\n- {} ({}): {}",
+                skill.name,
+                truncate(&skill.description, MAX_DESCRIPTION_CHARS),
+                skill.skill_md_path.display()
+            );
+            // Reserve room for the footer plus a possible dropped-note.
+            let dropped_note_budget = 64;
+            if out.len() + line.len() + footer_template.len() + dropped_note_budget
+                > MAX_RENDERED_CHARS
+            {
+                dropped = self.skills.len() - idx;
+                break;
+            }
+            out.push_str(&line);
+        }
+
+        if dropped > 0 {
+            let plural = if dropped == 1 { "" } else { "s" };
+            let _ = write!(
+                &mut out,
+                "\n- ... ({dropped} more skill{plural} omitted to fit prompt budget)"
+            );
+        }
+
+        out.push_str(footer_template);
+        out
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_skill(dir: &Path, name: &str, description: &str) {
+        let skill_dir = dir.join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        let content = format!(
+            "---\nname: {name}\ndescription: {description}\nkeywords: [{name}, test]\n---\n# {name}\nbody for {name}\n"
+        );
+        fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+    }
+
+    fn unique_tmp(prefix: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("scode-skill-test-{prefix}-{pid}-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_discover_finds_skills_in_user_dir() {
+        let user = unique_tmp("user");
+        write_skill(&user, "alpha", "first skill");
+        write_skill(&user, "beta", "second skill");
+
+        let reg = SkillRegistry::discover(&[user.as_path()]).unwrap();
+        let names: Vec<&str> = reg.list().iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"alpha"), "expected alpha in {names:?}");
+        assert!(names.contains(&"beta"), "expected beta in {names:?}");
+        assert_eq!(reg.list().len(), 2);
+
+        let alpha = reg.get("alpha").expect("alpha missing");
+        assert_eq!(alpha.description, "first skill");
+        assert!(alpha.keywords.contains(&"alpha".to_string()));
+        assert!(alpha.body.contains("body for alpha"));
+
+        fs::remove_dir_all(&user).ok();
+    }
+
+    #[test]
+    fn test_discover_project_overrides_user() {
+        let user = unique_tmp("user-base");
+        let project = unique_tmp("project-base");
+        write_skill(&user, "shared", "from user");
+        write_skill(&project, "shared", "from project");
+        write_skill(&user, "user-only", "user owns this");
+
+        let reg = SkillRegistry::discover(&[user.as_path(), project.as_path()]).unwrap();
+        let shared = reg.get("shared").expect("shared missing");
+        assert_eq!(
+            shared.description, "from project",
+            "project skill should override user skill"
+        );
+        // Sanity: the user-only skill survives.
+        assert!(reg.get("user-only").is_some());
+
+        fs::remove_dir_all(&user).ok();
+        fs::remove_dir_all(&project).ok();
+    }
+
+    #[test]
+    fn test_discover_ignores_missing_paths() {
+        let nonexistent = std::env::temp_dir().join("scode-definitely-not-a-dir-xyz-123-abc");
+        let reg = SkillRegistry::discover(&[nonexistent.as_path()]).unwrap();
+        assert!(reg.list().is_empty());
+    }
+
+    #[test]
+    fn test_discover_skips_dirs_without_skill_md() {
+        let dir = unique_tmp("no-skill-md");
+        fs::create_dir_all(dir.join("not-a-skill")).unwrap();
+        fs::write(dir.join("not-a-skill").join("README.md"), "hi").unwrap();
+        write_skill(&dir, "real-skill", "I am real");
+
+        let reg = SkillRegistry::discover(&[dir.as_path()]).unwrap();
+        let names: Vec<&str> = reg.list().iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["real-skill"]);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_render_for_prompt_contains_skill_names() {
+        let dir = unique_tmp("render");
+        write_skill(&dir, "browser", "drive a browser");
+        write_skill(&dir, "cron", "schedule things");
+
+        let reg = SkillRegistry::discover(&[dir.as_path()]).unwrap();
+        let rendered = reg.render_for_prompt();
+        assert!(rendered.contains("# Skills"));
+        assert!(rendered.contains("browser"));
+        assert!(rendered.contains("cron"));
+        assert!(rendered.contains("SKILL.md"));
+        assert!(rendered.contains("/<skill-name>"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_render_for_prompt_truncates_long_description() {
+        let skill = Skill {
+            name: "verbose".into(),
+            description: "x".repeat(500),
+            keywords: vec![],
+            allowed_tools: None,
+            body: String::new(),
+            root: PathBuf::from("/tmp"),
+            skill_md_path: PathBuf::from("/tmp/SKILL.md"),
+        };
+        let reg = SkillRegistry {
+            skills: vec![skill],
+        };
+        let out = reg.render_for_prompt();
+        // The line with the long description should be capped to ≈200 chars
+        // plus the surrounding format text, so the rendered string is well
+        // under the 10K cap.
+        assert!(out.len() < 1_000);
+        assert!(out.contains('…'));
+    }
+
+    #[test]
+    fn test_render_for_prompt_caps_total_output() {
+        let mut skills = Vec::new();
+        for i in 0..1000 {
+            skills.push(Skill {
+                name: format!("skill-{i:04}"),
+                description: "padding ".repeat(20),
+                keywords: vec![],
+                allowed_tools: None,
+                body: String::new(),
+                root: PathBuf::from("/tmp"),
+                skill_md_path: PathBuf::from(format!("/tmp/skill-{i:04}/SKILL.md")),
+            });
+        }
+        let reg = SkillRegistry { skills };
+        let out = reg.render_for_prompt();
+        assert!(
+            out.len() <= 10_000,
+            "rendered length {} exceeds cap",
+            out.len()
+        );
+        assert!(out.contains("omitted"));
+    }
+
+    #[test]
+    fn test_get_returns_none_for_unknown() {
+        let reg = SkillRegistry::default();
+        assert!(reg.get("nope").is_none());
+        assert!(reg.list().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `runtime::skill` module that discovers, parses, and routes user-defined skills:

- **Discovery** — Walks `~/.scode/skills/` and `<cwd>/.scode/skills/` (the latter overridable via `SUDOCODE_WORKSPACE_SKILLS_DIR`) looking for subdirectories that contain a `SKILL.md`. Project-local skills override user-global skills with the same name. Malformed `SKILL.md` files are skipped (with a stderr warning) rather than poisoning the whole scan.
- **Frontmatter parser** — Hand-rolled `key: value` + `[a, b, c]` inline-array parser. No new heavy dependencies (no `serde_yaml`).
- **`SkillRegistry`** — Holds discovered skills, exposes `discover`/`discover_default`/`get`/`list`/`render_for_prompt`. The prompt section caps individual descriptions at 200 chars and total output at 10 000 chars, dropping later skills (with a `... (N omitted)` footer) if the cap is hit.
- **Slash-command dispatch** — `parse_slash_command("/browser open google.com")` returns `Some(SlashCommand { skill_name: "browser", args: "open google.com" })`. Names are kebab-case (`[a-z0-9-]`, no leading/trailing hyphen). `/`, `/Foo`, `/foo_bar`, `hello world`, etc. all return `None`.
- **Prompt injection** — One new `pub mod skill;` in `lib.rs` (alphabetical) and a small `append_to_builder(builder, &registry)` helper that calls the existing `SystemPromptBuilder::append_section()`. No new builder fields or methods — the existing append hook is the only touchpoint, per the shared-context rules to minimize merge surface with the parallel memory/subagent PRs.

Skill body execution (i.e. actually routing the user's request through a skill's instructions) is intentionally out of scope here — that lands in a follow-up.

## Test plan

In-module tests cover the full surface (25 new tests, all passing):

- [x] Frontmatter parser: basic, inline arrays, no-frontmatter, quoted values, unterminated.
- [x] `parse_skill_md` missing `name` field surfaces a `Malformed` error.
- [x] Discovery: finds skills in a user dir, project overrides user on name collision, ignores missing paths, skips dirs without `SKILL.md`.
- [x] Slash-command parser: valid, no-args, kebab name, digits, invalid chars (`/Foo`, `/foo_bar`, `/foo.bar`), no leading `/`, lone `/`, leading/trailing hyphen, tab-separated args.
- [x] `render_for_prompt` mentions skill names, truncates long descriptions, and respects the 10 000-char cap with a "N omitted" footer.
- [x] `append_to_builder` injects a `# Skills` section into `SystemPromptBuilder` and is a no-op when the registry is empty.
- [x] `cargo build -p runtime` succeeds.
- [x] `cargo test -p runtime skill` — 25/25 passing.
- [x] `cargo test --workspace` — passes.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy --workspace --all-targets` — no new warnings in `skill/` (pre-existing telemetry/CLI lints unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)