### PR TITLE
docs(roadmap): planning-mode + TodoWrite covered; TaskList partial (2/5 P&S)

### DIFF
--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -505,8 +505,8 @@ coverage starts fresh and is tracked here as the single source.</p>
 <table>
   <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>EnterPlanMode</code> / <code>ExitPlanMode</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Plan → implement → test → iterate</td></tr>
-    <tr><td><code>TodoWrite</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Task list management</td></tr>
+    <tr><td><code>EnterPlanMode</code> / <code>ExitPlanMode</code></td><td data-priority="must-have">must-have</td><td data-status="covered">Covered</td><td>PTY: <code>pty_plan_mode.rs</code> (3 tests — fresh-workspace Enter, full lifecycle preserving prior <code>defaultMode</code>, Exit-without-Enter no-op). Merged in PR #276.</td><td>Plan → implement → test → iterate</td></tr>
+    <tr><td><code>TodoWrite</code></td><td data-priority="must-have">must-have</td><td data-status="covered">Covered</td><td>PTY: <code>pty_todo_write.rs</code> (2 tests — verbatim persistence for pending/in-progress list, all-completed wipe to <code>[]</code> matching CC parity). Merged in PR #276.</td><td>Task list management</td></tr>
     <tr><td><code>AskUserQuestion</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>scode prompts for clarification</td></tr>
     <tr><td><code>StructuredOutput</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Return structured data</td></tr>
     <tr><td><code>Sleep</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Low priority</td></tr>
@@ -518,7 +518,7 @@ coverage starts fresh and is tracked here as the single source.</p>
   <thead><tr><th>Feature</th><th>Hacker Priority</th><th>Status</th><th>Test</th><th>Notes</th></tr></thead>
   <tbody>
     <tr><td><code>Agent</code> (sub-agents)</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>LLM tool. Strict CC parity required — study latest CC design. When implemented, also introduce <a href="#cancel-architecture">CancelDispatcher</a> and <a href="#cancel-context">ESC context guards</a>.</td></tr>
-    <tr><td><code>TaskCreate</code> / <code>TaskGet</code> / <code>TaskList</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>LLM tool. Background task management. Strict CC parity.</td></tr>
+    <tr><td><code>TaskCreate</code> / <code>TaskGet</code> / <code>TaskList</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap — partial</td><td>PTY: <code>pty_task_family.rs</code> covers <code>TaskList</code> (empty-registry <code>count: 0</code> path). <code>TaskCreate</code> PTY blocked in mock: TaskCreate's subagent issues its own /v1/messages requests with no <code>PARITY_SCENARIO</code>, which the harness rejects — a scenario-inheritance refactor unblocks it. Unit-covered in <code>runtime::task_registry::tests</code>. Merged in PR #276.</td><td>LLM tool. Background task management. Strict CC parity.</td></tr>
     <tr><td>Workers (boot, trust, prompt)</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Worker lifecycle. Strict CC parity.</td></tr>
     <tr><td>Teams (parallel sub-agents)</td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Team coordination. Strict CC parity.</td></tr>
     <tr><td><code>CronCreate</code> / <code>CronDelete</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>sudowork has a cron implementation; when scode ships this, sudowork's becomes a wrapper/UI. Per <a href="#feature-parity">feature-parity rule</a>.</td></tr>
@@ -649,7 +649,7 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>Execution</td><td>4</td><td>0</td><td>0</td><td>4</td><td><strong>1</strong></td></tr>
     <tr><td>Search &amp; Web</td><td>3</td><td>0</td><td>0</td><td>3</td><td>0</td></tr>
     <tr><td>Code Intelligence</td><td>5</td><td>0</td><td>4</td><td>1</td><td>0</td></tr>
-    <tr><td>Planning &amp; Structured</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
+    <tr><td>Planning &amp; Structured</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>2</strong></td></tr>
     <tr><td>Background &amp; Parallel</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
     <tr><td>Git Workflow</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>1</strong></td></tr><!-- 3 must-have (bash git ops) + 2 nice (skill shortcuts) -->
     <tr><td>Session Management</td><td>11</td><td>0</td><td>0</td><td>11</td><td><strong>8</strong></td></tr>
@@ -657,12 +657,12 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>Diagnostics</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>3</strong></td></tr>
     <tr><td>Auth</td><td>5</td><td>0</td><td>0</td><td>5</td><td>0</td></tr>
     <tr><td>Memory System</td><td>12</td><td>0</td><td>0</td><td>12</td><td><strong>7</strong></td></tr>
-    <tr><th>Total</th><th>91</th><th>1</th><th>8</th><th>83</th><th>41</th></tr>
+    <tr><th>Total</th><th>91</th><th>1</th><th>8</th><th>83</th><th>43</th></tr>
   </tbody>
 </table>
 
 <p><strong>90% target = 75 features covered</strong> out of the 83 in-denominator
-features. <strong>Current coverage: 41 / 83 (49%).</strong>
+features. <strong>Current coverage: 43 / 83 (52%).</strong>
 <code>L2 deferred</code> items (LSP, MCP/plugin lifecycle) are tracked
 but do not count toward the 90% target.</p>
 


### PR DESCRIPTION
## Summary
Reflects the ACTUAL coverage landed in PR #276. My original PR body overclaimed "5/5 P&S" — TaskCreate is in the Background & Parallel group (not P&S), and TaskList is the only PTY test that landed there. Being explicit here so the roadmap doesn't drift from the merged code.

## Changes

### Feature-inventory §6 (Planning & Structured)
- `EnterPlanMode / ExitPlanMode`: Gap → Covered (`pty_plan_mode.rs`, 3 tests)
- `TodoWrite`: Gap → Covered (`pty_todo_write.rs`, 2 tests)
- `AskUserQuestion` / `StructuredOutput` / `Sleep`: unchanged (still Gap — not touched)

### Feature-inventory §7 (Background & Parallel)
- `TaskCreate / TaskGet / TaskList`: Gap → **Gap — partial**
  TaskList PTY-covered (`pty_task_family.rs` empty-registry). TaskCreate blocked in mock by scenario-inheritance gap (documented in the row + pty file). Unit-covered in `runtime::task_registry::tests`.

### Coverage denominator table
- Planning & Structured: 0 → **2** covered
- Total: 41 → **43** covered
- Percentage: 49% → **52%**

## Published
Same ShareOne URL updated: https://s.shareone.vip/s/sudo-code-roadmap

## Test plan
- [ ] Read the diff — no code, doc only
- [ ] Verify ShareOne renders the updated cells