### PR TITLE
feat(memory): project-scoped memory paths (CC parity Gap 4)

### DIFF
--- a/rust/crates/runtime/src/memory/loader.rs
+++ b/rust/crates/runtime/src/memory/loader.rs
@@ -95,7 +95,10 @@ fn sanitize_path(name: &str) -> String {
 fn simple_hash(s: &str) -> String {
     let mut hash: i32 = 0;
     for c in s.chars() {
-        hash = hash.wrapping_shl(5).wrapping_sub(hash).wrapping_add(c as i32);
+        hash = hash
+            .wrapping_shl(5)
+            .wrapping_sub(hash)
+            .wrapping_add(c as i32);
     }
     let abs = (hash as i64).unsigned_abs();
     format_radix_36(abs)

--- a/rust/crates/runtime/src/memory/loader.rs
+++ b/rust/crates/runtime/src/memory/loader.rs
@@ -1,9 +1,11 @@
 //! Filesystem discovery for memory entries.
 //!
-//! The default location is `~/.scode/memory/`, but `SUDOCODE_MEMORY_DIR`
+//! The default location is `~/.scode/projects/<slug>/memory/`, where
+//! `<slug>` is derived from the git root (or cwd). `SUDOCODE_MEMORY_DIR`
 //! takes precedence when set.
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use super::entry::MemoryEntry;
 use super::index::ParsedIndex;
@@ -11,21 +13,108 @@ use super::index::ParsedIndex;
 pub const MEMORY_DIR_ENV: &str = "SUDOCODE_MEMORY_DIR";
 pub const MEMORY_INDEX_FILE: &str = "MEMORY.md";
 
-/// Resolve the default memory directory.
+/// Resolve the default memory directory for a given working directory.
 ///
 /// Lookup order:
 /// 1. `SUDOCODE_MEMORY_DIR` environment variable (primary override).
-/// 2. `$HOME/.scode/memory/`.
-/// 3. Relative `.scode/memory/` if neither is available.
+/// 2. `~/.scode/projects/<slug>/memory/` where slug is derived from
+///    the git root (or `cwd` if not in a git repo).
+/// 3. Relative `.scode/projects/<slug>/memory/` if `$HOME` is unavailable.
 #[must_use]
-pub fn default_memory_dir() -> PathBuf {
+pub fn default_memory_dir_for(cwd: &Path) -> PathBuf {
     if let Some(dir) = std::env::var_os(MEMORY_DIR_ENV) {
         return PathBuf::from(dir);
     }
+    let base = find_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let slug = sanitize_path(&base.to_string_lossy());
     if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home).join(".scode").join("memory");
+        return PathBuf::from(home)
+            .join(".scode")
+            .join("projects")
+            .join(&slug)
+            .join("memory");
     }
-    PathBuf::from(".scode").join("memory")
+    PathBuf::from(".scode")
+        .join("projects")
+        .join(&slug)
+        .join("memory")
+}
+
+/// Resolve the default memory directory using the process's current
+/// working directory. Convenience wrapper around [`default_memory_dir_for`].
+#[must_use]
+pub fn default_memory_dir() -> PathBuf {
+    default_memory_dir_for(&std::env::current_dir().unwrap_or_default())
+}
+
+/// Ensure the memory directory exists, creating it (and parents) if needed.
+/// Errors are silently ignored — a missing directory simply means no
+/// memory will be loaded.
+pub fn ensure_memory_dir_exists(dir: &Path) {
+    let _ = std::fs::create_dir_all(dir);
+}
+
+/// Find the canonical git root for a directory by running
+/// `git rev-parse --show-toplevel`. Returns `None` when outside a
+/// git repository or if the command fails.
+fn find_git_root(cwd: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if root.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(root))
+}
+
+/// Sanitize a path string for use as a directory name, matching CC's
+/// `sessionStoragePortable.ts:sanitizePath`. Non-alphanumeric ASCII
+/// chars are replaced with `-`. If the result exceeds 200 chars, it is
+/// truncated and a hash suffix is appended for uniqueness.
+fn sanitize_path(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    if sanitized.len() <= 200 {
+        return sanitized;
+    }
+    let hash = simple_hash(name);
+    format!("{}-{}", &sanitized[..200], hash)
+}
+
+/// Port of CC's `simpleHash` from `sessionStoragePortable.ts`.
+/// Produces a base-36 string of the absolute value of a Java-style
+/// `hashCode` (shift-5 multiply-add).
+fn simple_hash(s: &str) -> String {
+    let mut hash: i32 = 0;
+    for c in s.chars() {
+        hash = hash.wrapping_shl(5).wrapping_sub(hash).wrapping_add(c as i32);
+    }
+    let abs = (hash as i64).unsigned_abs();
+    format_radix_36(abs)
+}
+
+/// Format an unsigned 64-bit integer in base 36 (digits 0–9, a–z),
+/// matching JavaScript's `Number.prototype.toString(36)`.
+fn format_radix_36(mut n: u64) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    const DIGITS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut buf = Vec::new();
+    while n > 0 {
+        buf.push(DIGITS[(n % 36) as usize]);
+        n /= 36;
+    }
+    buf.reverse();
+    String::from_utf8(buf).expect("base36 chars are valid utf8")
 }
 
 /// Load and parse `MEMORY.md` from the given directory, if present.
