### PR TITLE
fix(acp): keep session model and compaction durable across resume

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1874,7 +1874,12 @@ impl AcpCliAgent {
         let previous = self.model.clone();
         let session = self.sessions.get(session_id).unwrap();
         let message_count = session.runtime.session().messages.len();
-        let cloned_session = session.runtime.session().clone();
+        let mut cloned_session = session.runtime.session().clone();
+        // Keep the session's own model in sync with the switch. `build_runtime_with_plugin_state`
+        // only fills `session.model` when it is None (correct for a brand-new session), so without
+        // this the resumed/switched session keeps its OLD model — which then drives the wrong
+        // context-window in the pre-turn auto-compaction and can wedge the session on overflow.
+        cloned_session.model = Some(resolved.clone());
         let cwd = session.cwd.clone();
         let handle_id = session.handle.id.clone();
 
@@ -2441,6 +2446,25 @@ impl AcpSdkDelegate {
                 if result.removed_message_count > 0 {
                     // Update session with compacted version
                     *session.runtime.session_mut() = result.compacted_session.clone();
+                    // Persist the compacted state immediately. The end-of-turn save_to_path is
+                    // skipped by the still-over-limit early return below (and by any later turn
+                    // error), which would otherwise leave the on-disk JSONL holding the full
+                    // uncompacted history — so the next resume reloads the pre-compaction session
+                    // and overflows again. Best-effort: a persist hiccup must not abort the turn.
+                    if let Err(persist_err) =
+                        session.runtime.session().save_to_path(&session.handle.path)
+                    {
+                        if let Some(tracer) = session.runtime.session_tracer() {
+                            tracer.record("auto_compact_persist_error", {
+                                let mut attrs = Map::new();
+                                attrs.insert(
+                                    "error".to_string(),
+                                    Value::String(persist_err.to_string()),
+                                );
+                                attrs
+                            });
+                        }
+                    }
                     if let Some(tracer) = session.runtime.session_tracer() {
                         tracer.record("auto_compact_result", {
                             let mut attrs = Map::new();
@@ -3424,7 +3448,11 @@ impl LiveCli {
         }
 
         let previous = self.config.model.clone();
-        let session = self.runtime.session().clone();
+        let mut session = self.runtime.session().clone();
+        // Keep the session's own model in sync with the switch (see handle_acp_model_switch): the
+        // runtime builder only fills `session.model` when None, so otherwise it would retain the
+        // old model and mis-compute the context window for auto-compaction.
+        session.model = Some(model.clone());
         let session_id = self.session.id.clone();
         let message_count = session.messages.len();
         let runtime = self.build_replacement_runtime(

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -698,6 +698,115 @@ async fn acp_stdio_exits_on_stdin_close() {
     workspace.cleanup();
 }
 
+/// Resume across a process restart must restore prior conversation history.
+///
+/// Regression guard for the "amnesia on resume" bug. sudowork resumes a scode
+/// session by id via the ACP-standard `session/load`; previously it sent a
+/// generic `resumeSessionId` to `session/new`, which scode ignores, silently
+/// minting a fresh EMPTY session and losing all history. This test creates a
+/// session + one turn carrying a unique marker in process A, lets that process
+/// exit, then in a FRESH process B loads the same session id and runs another
+/// turn — asserting the upstream model request still carries process A's
+/// message (proving history was restored, not started fresh).
+#[tokio::test]
+async fn acp_stdio_resume_restores_history_across_reconnect() {
+    const HISTORY_MARKER: &str = "resume-marker-7f3a91c2";
+
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-resume");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+
+    // --- Process A: create a session, run one turn carrying HISTORY_MARKER, then exit ---
+    let session_id = {
+        let mut client = spawn_stdio_client(&workspace);
+        scenario_initialize(&mut client).await;
+        let session_id = scenario_session_new(&mut client, &workspace.root).await;
+
+        // The marker is a separate whitespace token, so detect_scenario still
+        // resolves `streaming_text`; the marker rides along into the persisted
+        // user message.
+        let first_prompt = format!("{SCENARIO_PREFIX}streaming_text {HISTORY_MARKER}");
+        let (_notifs, resp) = client
+            .send_request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": first_prompt }]
+                }),
+            )
+            .await;
+        assert!(
+            resp["result"].get("stopReason").is_some(),
+            "first turn should complete: {resp}"
+        );
+        client.shutdown().await;
+        session_id
+    };
+
+    // --- Process B: a brand-new server process over the same workspace ---
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+
+    // session/load of a session created by the previous process must SUCCEED.
+    let (load_notifs, load_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": session_id,
+                "cwd": workspace.root.to_string_lossy().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        load_notifs.is_empty(),
+        "session/load should not produce notifications"
+    );
+    assert!(
+        load_resp.get("error").is_none(),
+        "session/load of a prior-process session should succeed, got: {load_resp}"
+    );
+
+    // A follow-up turn on the resumed session must carry process A's message
+    // upstream — that only happens if history was restored from disk.
+    let before = server.captured_requests().await.len();
+    let (_n, follow_resp) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{
+                    "type": "text",
+                    "text": format!("{SCENARIO_PREFIX}streaming_text follow-up")
+                }]
+            }),
+        )
+        .await;
+    assert!(
+        follow_resp["result"].get("stopReason").is_some(),
+        "resumed turn should complete: {follow_resp}"
+    );
+
+    let requests = server.captured_requests().await;
+    assert!(
+        requests.len() > before,
+        "resumed prompt should reach the model"
+    );
+    let last = requests.last().expect("at least one captured request");
+    assert!(
+        last.raw_body.contains(HISTORY_MARKER),
+        "resumed model request must include the prior turn's message ({HISTORY_MARKER}); \
+         a fresh/empty session would omit it. body: {}",
+        last.raw_body
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
 #[tokio::test]
 async fn acp_ws_integration() {
     let server = MockAnthropicService::spawn()


### PR DESCRIPTION
## Context

Companion to sudoprivacy/sudowork#957. That PR makes sudowork resume scode sessions via the ACP-standard `session/load` (which scode already implements correctly). This PR fixes two engine-side defects that otherwise still let a resumed/long session lose or thrash its context.

## Fix 1 — model switch left `session.model` stale (FLAG A)

`handle_acp_model_switch` (ACP) and the REPL `/model` path clone the session and rebuild the runtime with the new model, but `build_runtime_with_plugin_state` only fills `session.model` when it is `None`. So after a switch the session kept its **old** model. The ACP pre-turn auto-compaction reads `session.model` to pick the context window — so it used the old model's window, compacting too late (overflow → wedged session) when switching to a smaller-context model, or too eagerly otherwise. Now both switch sites set the model on the clone before rebuilding.

## Fix 2 — compaction was durable only via the end-of-turn save (FLAG B)

The ACP pre-turn compaction updates the in-memory session, then returns an error early when the session is still over the limit after compacting. That early return (and any later turn error) skips the end-of-turn `save_to_path`, so the on-disk JSONL kept the **full uncompacted** history — and the next resume reloaded it and overflowed again. Now the compacted session is persisted immediately (best-effort; a persist hiccup is traced, not fatal), before any early return.

## Test

`acp_integration.rs::acp_stdio_resume_restores_history_across_reconnect`: create a session + one turn carrying a unique marker in process A, let it exit, then in a **fresh** process B `session/load` the same id and run another turn — asserting the upstream model request still carries process A's message (history restored, not started fresh). Verifies the end-to-end resume path sudowork now relies on.

> Note: this file is `#![cfg(unix)]` (the ACP stdio handshake hangs on Windows, per the file header), so the new test runs on CI/Linux, not on a Windows dev box.