### PR TITLE
docs(roadmap): hacker-priority column + §1 row definitions

### DIFF
--- a/ROADMAP.html
+++ b/ROADMAP.html
@@ -336,170 +336,178 @@ coverage starts fresh and is tracked here as the single source.</p>
   <li><strong>N/A</strong> — out of scope for <code>scode</code> itself.</li>
 </ul>
 
+<p><strong>Hacker priority</strong> (the new column):</p>
+<ul>
+  <li><strong>must-have</strong> — the hacker workflow blocks without it: invocation, streaming feedback, mid-flight cancel, bash/edit/grep, <code>/commit</code>, <code>/pr</code>, <code>/resume</code>, <code>--output-format json</code>.</li>
+  <li><strong>nice</strong> — L2-deferred surface (LSP, sub-agents, cron, MCP plugins): real features, not on the critical path for e2e &ge; 90%.</li>
+  <li><strong>N/A</strong> — sudowork-UI / credential-injection concerns; never enters <code>scode</code>'s coverage denominator.</li>
+</ul>
+
+<p>The aggregated tier view (P0/P1/P2/P3 across categories) still lives in <a href="#priority-sequencing">Priority sequencing</a>; the per-row column above is the hacker-priority lens &mdash; one decision per feature, not one decision per tier.</p>
+
 <h4>1. Core conversation</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td>Single-turn prompt</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td>Multi-turn context</td><td>Gap</td><td>—</td><td>Follow-up references prior turn</td></tr>
-    <tr><td>Streaming response</td><td>Gap</td><td>—</td><td>Implicit in every interaction</td></tr>
-    <tr><td>Multi-tool turn roundtrip</td><td>Gap</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — multiple tools in one assistant turn, each result feeds the next</td></tr>
-    <tr><td>Graceful cancel mid-execution</td><td>Gap</td><td>—</td><td>Integration-covered by <code>interrupt_e2e.rs</code>; PTY pending — SIGINT during bash, verify interrupted envelope and no continuation</td></tr>
-    <tr><td>Agent switching (Sudoclaw ↔ scode)</td><td>N/A</td><td>—</td><td>sudowork-UI concern</td></tr>
+    <tr><td>Single-turn prompt</td><td>must-have</td><td>Gap</td><td>—</td><td>Non-interactive, invocation-driven: <code>scode -p "…"</code> starts, streams the assistant turn, then exits. PTY verifies the process truly exits without TTY input.</td></tr>
+    <tr><td>Multi-turn context</td><td>must-have</td><td>Gap</td><td>—</td><td>Follow-up references prior turn</td></tr>
+    <tr><td>Streaming response</td><td>must-have</td><td>Gap</td><td>—</td><td>LLM-API streaming: assistant tokens render incrementally as they arrive. Pairing requirement for cancel-mid below.</td></tr>
+    <tr><td>Multi-tool turn roundtrip</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — multiple tools in one assistant turn, each result feeds the next</td></tr>
+    <tr><td>Graceful cancel mid-execution</td><td>must-have</td><td>Gap</td><td>—</td><td>User presses ESC during streaming output (LLM tokens or tool call) — scode stops the in-flight turn and no further iterations issue. Integration-covered by <code>interrupt_e2e.rs</code>; PTY pending — SIGINT during bash, verify interrupted envelope and no continuation.</td></tr>
   </tbody>
 </table>
 
 <h4>1b. Transport (ACP)</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td>ACP stdio transport</td><td>Gap</td><td>—</td><td>Integration-covered by <code>acp_integration.rs</code>; **kept as integration** — protocol-level surface, not REPL-fidelity, PTY adds no fidelity</td></tr>
