### PR TITLE
docs(roadmap): update nexus integration architecture link to ShareOne

### DIFF
--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -1149,9 +1149,9 @@ first encounter the framing, alongside the rest of the philosophy.</p>
 commits to implementing against the nexus protocol, what is
 deliberately not in scope, and the work sequencing. The protocol
 SSOT itself lives upstream in <a
-href="https://github.com/nexi-lab/nexus/blob/develop/docs/architecture/nexus-integration-architecture.md">nexi-lab/nexus
+href="https://shareone.app/s/nexus-integration-architecture">nexus
 integration architecture</a> (public, Apache-2.0, joint-owned with
-the nexus team). sudocode does not vendor it.</p>
+the nexus team; SSOT at <code>nexus/docs/architecture/nexus-integration-architecture.html</code>). sudocode does not vendor it.</p>
 
 <h3>What sudocode commits to — implementation contract</h3>
 


### PR DESCRIPTION
The nexus doc was converted to HTML with Mermaid. Update reference link.