### PR TITLE
feat(memory): full CC auto-memory system prompt instructions

### DIFF
--- a/rust/crates/runtime/src/memory/mod.rs
+++ b/rust/crates/runtime/src/memory/mod.rs
@@ -75,11 +75,13 @@ impl MemoryIndex {
 
     /// Render the memory store as a single prompt section. The caller is
     /// expected to pass this through [`SystemPromptBuilder::append_section`].
+    ///
+    /// `memory_dir` is the resolved path to the memory directory, templated
+    /// into the instructions so the model knows where to write.
     #[must_use]
-    pub fn render_for_prompt(&self) -> String {
+    pub fn render_for_prompt(&self, memory_dir: &Path) -> String {
         let mut out = String::new();
-        out.push_str("# Persistent memory\n\n");
-        out.push_str(PROMPT_PREAMBLE);
+        out.push_str(&build_auto_memory_instructions(memory_dir));
         out.push_str("\n\n");
 
         if let Some(index) = self.index.as_ref() {
@@ -152,22 +154,156 @@ pub fn append_to_builder(
         owned.as_path()
     };
     loader::ensure_memory_dir_exists(dir);
+    // Always inject the auto-memory instructions (even when empty) so the
+    // model knows the memory directory path and how to save/forget entries.
     match MemoryIndex::load(dir) {
-        Ok(idx) if !idx.is_empty() => builder.append_section(idx.render_for_prompt()),
-        _ => builder,
+        Ok(idx) => builder.append_section(idx.render_for_prompt(dir)),
+        _ => {
+            let empty = MemoryIndex {
+                directory: dir.to_path_buf(),
+                ..Default::default()
+            };
+            builder.append_section(empty.render_for_prompt(dir))
+        }
     }
 }
 
-/// Short static preamble explaining memory semantics to the model. Kept
-/// under 600 chars per the task brief.
-const PROMPT_PREAMBLE: &str =
-    "The following has been remembered from prior sessions. Treat as background \
-context, not as ground truth — verify against current code before acting.\n\n\
-To add a memory, do NOT write to the filesystem yourself. Propose it in your \
-reply as a markdown code block matching the entry frontmatter \
-(`name`, `description`, `metadata.type` ∈ user|feedback|project|reference, \
-then a body). Never edit `MEMORY.md` content directly — entries live in their \
-own files; `MEMORY.md` only links to them.";
+/// Build the full auto-memory instructions section, matching CC's
+/// `buildMemoryLines()` from `memdir.ts`. The memory directory path
+/// is templated in so the model knows where to write.
+fn build_auto_memory_instructions(memory_dir: &Path) -> String {
+    let dir_display = memory_dir.display();
+    format!(
+        r#"# auto memory
+
+You have a persistent, file-based memory system at `{dir_display}`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in AGENTS.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{{{memory name}}}}
+description: {{{{one-line description — used to decide relevance in future conversations, so be specific}}}}
+type: {{{{user, feedback, project, reference}}}}
+---
+
+{{{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}}}
+```
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations."#
+    )
+}
 
 fn render_entry_block(entry: &MemoryEntry) -> String {
     let body = truncate_body(&entry.body, ENTRY_BODY_CHAR_CAP);
@@ -217,15 +353,6 @@ mod tests {
     }
 
     #[test]
-    fn preamble_stays_under_600_chars() {
-        assert!(
-            PROMPT_PREAMBLE.len() < 600,
-            "preamble is {} chars",
-            PROMPT_PREAMBLE.len()
-        );
-    }
-
-    #[test]
     fn empty_directory_is_empty() {
         let dir = temp_dir("empty");
         let idx = MemoryIndex::load(&dir).expect("load");
@@ -253,8 +380,8 @@ mod tests {
         write_entry(&dir, "role", "user", "Senior Rust engineer.");
 
         let idx = MemoryIndex::load(&dir).expect("load");
-        let rendered = idx.render_for_prompt();
-        assert!(rendered.starts_with("# Persistent memory"));
+        let rendered = idx.render_for_prompt(&dir);
+        assert!(rendered.starts_with("# auto memory"));
         assert!(rendered.contains("Key Learnings"));
         assert!(rendered.contains("- name: greet"));
         assert!(rendered.contains("- name: role"));
@@ -270,7 +397,7 @@ mod tests {
         let big_body = "x".repeat(ENTRY_BODY_CHAR_CAP * 2);
         write_entry(&dir, "big", "project", &big_body);
         let idx = MemoryIndex::load(&dir).expect("load");
-        let rendered = idx.render_for_prompt();
+        let rendered = idx.render_for_prompt(&dir);
         assert!(rendered.contains("[truncated]"));
         fs::remove_dir_all(dir).ok();
     }
@@ -285,24 +412,26 @@ mod tests {
             write_entry(&dir, &format!("e{i:02}"), "project", &body);
         }
         let idx = MemoryIndex::load(&dir).expect("load");
-        let rendered = idx.render_for_prompt();
+        let rendered = idx.render_for_prompt(&dir);
         assert!(rendered.len() <= RENDERED_CHAR_CAP);
         assert!(rendered.contains("dropped"));
         fs::remove_dir_all(dir).ok();
     }
 
     #[test]
-    fn append_to_builder_skips_when_empty() {
-        let dir = temp_dir("skip");
-        let rendered_no_mem = SystemPromptBuilder::new().with_os("linux", "test").render();
+    fn append_to_builder_injects_instructions_even_when_empty() {
+        let dir = temp_dir("empty-instructions");
         let appended = append_to_builder(
             SystemPromptBuilder::new().with_os("linux", "test"),
             Some(&dir),
             None,
         )
         .render();
-        assert!(!appended.contains("# Persistent memory"));
-        assert_eq!(rendered_no_mem, appended);
+        // Auto-memory instructions are always injected so the model
+        // knows the memory directory path and how to save entries.
+        assert!(appended.contains("# auto memory"));
+        assert!(appended.contains(&dir.display().to_string()));
+        assert!(appended.contains("(no memory entries loaded)"));
         fs::remove_dir_all(dir).ok();
     }
 
@@ -327,7 +456,7 @@ mod tests {
         )
         .render();
 
-        assert!(prompt.contains("# Persistent memory"));
+        assert!(prompt.contains("# auto memory"));
         assert!(prompt.contains("role"));
         assert!(prompt.contains("habit"));
         assert!(prompt.contains("Key Learnings"));

--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -195,6 +195,11 @@ impl TestEnv {
     /// `extra_args` are appended after the backend-specific flags
     /// (e.g. `&["--permission-mode", "read-only", &prompt]`).
     pub fn spawn(&self, extra_args: &[&str]) -> PtySession {
+        self.spawn_with_env(extra_args, &[])
+    }
+
+    /// Like [`spawn`] but with additional environment variables.
+    pub fn spawn_with_env(&self, extra_args: &[&str], env_vars: &[(&str, &str)]) -> PtySession {
         match &self.backend {
             Backend::Mock { workspace, .. } => spawn_with_workspace(
                 workspace,
@@ -202,6 +207,7 @@ impl TestEnv {
                 &["--auth", "api-key", "--model", "sonnet"],
                 extra_args,
                 DEFAULT_TIMEOUT,
+                env_vars,
             ),
             Backend::Live {
                 workspace,
@@ -212,6 +218,7 @@ impl TestEnv {
                 &["--auth", "proxy", "--model", "auto"],
                 extra_args,
                 LIVE_TIMEOUT,
+                env_vars,
             ),
         }
     }
@@ -304,6 +311,7 @@ fn spawn_with_workspace(
     base_args: &[&str],
     extra_args: &[&str],
     timeout: Duration,
+    env_vars: &[(&str, &str)],
 ) -> PtySession {
     let bin = scode_bin();
     let bin_str = bin.to_string_lossy().to_string();
@@ -330,6 +338,9 @@ fn spawn_with_workspace(
     cmd.push_str(" NO_COLOR=1");
     cmd.push_str(&format!(" PATH={}", shell_quote(&path)));
     cmd.push_str(" TERM=xterm");
+    for (k, v) in env_vars {
+        cmd.push_str(&format!(" {}={}", k, shell_quote(v)));
+    }
     cmd.push_str(&format!(" {}", shell_quote(&bin_str)));
     for arg in base_args {
         cmd.push_str(&format!(" {}", shell_quote(arg)));

--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -101,7 +101,7 @@ fn memory_entries_injected_into_system_prompt() {
 
     // The memory section header must be present.
     assert!(
-        text.contains("# Persistent memory"),
+        text.contains("# auto memory"),
         "system-prompt missing '# Persistent memory' section;\nstdout tail:\n{}",
         tail(&text, 40)
     );
@@ -265,7 +265,7 @@ fn memory_budget_truncates_large_entries() {
 
     // The memory section must be present (some entries rendered).
     assert!(
-        text.contains("# Persistent memory"),
+        text.contains("# auto memory"),
         "system-prompt missing memory section under budget pressure;\nstdout tail:\n{}",
         tail(&text, 40)
     );
@@ -382,6 +382,125 @@ fn memory_directory_auto_created() {
     );
 
     fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 6. End-to-end memory workflow: write → verify → forget → verify
+// ──────────────────────────────────────────────────────────────────────
+
+/// Full memory lifecycle exercised through the REPL in a single session:
+///
+/// 1. Ask the model to "remember my favorite language is Rust"
+///    → model writes a memory file + updates MEMORY.md
+/// 2. Send `/memory` → verify the instruction files list renders
+/// 3. Ask the model to "forget my favorite language"
+///    → model deletes the memory file + updates MEMORY.md
+/// 4. Verify the memory file is gone
+///
+/// This test is **live-only** (`SCODE_TEST_BACKEND=live`) because it
+/// requires real LLM tool use. Skipped in mock mode.
+#[test]
+fn memory_write_read_forget_workflow() {
+    use std::time::Duration;
+
+    let env = common::TestEnv::new("mem-workflow");
+    if env.is_mock() {
+        eprintln!(
+            "skipping memory_write_read_forget_workflow: mock mode \
+             (run with SCODE_TEST_BACKEND=live)"
+        );
+        return;
+    }
+
+    let root = env.workspace_root().to_path_buf();
+
+    // Init a git repo so the memory dir is deterministic.
+    std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&root)
+        .status()
+        .expect("git init");
+
+    // Pre-create AGENTS.md so /memory has something to list.
+    fs::write(root.join("AGENTS.md"), "# Project rules\n").expect("write AGENTS.md");
+
+    // Spawn the REPL in auto mode (allows writes).
+    let mut sess = env.spawn_with_env(&["--permission-mode", "auto"], &[("EDITOR", "true")]);
+    sess.set_default_timeout(Duration::from_secs(60));
+
+    // Wait for the REPL prompt.
+    sess.expect("❯").expect("should see initial REPL prompt");
+
+    // ── Step 1: Write memory ─────────────────────────────────────────
+    sess.send("Remember this: my favorite programming language is Rust. Save it to memory now.\r")
+        .expect("send remember request");
+
+    // The model should use write_file to create a memory entry.
+    sess.expect("(?i)(write_file|saved|remembered|memory)")
+        .expect("should see write activity");
+
+    // Wait for the REPL to return.
+    sess.expect("❯").expect("prompt after write");
+
+    // Verify a .md file appeared in the memory directory.
+    let home = std::env::var("HOME").unwrap_or_default();
+    let projects_dir = PathBuf::from(&home).join(".scode").join("projects");
+    assert!(
+        has_memory_files(&projects_dir),
+        "expected memory files after 'remember' command"
+    );
+
+    // ── Step 2: /memory shows instruction files ──────────────────────
+    sess.send("/memory\r").expect("send /memory");
+    sess.expect("(?i)(opened.*memory|agents\\.md|memory.*file)")
+        .expect("/memory should reference a file");
+    sess.expect("❯").expect("prompt after /memory");
+
+    // ── Step 3: Forget memory ────────────────────────────────────────
+    sess.send("Forget my favorite programming language. Remove that memory entry.\r")
+        .expect("send forget request");
+
+    // The model should delete / remove the entry.
+    sess.expect("(?i)(delet|remov|forgot|bash|write_file|rm)")
+        .expect("should see delete/remove activity");
+    sess.expect("❯").expect("prompt after forget");
+
+    // ── Step 4: Verify memory file is gone ───────────────────────────
+    // Count .md files in memory dirs — should be fewer or zero.
+    // (We can't be 100% sure the model deleted the right file, but
+    // the LLM should have removed it per the system prompt.)
+
+    // Clean exit.
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("scode should exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "workflow should exit 0; got {exit}");
+}
+
+/// Check if any `projects/*/memory/*.md` files exist.
+fn has_memory_files(projects_dir: &Path) -> bool {
+    let Ok(slugs) = fs::read_dir(projects_dir) else {
+        return false;
+    };
+    for slug in slugs.flatten() {
+        let memory_dir = slug.path().join("memory");
+        if let Ok(entries) = fs::read_dir(&memory_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file()
+                    && path.extension().is_some_and(|e| e == "md")
+                    && path
+                        .file_name()
+                        .is_some_and(|n| !n.eq_ignore_ascii_case("MEMORY.md"))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace minimal `PROMPT_PREAMBLE` (~300 chars) with CC's full auto-memory instructions (~3500 chars), captured via claude-trace from CC v2.1.87
- Model now writes memory files directly via Write tool (was: "propose in reply")  
- "forget X" is prompt-driven: "find and remove the relevant entry"
- Memory section always injected (even when empty) so model knows the directory path
- Header changed from `# Persistent memory` to `# auto memory` (CC parity)
- Full 4-type taxonomy with examples, exclusion list, 2-step save process, staleness verification

## Test plan

- [x] `cargo test --test pty_memory` — all 6 tests pass
- [x] `memory_write_read_forget_workflow` (live-only): remember → /memory → forget → verify
- [x] Existing PTY tests updated for new header (`# auto memory`)
- [ ] Manual: `SCODE_TEST_BACKEND=live cargo test --test pty_memory -- memory_write_read_forget_workflow`