### PR TITLE
test(pty): /memory tab-completion test + test categorization rule

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -385,7 +385,49 @@ fn memory_directory_auto_created() {
 }
 
 // ──────────────────────────────────────────────────────────────────────
-// 6. End-to-end memory workflow: write → verify → forget → verify
+// 6. /memory tab-completion
+// ──────────────────────────────────────────────────────────────────────
+
+/// Type `/mem` then Tab in the REPL → should auto-complete to `/memory`.
+#[test]
+fn memory_tab_completion() {
+    use std::time::Duration;
+
+    let env = common::TestEnv::new("mem-tab");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[("EDITOR", "true")]);
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    // Wait for the REPL prompt.
+    sess.expect("❯").expect("should see REPL prompt");
+
+    // Type `/mem` then Tab.
+    sess.send("/mem\t").expect("send /mem + Tab");
+
+    // After Tab, the line should complete to `/memory`.
+    // Then press Enter to execute.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    sess.send("\r").expect("send Enter");
+
+    // `/memory` should execute — expect "Opened memory file" or
+    // "No instruction files found" (depending on whether AGENTS.md exists).
+    sess.expect("(?i)(opened.*memory|no instruction|memory)")
+        .expect("/memory should execute after tab completion");
+
+    // Wait for prompt, then exit.
+    sess.expect("❯").expect("prompt after /memory");
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should exit after tab test: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "tab completion test should exit 0; got {exit}");
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 7. End-to-end memory workflow: write → verify → forget → verify
 // ──────────────────────────────────────────────────────────────────────
 
 /// Full memory lifecycle exercised through the REPL in a single session:

--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -290,6 +290,20 @@ surface the human exercises.</p>
   key cause rate-limit failures. Mock tests stay parallel.</li>
 </ol>
 
+<h5>When to use mock vs live vs no-API</h5>
+
+<p>Not every PTY test needs an API call. Categorize by what the test exercises:</p>
+
+<table>
+  <thead><tr><th>Category</th><th>Backend</th><th>Example</th></tr></thead>
+  <tbody>
+    <tr><td><strong>No-API</strong> — pure CLI behavior (slash commands, subcommands, tab completion, system-prompt output)</td><td>Mock is fine (provides auth config so the REPL starts, but never calls the API). No <code>SCODE_TEST_BACKEND=live</code> needed.</td><td><code>memory_tab_completion</code>, <code>memory_entries_injected_into_system_prompt</code></td></tr>
+    <tr><td><strong>LLM-dependent</strong> — model must choose tools, generate output, make decisions</td><td>Live required (<code>SCODE_TEST_BACKEND=live</code>). Mock mode: skip with message. These are the tests that earn coverage credit.</td><td><code>memory_write_read_forget_workflow</code>, <code>multi_tool_roundtrip</code></td></tr>
+  </tbody>
+</table>
+
+<p>Rule of thumb: if the test never waits for a model response (no <code>expect</code> after a user message that requires LLM tool use), it's no-API. Use mock. Don't force live mode for tests that don't touch the model — it wastes API tokens and adds serial-lock contention.</p>
+
 <p><strong>Test depth convention</strong> (in the Notes column of coverage tables):</p>
 <ul>
   <li><strong>+error</strong> &mdash; error path also covered (permission denied, file not found, etc.).</li>


### PR DESCRIPTION
## Summary

- **memory_tab_completion** PTY test: types `/mem` + Tab → auto-completes to `/memory` → executes. No-API (mock mode).
- **Test categorization rule** added to roadmap test principles: no-API tests use mock, LLM-dependent tests require live.

## Test plan

- [x] `cargo test --test pty_memory` — all 7 tests pass
- [x] Tab completion verified: `/mem` + Tab → `/memory` → "Opened memory file"