### PR TITLE
test(pty): add memory system PTY tests

### DIFF
--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub mod mcp_lifecycle_hardened;
 pub mod mcp_server;
 mod mcp_stdio;
 pub mod mcp_tool_bridge;
+pub mod memory;
 mod oauth;
 pub mod permission_enforcer;
 mod permissions;

--- a/rust/crates/runtime/src/memory/entry.rs
+++ b/rust/crates/runtime/src/memory/entry.rs
@@ -1,0 +1,250 @@
+//! Individual memory entry: frontmatter + body parsing.
+//!
+//! A memory file is markdown with a small YAML-ish frontmatter block:
+//!
+//! ```markdown
+//! ---
+//! name: short-kebab-case-slug
+//! description: one-line summary
+//! metadata:
+//!   type: feedback
+//! ---
+//!
+//! Body text. Can use [[other-slug]] links.
+//! ```
+//!
+//! The parser is intentionally minimal — it does not pull in `serde_yaml`,
+//! since the frontmatter shape is fixed.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// One of the four memory categories used by the system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MemoryType {
+    User,
+    Feedback,
+    Project,
+    Reference,
+}
+
+impl MemoryType {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Feedback => "feedback",
+            Self::Project => "project",
+            Self::Reference => "reference",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "user" => Some(Self::User),
+            "feedback" => Some(Self::Feedback),
+            "project" => Some(Self::Project),
+            "reference" => Some(Self::Reference),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for MemoryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A parsed memory file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryEntry {
+    pub name: String,
+    pub description: String,
+    pub memory_type: MemoryType,
+    pub body: String,
+    pub path: PathBuf,
+}
+
+/// Errors raised while parsing a memory file.
+#[derive(Debug)]
+pub enum MemoryParseError {
+    MissingFrontmatter,
+    UnterminatedFrontmatter,
+    MissingField(&'static str),
+    UnknownType(String),
+}
+
+impl fmt::Display for MemoryParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingFrontmatter => f.write_str("memory file is missing `---` frontmatter"),
+            Self::UnterminatedFrontmatter => {
+                f.write_str("memory file frontmatter has no closing `---`")
+            }
+            Self::MissingField(name) => write!(f, "memory frontmatter missing field `{name}`"),
+            Self::UnknownType(value) => write!(f, "unknown memory type `{value}`"),
+        }
+    }
+}
+
+impl std::error::Error for MemoryParseError {}
+
+impl MemoryEntry {
+    /// Parse a memory file from disk. `path` is captured on the returned entry.
+    pub fn from_file(path: &Path) -> std::io::Result<Self> {
+        let raw = std::fs::read_to_string(path)?;
+        Self::parse(&raw, path)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+    }
+
+    /// Parse a memory file from an in-memory string.
+    pub fn parse(raw: &str, path: &Path) -> Result<Self, MemoryParseError> {
+        let mut lines = raw.lines();
+        let first = lines.next().ok_or(MemoryParseError::MissingFrontmatter)?;
+        if first.trim() != "---" {
+            return Err(MemoryParseError::MissingFrontmatter);
+        }
+
+        let mut frontmatter = Vec::new();
+        let mut found_close = false;
+        for line in lines.by_ref() {
+            if line.trim() == "---" {
+                found_close = true;
+                break;
+            }
+            frontmatter.push(line);
+        }
+        if !found_close {
+            return Err(MemoryParseError::UnterminatedFrontmatter);
+        }
+
+        let body: String = lines.collect::<Vec<_>>().join("\n");
+        let body = body.trim_start_matches('\n').trim_end().to_string();
+
+        let mut name: Option<String> = None;
+        let mut description: Option<String> = None;
+        let mut memory_type: Option<MemoryType> = None;
+        let mut in_metadata = false;
+
+        for line in &frontmatter {
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let indent = line.len() - line.trim_start().len();
+            let content = line.trim_start();
+
+            if indent == 0 {
+                in_metadata = false;
+                if let Some(value) = content.strip_prefix("name:") {
+                    name = Some(unquote(value.trim()).to_string());
+                } else if let Some(value) = content.strip_prefix("description:") {
+                    description = Some(unquote(value.trim()).to_string());
+                } else if let Some(value) = content.strip_prefix("type:") {
+                    // Allow `type: ...` at the top level too, for friendliness.
+                    let raw_type = unquote(value.trim());
+                    memory_type = Some(
+                        MemoryType::parse(raw_type)
+                            .ok_or_else(|| MemoryParseError::UnknownType(raw_type.to_string()))?,
+                    );
+                } else if content.starts_with("metadata:") {
+                    in_metadata = true;
+                }
+            } else if in_metadata {
+                if let Some(value) = content.strip_prefix("type:") {
+                    let raw_type = unquote(value.trim());
+                    memory_type = Some(
+                        MemoryType::parse(raw_type)
+                            .ok_or_else(|| MemoryParseError::UnknownType(raw_type.to_string()))?,
+                    );
+                }
+            }
+        }
+
+        Ok(Self {
+            name: name.ok_or(MemoryParseError::MissingField("name"))?,
+            description: description.ok_or(MemoryParseError::MissingField("description"))?,
+            memory_type: memory_type.ok_or(MemoryParseError::MissingField("metadata.type"))?,
+            body,
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn unquote(s: &str) -> &str {
+    let trimmed = s.trim();
+    if trimmed.len() >= 2 {
+        let bytes = trimmed.as_bytes();
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &trimmed[1..trimmed.len() - 1];
+        }
+    }
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(raw: &str) -> MemoryEntry {
+        MemoryEntry::parse(raw, Path::new("/tmp/sample.md")).expect("parse")
+    }
+
+    #[test]
+    fn parses_minimal_entry() {
+        let raw = "---\nname: greeting\ndescription: how to greet\nmetadata:\n  type: feedback\n---\n\nBody text here.\n";
+        let parsed = entry(raw);
+        assert_eq!(parsed.name, "greeting");
+        assert_eq!(parsed.description, "how to greet");
+        assert_eq!(parsed.memory_type, MemoryType::Feedback);
+        assert_eq!(parsed.body, "Body text here.");
+        assert_eq!(parsed.path, Path::new("/tmp/sample.md"));
+    }
+
+    #[test]
+    fn allows_quoted_values() {
+        let raw =
+            "---\nname: \"greet\"\ndescription: 'a hello'\nmetadata:\n  type: 'user'\n---\nbody\n";
+        let parsed = entry(raw);
+        assert_eq!(parsed.name, "greet");
+        assert_eq!(parsed.description, "a hello");
+        assert_eq!(parsed.memory_type, MemoryType::User);
+    }
+
+    #[test]
+    fn rejects_missing_frontmatter() {
+        let err = MemoryEntry::parse("no frontmatter here", Path::new("/x")).unwrap_err();
+        assert!(matches!(err, MemoryParseError::MissingFrontmatter));
+    }
+
+    #[test]
+    fn rejects_unterminated_frontmatter() {
+        let err =
+            MemoryEntry::parse("---\nname: x\ndescription: y\n", Path::new("/x")).unwrap_err();
+        assert!(matches!(err, MemoryParseError::UnterminatedFrontmatter));
+    }
+
+    #[test]
+    fn rejects_missing_field() {
+        let raw = "---\nname: only-name\nmetadata:\n  type: user\n---\nbody\n";
+        let err = MemoryEntry::parse(raw, Path::new("/x")).unwrap_err();
+        assert!(matches!(err, MemoryParseError::MissingField("description")));
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        let raw = "---\nname: x\ndescription: y\nmetadata:\n  type: bogus\n---\nbody\n";
+        let err = MemoryEntry::parse(raw, Path::new("/x")).unwrap_err();
+        assert!(matches!(err, MemoryParseError::UnknownType(_)));
+    }
+
+    #[test]
+    fn accepts_top_level_type_shorthand() {
+        let raw = "---\nname: a\ndescription: b\ntype: project\n---\nbody\n";
+        let parsed = entry(raw);
+        assert_eq!(parsed.memory_type, MemoryType::Project);
+    }
+}

--- a/rust/crates/runtime/src/memory/index.rs
+++ b/rust/crates/runtime/src/memory/index.rs
@@ -1,0 +1,129 @@
+//! `MEMORY.md` is an index of memory entries — a flat markdown bullet list
+//! that links to the per-entry files. It is NOT a place to store memory
+//! content; entries live in their own files alongside it.
+//!
+//! Format:
+//!
+//! ```markdown
+//! # Key Learnings
+//!
+//! ## Section heading
+//! - [Title](filename.md) — one-line hook
+//! - [Other title](other.md) — hook
+//! ```
+//!
+//! For prompt injection, the raw text is passed through verbatim. This
+//! module records light structural information for callers that want it.
+
+use std::path::PathBuf;
+
+/// One bullet item in `MEMORY.md`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexPointer {
+    pub title: String,
+    pub file: String,
+    pub hook: Option<String>,
+}
+
+/// Parsed form of `MEMORY.md`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParsedIndex {
+    pub raw: String,
+    pub pointers: Vec<IndexPointer>,
+    pub path: Option<PathBuf>,
+}
+
+impl ParsedIndex {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.raw.trim().is_empty() && self.pointers.is_empty()
+    }
+
+    pub fn parse(raw: impl Into<String>) -> Self {
+        let raw = raw.into();
+        let pointers = collect_pointers(&raw);
+        Self {
+            raw,
+            pointers,
+            path: None,
+        }
+    }
+}
+
+fn collect_pointers(raw: &str) -> Vec<IndexPointer> {
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+        else {
+            continue;
+        };
+        let Some(pointer) = parse_pointer(rest) else {
+            continue;
+        };
+        out.push(pointer);
+    }
+    out
+}
+
+fn parse_pointer(rest: &str) -> Option<IndexPointer> {
+    let title_start = rest.find('[')?;
+    let title_end_rel = rest[title_start + 1..].find(']')?;
+    let title_end = title_start + 1 + title_end_rel;
+    let after_title = &rest[title_end + 1..];
+    let link_start_rel = after_title.find('(')?;
+    let link_end_rel = after_title[link_start_rel + 1..].find(')')?;
+    let link_start = title_end + 1 + link_start_rel;
+    let link_end = link_start + 1 + link_end_rel;
+    let title = rest[title_start + 1..title_end].trim().to_string();
+    let file = rest[link_start + 1..link_end].trim().to_string();
+    let tail = rest[link_end + 1..].trim();
+    let hook = if tail.is_empty() {
+        None
+    } else {
+        let trimmed = tail
+            .trim_start_matches(|c: char| c == '—' || c == '-' || c == ':' || c.is_whitespace())
+            .trim()
+            .to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    };
+    Some(IndexPointer { title, file, hook })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_index() {
+        let raw = "# Key Learnings\n\n## Section\n- [Greeting](greeting.md) — how to greet\n- [Other](other.md) hook only\n";
+        let parsed = ParsedIndex::parse(raw);
+        assert_eq!(parsed.pointers.len(), 2);
+        assert_eq!(parsed.pointers[0].title, "Greeting");
+        assert_eq!(parsed.pointers[0].file, "greeting.md");
+        assert_eq!(parsed.pointers[0].hook.as_deref(), Some("how to greet"));
+        assert_eq!(parsed.pointers[1].title, "Other");
+        assert_eq!(parsed.pointers[1].file, "other.md");
+        assert_eq!(parsed.pointers[1].hook.as_deref(), Some("hook only"));
+    }
+
+    #[test]
+    fn ignores_non_bullet_lines() {
+        let raw = "# Index\n\nNot a bullet\n  - [Nested](nested.md) — ok\n";
+        let parsed = ParsedIndex::parse(raw);
+        assert_eq!(parsed.pointers.len(), 1);
+        assert_eq!(parsed.pointers[0].file, "nested.md");
+    }
+
+    #[test]
+    fn empty_index_is_empty() {
+        let parsed = ParsedIndex::parse("");
+        assert!(parsed.is_empty());
+    }
+}

