### PR TITLE
feat(memory): write path carve-out + /memory editor command

### DIFF
--- a/rust/crates/runtime/src/permissions.rs
+++ b/rust/crates/runtime/src/permissions.rs
@@ -214,6 +214,27 @@ impl PermissionPolicy {
         self
     }
 
+    /// Inject synthetic allow rules for the auto-memory directory.
+    /// CC carve-out: writes to `~/.scode/projects/<slug>/memory/` are auto-allowed
+    /// regardless of permission mode (except ReadOnly and deny rules).
+    #[must_use]
+    pub fn with_memory_allow_rules(mut self, memory_dir: &std::path::Path) -> Self {
+        let prefix = memory_dir.to_string_lossy();
+        let dir_prefix = if prefix.ends_with('/') {
+            prefix.to_string()
+        } else {
+            format!("{}/", prefix)
+        };
+        for tool in &["write_file", "edit_file"] {
+            self.allow_rules.push(PermissionRule {
+                raw: format!("{tool}({dir_prefix}:*)"),
+                tool_name: tool.to_string(),
+                matcher: PermissionRuleMatcher::Prefix(dir_prefix.clone()),
+            });
+        }
+        self
+    }
+
     #[must_use]
     pub fn active_mode(&self) -> PermissionMode {
         self.active_mode
@@ -405,14 +426,14 @@ impl PermissionPolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct PermissionRule {
-    raw: String,
-    tool_name: String,
-    matcher: PermissionRuleMatcher,
+pub(crate) struct PermissionRule {
+    pub(crate) raw: String,
+    pub(crate) tool_name: String,
+    pub(crate) matcher: PermissionRuleMatcher,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum PermissionRuleMatcher {
+pub(crate) enum PermissionRuleMatcher {
     Any,
     Exact(String),
     Prefix(String),

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -395,9 +395,13 @@ pub(crate) fn permission_policy(
     mode: PermissionMode,
     feature_config: &runtime::RuntimeFeatureConfig,
     tool_registry: &GlobalToolRegistry,
+    cwd: &std::path::Path,
 ) -> Result<PermissionPolicy, String> {
+    let memory_dir = runtime::memory::default_memory_dir_for(cwd);
     Ok(tool_registry.permission_specs(None)?.into_iter().fold(
-        PermissionPolicy::new(mode).with_permission_rules(feature_config.permission_rules()),
+        PermissionPolicy::new(mode)
+            .with_permission_rules(feature_config.permission_rules())
+            .with_memory_allow_rules(&memory_dir),
         |policy, (name, required_permission)| {
             policy.with_tool_requirement(name, required_permission)
         },

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3104,7 +3104,7 @@ impl LiveCli {
                 false
             }
             SlashCommand::Memory => {
-                Self::print_memory()?;
+                Self::edit_memory()?;
                 false
             }
             SlashCommand::Init => {
@@ -3505,6 +3505,63 @@ impl LiveCli {
     fn print_memory() -> Result<(), Box<dyn std::error::Error>> {
         print_with_pager(&render_memory_report()?);
         Ok(())
+    }
+
+    fn open_in_editor(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if !path.exists() {
+            fs::write(path, "")?;
+        }
+        let (editor, source) = if let Ok(v) = env::var("VISUAL") {
+            (v, "$VISUAL")
+        } else if let Ok(e) = env::var("EDITOR") {
+            (e, "$EDITOR")
+        } else {
+            ("vi".to_string(), "default")
+        };
+        let status = std::process::Command::new(&editor).arg(path).status()?;
+        if !status.success() {
+            return Err(format!("Editor '{}' exited with {}", editor, status).into());
+        }
+        println!("Opened memory file at {}", path.display());
+        if source == "default" {
+            println!(
+                "> To use a different editor, set the $EDITOR or $VISUAL environment variable."
+            );
+        } else {
+            println!(
+                "> Using {}=\"{}\". To change editor, set $EDITOR or $VISUAL environment variable.",
+                source, editor
+            );
+        }
+        Ok(())
+    }
+
+    fn edit_memory() -> Result<(), Box<dyn std::error::Error>> {
+        let cwd = env::current_dir()?;
+        let project_context = ProjectContext::discover(&cwd, runtime::today_local())?;
+        let files = &project_context.instruction_files;
+        let target: PathBuf = if files.is_empty() {
+            // No instruction files found — default to AGENTS.md in cwd.
+            println!("No instruction files found. Creating AGENTS.md in the current directory.");
+            cwd.join("AGENTS.md")
+        } else if files.len() == 1 {
+            files[0].path.clone()
+        } else {
+            let labels: Vec<String> = files.iter().map(|f| f.path.display().to_string()).collect();
+            let selection = Select::new()
+                .with_prompt("Select memory file to edit")
+                .items(&labels)
+                .default(0)
+                .interact_opt()?;
+            match selection {
+                Some(idx) => files[idx].path.clone(),
+                None => return Ok(()),
+            }
+        };
+        Self::open_in_editor(&target)
     }
 
     fn print_agents(
@@ -4402,10 +4459,11 @@ fn build_runtime_for_cwd(
     let loader = ConfigLoader::default_for(cwd);
     let file_config = loader.load()?;
     let runtime_plugin_state = build_runtime_plugin_state_with_loader(cwd, &loader, &file_config)?;
-    build_runtime_with_plugin_state(session, session_id, config, runtime_plugin_state)
+    build_runtime_with_plugin_state(cwd, session, session_id, config, runtime_plugin_state)
 }
 
 fn build_runtime_with_plugin_state(
+    cwd: &Path,
     mut session: Session,
     session_id: &str,
     config: RuntimeConfig,
@@ -4422,13 +4480,14 @@ fn build_runtime_with_plugin_state(
         plugin_load_outcome,
         mcp_state,
     } = runtime_plugin_state;
-    let policy = match permission_policy(config.permission_mode, &feature_config, &tool_registry) {
-        Ok(policy) => policy,
-        Err(error) => {
-            shutdown_mcp_state_best_effort(&mcp_state);
-            return Err(Box::new(std::io::Error::other(error)));
-        }
-    };
+    let policy =
+        match permission_policy(config.permission_mode, &feature_config, &tool_registry, cwd) {
+            Ok(policy) => policy,
+            Err(error) => {
+                shutdown_mcp_state_best_effort(&mcp_state);
+                return Err(Box::new(std::io::Error::other(error)));
+            }
+        };
     let mut system_prompt = config.system_prompt.clone();
     if let Some(section) = render_plugin_capabilities_section(&plugin_load_outcome.loaded_plugins) {
         system_prompt.dynamic_sections.push(section);


### PR DESCRIPTION
## Summary

- **Write path (CC parity)**: Auto-allow writes to `~/.scode/projects/<slug>/memory/` via synthetic allow rules injected at permission policy construction. Matches CC's `checkEditableInternalPath()` carve-out.
- **`/memory` command (CC parity)**: Opens instruction files (AGENTS.md) in `$VISUAL` > `$EDITOR` > `vi`. Discovers files via `ProjectContext::discover`, presents selector if multiple found, creates AGENTS.md if none exist.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --check` — clean  
- [x] `cargo test --test pty_memory` — all 5 existing tests pass (no regression)
- [ ] Manual: `scode /memory` — opens AGENTS.md in editor
- [ ] Manual: model writes to memory dir without permission prompt in workspace-write mode