### PR TITLE
refactor(browser): slim SKILL.md — remove DRY violations against CLI --help

### DIFF
--- a/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
+++ b/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
@@ -25,3 +25,9 @@ browser tab list --json                               # list open tabs
 ```
 
 When stdout is not a TTY, `--json` mode is auto-enabled so output is always pipe-safe.
+
+Every CLI command has an identical Python function in `ai_dev_browser.core` — explore interactively with CLI, then script with the same functions:
+
+```python
+from ai_dev_browser.core import page_goto, click_by_text, page_discover
+```

--- a/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
+++ b/rust/crates/plugins/bundled/browser/skills/browser/SKILL.md
@@ -5,75 +5,23 @@ description: "AI-native browser. Explore websites, discover page structure, take
 
 # Browser
 
-`browser <noun> <verb> [flags]` wraps ai-dev-browser's tools. Data goes to
-stdout, errors to stderr. Requires a Chrome/Chromium install for live browsing.
-
-## Output modes (every command)
-
-- `--json`   machine-readable JSON.
-- `--quiet`  just the primary scalar (port, url, path, count, ...).
-- `--full`   dump every field (default output is terse: ~3-4 fields/item).
-- `--no-interactive`  never prompt; missing required values error out.
-
-When stdout is not a TTY, `--json --quiet --no-interactive` are auto-enabled,
-so output is always pipe-safe and never hangs.
+`browser <noun> <verb> [flags]` — control a headless or headed Chrome session.
 
 ## Discover commands
 
 ```bash
-browser --help                 # list nouns
-browser page --help            # list verbs under `page`
-browser page goto --help       # flags for one command
+browser --help               # list all nouns
+browser <noun> --help         # list verbs under a noun
 ```
 
-## 5 most-used commands
+## Quick-start examples
 
 ```bash
-# 1. Start (or reuse) a browser — idempotent: reuses an idle Chrome by default
-browser session start --json
-browser session start --headless --json
-
-# 2. Navigate
-browser page goto --url https://example.com --json
-
-# 3. See what's interactable (returns refs for click/type by ref)
-browser page discover --json
-
-# 4. Click / type
-browser click text --text "Sign in" --json
-browser type text --text "hello" --name "Search" --json
-
-# 5. List sessions / tabs
-browser session list --json
-browser tab list --json
+browser session start --json                          # launch (or reuse) a Chrome session
+browser page goto --url https://example.com --json    # navigate
+browser page discover --json                          # list interactable elements
+browser click text --text "Sign in" --json            # click by visible text
+browser tab list --json                               # list open tabs
 ```
 
-## Exit codes
-
-`0` ok · `2` validation · `4` not-found (element or no browser) · `5` conflict
-· `7` auth · `8` rate-limit · `9` transient (timeout, connection). Never `1`
-for everything — branch on the code.
-
-In `--json` mode an error is printed to **stderr** as:
-
-```json
-{"error": {"code": 4, "message": "...", "retryable": true, "hint": "..."}}
-```
-
-## Common error recoveries
-
-- `code 4` + "Failed to connect to Chrome" → no browser running. Run
-  `browser session start` first (retryable).
-- `code 4` + "not found" → the element isn't there. Re-run
-  `browser page discover` and use a fresh `--ref`, or widen your selector.
-- `code 9` + "timeout" → bump `--timeout`, or `browser page wait-ready`
-  before acting; then retry.
-
-## Notes
-
-- Noun-verb tree: session, page, tab, click, find, type, element, mouse,
-  cookies, storage, window, js, cdp, dialog, download, login.
-- `browser login interactive` is human-in-the-loop; it fails fast (code 7)
-  under `--no-interactive` or when stdout is not a TTY.
-- Every CLI command has an identical Python function in `ai_dev_browser.core`
-  for scripting, e.g. `from ai_dev_browser.core import page_goto, click_by_text`.
+When stdout is not a TTY, `--json` mode is auto-enabled so output is always pipe-safe.


### PR DESCRIPTION
## Summary

- Slimmed `rust/crates/plugins/bundled/browser/skills/browser/SKILL.md` from ~80 lines to ~20 lines
- Removed sections that duplicate the CLI's own self-documenting surface: "Output modes", "Exit codes", "Common error recoveries", and "Notes"
- Kept YAML frontmatter, one-line description, discovery instructions (`--help`), and 5 quick-start examples

## Rationale

SKILL.md should **point at** the CLI's self-documenting surface (`--help` output, structured error `hint` fields), not **duplicate** it. When guidance lives in two places, the copy in the doc inevitably goes stale — and stale guidance is worse than no guidance. This follows the CLI Steering Engineering principle of single source of truth (SSOT):

- Exit codes and error hints are defined in code and surfaced via `--json` error responses. Duplicating them in a markdown file creates a maintenance burden with no benefit.
- The `--help` flag on every noun and verb already documents available flags, defaults, and usage. Repeating that in SKILL.md means two places to update on every CLI change.
- The remaining quick-start examples give an LLM enough context to bootstrap, then `--help` takes over.

## Test plan

- [ ] Verify the slimmed SKILL.md renders correctly and contains accurate examples
- [ ] Confirm `browser --help` and `browser <noun> --help` remain the authoritative reference