### PR TITLE
chore!: rename ROADMAP.html → sudo-code-roadmap.html

### DIFF
--- a/.github/scripts/check_doc_source_of_truth.py
+++ b/.github/scripts/check_doc_source_of_truth.py
@@ -8,7 +8,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 FILES = [
     ROOT / 'README.md',
-    ROOT / 'ROADMAP.html',
+    ROOT / 'sudo-code-roadmap.html',
     ROOT / 'CLAUDE.md',
     ROOT / 'CONTRIBUTING.md',
     ROOT / '.github' / 'FUNDING.yml',

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,7 +12,7 @@ on:
       - .github/scripts/check_doc_source_of_truth.py
       - .github/FUNDING.yml
       - README.md
-      - ROADMAP.html
+      - sudo-code-roadmap.html
       - CLAUDE.md
       - CONTRIBUTING.md
       - LAST_PARITY_SYNC_COMMIT
@@ -28,7 +28,7 @@ on:
       - .github/scripts/check_doc_source_of_truth.py
       - .github/FUNDING.yml
       - README.md
-      - ROADMAP.html
+      - sudo-code-roadmap.html
       - CLAUDE.md
       - CONTRIBUTING.md
       - LAST_PARITY_SYNC_COMMIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ and AI agents follow the same rules in here.** Read it once before
 your first contribution.
 
 > **Before you write code, read [`README.md`](./README.md) and
-> [`ROADMAP.html`](./ROADMAP.html).** Sudo Code has a small but
+> [`sudo-code-roadmap.html`](./sudo-code-roadmap.html).** Sudo Code has a small but
 > bright-line set of design rules; PRs that contradict them are
 > declined regardless of code quality. The fast summary lives in
 > [Design principles you must respect](#design-principles-you-must-respect)
-> below; the full statement is in `ROADMAP.html`.
+> below; the full statement is in `sudo-code-roadmap.html`.
 
 ## Table of Contents
 
@@ -42,7 +42,7 @@ personal or off-topic.
 
 These are bright-line rules. PRs that introduce any of the items
 below will be asked to remove them or are closed. Reopening any rule
-requires a separate `ROADMAP.html` edit before the code lands — not
+requires a separate `sudo-code-roadmap.html` edit before the code lands — not
 the code first.
 
 **Hard NOs (the ones contributors trip on most):**
@@ -101,10 +101,10 @@ themselves in caught bugs. The PTY layer plus structured-log trace
 quality is our substitute for fine-grained failure attribution.
 
 **Reopening this rule** requires a concrete bug a unit test would
-have caught and a PTY scenario would not, plus a `ROADMAP.html` edit
+have caught and a PTY scenario would not, plus a `sudo-code-roadmap.html` edit
 to change the rule before the unit test lands.
 
-(See `ROADMAP.html` § Goal 1 → "Test layer policy" for the long form.)
+(See `sudo-code-roadmap.html` § Goal 1 → "Test layer policy" for the long form.)
 
 ### Running tests
 
@@ -142,16 +142,16 @@ source for our Rust tree; we read it for understanding only. The
 full triage flow, the Tier 1 source list (public CC surfaces,
 the private `sudoprivacy/claude-code` snapshot, the runtime-
 observation combo), the sync markers, and the resolution
-taxonomy now live in [`ROADMAP.html`](./ROADMAP.html) under
+taxonomy now live in [`sudo-code-roadmap.html`](./sudo-code-roadmap.html) under
 Goal 2.
 
 Every design write-up for a feature with parity intent **leads**
 with a CCB validation section: which CCB files were read, what
 behavior was confirmed, what surprises were found, and what
 decisions follow. Design write-ups live in
-[`ROADMAP.html`](./ROADMAP.html) under the goal they belong to.
+[`sudo-code-roadmap.html`](./sudo-code-roadmap.html) under the goal they belong to.
 When a plan ships or is superseded, remove its content from
-`ROADMAP.html` in the same PR; ROADMAP tracks the live state, not
+`sudo-code-roadmap.html` in the same PR; ROADMAP tracks the live state, not
 history.
 
 ## Project Layout
@@ -368,11 +368,11 @@ syncing your feature branch onto the latest `main` —
 
 ## Publishing the roadmap to ShareOne (interim, manual)
 
-`ROADMAP.html` is the SSOT plan file. Mirroring it to ShareOne for
+`sudo-code-roadmap.html` is the SSOT plan file. Mirroring it to ShareOne for
 at-a-glance external viewing is currently a manual maintainer step
 — both human and AI contributors can run it. The long-term plan
 exposes `publish_to_shareone` as an LLM tool that any `scode` agent
-can call, tracked as a Goal 3 candidate inside `ROADMAP.html`; it
+can call, tracked as a Goal 3 candidate inside `sudo-code-roadmap.html`; it
 ships when a real user asks for it.
 
 Until that tool exists, the documented manual recipes are:
@@ -383,7 +383,7 @@ Until that tool exists, the documented manual recipes are:
 curl -s -X POST https://shareone.app/api/v1/pages \
   -H "X-API-Key: $SHAREONE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d "{\"filename\":\"ROADMAP.html\",\"html_content\":$(jq -Rs . < ROADMAP.html),\"allow_comments\":true}"
+  -d "{\"filename\":\"sudo-code-roadmap.html\",\"html_content\":$(jq -Rs . < sudo-code-roadmap.html),\"allow_comments\":true}"
 ```
 
 The response includes `share_url` — that is the page to share.
@@ -395,7 +395,7 @@ got back from a prior POST):
 curl -s -X PUT "https://shareone.app/api/v1/pages/<share_id>" \
   -H "X-API-Key: $SHAREONE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d "{\"filename\":\"ROADMAP.html\",\"html_content\":$(jq -Rs . < ROADMAP.html),\"allow_comments\":true}"
+  -d "{\"filename\":\"sudo-code-roadmap.html\",\"html_content\":$(jq -Rs . < sudo-code-roadmap.html),\"allow_comments\":true}"
 ```
 
 Get a `SHAREONE_API_KEY` from <https://shareone.app>. URL stability

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
   Rust-native CLI coding agent for hackers — terminal-native,
   pipe-composable, scrollback-safe. Built because Claude Code chose
-  non-coders. This README is the canonical voice; ROADMAP.html holds
+  non-coders. This README is the canonical voice; sudo-code-roadmap.html holds
   the engineering plan; docs/ holds mechanism-level reference.
 -->
 
@@ -226,7 +226,7 @@ flowchart LR
 
 Sudo Code is the agent unit underneath that whole future picture.
 For the engineering plan to get there, see
-[`ROADMAP.html` § Goal 4](./ROADMAP.html).
+[`sudo-code-roadmap.html` § Goal 4](./sudo-code-roadmap.html).
 
 ---
 
@@ -334,7 +334,7 @@ The Cargo workspace is described in
 
 ## Documentation
 
-- [`ROADMAP.html`](./ROADMAP.html) — goals, design notes, engineering sequencing.
+- [`sudo-code-roadmap.html`](./sudo-code-roadmap.html) — goals, design notes, engineering sequencing.
 - [`docs/usage.md`](./docs/usage.md) — REPL, one-shot, JSON output, resume, doctor.
 - [`docs/authentication.md`](./docs/authentication.md) — auth modes and credentials.
 - [`docs/permissions-and-sandbox.md`](./docs/permissions-and-sandbox.md) — permission modes, Linux sandbox.
@@ -342,7 +342,7 @@ The Cargo workspace is described in
 - [`docs/models.md`](./docs/models.md) — aliases, provider-specific handling.
 - [`docs/plugins.md`](./docs/plugins.md) — authoring and using `scode` plugins.
 - [`docs/container.md`](./docs/container.md) — building and running inside a container.
-- [`ROADMAP.html`](./ROADMAP.html) Goal 2 — what claude-code parity means and how it is tracked (reference sources, resolution taxonomy, sync markers).
+- [`sudo-code-roadmap.html`](./sudo-code-roadmap.html) Goal 2 — what claude-code parity means and how it is tracked (reference sources, resolution taxonomy, sync markers).
 - [`docs/mock-parity-harness.md`](./docs/mock-parity-harness.md) — the deterministic mock backend and harness.
 - [`rust/README.md`](./rust/README.md) — Cargo workspace map.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ the content.
 
 ## Project mechanics
 
-- Parity mechanism — inlined in [`../ROADMAP.html`](../ROADMAP.html)
+- Parity mechanism — inlined in [`../sudo-code-roadmap.html`](../sudo-code-roadmap.html)
   under Goal 2: reference sources (public CC surfaces, the private
   `sudoprivacy/claude-code` snapshot, runtime-observation combos,
   CCB, claw-code), the mandatory "CHANGELOG → grep CCB → align"
@@ -35,7 +35,7 @@ the content.
 
 ## Plan
 
-- [`../ROADMAP.html`](../ROADMAP.html) — single SSOT plan file. Project
+- [`../sudo-code-roadmap.html`](../sudo-code-roadmap.html) — single SSOT plan file. Project
   goals plus the active design detail for each goal (e2e coverage
   inventory under Goal 1, `!` bash mode + TUI enhancement under
   Goal 3, etc.). All plan content lives here.
@@ -43,7 +43,7 @@ the content.
 ## See also
 
 - [`../README.md`](../README.md) — project entry, install, quick start.
-- [`../ROADMAP.html`](../ROADMAP.html) — project goals.
+- [`../sudo-code-roadmap.html`](../sudo-code-roadmap.html) — project goals.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contributor setup and PR
   workflow.
 - [`../rust/README.md`](../rust/README.md) — Cargo workspace map.

--- a/docs/mock-parity-harness.md
+++ b/docs/mock-parity-harness.md
@@ -3,7 +3,7 @@
 The mock parity harness exercises the `scode` CLI end-to-end against a
 deterministic, Anthropic-compatible mock backend in a clean environment.
 It is the measurement vehicle for the e2e coverage goal described in
-[`../ROADMAP.html`](../ROADMAP.html) (Goal 1).
+[`../sudo-code-roadmap.html`](../sudo-code-roadmap.html) (Goal 1).
 
 ## Components
 

--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -1000,7 +1000,7 @@ externally" / "publish my plan" / "give me a shareable link".</p>
 <table>
   <thead><tr><th></th><th>Detail</th></tr></thead>
   <tbody>
-    <tr><td>Source signal</td><td>Maintainers currently publish <code>ROADMAP.html</code> by hand via the shareone-skill or by curling the API. As the agent surface grows, users will start asking <code>scode</code> directly to share files; needing them to know about an external skill defeats the "scode is the agent" framing.</td></tr>
+    <tr><td>Source signal</td><td>Maintainers currently publish <code>sudo-code-roadmap.html</code> by hand via the shareone-skill or by curling the API. As the agent surface grows, users will start asking <code>scode</code> directly to share files; needing them to know about an external skill defeats the "scode is the agent" framing.</td></tr>
     <tr><td>Tool shape</td><td>Single tool: <code>publish_to_shareone(file_path, options)</code>. Options include <code>filename</code> (defaults to file basename), <code>allow_comments</code> (default true), <code>share_id</code> (optional — passing this PUT-updates an existing share so the URL stays stable; omitting it POSTs a new share). Returns the resulting <code>share_url</code>.</td></tr>
     <tr><td>Implementation</td><td>~100 lines of Rust hitting <code>POST /api/v1/pages</code> (new) and <code>PUT /api/v1/pages/{share_id}</code> (update) on the public ShareOne HTTP API. No skill dependency, no <code>npm</code>, no vendored client. Reads <code>SHAREONE_API_KEY</code> from env. Requires no infra change beyond adding the tool entry to <code>runtime::tools</code> registry.</td></tr>
     <tr><td>Permission</td><td>Routes through the same permission validator chain as <code>WebFetch</code>: <code>read-only</code> and <code>workspace-write</code> reject the call (publishing is a privileged side effect, like a network write); <code>danger-full-access</code> and explicit user approval pass.</td></tr>
@@ -1009,7 +1009,7 @@ externally" / "publish my plan" / "give me a shareable link".</p>
   </tbody>
 </table>
 
-<p>For now, while the tool does not exist, <code>ROADMAP.html</code> is
+<p>For now, while the tool does not exist, <code>sudo-code-roadmap.html</code> is
 published by hand. The exact curl call is documented in
 <a href="https://github.com/sudoprivacy/sudocode/blob/main/CONTRIBUTING.md"><code>CONTRIBUTING.md</code> § Publishing the roadmap to ShareOne</a>.</p>
 
@@ -1238,7 +1238,7 @@ PR — the roadmap tracks the live state, not history.</p>
 </ul>
 
 <footer>
-  Sudo Code Roadmap — <code>ROADMAP.html</code> is the single SSOT plan file.
+  Sudo Code Roadmap — <code>sudo-code-roadmap.html</code> is the single SSOT plan file.
 </footer>
 
 </body>


### PR DESCRIPTION
## Summary
- Rename `ROADMAP.html` → `sudo-code-roadmap.html` to match the ShareOne slug (`shareone.app/s/sudo-code-roadmap`)
- AI agents seeing the URL can now find the source file by name, and vice versa

## BREAKING
`ROADMAP.html` no longer exists at the old path. Any scripts or AI sessions referencing it by name will need to update. The `chore!:` commit prefix signals this.

## Files updated
All references across 7 files: CI workflow, CONTRIBUTING.md, README.md, docs/README.md, docs/mock-parity-harness.md, check_doc_source_of_truth.py, and self-references inside the HTML.