-    <tr><td>ACP WebSocket transport</td><td>Gap</td><td>—</td><td>Same as above — protocol-level, integration is the right layer</td></tr>
-    <tr><td>ACP session lifecycle (EOF / orphan)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>acp_integration.rs</code>; tests that host stdin EOF makes the agent exit cleanly without orphans</td></tr>
-    <tr><td>Live API smoke (real Anthropic)</td><td>N/A</td><td>—</td><td>Covered by <code>acp_live_smoke.rs</code>; runs only on main with <code>CLAUDE_CODE_OAUTH_TOKEN</code>; live-gate, not a coverage-denominator concern</td></tr>
+    <tr><td>ACP stdio transport</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>acp_integration.rs</code>; **kept as integration** — protocol-level surface, not REPL-fidelity, PTY adds no fidelity</td></tr>
+    <tr><td>ACP WebSocket transport</td><td>must-have</td><td>Gap</td><td>—</td><td>Same as above — protocol-level, integration is the right layer</td></tr>
+    <tr><td>ACP session lifecycle (EOF / orphan)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>acp_integration.rs</code>; tests that host stdin EOF makes the agent exit cleanly without orphans</td></tr>
+    <tr><td>Live API smoke (real Anthropic)</td><td>N/A</td><td>N/A</td><td>—</td><td>Covered by <code>acp_live_smoke.rs</code>; runs only on main with <code>CLAUDE_CODE_OAUTH_TOKEN</code>; live-gate, not a coverage-denominator concern</td></tr>
   </tbody>
 </table>
 
 <h4>2. Tool usage — file operations</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>read_file</code></td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>write_file</code></td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>edit_file</code></td><td>Gap</td><td>—</td><td>Write → edit → read back</td></tr>
-    <tr><td><code>glob_search</code></td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>grep_search</code></td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>read_file</code></td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>write_file</code></td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>edit_file</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Write → edit → read back</td></tr>
+    <tr><td><code>glob_search</code></td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>grep_search</code></td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
   </tbody>
 </table>
 
 <h4>3. Tool usage — execution</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>bash</code></td><td>Gap</td><td>—</td><td>Run script, echo, sleep</td></tr>
-    <tr><td>REPL (persistent Python/JS subprocess)</td><td>Gap</td><td>—</td><td>Different from one-shot bash</td></tr>
-    <tr><td>PowerShell</td><td>Gap</td><td>—</td><td>Windows-only path</td></tr>
-    <tr><td><code>NotebookEdit</code> (Jupyter)</td><td>Gap</td><td>—</td><td>Needs <code>.ipynb</code> fixture</td></tr>
+    <tr><td><code>bash</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Run script, echo, sleep</td></tr>
+    <tr><td>REPL (persistent Python/JS subprocess)</td><td>must-have</td><td>Gap</td><td>—</td><td>Different from one-shot bash</td></tr>
+    <tr><td>PowerShell</td><td>must-have</td><td>Gap</td><td>—</td><td>Windows-only path</td></tr>
+    <tr><td><code>NotebookEdit</code> (Jupyter)</td><td>must-have</td><td>Gap</td><td>—</td><td>Needs <code>.ipynb</code> fixture</td></tr>
   </tbody>
 </table>
 
 <h4>4. Tool usage — search &amp; web</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>WebSearch</code></td><td>Gap</td><td>—</td><td>Searches current info, verifies results</td></tr>
-    <tr><td><code>WebFetch</code> (URL → extract)</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>WebSearch</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Searches current info, verifies results</td></tr>
+    <tr><td><code>WebFetch</code> (URL → extract)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
   </tbody>
 </table>
 
 <h4>5. Tool usage — code intelligence</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td>LSP <code>goToDefinition</code></td><td>Gap (L2)</td><td>—</td><td>Needs mock language server</td></tr>
-    <tr><td>LSP <code>findReferences</code></td><td>Gap (L2)</td><td>—</td><td></td></tr>
-    <tr><td>LSP <code>hover</code></td><td>Gap (L2)</td><td>—</td><td></td></tr>
-    <tr><td>LSP <code>documentSymbol</code></td><td>Gap (L2)</td><td>—</td><td></td></tr>
-    <tr><td><code>ToolSearch</code></td><td>Gap</td><td>—</td><td>Search for tools by keyword</td></tr>
+    <tr><td>LSP <code>goToDefinition</code></td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Needs mock language server</td></tr>
+    <tr><td>LSP <code>findReferences</code></td><td>nice</td><td>Gap (L2)</td><td>—</td><td></td></tr>
+    <tr><td>LSP <code>hover</code></td><td>nice</td><td>Gap (L2)</td><td>—</td><td></td></tr>
+    <tr><td>LSP <code>documentSymbol</code></td><td>nice</td><td>Gap (L2)</td><td>—</td><td></td></tr>
+    <tr><td><code>ToolSearch</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Search for tools by keyword</td></tr>
   </tbody>
 </table>
 
 <h4>6. Tool usage — planning &amp; structured</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>EnterPlanMode</code> / <code>ExitPlanMode</code></td><td>Gap</td><td>—</td><td>Plan → implement → test → iterate</td></tr>
