### PR TITLE
fix(mcp): reset spawn_attempts on successful initialize

### DIFF
--- a/rust/crates/runtime/src/mcp_stdio.rs
+++ b/rust/crates/runtime/src/mcp_stdio.rs
@@ -1208,6 +1208,10 @@ impl McpServerManager {
 
             let server = self.server_mut(server_name)?;
             server.initialized = true;
+            // A successful initialize proves the server can start — reset
+            // the spawn counter so a later transport-drop + respawn does
+            // not inherit stale attempts from a prior lifecycle.
+            server.spawn_attempts = 0;
             return Ok(());
         }
     }


### PR DESCRIPTION
## Summary
Reset `spawn_attempts` to 0 after a successful MCP server initialize handshake.

## Root cause
`spawn_attempts` is a lifetime counter capped at `MCP_SPAWN_ATTEMPT_LIMIT` (2) to prevent fork-loops from broken plugins. But it was never reset on success, so a single retry cycle (spawn → retryable error → reset → respawn → succeed) consumed 2/2 attempts. Any later transport-drop + respawn then hit `PermanentlyFailed` even though the server was healthy.

## Fix
One line: `server.spawn_attempts = 0` after `server.initialized = true`. The counter now tracks consecutive failed session lifetimes, not total spawns across the manager's lifetime. A server that proves it can start gets a fresh budget for future recoveries.

## Tests
Fixes flaky macOS CI failures in:
- `mcp_stdio::tests::given_child_exits_after_discovery_when_calling_twice_then_second_call_succeeds_after_reset`
- `mcp_stdio::tests::given_initialize_hangs_once_when_discover_tools_then_manager_retries_and_succeeds`

Full `cargo test --workspace` passes locally (1,167 tests, 0 failures).