--- a/rust/crates/runtime/src/memory/loader.rs
+++ b/rust/crates/runtime/src/memory/loader.rs
@@ -1,0 +1,179 @@
+//! Filesystem discovery for memory entries.
+//!
+//! The default location is `~/.scode/memory/`, but `SUDOCODE_MEMORY_DIR`
+//! takes precedence when set.
+
+use std::path::{Path, PathBuf};
+
+use super::entry::MemoryEntry;
+use super::index::ParsedIndex;
+
+pub const MEMORY_DIR_ENV: &str = "SUDOCODE_MEMORY_DIR";
+pub const MEMORY_INDEX_FILE: &str = "MEMORY.md";
+
+/// Resolve the default memory directory.
+///
+/// Lookup order:
+/// 1. `SUDOCODE_MEMORY_DIR` environment variable (primary override).
+/// 2. `$HOME/.scode/memory/`.
+/// 3. Relative `.scode/memory/` if neither is available.
+#[must_use]
+pub fn default_memory_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os(MEMORY_DIR_ENV) {
+        return PathBuf::from(dir);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(".scode").join("memory");
+    }
+    PathBuf::from(".scode").join("memory")
+}
+
+/// Load and parse `MEMORY.md` from the given directory, if present.
+pub fn load_index(memory_dir: &Path) -> std::io::Result<Option<ParsedIndex>> {
+    let path = memory_dir.join(MEMORY_INDEX_FILE);
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => {
+            let mut parsed = ParsedIndex::parse(raw);
+            parsed.path = Some(path);
+            Ok(Some(parsed))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// Discover memory entries in `memory_dir`. Skips `MEMORY.md`, hidden files,
+/// and non-`.md` files. Returns entries sorted by `name` for determinism.
+///
+/// Files that fail to parse are skipped — a corrupt entry should not break
+/// loading the rest of the memory store.
+pub fn load_entries(memory_dir: &Path) -> std::io::Result<Vec<MemoryEntry>> {
+    let mut entries = Vec::new();
+    let read_dir = match std::fs::read_dir(memory_dir) {
+        Ok(rd) => rd,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(entries),
+        Err(err) => return Err(err),
+    };
+
+    for dir_entry in read_dir {
+        let dir_entry = dir_entry?;
+        let path = dir_entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        if name.eq_ignore_ascii_case(MEMORY_INDEX_FILE) {
+            continue;
+        }
+        if !name.to_ascii_lowercase().ends_with(".md") {
+            continue;
+        }
+        if let Ok(entry) = MemoryEntry::from_file(&path) {
+            entries.push(entry);
+        }
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("runtime-memory-{prefix}-{nanos}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    #[test]
+    fn env_var_overrides_default() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let custom = temp_dir("envvar");
+        let prior = std::env::var_os(MEMORY_DIR_ENV);
+        std::env::set_var(MEMORY_DIR_ENV, &custom);
+        let resolved = default_memory_dir();
+        if let Some(value) = prior {
+            std::env::set_var(MEMORY_DIR_ENV, value);
+        } else {
+            std::env::remove_var(MEMORY_DIR_ENV);
+        }
+        assert_eq!(resolved, custom);
+        fs::remove_dir_all(custom).ok();
+    }
+
+    #[test]
+    fn falls_back_to_home_when_env_missing() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prior_env = std::env::var_os(MEMORY_DIR_ENV);
+        let prior_home = std::env::var_os("HOME");
+        std::env::remove_var(MEMORY_DIR_ENV);
+        std::env::set_var("HOME", "/tmp/sudocode-test-home");
+        let resolved = default_memory_dir();
+        if let Some(value) = prior_env {
+            std::env::set_var(MEMORY_DIR_ENV, value);
+        } else {
+            std::env::remove_var(MEMORY_DIR_ENV);
+        }
+        if let Some(value) = prior_home {
+            std::env::set_var("HOME", value);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        assert_eq!(
+            resolved,
+            PathBuf::from("/tmp/sudocode-test-home/.scode/memory")
+        );
+    }
+
+    #[test]
+    fn load_entries_skips_index_hidden_and_non_md() {
+        let dir = temp_dir("entries");
+        fs::write(dir.join("MEMORY.md"), "# Key Learnings\n").unwrap();
+        fs::write(dir.join(".hidden.md"), "ignored").unwrap();
+        fs::write(dir.join("notes.txt"), "ignored").unwrap();
+        fs::write(
+            dir.join("good.md"),
+            "---\nname: good\ndescription: a good entry\nmetadata:\n  type: user\n---\nbody\n",
+        )
+        .unwrap();
+        let entries = load_entries(&dir).expect("load entries");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "good");
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn load_index_returns_none_when_missing() {
+        let dir = temp_dir("noindex");
+        assert!(load_index(&dir).expect("load").is_none());
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn load_entries_handles_missing_dir() {
+        let dir = std::env::temp_dir().join("runtime-memory-does-not-exist-xyz");
+        // Ensure it really doesn't exist.
+        fs::remove_dir_all(&dir).ok();
+        let entries = load_entries(&dir).expect("missing dir is empty");
+        assert!(entries.is_empty());
+    }
+}

--- a/rust/crates/runtime/src/memory/mod.rs
+++ b/rust/crates/runtime/src/memory/mod.rs
@@ -1,0 +1,346 @@
+//! File-based persistent memory, modeled on Claude Code's
+//! `~/.claude/projects/<slug>/memory/` system.
+//!
+//! Layout under the memory directory (default `~/.scode/memory/`,
+//! overridable via the `SUDOCODE_MEMORY_DIR` env var):
+//!
+//! - `MEMORY.md` — flat markdown index of pointers to entries.
+//! - `<slug>.md` — one file per remembered fact, with YAML-ish frontmatter
+//!   (`name`, `description`, `metadata.type`) plus a body.
+//!
+//! The runtime reads memory at prompt-build time and appends a rendered
+//! section to the [`SystemPromptBuilder`]. Writing is out of scope here —
+//! the model is instructed to *propose* additions in its output, and a
+//! follow-up PR will persist them.
+
+pub mod entry;
+pub mod index;
+pub mod loader;
+
+use std::path::{Path, PathBuf};
+
+pub use entry::{MemoryEntry, MemoryParseError, MemoryType};
+pub use index::{IndexPointer, ParsedIndex};
+pub use loader::{default_memory_dir, MEMORY_DIR_ENV, MEMORY_INDEX_FILE};
+
+use crate::prompt::SystemPromptBuilder;
+
+/// Cap individual entry body at 2000 chars when rendering.
+pub const ENTRY_BODY_CHAR_CAP: usize = 2_000;
+/// Cap total rendered output at 16000 chars; entries past the limit are dropped.
+pub const RENDERED_CHAR_CAP: usize = 16_000;
+
+/// Loaded memory store. Combines an optional `MEMORY.md` index with the
+/// parsed entry files.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryIndex {
+    pub directory: PathBuf,
+    pub index: Option<ParsedIndex>,
+    pub entries: Vec<MemoryEntry>,
+}
+
+impl MemoryIndex {
+    /// Load memory from the given directory. Missing directory is treated
+    /// as "no memory" rather than an error.
+    pub fn load(memory_dir: &Path) -> std::io::Result<Self> {
+        let index = loader::load_index(memory_dir)?;
+        let entries = loader::load_entries(memory_dir)?;
+        Ok(Self {
+            directory: memory_dir.to_path_buf(),
+            index,
+            entries,
+        })
+    }
+
+    /// Load memory from [`default_memory_dir`], honoring `SUDOCODE_MEMORY_DIR`.
+    pub fn load_default() -> std::io::Result<Self> {
+        Self::load(&default_memory_dir())
+    }
+
+    #[must_use]
+    pub fn entries(&self) -> &[MemoryEntry] {
+        &self.entries
+    }
+
+    #[must_use]
+    pub fn index(&self) -> Option<&ParsedIndex> {
+        self.index.as_ref()
+    }
+
+    /// `true` when there is nothing to inject into the prompt.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty() && self.index.as_ref().is_none_or(ParsedIndex::is_empty)
+    }
+
+    /// Render the memory store as a single prompt section. The caller is
+    /// expected to pass this through [`SystemPromptBuilder::append_section`].
+    #[must_use]
+    pub fn render_for_prompt(&self) -> String {
+        let mut out = String::new();
+        out.push_str("# Persistent memory\n\n");
+        out.push_str(PROMPT_PREAMBLE);
+        out.push_str("\n\n");
+
+        if let Some(index) = self.index.as_ref() {
+            let trimmed = index.raw.trim_end();
+            if !trimmed.is_empty() {
+                out.push_str(trimmed);
+                out.push_str("\n\n");
+            }
+        }
+
+        out.push_str("## Loaded memory files\n");
+        if self.entries.is_empty() {
+            out.push_str("\n(no memory entries loaded)\n");
+            return out;
+        }
+
+        let mut dropped = 0usize;
+        let mut rendered_any = false;
+        for entry in &self.entries {
+            let block = render_entry_block(entry);
+            // Reserve a little headroom for the trailing "dropped N" line.
+            if out.len() + block.len() + 80 > RENDERED_CHAR_CAP {
+                dropped += 1;
+                continue;
+            }
+            out.push('\n');
+            out.push_str(&block);
+            rendered_any = true;
+        }
+
+        if !rendered_any && !self.entries.is_empty() {
+            // We had entries but every one of them blew the budget. Note it.
+            dropped = self.entries.len();
+        }
+
+        if dropped > 0 {
+            use std::fmt::Write as _;
+            let plural = if dropped == 1 { "y" } else { "ies" };
+            let _ = write!(
+                out,
+                "\n[memory] {dropped} additional entr{plural} dropped to fit the 16000-char budget.\n"
+            );
+        }
+
+        out
+    }
+}
+
+/// Helper that appends the rendered memory section onto a
+/// [`SystemPromptBuilder`]. No-op when there's nothing to render or when
+/// loading fails.
+#[must_use]
+pub fn append_to_builder(
+    builder: SystemPromptBuilder,
+    memory_dir: Option<&Path>,
+) -> SystemPromptBuilder {
+    let owned;
+    let dir = if let Some(d) = memory_dir {
+        d
+    } else {
+        owned = default_memory_dir();
+        owned.as_path()
+    };
+    match MemoryIndex::load(dir) {
+        Ok(idx) if !idx.is_empty() => builder.append_section(idx.render_for_prompt()),
+        _ => builder,
+    }
+}
+
+/// Short static preamble explaining memory semantics to the model. Kept
+/// under 600 chars per the task brief.
+const PROMPT_PREAMBLE: &str =
+    "The following has been remembered from prior sessions. Treat as background \
+context, not as ground truth — verify against current code before acting.\n\n\
+To add a memory, do NOT write to the filesystem yourself. Propose it in your \
+reply as a markdown code block matching the entry frontmatter \
+(`name`, `description`, `metadata.type` ∈ user|feedback|project|reference, \
+then a body). Never edit `MEMORY.md` content directly — entries live in their \
+own files; `MEMORY.md` only links to them.";
+
+fn render_entry_block(entry: &MemoryEntry) -> String {
+    let body = truncate_body(&entry.body, ENTRY_BODY_CHAR_CAP);
+    format!(
+        "- name: {name}  type: {ty}  description: {desc}\n  body: {body}\n",
+        name = entry.name,
+        ty = entry.memory_type,
+        desc = entry.description,
+        body = body.replace('\n', "\n        "),
+    )
+}
+
+fn truncate_body(body: &str, cap: usize) -> String {
+    if body.chars().count() <= cap {
+        return body.to_string();
+    }
+    let mut out: String = body.chars().take(cap).collect();
+    out.push_str(" [truncated]");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prompt::SystemPromptBuilder;
+    use std::fs;
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("runtime-mem-mod-{prefix}-{nanos}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn write_entry(dir: &Path, slug: &str, ty: &str, body: &str) {
+        let raw = format!(
+            "---\nname: {slug}\ndescription: desc for {slug}\nmetadata:\n  type: {ty}\n---\n\n{body}\n"
+        );
+        fs::write(dir.join(format!("{slug}.md")), raw).unwrap();
+    }
+
+    #[test]
+    fn preamble_stays_under_600_chars() {
+        assert!(
+            PROMPT_PREAMBLE.len() < 600,
+            "preamble is {} chars",
+            PROMPT_PREAMBLE.len()
+        );
+    }
+
+    #[test]
+    fn empty_directory_is_empty() {
+        let dir = temp_dir("empty");
+        let idx = MemoryIndex::load(&dir).expect("load");
+        assert!(idx.is_empty());
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn missing_directory_is_empty() {
+        let dir = std::env::temp_dir().join("runtime-mem-mod-missing-xyz");
+        fs::remove_dir_all(&dir).ok();
+        let idx = MemoryIndex::load(&dir).expect("missing dir is empty");
+        assert!(idx.is_empty());
+    }
+
+    #[test]
+    fn renders_index_and_entries() {
+        let dir = temp_dir("renders");
+        fs::write(
+            dir.join("MEMORY.md"),
+            "# Key Learnings\n\n## Habits\n- [Greet](greet.md) — say hi\n",
+        )
+        .unwrap();
+        write_entry(&dir, "greet", "feedback", "Always greet warmly.");
+        write_entry(&dir, "role", "user", "Senior Rust engineer.");
+
+        let idx = MemoryIndex::load(&dir).expect("load");
+        let rendered = idx.render_for_prompt();
+        assert!(rendered.starts_with("# Persistent memory"));
+        assert!(rendered.contains("Key Learnings"));
+        assert!(rendered.contains("- name: greet"));
+        assert!(rendered.contains("- name: role"));
+        assert!(rendered.contains("type: feedback"));
+        assert!(rendered.contains("Always greet warmly."));
+        assert!(rendered.len() <= RENDERED_CHAR_CAP);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn truncates_oversize_body() {
+        let dir = temp_dir("truncate");
+        let big_body = "x".repeat(ENTRY_BODY_CHAR_CAP * 2);
+        write_entry(&dir, "big", "project", &big_body);
+        let idx = MemoryIndex::load(&dir).expect("load");
+        let rendered = idx.render_for_prompt();
+        assert!(rendered.contains("[truncated]"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn drops_entries_past_budget() {
+        let dir = temp_dir("budget");
+        // Each entry body is ~1900 chars; with 16000 cap and ~10 entries we
+        // should exceed the budget and drop some.
+        let body = "y".repeat(1_900);
+        for i in 0..12 {
+            write_entry(&dir, &format!("e{i:02}"), "project", &body);
+        }
+        let idx = MemoryIndex::load(&dir).expect("load");
+        let rendered = idx.render_for_prompt();
+        assert!(rendered.len() <= RENDERED_CHAR_CAP);
+        assert!(rendered.contains("dropped"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn append_to_builder_skips_when_empty() {
+        let dir = temp_dir("skip");
+        let rendered_no_mem = SystemPromptBuilder::new().with_os("linux", "test").render();
+        let appended = append_to_builder(
+            SystemPromptBuilder::new().with_os("linux", "test"),
+            Some(&dir),
+        )
+        .render();
+        assert!(!appended.contains("# Persistent memory"));
+        assert_eq!(rendered_no_mem, appended);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn append_to_builder_injects_section() {
+        let dir = temp_dir("inject");
+        fs::write(
+            dir.join("MEMORY.md"),
+            "# Key Learnings\n\n- [Role](role.md) — who the user is\n",
+        )
+        .unwrap();
+        write_entry(&dir, "role", "user", "Senior Rust engineer.");
+        write_entry(&dir, "habit", "feedback", "Prefer terse responses.");
+
+        let idx = MemoryIndex::load(&dir).expect("load");
+        assert!(!idx.is_empty());
+
+        let prompt = append_to_builder(
+            SystemPromptBuilder::new().with_os("linux", "test"),
+            Some(&dir),
+        )
+        .render();
+
+        assert!(prompt.contains("# Persistent memory"));
+        assert!(prompt.contains("role"));
+        assert!(prompt.contains("habit"));
+        assert!(prompt.contains("Key Learnings"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn load_default_honors_env_var() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = temp_dir("default-env");
+        write_entry(&dir, "via-env", "reference", "Look here for X.");
+        let prior = std::env::var_os(MEMORY_DIR_ENV);
+        std::env::set_var(MEMORY_DIR_ENV, &dir);
+        let result = MemoryIndex::load_default();
+        if let Some(value) = prior {
+            std::env::set_var(MEMORY_DIR_ENV, value);
+        } else {
+            std::env::remove_var(MEMORY_DIR_ENV);
+        }
+        let idx = result.expect("load default");
+        assert_eq!(idx.entries().len(), 1);
+        assert_eq!(idx.entries()[0].name, "via-env");
+        fs::remove_dir_all(dir).ok();
+    }
+}

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -535,12 +535,15 @@ pub fn load_system_prompt_with(
     let cwd = cwd.into();
     let project_context = ProjectContext::discover_with_git_fs(&cwd, current_date.into(), fs)?;
     let config = ConfigLoader::default_for(&cwd).load()?;
-    Ok(SystemPromptBuilder::new()
-        .with_os(os_name, os_version)
-        .with_model_family(model_family)
-        .with_project_context(project_context)
-        .with_runtime_config(config)
-        .build())
+    let builder = crate::memory::append_to_builder(
+        SystemPromptBuilder::new()
+            .with_os(os_name, os_version)
+            .with_model_family(model_family)
+            .with_project_context(project_context)
+            .with_runtime_config(config),
+        None,
+    );
+    Ok(builder.build())
 }
 
 fn render_config_section(config: &RuntimeConfig) -> String {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -1,0 +1,306 @@
+//! PTY tests for the persistent memory system (`runtime::memory`).
+//!
+//! Three scenarios exercised end-to-end through `scode system-prompt`:
+//!
+//! 1. Happy path: memory files with valid frontmatter are injected into
+//!    the system prompt.
+//! 2. Resilience: malformed and non-markdown files are skipped without
+//!    crashing; valid entries still surface.
+//! 3. Budget enforcement: when total rendered memory exceeds the
+//!    16 000-char cap, excess entries are dropped with a notice.
+//!
+//! All tests set `SUDOCODE_MEMORY_DIR` to a temp directory, avoiding
+//! any interaction with the user's real `~/.scode/memory/`.
+
+mod common;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_millis();
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "scode-pty-mem-{label}-{}-{millis}-{counter}",
+        std::process::id()
+    ))
+}
+
+/// Write a valid memory entry file.
+fn write_entry(dir: &Path, slug: &str, entry_type: &str, description: &str, body: &str) {
+    let content = format!(
+        "---\nname: {slug}\ndescription: {description}\nmetadata:\n  type: {entry_type}\n---\n\n{body}\n"
+    );
+    fs::write(dir.join(format!("{slug}.md")), content).expect("write entry");
+}
+
+/// Run `scode system-prompt` with the given env vars and return the output.
+fn run_system_prompt(cwd: &Path, envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_scode"));
+    cmd.current_dir(cwd);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.arg("system-prompt");
+    cmd.output().expect("scode binary should launch")
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 1. Happy path: entries injected into system prompt
+// ──────────────────────────────────────────────────────────────────────
+
+/// Create two valid memory files and an index, verify the rendered
+/// system prompt contains their content.
+#[test]
+fn memory_entries_injected_into_system_prompt() {
+    let root = unique_temp_dir("inject");
+    let memory_dir = root.join("memory");
+    fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+    write_entry(
+        &memory_dir,
+        "feedback_testing",
+        "feedback",
+        "Testing best practices",
+        "Always run tests before committing",
+    );
+    write_entry(
+        &memory_dir,
+        "user_role",
+        "user",
+        "Who the user is",
+        "Senior Rust developer",
+    );
+    fs::write(
+        memory_dir.join("MEMORY.md"),
+        "# Key Learnings\n\n\
+         - [Testing](feedback_testing.md) — testing best practices\n\
+         - [Role](user_role.md) — who the user is\n",
+    )
+    .expect("write MEMORY.md");
+
+    let output = run_system_prompt(
+        &root,
+        &[("SUDOCODE_MEMORY_DIR", memory_dir.to_str().expect("utf8"))],
+    );
+    assert!(
+        output.status.success(),
+        "system-prompt should exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let text = String::from_utf8(output.stdout).expect("stdout utf8");
+
+    // The memory section header must be present.
+    assert!(
+        text.contains("# Persistent memory"),
+        "system-prompt missing '# Persistent memory' section;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // The MEMORY.md index content is passed through.
+    assert!(
+        text.contains("Key Learnings"),
+        "system-prompt missing MEMORY.md index content;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // Both entry names appear.
+    assert!(
+        text.contains("name: feedback_testing"),
+        "system-prompt missing feedback_testing entry;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+    assert!(
+        text.contains("name: user_role"),
+        "system-prompt missing user_role entry;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // Both bodies appear.
+    assert!(
+        text.contains("Always run tests before committing"),
+        "system-prompt missing feedback_testing body;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+    assert!(
+        text.contains("Senior Rust developer"),
+        "system-prompt missing user_role body;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // Type annotations appear.
+    assert!(
+        text.contains("type: feedback"),
+        "system-prompt missing type: feedback;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+    assert!(
+        text.contains("type: user"),
+        "system-prompt missing type: user;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 2. Resilience: malformed / non-markdown files are skipped
+// ──────────────────────────────────────────────────────────────────────
+
+/// Mix valid, malformed (unterminated frontmatter), and non-markdown files.
+/// The command must exit 0, include the valid entry, and silently skip the rest.
+#[test]
+fn memory_resilient_on_missing_or_malformed() {
+    let root = unique_temp_dir("resilient");
+    let memory_dir = root.join("memory");
+    fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+    // Valid entry.
+    write_entry(
+        &memory_dir,
+        "valid_entry",
+        "project",
+        "A valid memory entry",
+        "This entry should survive",
+    );
+
+    // Malformed entry: missing closing `---`.
+    fs::write(
+        memory_dir.join("malformed.md"),
+        "---\nname: broken\ndescription: bad entry\nmetadata:\n  type: feedback\nThis has no closing delimiter\n",
+    )
+    .expect("write malformed entry");
+
+    // Non-markdown file: should be ignored entirely.
+    fs::write(memory_dir.join("notes.txt"), "plain text, not markdown")
+        .expect("write non-markdown file");
+
+    let output = run_system_prompt(
+        &root,
+        &[("SUDOCODE_MEMORY_DIR", memory_dir.to_str().expect("utf8"))],
+    );
+    assert!(
+        output.status.success(),
+        "system-prompt should exit 0 even with malformed files; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let text = String::from_utf8(output.stdout).expect("stdout utf8");
+
+    // The valid entry must still appear.
+    assert!(
+        text.contains("name: valid_entry"),
+        "valid entry missing after malformed sibling;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+    assert!(
+        text.contains("This entry should survive"),
+        "valid entry body missing after malformed sibling;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // The malformed entry must NOT appear.
+    assert!(
+        !text.contains("name: broken"),
+        "malformed entry should be skipped;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // The non-markdown file must NOT appear.
+    assert!(
+        !text.contains("plain text, not markdown"),
+        "non-markdown file should be ignored;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 3. Budget enforcement: large entries get dropped
+// ──────────────────────────────────────────────────────────────────────
+
+/// Create many large memory files whose total exceeds the 16 000-char
+/// budget. Verify the output stays within budget and includes a
+/// "dropped" notice.
+#[test]
+fn memory_budget_truncates_large_entries() {
+    let root = unique_temp_dir("budget");
+    let memory_dir = root.join("memory");
+    fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+    // Each entry body is ~1900 chars. With the preamble, index, and
+    // per-entry overhead, 12 entries will exceed the 16 000-char cap.
+    let large_body = "x".repeat(1_900);
+    for i in 0..12 {
+        write_entry(
+            &memory_dir,
+            &format!("entry_{i:02}"),
+            "project",
+            &format!("Large entry number {i}"),
+            &large_body,
+        );
+    }
+
+    let output = run_system_prompt(
+        &root,
+        &[("SUDOCODE_MEMORY_DIR", memory_dir.to_str().expect("utf8"))],
+    );
+    assert!(
+        output.status.success(),
+        "system-prompt should exit 0 with budget overflow; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let text = String::from_utf8(output.stdout).expect("stdout utf8");
+
+    // The memory section must be present (some entries rendered).
+    assert!(
+        text.contains("# Persistent memory"),
+        "system-prompt missing memory section under budget pressure;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // At least one entry rendered (the first ones fit the budget).
+    assert!(
+        text.contains("name: entry_"),
+        "no entries rendered under budget pressure;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // The budget-drop notice must appear.
+    assert!(
+        text.contains("dropped"),
+        "missing 'dropped' budget notice;\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    // The notice mentions the 16000-char budget.
+    assert!(
+        text.contains("16000-char budget"),
+        "budget notice should mention '16000-char budget';\nstdout tail:\n{}",
+        tail(&text, 40)
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+/// Return the last `n` lines of `s`, useful for assertion messages.
+fn tail(s: &str, n: usize) -> String {
+    let lines: Vec<&str> = s.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
+}


### PR DESCRIPTION
## Summary

- Cherry-picks the `feat/memory-infra` memory module (`runtime::memory`) onto `main`
- Wires `memory::append_to_builder` into `load_system_prompt_with` so `scode system-prompt` includes persistent memory when `SUDOCODE_MEMORY_DIR` is set
- Adds `tests/pty_memory.rs` with 3 end-to-end scenarios:
  1. **Happy path** -- two valid entries + MEMORY.md index are injected into system-prompt output
  2. **Resilience** -- malformed frontmatter and non-markdown files are silently skipped; valid entries still surface
  3. **Budget enforcement** -- 12 large entries exceed the 16000-char cap; output includes a "dropped" notice

## Test plan

- [x] `cargo test --test pty_memory` passes (3/3)
- [x] `cargo test --test system_prompt_command` still passes (no regression)
- [ ] CI green