-    <tr><td><code>TodoWrite</code></td><td>Gap</td><td>—</td><td>Task list management</td></tr>
-    <tr><td><code>AskUserQuestion</code></td><td>Gap</td><td>—</td><td>scode prompts for clarification</td></tr>
-    <tr><td><code>StructuredOutput</code></td><td>Gap</td><td>—</td><td>Return structured data</td></tr>
-    <tr><td><code>Sleep</code></td><td>Gap</td><td>—</td><td>Low priority</td></tr>
+    <tr><td><code>EnterPlanMode</code> / <code>ExitPlanMode</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Plan → implement → test → iterate</td></tr>
+    <tr><td><code>TodoWrite</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Task list management</td></tr>
+    <tr><td><code>AskUserQuestion</code></td><td>must-have</td><td>Gap</td><td>—</td><td>scode prompts for clarification</td></tr>
+    <tr><td><code>StructuredOutput</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Return structured data</td></tr>
+    <tr><td><code>Sleep</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Low priority</td></tr>
   </tbody>
 </table>
 
 <h4>7. Tool usage — background &amp; parallel</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>Agent</code> (sub-agents)</td><td>Gap (L2)</td><td>—</td><td>Launch parallel sub-agents</td></tr>
-    <tr><td><code>TaskCreate</code> / <code>TaskGet</code> / <code>TaskList</code></td><td>Gap (L2)</td><td>—</td><td>Background task management</td></tr>
-    <tr><td>Workers (boot, trust, prompt)</td><td>Gap (L2)</td><td>—</td><td>Worker lifecycle</td></tr>
-    <tr><td>Teams (parallel sub-agents)</td><td>Gap (L2)</td><td>—</td><td>Team coordination</td></tr>
-    <tr><td><code>CronCreate</code> / <code>CronDelete</code></td><td>Gap (L2)</td><td>—</td><td>Needs wall-clock or fake timer</td></tr>
+    <tr><td><code>Agent</code> (sub-agents)</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Launch parallel sub-agents</td></tr>
+    <tr><td><code>TaskCreate</code> / <code>TaskGet</code> / <code>TaskList</code></td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Background task management</td></tr>
+    <tr><td>Workers (boot, trust, prompt)</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Worker lifecycle</td></tr>
+    <tr><td>Teams (parallel sub-agents)</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Team coordination</td></tr>
+    <tr><td><code>CronCreate</code> / <code>CronDelete</code></td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Needs wall-clock or fake timer</td></tr>
   </tbody>
 </table>
 
 <h4>8. Git workflow</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>/commit</code> (generate + create)</td><td>Gap</td><td>—</td><td>Init repo → write → commit → verify log</td></tr>
-    <tr><td><code>/pr</code> (draft / create PR)</td><td>Gap</td><td>—</td><td><strong>P0</strong> — core workflow</td></tr>
-    <tr><td><code>/diff</code> (show changes)</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>/issue</code> (create GitHub issue)</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>/review</code> (code review)</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/commit</code> (generate + create)</td><td>must-have</td><td>Gap</td><td>—</td><td>Init repo → write → commit → verify log</td></tr>
+    <tr><td><code>/pr</code> (draft / create PR)</td><td>must-have</td><td>Gap</td><td>—</td><td><strong>P0</strong> — core workflow</td></tr>
+    <tr><td><code>/diff</code> (show changes)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/issue</code> (create GitHub issue)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/review</code> (code review)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
   </tbody>
 </table>
 
 <h4>9. Session management</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td>Session auto-save</td><td>Gap</td><td>—</td><td>Persists across turns</td></tr>
