### PR TITLE
docs(roadmap): fix summary table — 20/80 (25%)

### DIFF
--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -636,13 +636,13 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>Config &amp; Discovery</td><td>16</td><td>0</td><td>4</td><td>12</td><td>0</td></tr>
     <tr><td>Diagnostics</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
     <tr><td>Auth</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
-    <tr><td>Memory System</td><td>12</td><td>0</td><td>0</td><td>12</td><td><strong>5</strong></td></tr>
-    <tr><th>Total</th><th>89</th><th>1</th><th>8</th><th>80</th><th>17</th></tr>
+    <tr><td>Memory System</td><td>12</td><td>0</td><td>0</td><td>12</td><td><strong>7</strong></td></tr>
+    <tr><th>Total</th><th>89</th><th>1</th><th>8</th><th>80</th><th>20</th></tr>
   </tbody>
 </table>
 
 <p><strong>90% target = 72 features covered</strong> out of the 80 in-denominator
-features. <strong>Current coverage: 17 / 80 (21%).</strong>
+features. <strong>Current coverage: 20 / 80 (25%).</strong>
 <code>L2 deferred</code> items (LSP, MCP/plugin lifecycle) are tracked
 but do not count toward the 90% target.</p>
 


### PR DESCRIPTION
Summary table was stale. Reconciled with actual data-status attributes.