### PR TITLE
fix(runtime): context window default lives in the SSOT file, not a hardcode

### DIFF
--- a/rust/crates/runtime/src/model-capabilities.bundled.json
+++ b/rust/crates/runtime/src/model-capabilities.bundled.json
@@ -1,5 +1,6 @@
 {
   "updated_at": 0,
+  "default": { "context_window": 200000, "max_output_tokens": 64000 },
   "models": {
     "claude-opus-4-6": { "context_window": 200000, "max_output_tokens": 32000 },
     "claude-opus-4-7": { "context_window": 200000, "max_output_tokens": 32000 },

--- a/rust/crates/runtime/src/model_capabilities.rs
+++ b/rust/crates/runtime/src/model_capabilities.rs
@@ -36,16 +36,23 @@ pub struct ModelCapability {
 pub struct ModelCapabilitiesFile {
     /// Unix timestamp (seconds) of the last successful refresh.
     pub updated_at: u64,
+    /// Fallback capability for models not present in `models`. This is the
+    /// single source of truth for the "unknown model" default — it lives in
+    /// the SSOT file (bundled seed, preserved across sudorouter refreshes),
+    /// never hardcoded in code.
+    pub default: ModelCapability,
     /// Wire model ID → capability metadata.
     pub models: BTreeMap<String, ModelCapability>,
 }
 
 impl Default for ModelCapabilitiesFile {
     fn default() -> Self {
-        parse_capabilities_json(BUNDLED_CAPABILITIES).unwrap_or_else(|| Self {
-            updated_at: 0,
-            models: BTreeMap::new(),
-        })
+        // The bundled JSON is compiled into the binary, so a parse failure is a
+        // build defect (malformed asset, or missing the required `default`
+        // entry) — fail fast rather than silently degrading to an empty,
+        // default-less table.
+        parse_capabilities_json(BUNDLED_CAPABILITIES)
+            .expect("bundled model-capabilities.json must parse and contain a 'default' entry")
     }
 }
 
@@ -69,6 +76,23 @@ pub fn lookup(model_id: &str) -> Option<ModelCapability> {
         .iter()
         .find(|(id, _)| id.eq_ignore_ascii_case(base))
         .map(|(_, cap)| *cap)
+}
+
+/// Context window for a wire model ID, falling back to the SSOT file's
+/// `default` entry when the model is unknown. The single source of truth for
+/// both per-model values and the unknown-model default is this capabilities
+/// file (bundled seed or sudorouter refresh) — never a hardcoded constant.
+#[must_use]
+pub fn context_window_or_default(model_id: &str) -> u32 {
+    lookup(model_id).map_or_else(
+        || {
+            CAPABILITIES
+                .get_or_init(ModelCapabilitiesFile::default)
+                .default
+                .context_window
+        },
+        |cap| cap.context_window,
+    )
 }
 
 /// Load the SSOT file into the in-memory snapshot. Call once at startup.
@@ -218,6 +242,13 @@ mod tests {
         let file: ModelCapabilitiesFile =
             serde_json::from_str(BUNDLED_CAPABILITIES).expect("bundled JSON must parse");
         assert!(!file.models.is_empty(), "bundled JSON must have models");
+        // The `default` entry is the SSOT for the unknown-model fallback; guard
+        // that the bundled seed carries a sane value (no hardcoded fallback exists
+        // in code anymore, so a missing/zero default would be a real regression).
+        assert!(
+            file.default.context_window > 0,
+            "bundled JSON must define a non-zero default context window"
+        );
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -31,11 +31,11 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    base_url_for_mode, model_family_identity_for, model_token_limit, resolve_startup_auth_source,
-    AnthropicClient, AuthMode, AuthSource, ContentBlockDelta, InputContentBlock, InputMessage,
-    MessageRequest, MessageResponse, OutputContentBlock, PromptCache,
-    ProviderClient as ApiProviderClient, ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice,
-    ToolDefinition, ToolResultContentBlock,
+    base_url_for_mode, model_family_identity_for, resolve_startup_auth_source, AnthropicClient,
+    AuthMode, AuthSource, ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient,
+    ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
+    ToolResultContentBlock,
 };
 
 use cli::api_client::{
@@ -2396,9 +2396,9 @@ impl AcpSdkDelegate {
             .model
             .as_ref()
             .unwrap_or(&self.inner.model);
-        let context_limit = model_token_limit(model)
-            .map(|limit| limit.context_window_tokens as usize)
-            .unwrap_or(200_000);
+        // Context window comes from the model-capabilities SSOT file (per-model
+        // entry, else the file's `default`). No hardcoded fallback here.
+        let context_limit = runtime::model_capabilities::context_window_or_default(model) as usize;
 
         // Estimate current session tokens
         let estimated_tokens = estimate_session_tokens(session.runtime.session());


### PR DESCRIPTION
## Problem

The per-turn `context_limit` (drives the UI context-window display, the auto-compact 85% threshold, and overflow error text) fell back to a hardcoded `unwrap_or(200_000)` whenever a model was absent from the capabilities table. A 1M-context model missing from the table would display **200K** *and* auto-compact **~5x too early**, silently discarding usable context. (This is the bug behind "sudowork bottom-right always shows 200K".)

## Fix — make the model-capabilities SSOT file the single source of truth, incl. the unknown-model default

- add a top-level `default` entry to the bundled JSON + file schema
- `model_capabilities::context_window_or_default()` returns the per-model value, else the file's `default` (reuses `lookup()`; no duplicated logic)
- `main.rs` uses it directly — the `.unwrap_or(200_000)` hardcode is gone
- `ModelCapabilitiesFile::default()` now **fail-fasts** if the compiled-in bundled JSON can't parse (a build defect) instead of silently degrading to an empty, default-less table

No new public API on the api/registry layer (the SSOT owner owns the defaulting). No nexus/ABI surface touched. `cargo check` + `clippy` clean; existing bundled-parse test strengthened to guard the new `default` contract.

## Not yet covered (follow-up)
Behavioural e2e (unknown model → file default → ACP `_meta.sudocode.contextWindowTokens` + auto-compact threshold) needs a PTY/mock-model scenario — filed separately, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)