-    <tr><td>Session JSONL persistence (model + transcript)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>acp_live_smoke.rs</code> + <code>resume_slash_commands.rs</code>; PTY pending — assistant messages carry model field, transcript replayable</td></tr>
-    <tr><td><code>/resume</code> (load saved session)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>resume_slash_commands.rs</code>; PTY pending — send → close → resume → verify</td></tr>
-    <tr><td><code>--resume latest</code> shortcut</td><td>Gap</td><td>—</td><td>Integration-covered by <code>resume_slash_commands.rs</code>; PTY pending — restores most-recent managed session without an explicit id</td></tr>
-    <tr><td><code>/session list</code> / <code>switch</code> / <code>fork</code></td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>/export</code> (session to markdown)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>resume_slash_commands.rs</code> + <code>output_format_contract.rs</code>; PTY pending — JSON + plaintext modes</td></tr>
-    <tr><td><code>/undo</code> (edit_file / write_file rollback)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>undo_e2e.rs</code>; PTY pending — restore after edit, delete created file, nothing-to-undo, hook-feedback robustness, JSON output</td></tr>
-    <tr><td><code>/compact</code> (compress history)</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td>Auto-compact trigger</td><td>Gap</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — runtime-initiated compaction when context fills, distinct from manual <code>/compact</code></td></tr>
+    <tr><td>Session auto-save</td><td>must-have</td><td>Gap</td><td>—</td><td>Persists across turns</td></tr>
+    <tr><td>Session JSONL persistence (model + transcript)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>acp_live_smoke.rs</code> + <code>resume_slash_commands.rs</code>; PTY pending — assistant messages carry model field, transcript replayable</td></tr>
+    <tr><td><code>/resume</code> (load saved session)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>resume_slash_commands.rs</code>; PTY pending — send → close → resume → verify</td></tr>
+    <tr><td><code>--resume latest</code> shortcut</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>resume_slash_commands.rs</code>; PTY pending — restores most-recent managed session without an explicit id</td></tr>
+    <tr><td><code>/session list</code> / <code>switch</code> / <code>fork</code></td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/export</code> (session to markdown)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>resume_slash_commands.rs</code> + <code>output_format_contract.rs</code>; PTY pending — JSON + plaintext modes</td></tr>
+    <tr><td><code>/undo</code> (edit_file / write_file rollback)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>undo_e2e.rs</code>; PTY pending — restore after edit, delete created file, nothing-to-undo, hook-feedback robustness, JSON output</td></tr>
+    <tr><td><code>/compact</code> (compress history)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td>Auto-compact trigger</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — runtime-initiated compaction when context fills, distinct from manual <code>/compact</code></td></tr>
   </tbody>
 </table>
 
 <h4>10. Configuration &amp; discovery</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>/model</code> (switch model)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — <code>--model X</code> wiring + persisted in resumed status</td></tr>
