### PR TITLE
fix(runtime): seed claude-opus-4-8 at 1M context + cover SSOT fallback

### DIFF
--- a/rust/crates/runtime/src/model-capabilities.bundled.json
+++ b/rust/crates/runtime/src/model-capabilities.bundled.json
@@ -4,7 +4,7 @@
   "models": {
     "claude-opus-4-6": { "context_window": 200000, "max_output_tokens": 32000 },
     "claude-opus-4-7": { "context_window": 200000, "max_output_tokens": 32000 },
-    "claude-opus-4-8": { "context_window": 200000, "max_output_tokens": 32000 },
+    "claude-opus-4-8": { "context_window": 1000000, "max_output_tokens": 32000 },
     "claude-sonnet-4-6": { "context_window": 200000, "max_output_tokens": 64000 },
     "claude-haiku-4-5-20251213": { "context_window": 200000, "max_output_tokens": 64000 },
     "grok-3": { "context_window": 131072, "max_output_tokens": 64000 },

--- a/rust/crates/runtime/tests/integration_tests.rs
+++ b/rust/crates/runtime/tests/integration_tests.rs
@@ -384,3 +384,28 @@ fn worker_provider_failure_flows_through_recovery_to_policy() {
         "post-recovery green+approved lane should be merge-ready"
     );
 }
+
+/// model_capabilities resolution end to end:
+/// a known wire model id returns its own context window from the SSOT table,
+/// and an unknown id falls back to the file's `default` entry — never a
+/// hardcoded constant. Also pins `claude-opus-4-8` at its 1M context window so
+/// a regression back to 200K (the old hardcoded default) is caught.
+#[test]
+fn context_window_resolves_from_ssot_with_default_fallback() {
+    use runtime::model_capabilities::{context_window_or_default, ModelCapabilitiesFile};
+
+    // The lazy snapshot is seeded from the bundled SSOT JSON.
+    let file_default = ModelCapabilitiesFile::default().default.context_window;
+    assert!(file_default > 0, "SSOT must define a non-zero default");
+
+    // unknown model → file's default (sourced from the SSOT, not code)
+    assert_eq!(
+        context_window_or_default("definitely-not-a-real-model-xyz"),
+        file_default
+    );
+
+    // known model → its own value; 1M for opus-4-8, distinct from the default
+    let opus = context_window_or_default("claude-opus-4-8");
+    assert_eq!(opus, 1_000_000);
+    assert_ne!(opus, file_default);
+}


### PR DESCRIPTION
Closes the two follow-ups from #259 (context-window SSOT), in one PR.

## 1. Seed `claude-opus-4-8` at its real 1M context window
The bundled SSOT seed had `claude-opus-4-8: 200000`, but its real context window is **1M** (`claude-opus-4-8[1m]`; observed live from sudorouter). On a fresh/offline install — before the first sudorouter refresh — it displayed 200K **and auto-compacted ~5x too early**. Seed it at `1_000_000` to match the authoritative value.

Only the confirmed value is changed; `4-6`/`4-7` are left for sudorouter refresh (don't write values I can't confirm).

## 2. Cover the SSOT fallback (was untested)
Adds a `runtime` **integration test** (policy-compliant layer — no unit test) for `context_window_or_default`:
- unknown model → the SSOT file's `default` (never a code constant)
- known model → its own value
- `claude-opus-4-8` pinned at 1M, so a regression back to 200K is caught

## Quality
No nexus/ABI surface, no new API, SSOT-resident data, DRY (test reuses the public fn + type). `cargo fmt` / `cargo test -p runtime` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)