### PR TITLE
feat(cli): ESC key cancels mid-execution (CC parity) + PTY test

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2530,9 +2530,43 @@ impl HookAbortMonitor {
                 return;
             };
 
+            // Enable raw mode so crossterm can detect ESC keypresses
+            // during streaming / tool execution (CC parity). The
+            // rendering layer uses ANSI cursor control (not println!)
+            // during a turn, so raw mode is safe here. Restored when
+            // the monitor stops.
+            let is_tty = io::stdin().is_terminal();
+            let raw_enabled = is_tty && crossterm::terminal::enable_raw_mode().is_ok();
+
             runtime.block_on(async move {
-                let wait_for_stop = tokio::task::spawn_blocking(move || {
-                    let _ = stop_rx.recv();
+                let esc_abort = abort_signal.clone();
+                let wait_for_esc_or_stop = tokio::task::spawn_blocking(move || {
+                    use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+                    loop {
+                        if stop_rx.try_recv().is_ok() {
+                            return;
+                        }
+                        if !raw_enabled {
+                            match stop_rx.recv_timeout(Duration::from_millis(50)) {
+                                Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
+                                Err(RecvTimeoutError::Timeout) => continue,
+                            }
+                        }
+                        if event::poll(Duration::from_millis(50)).unwrap_or(false) {
+                            if let Ok(Event::Key(key)) = event::read() {
+                                if key.kind != KeyEventKind::Press {
+                                    continue;
+                                }
+                                let is_esc = key.code == KeyCode::Esc;
+                                let is_ctrl_c = key.code == KeyCode::Char('c')
+                                    && key.modifiers.contains(event::KeyModifiers::CONTROL);
+                                if is_esc || is_ctrl_c {
+                                    esc_abort.abort();
+                                    return;
+                                }
+                            }
+                        }
+                    }
                 });
 
                 tokio::select! {
@@ -2541,9 +2575,13 @@ impl HookAbortMonitor {
                             abort_signal.abort();
                         }
                     }
-                    _ = wait_for_stop => {}
+                    _ = wait_for_esc_or_stop => {}
                 }
             });
+
+            if raw_enabled {
+                let _ = crossterm::terminal::disable_raw_mode();
+            }
         })
     }
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_core_conversation.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_core_conversation.rs
@@ -254,3 +254,49 @@ fn sigint_cancels_streaming() {
         .expect_eof()
         .expect("scode should exit after Ctrl+C, not hang");
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// 6. ESC key cancels mid-execution (CC parity)
+// ──────────────────────────────────────────────────────────────────────
+
+/// ESC key during a long-running bash tool exits cleanly — same
+/// behavior as Ctrl+C but triggered by the Escape key (CC parity).
+///
+/// Steps with causal data flow:
+/// 1. Spawn scode with a bash scenario that sleeps 30s.
+/// 2. Expect "bash" — proves the tool call started.
+/// 3. Send ESC byte (0x1B) — simulates the user pressing Escape.
+/// 4. expect_eof — proves the process handled ESC and exited.
+///
+/// Catches: ESC not detected during streaming, raw mode not enabled,
+/// process hanging after ESC.
+#[test]
+#[cfg(unix)]
+fn esc_cancels_streaming() {
+    let env = TestEnv::new("esc-cancel");
+    let prompt = env.prompt(
+        "Run this exact bash command: printf 'esc-start'; sleep 30; printf 'esc-done'",
+        "bash_interrupt_long_running",
+    );
+
+    let mut sess = env.spawn(&[
+        "--permission-mode",
+        "danger-full-access",
+        "--allowedTools",
+        "bash",
+        &prompt,
+    ]);
+
+    // Wait until the bash tool call starts executing.
+    sess.expect("bash").expect("should see bash tool call");
+
+    // Let the command start, then send ESC.
+    std::thread::sleep(Duration::from_millis(500));
+    sess.send("\x1b").expect("send ESC");
+
+    // Process should exit — the assertion is that it does NOT hang.
+    sess.set_default_timeout(Duration::from_secs(15));
+    let _exit = sess
+        .expect_eof()
+        .expect("scode should exit after ESC, not hang");
+}


### PR DESCRIPTION
## Summary

ESC key now cancels the current turn during streaming/tool execution, same as Ctrl+C (CC parity).

### Implementation

HookAbortMonitor enables crossterm raw mode during turns and polls for both ESC and Ctrl+C via `crossterm::event`. In raw mode, Ctrl+C arrives as a KeyEvent rather than a POSIX signal, so both keys are handled uniformly in the same event loop.

### PTY test

`esc_cancels_streaming`: spawns scode with a 30s bash sleep, sends ESC byte, verifies process exits.

## Testing

```
cargo test --test pty_core_conversation  # 6/6 pass (incl. new ESC test)
cargo test --test pty_file_operations    # 3/3 pass
cargo test --test mock_parity_harness    # 1/1 pass
```