-    <tr><td><code>/permissions</code> (switch mode)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — read-only / workspace-write / danger</td></tr>
-    <tr><td>Permission prompt flow (approve / deny)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — interactive approval at the boundary, not just mode switch</td></tr>
-    <tr><td><code>/auth</code> (switch auth mode)</td><td>N/A</td><td>—</td><td>sudowork credential injection concern</td></tr>
-    <tr><td>Informational commands bypass credential check</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — help / version / config / status / sandbox succeed without any auth</td></tr>
-    <tr><td><code>/skills</code> (list / invoke)</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>/agents</code> (list)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>output_format_contract.rs</code>; PTY pending — structured-JSON agent entries</td></tr>
-    <tr><td><code>/mcp</code> (list / show servers)</td><td>Gap (L2)</td><td>—</td><td>Plugin lifecycle</td></tr>
-    <tr><td><code>/plugins</code> (manage)</td><td>Gap (L2)</td><td>—</td><td>Plugin install/enable/disable</td></tr>
-    <tr><td>Plugin → system-prompt injection</td><td>Gap (L2)</td><td>—</td><td>Was unit-covered by deleted <code>plugin_prompt_injection.rs</code>; also exercised by <code>system_prompt_command.rs</code>; PTY pending — enabled plugin lands in dynamic sections, disabled does not</td></tr>
-    <tr><td>Plugin tool roundtrip</td><td>Gap (L2)</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — plugin-defined tool executes through the agent loop</td></tr>
-    <tr><td><code>/config</code> (inspect)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code> + <code>output_format_contract.rs</code>; PTY pending — JSON section access + standard-location loading</td></tr>
-    <tr><td><code>--output-format json</code> (universal flag)</td><td>Gap</td><td>—</td><td>Integration-covered extensively by <code>output_format_contract.rs</code>; PTY pending — applies across help, version, status, sandbox, inventory, agents, bootstrap, system-prompt, dump-manifests, init, doctor, resume-status, config, export-help</td></tr>
-    <tr><td><code>--compact</code> output flag</td><td>Gap</td><td>—</td><td>Integration-covered by <code>compact_output.rs</code>; PTY pending — final assistant text only, no tool-call details. Distinct from <code>/compact</code> slash command</td></tr>
-    <tr><td>Slash command UX (fuzzy suggest + OMC compat hint)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — typo'd slash shows nearest match; OMC-namespaced commands surface targeted compat hint</td></tr>
-    <tr><td>Informational CLI subcommands (<code>help</code>/<code>version</code>/<code>init</code>/<code>bootstrap</code>/<code>system-prompt</code>/<code>dump-manifests</code>)</td><td>Gap</td><td>—</td><td>Integration-covered by <code>output_format_contract.rs</code> + <code>system_prompt_command.rs</code>; PTY pending — each subcommand has both plaintext and structured-JSON modes</td></tr>
+    <tr><td><code>/model</code> (switch model)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — <code>--model X</code> wiring + persisted in resumed status</td></tr>
+    <tr><td><code>/permissions</code> (switch mode)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — read-only / workspace-write / danger</td></tr>
+    <tr><td>Permission prompt flow (approve / deny)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — interactive approval at the boundary, not just mode switch</td></tr>
+    <tr><td><code>/auth</code> (switch auth mode)</td><td>N/A</td><td>N/A</td><td>—</td><td>sudowork credential injection concern</td></tr>
+    <tr><td>Informational commands bypass credential check</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — help / version / config / status / sandbox succeed without any auth</td></tr>
+    <tr><td><code>/skills</code> (list / invoke)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/agents</code> (list)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>output_format_contract.rs</code>; PTY pending — structured-JSON agent entries</td></tr>
+    <tr><td><code>/mcp</code> (list / show servers)</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Plugin lifecycle</td></tr>
+    <tr><td><code>/plugins</code> (manage)</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Plugin install/enable/disable</td></tr>
+    <tr><td>Plugin → system-prompt injection</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Was unit-covered by deleted <code>plugin_prompt_injection.rs</code>; also exercised by <code>system_prompt_command.rs</code>; PTY pending — enabled plugin lands in dynamic sections, disabled does not</td></tr>
+    <tr><td>Plugin tool roundtrip</td><td>nice</td><td>Gap (L2)</td><td>—</td><td>Integration-covered by <code>mock_parity_harness.rs</code>; PTY pending — plugin-defined tool executes through the agent loop</td></tr>
+    <tr><td><code>/config</code> (inspect)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code> + <code>output_format_contract.rs</code>; PTY pending — JSON section access + standard-location loading</td></tr>
+    <tr><td><code>--output-format json</code> (universal flag)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered extensively by <code>output_format_contract.rs</code>; PTY pending — applies across help, version, status, sandbox, inventory, agents, bootstrap, system-prompt, dump-manifests, init, doctor, resume-status, config, export-help</td></tr>
+    <tr><td><code>--compact</code> output flag</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>compact_output.rs</code>; PTY pending — final assistant text only, no tool-call details. Distinct from <code>/compact</code> slash command</td></tr>
+    <tr><td>Slash command UX (fuzzy suggest + OMC compat hint)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>cli_flags_and_config_defaults.rs</code>; PTY pending — typo'd slash shows nearest match; OMC-namespaced commands surface targeted compat hint</td></tr>
+    <tr><td>Informational CLI subcommands (<code>help</code>/<code>version</code>/<code>init</code>/<code>bootstrap</code>/<code>system-prompt</code>/<code>dump-manifests</code>)</td><td>must-have</td><td>Gap</td><td>—</td><td>Integration-covered by <code>output_format_contract.rs</code> + <code>system_prompt_command.rs</code>; PTY pending — each subcommand has both plaintext and structured-JSON modes</td></tr>
   </tbody>
 </table>
 
 <h4>11. Diagnostics</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>/doctor</code></td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>/status</code></td><td>Gap</td><td>—</td><td>Model, permissions, usage</td></tr>
