### PR TITLE
chore(release): bump workspace version to 0.1.12

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "base64",
  "criterion",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "plugins",
  "runtime",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "commands",
  "runtime",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "api",
  "serde_json",
@@ -2020,7 +2020,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3095,7 +3095,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "api",
  "arboard",
@@ -3112,6 +3112,7 @@ dependencies = [
  "plugins",
  "pty-expect",
  "pulldown-cmark",
+ "reqwest",
  "runtime",
  "rustyline",
  "serde",
@@ -3589,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "chrono",
  "dirs",
@@ -3938,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Version bump for the **v0.1.12** scode release — an out-of-band SEV-0 hotfix.

This release ships the session-resume engine fixes from #264:
- model switch now syncs `session.model` (correct context window for pre-turn auto-compaction)
- compaction is persisted immediately, before the still-over-limit early return, so a resumed session carries the compacted summary instead of re-overflowing

Once merged, `v0.1.12` is tagged so `release.yml` publishes the scode-{os}-{arch} artifacts, which sudowork v0.2.10 then bundles (runtime-versions.scode -> 0.1.12) for a COS release. Context in the Engineering / SudoWork 开发 Feishu threads.

Only `rust/Cargo.toml` workspace version + the matching `Cargo.lock` workspace-member entries change; no external deps touched.