@@ -119,15 +208,16 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_home_when_env_missing() {
+    fn falls_back_to_project_scoped_path_when_env_missing() {
         let _guard = ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cwd = temp_dir("fallback-cwd");
         let prior_env = std::env::var_os(MEMORY_DIR_ENV);
         let prior_home = std::env::var_os("HOME");
         std::env::remove_var(MEMORY_DIR_ENV);
         std::env::set_var("HOME", "/tmp/sudocode-test-home");
-        let resolved = default_memory_dir();
+        let resolved = default_memory_dir_for(&cwd);
         if let Some(value) = prior_env {
             std::env::set_var(MEMORY_DIR_ENV, value);
         } else {
@@ -138,10 +228,15 @@ mod tests {
         } else {
             std::env::remove_var("HOME");
         }
+        // The path should be under projects/<slug>/memory/
+        let slug = sanitize_path(&cwd.to_string_lossy());
         assert_eq!(
             resolved,
-            PathBuf::from("/tmp/sudocode-test-home/.scode/memory")
+            PathBuf::from("/tmp/sudocode-test-home/.scode/projects")
+                .join(&slug)
+                .join("memory")
         );
+        fs::remove_dir_all(cwd).ok();
     }
 
     #[test]

--- a/rust/crates/runtime/src/memory/mod.rs
+++ b/rust/crates/runtime/src/memory/mod.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 
 pub use entry::{MemoryEntry, MemoryParseError, MemoryType};
 pub use index::{IndexPointer, ParsedIndex};
-pub use loader::{default_memory_dir, MEMORY_DIR_ENV, MEMORY_INDEX_FILE};
+pub use loader::{default_memory_dir, default_memory_dir_for, MEMORY_DIR_ENV, MEMORY_INDEX_FILE};
 
 use crate::prompt::SystemPromptBuilder;
 
@@ -131,18 +131,27 @@ impl MemoryIndex {
 /// Helper that appends the rendered memory section onto a
 /// [`SystemPromptBuilder`]. No-op when there's nothing to render or when
 /// loading fails.
+///
+/// When `memory_dir` is `None`, the directory is derived from `cwd`
+/// (project-scoped path under `~/.scode/projects/<slug>/memory/`).
+/// When `cwd` is also `None`, falls back to `default_memory_dir()`.
 #[must_use]
 pub fn append_to_builder(
     builder: SystemPromptBuilder,
     memory_dir: Option<&Path>,
+    cwd: Option<&Path>,
 ) -> SystemPromptBuilder {
     let owned;
     let dir = if let Some(d) = memory_dir {
         d
+    } else if let Some(cwd) = cwd {
+        owned = default_memory_dir_for(cwd);
+        owned.as_path()
     } else {
         owned = default_memory_dir();
         owned.as_path()
     };
+    loader::ensure_memory_dir_exists(dir);
     match MemoryIndex::load(dir) {
         Ok(idx) if !idx.is_empty() => builder.append_section(idx.render_for_prompt()),
         _ => builder,
@@ -289,6 +298,7 @@ mod tests {
         let appended = append_to_builder(
             SystemPromptBuilder::new().with_os("linux", "test"),
             Some(&dir),
+            None,
         )
         .render();
         assert!(!appended.contains("# Persistent memory"));
@@ -313,6 +323,7 @@ mod tests {
         let prompt = append_to_builder(
             SystemPromptBuilder::new().with_os("linux", "test"),
             Some(&dir),
+            None,
         )
         .render();
 

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -542,6 +542,7 @@ pub fn load_system_prompt_with(
             .with_project_context(project_context)
             .with_runtime_config(config),
         None,
+        Some(&cwd),
     );
     Ok(builder.build())
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -295,6 +295,88 @@ fn memory_budget_truncates_large_entries() {
 }
 
 // ──────────────────────────────────────────────────────────────────────
+// 4. Project-scoped memory path
+// ──────────────────────────────────────────────────────────────────────
+
+/// When run inside a git repo without `SUDOCODE_MEMORY_DIR`, the
+/// resolved memory path should be project-scoped under
+/// `~/.scode/projects/<slug>/memory/`.
+#[test]
+fn memory_project_scoped_path() {
+    let root = unique_temp_dir("proj-scope");
+    fs::create_dir_all(&root).expect("create root");
+
+    // Init a git repo so `find_git_root` succeeds.
+    std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&root)
+        .status()
+        .expect("git init");
+
+    // Run without SUDOCODE_MEMORY_DIR so it falls through to the
+    // project-scoped default.
+    let output = run_system_prompt(&root, &[]);
+    assert!(
+        output.status.success(),
+        "system-prompt should exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The memory directory auto-created should be under projects/<slug>/memory.
+    // We can verify by checking that the ~/.scode/projects/ dir was populated.
+    let home = std::env::var("HOME").expect("HOME should be set");
+    let projects_dir = PathBuf::from(&home).join(".scode").join("projects");
+    assert!(
+        projects_dir.exists(),
+        "~/.scode/projects/ should exist after system-prompt runs"
+    );
+
+    // There should be at least one slug directory under projects/.
+    let entries: Vec<_> = fs::read_dir(&projects_dir)
+        .expect("read projects dir")
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        !entries.is_empty(),
+        "~/.scode/projects/ should have at least one slug directory"
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 5. Memory directory auto-creation
+// ──────────────────────────────────────────────────────────────────────
+
+/// When `SUDOCODE_MEMORY_DIR` points to a non-existent directory,
+/// running `scode system-prompt` should auto-create it.
+#[test]
+fn memory_directory_auto_created() {
+    let root = unique_temp_dir("auto-create");
+    fs::create_dir_all(&root).expect("create root");
+
+    let memory_dir = root.join("does-not-exist-yet").join("memory");
+    assert!(!memory_dir.exists(), "precondition: dir should not exist");
+
+    let output = run_system_prompt(
+        &root,
+        &[("SUDOCODE_MEMORY_DIR", memory_dir.to_str().expect("utf8"))],
+    );
+    assert!(
+        output.status.success(),
+        "system-prompt should exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        memory_dir.exists(),
+        "SUDOCODE_MEMORY_DIR should be auto-created after system-prompt runs"
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────────────────────────────
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -303,6 +303,16 @@ fn memory_budget_truncates_large_entries() {
 /// `~/.scode/projects/<slug>/memory/`.
 #[test]
 fn memory_project_scoped_path() {
+    // HOME is not set on Windows; the loader falls back to a relative
+    // path in that case so we can only verify this on Unix-like systems.
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => {
+            eprintln!("skipping memory_project_scoped_path: HOME not set (Windows)");
+            return;
+        }
+    };
+
     let root = unique_temp_dir("proj-scope");
     fs::create_dir_all(&root).expect("create root");
 
@@ -323,8 +333,6 @@ fn memory_project_scoped_path() {
     );
 
     // The memory directory auto-created should be under projects/<slug>/memory.
-    // We can verify by checking that the ~/.scode/projects/ dir was populated.
-    let home = std::env::var("HOME").expect("HOME should be set");
     let projects_dir = PathBuf::from(&home).join(".scode").join("projects");
     assert!(
         projects_dir.exists(),

--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -564,8 +564,12 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>Memory budget truncation</td><td data-priority="must-have">must-have</td><td data-status="covered" data-live-verified="no-api"><strong>Covered</strong></td><td><code>pty_memory::memory_budget_truncates_large_entries</code></td><td>Large entries truncated to fit context budget</td></tr>
     <tr><td>Memory write path ("remember X")</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>LLM writes memory files via Write tool; responds to "remember X" / "forget X"</td></tr>
     <tr><td><code>/memory</code> slash command</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Shows loaded memory entries in the REPL</td></tr>
-    <tr><td>Project-scoped memory</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>CC: <code>~/.claude/projects/&lt;slug&gt;/memory/</code>; scode: currently global <code>~/.scode/memory/</code></td></tr>
+    <tr><td>Project-scoped memory</td><td data-priority="must-have">must-have</td><td data-status="covered" data-live-verified="no-api"><strong>Covered</strong></td><td><code>pty_memory::memory_project_scoped_path</code>, <code>pty_memory::memory_directory_auto_created</code></td><td>CC: <code>~/.claude/projects/&lt;slug&gt;/memory/</code>; scode: <code>~/.scode/projects/&lt;slug&gt;/memory/</code>. PR #229.</td></tr>
     <tr><td>Memory system prompt (full CC parity)</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Detailed instructions for when/how to save/update/delete. Current preamble ~300 chars vs CC's ~3000</td></tr>
+    <tr><td>Session memory</td><td data-priority="nice">nice</td><td data-status="gap">Gap</td><td>—</td><td>CC: background subagent extracts structured notes per-session. Behind <code>tengu_session_memory</code> flag. Requires forked-agent infra.</td></tr>
+    <tr><td>Background extract-memories agent</td><td data-priority="nice">nice</td><td data-status="gap">Gap</td><td>—</td><td>CC: separate post-sampling subagent proactively mines conversation for memory-worthy facts. Behind <code>tengu_passport_quail</code>.</td></tr>
+    <tr><td>Team memory</td><td data-priority="nice">nice</td><td data-status="gap">Gap</td><td>—</td><td>CC: <code>&lt;autoMemPath&gt;/team/</code> subdirectory with per-type scope guidance. Behind <code>tengu_herring_clock</code>. Enterprise feature.</td></tr>
+    <tr><td>Agent memory</td><td data-priority="nice">nice</td><td data-status="gap">Gap</td><td>—</td><td>CC: spawned subagents auto-read/write their own memory dirs. Depends on Agent tool infra.</td></tr>
   </tbody>
 </table>
 
@@ -889,7 +893,12 @@ injection, 3 PTY tests). The following gaps remain for full CC parity:</p>
     <tr><td><code>/memory</code> slash command</td><td>Shows loaded memory entries in the REPL</td><td>Gap — needs main.rs wiring</td></tr>
     <tr><td>Write path</td><td>LLM writes memory files via the <code>Write</code> tool; also responds to "remember X" / "forget X"</td><td>Gap — PR #205 deferred this to follow-up</td></tr>
     <tr><td>System prompt instructions</td><td>Detailed instructions telling the LLM when/how to save, update, and delete memory</td><td>Partial — <code>PROMPT_PREAMBLE</code> exists but is minimal (~300 chars vs CC's ~3000 chars)</td></tr>
-    <tr><td>Project-scoped memory</td><td><code>~/.claude/projects/&lt;slug&gt;/memory/</code> — isolated per workspace</td><td>Gap — current path is global <code>~/.scode/memory/</code></td></tr>
+    <tr><td>Project-scoped memory</td><td><code>~/.claude/projects/&lt;slug&gt;/memory/</code> — isolated per workspace</td><td>Done — <code>~/.scode/projects/&lt;slug&gt;/memory/</code>, PTY tests <code>memory_project_scoped_path</code> + <code>memory_directory_auto_created</code> (PR #229)</td></tr>
+    <tr><td>Session memory</td><td>Background subagent extracts structured notes per-session into <code>summary.md</code> (9 sections, fires after token/tool-call thresholds). Used for compaction. Behind <code>tengu_session_memory</code> flag.</td><td>Gap — requires forked-agent infrastructure</td></tr>
+    <tr><td>Background extract-memories agent</td><td>Separate post-sampling subagent with Read/Grep/Glob/Edit/Write tools, parallelized 2-turn strategy. Behind <code>tengu_passport_quail</code> flag.</td><td>Gap — proactively mines conversation for memory-worthy facts</td></tr>
+    <tr><td>Team memory</td><td><code>&lt;autoMemPath&gt;/team/</code> subdirectory with combined prompt and per-type scope guidance. Behind <code>tengu_herring_clock</code> flag.</td><td>Gap — enterprise feature, low priority</td></tr>
+    <tr><td>Agent memory</td><td>Spawned subagents auto-read/write their own memory dirs (<code>/agent-memory/</code>, <code>/agent-memory-local/</code>)</td><td>Gap — depends on Agent tool infra</td></tr>
+    <tr><td>Memory prefetch via attachments</td><td>Behind <code>tengu_moth_copse</code> — memory files surfaced as attachments instead of system prompt injection</td><td>Gap — optimization, not functional</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary

- Memory directory now derives from git root (or cwd) as `~/.scode/projects/<slug>/memory/`, matching CC's `~/.claude/projects/<slug>/memory/` convention
- Directory auto-created on first use via `ensure_memory_dir_exists`
- `SUDOCODE_MEMORY_DIR` env override still takes precedence (no regression)
- Ports CC's `sanitizePath`, `simpleHash`, and `findCanonicalGitRoot` to Rust
- Plumbs `cwd` through `append_to_builder` → `load_system_prompt`

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --test pty_memory` — all 5 tests pass (3 existing + 2 new)
- [x] `memory_project_scoped_path` — init git repo, run `system-prompt`, verify `~/.scode/projects/` populated
- [x] `memory_directory_auto_created` — set `SUDOCODE_MEMORY_DIR` to non-existent path, verify auto-created
- [x] Existing PTY memory tests still pass (no regression)