-    <tr><td><code>/sandbox</code></td><td>Gap</td><td>—</td><td>Isolation status</td></tr>
-    <tr><td><code>/cost</code> (token usage)</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td>Prompt-response token usage</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/doctor</code></td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>/status</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Model, permissions, usage</td></tr>
+    <tr><td><code>/sandbox</code></td><td>must-have</td><td>Gap</td><td>—</td><td>Isolation status</td></tr>
+    <tr><td><code>/cost</code> (token usage)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td>Prompt-response token usage</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
   </tbody>
 </table>
 
 <h4>12. Auth</h4>
 <table>
-  <thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
+  <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td>Subscription auth (CC OAuth)</td><td>Gap</td><td>—</td><td>Uses injected <code>CLAUDE_CODE_OAUTH_TOKEN</code></td></tr>
-    <tr><td>Proxy auth (sudorouter)</td><td>Gap</td><td>—</td><td>Via <code>ANTHROPIC_API_KEY</code> injection</td></tr>
-    <tr><td>API key auth</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>scode login</code> (CLI)</td><td>Gap</td><td>—</td><td></td></tr>
-    <tr><td><code>scode logout</code> (CLI)</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td>Subscription auth (CC OAuth)</td><td>must-have</td><td>Gap</td><td>—</td><td>Uses injected <code>CLAUDE_CODE_OAUTH_TOKEN</code></td></tr>
+    <tr><td>Proxy auth (sudorouter)</td><td>must-have</td><td>Gap</td><td>—</td><td>Via <code>ANTHROPIC_API_KEY</code> injection</td></tr>
+    <tr><td>API key auth</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>scode login</code> (CLI)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
+    <tr><td><code>scode logout</code> (CLI)</td><td>must-have</td><td>Gap</td><td>—</td><td></td></tr>
   </tbody>
 </table>
 
@@ -508,7 +516,7 @@ coverage starts fresh and is tracked here as the single source.</p>
 <table>
   <thead><tr><th>Category</th><th>Total</th><th>N/A</th><th>L2 deferred</th><th>In current denominator</th></tr></thead>
   <tbody>
-    <tr><td>Core Conversation</td><td>6</td><td>1</td><td>0</td><td>5</td></tr>
+    <tr><td>Core Conversation</td><td>5</td><td>0</td><td>0</td><td>5</td></tr>
     <tr><td>Transport (ACP)</td><td>4</td><td>1</td><td>0</td><td>3</td></tr>
     <tr><td>File Operations</td><td>5</td><td>0</td><td>0</td><td>5</td></tr>
     <tr><td>Execution</td><td>4</td><td>0</td><td>0</td><td>4</td></tr>
@@ -521,7 +529,7 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>Config &amp; Discovery</td><td>16</td><td>1</td><td>4</td><td>11</td></tr>
     <tr><td>Diagnostics</td><td>5</td><td>0</td><td>0</td><td>5</td></tr>
     <tr><td>Auth</td><td>5</td><td>0</td><td>0</td><td>5</td></tr>
-    <tr><th>Total</th><th>76</th><th>3</th><th>13</th><th>60</th></tr>
+    <tr><th>Total</th><th>75</th><th>2</th><th>13</th><th>60</th></tr>
   </tbody>
 </table>
 
