### PR TITLE
chore(runtime): remove dead code (3 never-used fns)

### DIFF
--- a/rust/crates/runtime/src/file_redirect.rs
+++ b/rust/crates/runtime/src/file_redirect.rs
@@ -66,41 +66,6 @@ pub fn get_drafts_dir(workspace_root: &Path) -> PathBuf {
     workspace_root.join(DRAFTS_DIR_NAME)
 }
 
-/// Clean up old draft files (optional utility).
-///
-/// Remove draft files older than `max_age_days` days.
-pub fn cleanup_old_drafts(workspace_root: &Path, max_age_days: u64) -> Vec<PathBuf> {
-    let drafts_dir = workspace_root.join(DRAFTS_DIR_NAME);
-    let mut removed = Vec::new();
-
-    if !drafts_dir.exists() {
-        return removed;
-    }
-
-    let now = SystemTime::now();
-    let max_age = std::time::Duration::from_secs(max_age_days * 24 * 60 * 60);
-
-    if let Ok(entries) = fs::read_dir(&drafts_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_file() {
-                if let Ok(metadata) = entry.metadata() {
-                    if let Ok(modified) = metadata.modified() {
-                        if let Ok(age) = now.duration_since(modified) {
-                            if age > max_age {
-                                let _ = fs::remove_file(&path);
-                                removed.push(path);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    removed
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/crates/runtime/src/oauth.rs
+++ b/rust/crates/runtime/src/oauth.rs
@@ -501,10 +501,6 @@ fn credentials_home_dir() -> io::Result<PathBuf> {
     Ok(PathBuf::from(home).join(".nexus").join("sudocode"))
 }
 
-fn read_credentials_root(path: &PathBuf) -> io::Result<Map<String, Value>> {
-    read_credentials_root_with(path, &StdFsBackend)
-}
-
 fn read_credentials_root_with(
     path: &PathBuf,
     fs: &dyn FsBackend,
@@ -528,10 +524,6 @@ fn read_credentials_root_with(
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Map::new()),
         Err(error) => Err(error),
     }
-}
-
-fn write_credentials_root(path: &PathBuf, root: &Map<String, Value>) -> io::Result<()> {
-    write_credentials_root_with(path, root, &StdFsBackend)
 }
 
 fn write_credentials_root_with(


### PR DESCRIPTION
Removes 3 compiler `dead_code` warnings, each verified as genuinely unreachable (zero callers across the crate incl. tests/cfg):

- `oauth.rs`: `read_credentials_root` / `write_credentials_root` — the `StdFsBackend`-hardcoded convenience wrappers, superseded everywhere by the FsBackend-injected `*_with` variants (which remain and are used).
- `file_redirect.rs`: `cleanup_old_drafts` — a `pub` "optional utility" added 2026-05-20 that was never wired to a caller.

No import became unused (`StdFsBackend`, `fs`, `SystemTime`, `UNIX_EPOCH` all still used by other code in their files). `cargo check` clean — the 3 `never used` warnings are gone with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)