@@ -539,7 +547,7 @@ multiple Goal 1 rows show "Integration-covered by &lt;file.rs&gt;; PTY
 pending" — they are real feature surface a heavy user touches, but the
 coverage measure waits on PTY.</p>
 
-<h3>Priority sequencing</h3>
+<h3 id="priority-sequencing">Priority sequencing</h3>
 
 <table>
   <thead><tr><th>Tier</th><th>Items</th></tr></thead>

--- a/scripts/roadmap-prio-column.py
+++ b/scripts/roadmap-prio-column.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# One-off: add "Hacker Priority" column to every inventory table in
+# ROADMAP.html, refine 3 row descriptions (single-turn / streaming /
+# graceful cancel), and drop the agent-switching row. Lives under
+# scripts/ purely so the diff is reproducible; not part of the build.
+
+import re, sys, io, pathlib
+
+PATH = pathlib.Path("ROADMAP.html")
+src = PATH.read_text(encoding="utf-8")
+
+# Refine §1 Core conversation rows ---------------------------------------------
+src = src.replace(
+    '<tr><td>Single-turn prompt</td><td>Gap</td><td>—</td><td></td></tr>',
+    '<tr><td>Single-turn prompt</td><td>Gap</td><td>—</td><td>'
+    'Non-interactive, invocation-driven: <code>scode -p "…"</code> starts, '
+    'streams the assistant turn, then exits. PTY verifies the process truly '
+    'exits without TTY input.</td></tr>'
+)
+src = src.replace(
+    '<tr><td>Streaming response</td><td>Gap</td><td>—</td><td>Implicit in every interaction</td></tr>',
+    '<tr><td>Streaming response</td><td>Gap</td><td>—</td><td>'
+    'LLM-API streaming: assistant tokens render incrementally as they arrive. '
+    'Pairing requirement for cancel-mid below.</td></tr>'
+)
+src = src.replace(
+    '<tr><td>Graceful cancel mid-execution</td><td>Gap</td><td>—</td><td>'
+    'Integration-covered by <code>interrupt_e2e.rs</code>; PTY pending — '
+    'SIGINT during bash, verify interrupted envelope and no continuation</td></tr>',
+    '<tr><td>Graceful cancel mid-execution</td><td>Gap</td><td>—</td><td>'
+    'User presses ESC during streaming output (LLM tokens or tool call) — '
+    'scode stops the in-flight turn and no further iterations issue. '
+    'Integration-covered by <code>interrupt_e2e.rs</code>; PTY pending — '
+    'SIGINT during bash, verify interrupted envelope and no continuation.</td></tr>'
+)
+
+# Drop the agent-switching row (sudowork-UI concern, per shareone comment).
+src = re.sub(
+    r'\s*<tr><td>Agent switching \(Sudoclaw ↔ scode\)</td>'
+    r'<td>N/A</td><td>—</td><td>sudowork-UI concern</td></tr>\n',
+    '\n',
+    src
+)
+
+# Add "Hacker Priority" column to every inventory table -------------------------
+# Inventory tables sit between <h3>Feature inventory</h3> and the next
+# <h3>Coverage denominator</h3>. Only those tables get the new column.
+start = src.index('<h3>Feature inventory</h3>')
+end = src.index('<h3>Coverage denominator')
+head_block = src[start:end]
+
+# Rewrite thead — Feature | Hacker Priority | Status | Test | Notes
+head_block = head_block.replace(
+    '<thead><tr><th>Feature</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>',
+    '<thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th>'
+    '<th>Test</th><th>Notes</th></tr></thead>'
+)
+
+# Tag each tbody row with a priority td derived from its status / L2 marker.
+#   - Status == "N/A"   → "N/A"     (out of scope for scode)
+#   - "L2" in status    → "nice"    (L2-deferred = not blocking for hacker MVP)
+#   - everything else   → "must-have"
+def add_prio(match):
+    feature_td, status_td, rest = match.group(1), match.group(2), match.group(3)
+    status_text = re.sub(r'<[^>]+>', '', status_td)
+    if 'N/A' in status_text:
+        prio = 'N/A'
+    elif 'L2' in status_text:
+        prio = 'nice'
+    else:
+        prio = 'must-have'
+    return f'<tr><td>{feature_td}</td><td>{prio}</td><td>{status_td}</td>{rest}'
+
+row_re = re.compile(
+    r'<tr><td>(.*?)</td><td>(Gap[^<]*|Covered[^<]*|N/A[^<]*)</td>(.*?</tr>)',
+    re.DOTALL
+)
+head_block = row_re.sub(add_prio, head_block)
+
+src = src[:start] + head_block + src[end:]
+
+# Insert the legend right after the "Status values:" bullet list, so the new
+# column is documented inline.
+status_marker = ("  <li><strong>N/A</strong> — out of scope for "
+                 "<code>scode</code> itself.</li>\n</ul>")
+legend = (
+    "  <li><strong>N/A</strong> — out of scope for <code>scode</code> itself.</li>\n"
+    "</ul>\n\n"
+    "<p><strong>Hacker priority</strong> (the new column):</p>\n"
+    "<ul>\n"
+    "  <li><strong>must-have</strong> — the hacker workflow blocks without "
+    "it: invocation, streaming feedback, mid-flight cancel, bash/edit/grep, "
+    "<code>/commit</code>, <code>/pr</code>, <code>/resume</code>, "
+    "<code>--output-format json</code>.</li>\n"
+    "  <li><strong>nice</strong> — L2-deferred surface (LSP, sub-agents, "
+    "cron, MCP plugins): real features, not on the critical path for "
+    "e2e &ge; 90%.</li>\n"
+    "  <li><strong>N/A</strong> — sudowork-UI / credential-injection "
+    "concerns; never enters <code>scode</code>'s coverage denominator.</li>\n"
+    "</ul>\n\n"
+    "<p>The aggregated tier view (P0/P1/P2/P3 across categories) still "
+    "lives in <a href=\"#priority-sequencing\">Priority sequencing</a>; "
+    "the per-row column above is the hacker-priority lens "
+    "&mdash; one decision per feature, not one decision per tier.</p>"
+)
+assert status_marker in src, "status_marker not found"
+src = src.replace(status_marker, legend, 1)
+
+# Anchor the Priority sequencing h3 so the legend link resolves.
+src = src.replace(
+    '<h3>Priority sequencing</h3>',
+    '<h3 id="priority-sequencing">Priority sequencing</h3>',
+    1,
+)
+
+PATH.write_text(src, encoding="utf-8")
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+print("OK")


### PR DESCRIPTION
## Summary
Address open shareone comments on https://shareone.app/s/sudo-code-roadmap (share `tSuFEZMXszyR7bQa`).

- New **Hacker Priority** column on every inventory table (§1-13), with legend. Rule: `L2-deferred → "nice"`, `N/A → "N/A"`, otherwise `"must-have"`. Per-feature lens; complements the existing P0/P1/P2/P3 tier sequencing.
- §1 Core conversation row definitions refined:
  - **Single-turn prompt** — non-interactive, invocation-driven, exit-on-output. PTY confirms no-TTY-input.
  - **Streaming response** — LLM-API token streaming; pairing requirement for cancel-mid.
  - **Graceful cancel mid-execution** — ESC during streaming output is the user trigger (not just SIGINT).
- **Drop** §1 `Agent switching (Sudoclaw ↔ scode)` row — sudowork-UI concern, never enters scode's denominator. Coverage table updated (Core Conversation 6→5; Total 76→75, N/A 3→2).

`scripts/roadmap-prio-column.py` records the one-off transform.

## Test plan
- [x] ROADMAP.html renders (no broken tags)
- [x] Coverage denominator totals consistent (75 = 60 + 13 + 2)
- [x] `#priority-sequencing` anchor resolves from legend link

Closes shareone threads `1f7eaa85` (priority column), `b5527e6b` (single-turn), `cb821974` (streaming), `f3df0786` (cancel-mid), `15ca9c3f` (agent-switching drop).