### PR TITLE
Add native installers (Windows .exe / macOS .pkg) with first-run config wizard

### DIFF
--- a/.github/workflows/installer-preview.yml
+++ b/.github/workflows/installer-preview.yml
@@ -77,8 +77,17 @@ jobs:
           mkdir -p "$pkgroot"
           cp "target/release/${{ matrix.bin }}" "$pkgroot/scode"
           chmod +x "$pkgroot/scode"
+          # Bundle the interactive config wizard alongside the binary.
+          cp "../packaging/macos/scode-setup.sh" "$pkgroot/scode-setup"
+          chmod +x "$pkgroot/scode-setup"
+          # postinstall launches the wizard in the user's Terminal.
+          scriptsdir="$(mktemp -d)/scripts"
+          mkdir -p "$scriptsdir"
+          cp "../packaging/macos/postinstall" "$scriptsdir/postinstall"
+          chmod +x "$scriptsdir/postinstall"
           pkgbuild \
             --root "$pkgroot" \
+            --scripts "$scriptsdir" \
             --identifier com.sudocode.scode \
             --version "${{ steps.version.outputs.version }}" \
             --install-location /usr/local/bin \

--- a/.github/workflows/installer-preview.yml
+++ b/.github/workflows/installer-preview.yml
@@ -97,7 +97,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install innosetup -y --no-progress
+          # Pin to 6.5.x so the compiler's message set matches the bundled
+          # Simplified Chinese language file (ChineseSimplified.isl, 6.5.0+).
+          choco install innosetup --version=6.5.4 -y --no-progress --allow-downgrade
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
           if (-not (Test-Path $iscc)) { throw "ISCC.exe not found at $iscc" }
           $base = "${{ matrix.installer_name }}" -replace '\.exe$', ''

--- a/.github/workflows/installer-preview.yml
+++ b/.github/workflows/installer-preview.yml
@@ -1,0 +1,108 @@
+name: Installer preview
+
+# Standalone workflow to validate native installers (Windows .exe / macOS .pkg)
+# before wiring them into the production release pipeline. Runs on pushes to the
+# feature branch and on manual dispatch; uploads installers as build artifacts.
+
+on:
+  push:
+    branches:
+      - feat/native-installers
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-installer:
+    name: installer-${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-arm64
+            os: macos-15
+            bin: scode
+            installer_name: scode-macos-arm64.pkg
+          - name: macos-x64
+            os: macos-15-intel
+            bin: scode
+            installer_name: scode-macos-x64.pkg
+          - name: windows-x64
+            os: windows-2022
+            bin: scode.exe
+            installer_name: scode-windows-x64-setup.exe
+          - name: windows-arm64
+            os: windows-11-arm
+            bin: scode.exe
+            installer_name: scode-windows-arm64-setup.exe
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: Build release binary
+        run: cargo build --locked --release -p rusty-sudocode-cli --bin scode
+
+      - name: Stage dist dir
+        shell: bash
+        run: mkdir -p dist
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0-dev"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build macOS installer (pkg)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkgroot="$(mktemp -d)/root"
+          mkdir -p "$pkgroot"
+          cp "target/release/${{ matrix.bin }}" "$pkgroot/scode"
+          chmod +x "$pkgroot/scode"
+          pkgbuild \
+            --root "$pkgroot" \
+            --identifier com.sudocode.scode \
+            --version "${{ steps.version.outputs.version }}" \
+            --install-location /usr/local/bin \
+            "dist/${{ matrix.installer_name }}"
+
+      - name: Build Windows installer (Inno Setup)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install innosetup -y --no-progress
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) { throw "ISCC.exe not found at $iscc" }
+          $base = "${{ matrix.installer_name }}" -replace '\.exe$', ''
+          & $iscc `
+            "/DAppVersion=${{ steps.version.outputs.version }}" `
+            "/DSourceExe=$((Resolve-Path 'target/release/scode.exe').Path)" `
+            "/DOutputDir=$((Resolve-Path 'dist').Path)" `
+            "/DOutputBase=$base" `
+            "../packaging/windows/scode.iss"
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit code $LASTEXITCODE" }
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.installer_name }}
+          path: rust/dist/${{ matrix.installer_name }}
+          if-no-files-found: error

--- a/packaging/macos/postinstall
+++ b/packaging/macos/postinstall
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# pkg postinstall: best-effort launch of the scode config wizard in the
+# console user's Terminal right after install. Runs as root during install,
+# so we drop to the logged-in user's GUI session to open Terminal. Failure
+# here never fails the install — the user can always run `scode-setup`.
+
+set +e
+
+consoleUser="$(stat -f "%Su" /dev/console 2>/dev/null)"
+if [ -z "$consoleUser" ] || [ "$consoleUser" = "root" ]; then
+  exit 0
+fi
+
+uid="$(id -u "$consoleUser" 2>/dev/null)"
+if [ -z "$uid" ]; then
+  exit 0
+fi
+
+launchctl asuser "$uid" sudo -u "$consoleUser" /usr/bin/osascript \
+  -e 'tell application "Terminal" to activate' \
+  -e 'tell application "Terminal" to do script "/usr/local/bin/scode-setup"' \
+  >/dev/null 2>&1
+
+exit 0

--- a/packaging/macos/scode-setup.sh
+++ b/packaging/macos/scode-setup.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+#
+# Interactive first-run configuration wizard for the `scode` CLI on macOS.
+#
+# Mirrors the logic of the browser-based config-tool: the user supplies a
+# sudorouter API key, we fetch the available model list over HTTPS (with a
+# built-in preset fallback), pick a default model, and write ready-to-use
+# sudocode.json + settings.json into ~/.nexus/sudocode. Pure bash + curl,
+# no python/jq dependency, so it runs on a stock macOS.
+#
+# Installed to /usr/local/bin/scode-setup by the .pkg. Safe to re-run; it
+# asks before overwriting an existing config.
+
+set -euo pipefail
+
+DEFAULT_BASE_URL="https://hk.sudorouter.ai/v1"
+DEFAULT_MODEL="deepseek-v4-pro"
+SEARCH_API_URL="https://hk.sudorouter.ai/search/tavily/search"
+CONFIG_DIR="${SUDO_CODE_CONFIG_HOME:-$HOME/.nexus/sudocode}"
+
+PRESET_MODELS='auto
+grok-4-20-reasoning
+grok-4.3
+deepseek-v4-flash
+deepseek-v4-pro
+glm-5.1
+MiniMax-M2.5
+gemini-3.5-flash
+gemini-3.1-flash-lite
+gemini-3-flash-preview
+gemini-3.1-pro-preview
+Kimi-K2.6
+gpt-5.3-codex
+gpt-5.4
+gpt-5.5
+claude-sonnet-4-6
+claude-opus-4-6
+claude-opus-4-7
+claude-opus-4-8'
+
+echo "================================================"
+echo "     Sudo Code · scode 首次配置向导"
+echo "================================================"
+echo
+
+if [ -f "$CONFIG_DIR/sudocode.json" ]; then
+  printf "检测到已存在配置：%s/sudocode.json\n是否覆盖？[y/N] " "$CONFIG_DIR"
+  read -r ans
+  case "$ans" in
+    [yY]*) ;;
+    *) echo "已取消，保留现有配置。"; exit 0 ;;
+  esac
+fi
+
+# --- Base URL (fixed default, editable) ---
+printf "Base URL [%s]: " "$DEFAULT_BASE_URL"
+read -r BASE_URL
+BASE_URL="${BASE_URL:-$DEFAULT_BASE_URL}"
+BASE_URL="${BASE_URL%/}"
+case "$BASE_URL" in
+  http://*|https://*) ;;
+  *) echo "Base URL 需以 http:// 或 https:// 开头"; exit 1 ;;
+esac
+
+# --- API Key (hidden input) ---
+printf "API Key (sk-...): "
+read -r -s API_KEY
+echo
+if [ -z "$API_KEY" ]; then
+  echo "API Key 不能为空。"
+  exit 1
+fi
+
+# --- Fetch models ---
+echo "正在拉取模型列表…"
+MODELS="$(curl -fsS -H "Authorization: Bearer $API_KEY" "$BASE_URL/models" 2>/dev/null \
+  | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  | sed -E 's/.*"([^"]*)"$/\1/' \
+  | awk 'NF && !seen[$0]++' || true)"
+
+if [ -z "$MODELS" ]; then
+  echo "⚠ 拉取失败或列表为空（可能是网络/密钥/CORS），改用内置预设列表。"
+  MODELS="$PRESET_MODELS"
+else
+  COUNT="$(printf '%s\n' "$MODELS" | grep -c . || true)"
+  echo "✓ 已拉取 $COUNT 个模型"
+fi
+
+# --- Select default model ---
+echo
+echo "请选择默认模型（输入编号，回车默认 ${DEFAULT_MODEL}）："
+i=1
+DEF_INDEX=""
+while IFS= read -r m; do
+  [ -z "$m" ] && continue
+  printf "  %2d) %s\n" "$i" "$m"
+  if [ "$m" = "$DEFAULT_MODEL" ]; then DEF_INDEX="$i"; fi
+  i=$((i + 1))
+done <<< "$MODELS"
+TOTAL=$((i - 1))
+
+printf "编号 [%s]: " "${DEF_INDEX:-1}"
+read -r sel
+sel="${sel:-${DEF_INDEX:-1}}"
+if ! printf '%s' "$sel" | grep -qE '^[0-9]+$' || [ "$sel" -lt 1 ] || [ "$sel" -gt "$TOTAL" ]; then
+  echo "编号无效，使用默认。"
+  sel="${DEF_INDEX:-1}"
+fi
+CHOSEN_MODEL="$(printf '%s\n' "$MODELS" | awk 'NF' | sed -n "${sel}p")"
+echo "默认模型：$CHOSEN_MODEL"
+
+# --- web_search ---
+printf "启用联网搜索 web_search？（密钥自动复用上面的 API Key）[Y/n] "
+read -r ws
+case "$ws" in
+  [nN]*) ENABLE_SEARCH=0 ;;
+  *) ENABLE_SEARCH=1 ;;
+esac
+
+# --- Build sudocode.json ---
+is_vision() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    *gpt-5*|*gpt-4o*|*gpt-4.1*|*gemini*|*claude-3*|*claude-opus*|*claude-sonnet*|*claude-haiku*|*vision*|*-vl*|*llava*|*pixtral*|*-image*|*multimodal*|*omni*)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+MODELS_BLOCK=""
+first=1
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  if is_vision "$id"; then input='["text", "image"]'; else input='["text"]'; fi
+  entry=$(printf '    "%s": {\n      "alias": "%s",\n      "name": "%s",\n      "input": %s,\n      "providers": {\n        "proxy": { "provider": "sudorouter", "model": "%s", "api": "openai-completions" }\n      }\n    }' \
+    "$id" "$id" "$id" "$input" "$id")
+  if [ $first -eq 1 ]; then
+    MODELS_BLOCK="$entry"
+    first=0
+  else
+    MODELS_BLOCK="$MODELS_BLOCK,
+$entry"
+  fi
+done <<< "$MODELS"
+
+if [ "$ENABLE_SEARCH" -eq 1 ]; then
+  WEB_SEARCH=",
+  \"web_search\": {
+    \"provider\": \"tavily\",
+    \"apiUrl\": \"$SEARCH_API_URL\",
+    \"apiKey\": \"\"
+  }"
+else
+  WEB_SEARCH=""
+fi
+
+SUDOCODE_JSON="{
+  \"models\": {
+$MODELS_BLOCK
+  },
+  \"auth_modes\": {
+    \"proxy\": {
+      \"sudorouter\": { \"baseUrl\": \"$BASE_URL\", \"apiKey\": \"$API_KEY\" }
+    }
+  }$WEB_SEARCH
+}"
+
+SETTINGS_JSON="{ \"model\": \"$CHOSEN_MODEL\" }"
+
+# --- Write files ---
+mkdir -p "$CONFIG_DIR"
+printf '%s\n' "$SUDOCODE_JSON" > "$CONFIG_DIR/sudocode.json"
+printf '%s\n' "$SETTINGS_JSON" > "$CONFIG_DIR/settings.json"
+
+echo
+echo "✓ 配置已写入："
+echo "    $CONFIG_DIR/sudocode.json"
+echo "    $CONFIG_DIR/settings.json"
+echo
+echo "运行 'scode doctor' 体检，或 'scode -p \"你好\"' 试跑。"

--- a/packaging/windows/ChineseSimplified.isl
+++ b/packaging/windows/ChineseSimplified.isl
@@ -1,0 +1,417 @@
+; *** Inno Setup version 6.5.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintainer: Zhenghan Yang (Kira)
+; Email: 847320916@QQ.com
+; Github: https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+; Encoding: UTF-8
+; Translation based on network resource
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+; LanguageCodePage should always be set if possible, even if this file is Unicode
+; For English it's set to zero anyway because English only uses ASCII characters
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=无法创建临时文件。安装程序已中止
+LdrCannotExecTemp=无法执行临时目录中的文件。安装程序已中止
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1。%n%n错误 %2: %3
+SetupFileMissing=安装目录中缺少文件 %1。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序已在运行。
+WindowsVersionNotSupported=此程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=此程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=此程序不能在 %1 上运行。
+OnlyOnThisPlatform=此程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=此程序只能安装到为下列处理器架构设计的 Windows 版本中：%n%n%1
+WinVersionTooLowError=此程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=此程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装此程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装此程序时您必须以管理员身份或高级用户组身份登录。
+SetupAppRunningError=安装程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+UninstallAppRunningError=卸载程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=选择安装程序安装模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装（需要管理员权限），或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 可以仅为您安装，或为所有用户安装（需要管理员权限）。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A)（推荐）
+PrivilegesRequiredOverrideCurrentUser=仅为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=仅为我安装(&M)（推荐）
+
+; *** Misc. errors
+ErrorCreatingDir=安装程序无法创建目录“%1”
+ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件
+
+; *** Setup common messages
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=简体中文翻译由 Kira（847320916@qq.com）维护。项目地址：https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+; *** Buttons
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时使用的语言。
+
+; *** Common wizard text
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下面的列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** "Welcome" wizard page
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=即将在您的计算机上安装 [name/ver]。%n%n建议您在继续安装前关闭所有其他应用程序。
+
+; *** "Password" wizard page
+WizardPassword=密码
+PasswordLabel1=此安装程序需要密码验证。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您输入的密码不正确，请重新输入。
+
+; *** "License Agreement" wizard page
+WizardLicense=许可协议
+LicenseLabel=请在继续安装前阅读以下重要信息。
+LicenseLabel3=请阅读下列许可协议。在继续安装前您必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读以下重要信息。
+InfoBeforeClickLabel=准备好继续安装后，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读以下重要信息。
+InfoAfterClickLabel=准备好继续安装后，点击“下一步”。
+
+; *** "User Information" wizard page
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=请输入用户名。
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下面的文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
+InvalidPath=您必须输入一个带驱动器盘符的完整路径，例如：%n%nC:\App%n%n或UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其他位置。
+DiskSpaceWarningTitle=磁盘空间不足
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您确定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您确定安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** "Select Components" wizard page
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已安装在您的计算机中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n您确定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名称。
+GroupNameTooLong=文件夹名称或路径太长。
+InvalidGroupName=文件夹名称无效。
+BadGroupName=文件夹名称不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=准备安装
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的计算机。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新查看或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=已选择组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=正在下载文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止
+ErrorDownloadFailed=下载失败：%1 %2
+ErrorDownloadSizeFailed=获取大小失败：%1 %2
+ErrorProgress=无效的进度：%1 / %2
+ErrorFileSize=文件大小错误：预期 %1，实际 %2
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=正在提取文件...
+ButtonStopExtraction=停止提取(&S)
+StopExtraction=您确定要停止提取吗？
+ErrorExtractionAborted=提取已中止
+ErrorExtractionFailed=提取失败：%1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=密码不正确
+ArchiveIsCorrupted=压缩包已损坏
+ArchiveUnsupportedFormat=不支持的压缩包格式
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的计算机。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，需要您重启计算机以完成该安装。%n%n在重启计算机后，再次运行安装程序以完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n要立即重启吗？
+
+; *** "Installing" wizard page
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的计算机，请稍候。
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=完成 [name] 安装向导
+FinishedLabelNoIcons=安装程序已在您的计算机中安装了 [name]。
+FinishedLabel=安装程序已在您的计算机中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的计算机。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的计算机。%n%n要立即重启吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重启计算机(&Y)
+NoRadio=否，稍后重启计算机(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其他文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** Installation phase messages
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=取消安装
+RetryCancelSelectAction=选择操作
+RetryCancelRetry=重试(&T)
+RetryCancelCancel=取消
+
+; *** Installation status messages
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在提取文件...
+StatusDownloadFiles=正在下载文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** Misc. errors
+ErrorInternal2=内部错误：%1
+ErrorFunctionFailedNoCode=%1 失败
+ErrorFunctionFailed=%1 失败；错误代码 %2
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2.%n%3
+ErrorExecutingProgram=无法执行文件：%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S)（不推荐）
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I)（不推荐）
+SourceIsCorrupted=源文件已损坏
+SourceDoesntExist=源文件“%1”不存在
+SourceVerificationFailed=源文件验证失败：%1
+VerificationSignatureDoesntExist=签名文件“%1”不存在
+VerificationSignatureInvalid=签名文件“%1”无效
+VerificationKeyNotFound=签名文件“%1”使用了未知的密钥
+VerificationFileNameIncorrect=文件名不正确
+VerificationFileTagIncorrect=文件标签不正确
+VerificationFileSizeIncorrect=文件大小不正确
+VerificationFileHashIncorrect=文件哈希值不正确
+ExistingFileReadOnly2=无法替换已存在的文件，它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留已存在的文件(&K)
+ErrorReadingExistingDest=尝试读取已存在的文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
+FileExistsKeepExisting=保留已存在的文件(&K)
+FileExistsOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=已存在的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
+ExistingFileNewerKeepExisting=保留已存在的文件(&K)（推荐）
+ExistingFileNewerOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列已存在的文件属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorDownloading=尝试下载文件时出错：
+ErrorExtracting=尝试提取压缩包时出错：
+ErrorReplacingExistingFile=尝试替换已存在的文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1
+ErrorRegisterTypeLib=无法注册类型库：%1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** Post-installation errors
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序无法重启计算机，请手动重启。
+
+; *** Uninstaller messages
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载
+UninstallUnknownEntry=卸载日志中遇到一个未知条目（%1）
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的计算机中移除 %1，请稍候。
+UninstalledAll=已顺利从您的计算机中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的计算机。%n%n要立即重启吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=删除共享文件？
+ConfirmDeleteSharedFile2=系统表示下列共享文件已不再有任何程序使用。您希望卸载程序删除此共享文件吗？%n%n如果仍有程序正在使用此文件，删除后这些程序可能无法正常运行。如果您不能确定，请选择“否”，保留此文件在系统中不会造成任何损害。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您确定要继续吗？

--- a/packaging/windows/scode.iss
+++ b/packaging/windows/scode.iss
@@ -1,0 +1,65 @@
+; Inno Setup script for the `scode` CLI.
+;
+; Builds a per-user installer that drops scode.exe into a directory and
+; appends that directory to the user's PATH, so `scode` works from any
+; new terminal after install. No administrator rights required.
+;
+; Defines are supplied by CI via ISCC command-line flags:
+;   /DAppVersion=<version>   e.g. 0.1.12
+;   /DSourceExe=<path>       absolute path to the built scode.exe
+;   /DOutputDir=<dir>        directory to write the setup .exe into
+;   /DOutputBase=<name>      output filename without extension
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#ifndef SourceExe
+  #define SourceExe "scode.exe"
+#endif
+#ifndef OutputDir
+  #define OutputDir "."
+#endif
+#ifndef OutputBase
+  #define OutputBase "scode-setup"
+#endif
+
+[Setup]
+AppId={{9C2E7B7A-1F2D-4C3E-9A5B-5C0DE0000001}
+AppName=scode
+AppVersion={#AppVersion}
+AppPublisher=sudocode
+DefaultDirName={localappdata}\Programs\scode
+DisableProgramGroupPage=yes
+UninstallDisplayName=scode
+UninstallDisplayIcon={app}\scode.exe
+OutputDir={#OutputDir}
+OutputBaseFilename={#OutputBase}
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+ChangesEnvironment=yes
+
+[Files]
+Source: "{#SourceExe}"; DestDir: "{app}"; DestName: "scode.exe"; Flags: ignoreversion
+
+[Registry]
+; Append the install dir to the per-user PATH (HKA resolves to HKCU for a
+; per-user install). Only added when it is not already present.
+Root: HKA; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; \
+    ValueData: "{olddata};{app}"; \
+    Check: NeedsAddPath('{app}')
+
+[Code]
+function NeedsAddPath(Param: string): Boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKA, 'Environment', 'Path', OrigPath) then
+  begin
+    Result := True;
+    exit;
+  end;
+  { Wrap in semicolons so we match whole path segments, not substrings. }
+  Result := Pos(';' + Uppercase(Param) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
+end;

--- a/packaging/windows/scode.iss
+++ b/packaging/windows/scode.iss
@@ -4,6 +4,12 @@
 ; appends that directory to the user's PATH, so `scode` works from any
 ; new terminal after install. No administrator rights required.
 ;
+; It also runs a first-run configuration wizard: the user enters their
+; sudorouter API key, the installer fetches the available model list over
+; HTTPS, and writes ready-to-use sudocode.json + settings.json into the
+; per-user config home (~/.nexus/sudocode) so `scode` works with no extra
+; manual setup. The wizard is skipped when a sudocode.json already exists.
+;
 ; Defines are supplied by CI via ISCC command-line flags:
 ;   /DAppVersion=<version>   e.g. 0.1.12
 ;   /DSourceExe=<path>       absolute path to the built scode.exe
@@ -40,26 +46,479 @@ WizardStyle=modern
 PrivilegesRequired=lowest
 ChangesEnvironment=yes
 
+[Tasks]
+; Default-checked: append the install dir to the user's PATH.
+Name: "addtopath"; Description: "将安装目录加入 PATH（推荐，新开终端即可运行 scode）"
+
 [Files]
 Source: "{#SourceExe}"; DestDir: "{app}"; DestName: "scode.exe"; Flags: ignoreversion
 
 [Registry]
 ; Append the install dir to the per-user PATH (HKA resolves to HKCU for a
-; per-user install). Only added when it is not already present.
+; per-user install). Only added when the task is selected and it is not
+; already present.
 Root: HKA; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; \
     ValueData: "{olddata};{app}"; \
-    Check: NeedsAddPath('{app}')
+    Check: ShouldAddPath('{app}')
 
 [Code]
-function NeedsAddPath(Param: string): Boolean;
+const
+  DefaultBaseUrl = 'https://hk.sudorouter.ai/v1';
+  DefaultModel = 'deepseek-v4-pro';
+
+var
+  ConfigPage: TWizardPage;
+  BaseUrlEdit: TNewEdit;
+  ApiKeyEdit: TPasswordEdit;
+  FetchButton: TNewButton;
+  PresetButton: TNewButton;
+  ModelCombo: TNewComboBox;
+  SearchCheck: TNewCheckBox;
+  StatusLabel: TNewStaticText;
+  ConfigDone: Boolean;
+
+{ ---- PATH helper ------------------------------------------------------- }
+
+function ShouldAddPath(Param: string): Boolean;
 var
   OrigPath: string;
+  AlreadyPresent: Boolean;
 begin
+  if not WizardIsTaskSelected('addtopath') then
+  begin
+    Result := False;
+    exit;
+  end;
   if not RegQueryStringValue(HKA, 'Environment', 'Path', OrigPath) then
   begin
     Result := True;
     exit;
   end;
   { Wrap in semicolons so we match whole path segments, not substrings. }
-  Result := Pos(';' + Uppercase(Param) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
+  AlreadyPresent := Pos(';' + Uppercase(Param) + ';', ';' + Uppercase(OrigPath) + ';') > 0;
+  Result := not AlreadyPresent;
+end;
+
+{ ---- Small string / JSON helpers -------------------------------------- }
+
+function TrimTrailingSlashes(S: string): string;
+begin
+  while (Length(S) > 0) and (S[Length(S)] = '/') do
+    Delete(S, Length(S), 1);
+  Result := S;
+end;
+
+{ Minimal JSON string escaping (backslash + double quote), wrapped in quotes. }
+function JsonStr(S: string): string;
+var
+  I: Integer;
+  C: Char;
+  R: string;
+begin
+  R := '';
+  for I := 1 to Length(S) do
+  begin
+    C := S[I];
+    if C = '\' then
+      R := R + '\\'
+    else if C = '"' then
+      R := R + '\"'
+    else
+      R := R + C;
+  end;
+  Result := '"' + R + '"';
+end;
+
+{ Name-based inference of image-input support, mirroring config-tool.html. }
+function IsVisionModel(Id: string): Boolean;
+var
+  S: string;
+begin
+  S := Lowercase(Id);
+  Result :=
+    (Pos('gpt-5', S) > 0) or (Pos('gpt-4o', S) > 0) or (Pos('gpt-4.1', S) > 0) or
+    (Pos('gemini', S) > 0) or (Pos('claude-3', S) > 0) or (Pos('claude-opus', S) > 0) or
+    (Pos('claude-sonnet', S) > 0) or (Pos('claude-haiku', S) > 0) or
+    (Pos('vision', S) > 0) or (Pos('-vl', S) > 0) or (Pos('llava', S) > 0) or
+    (Pos('pixtral', S) > 0) or (Pos('-image', S) > 0) or (Pos('multimodal', S) > 0) or
+    (Pos('omni', S) > 0);
+end;
+
+{ ---- Config directory ------------------------------------------------- }
+
+function ConfigDir: string;
+begin
+  { scode's default config home when SUDO_CODE_CONFIG_HOME is unset. }
+  Result := ExpandConstant('{%USERPROFILE}') + '\.nexus\sudocode';
+end;
+
+function ConfigAlreadyExists: Boolean;
+begin
+  Result := FileExists(ConfigDir + '\sudocode.json');
+end;
+
+{ ---- Model list fetching ---------------------------------------------- }
+
+{ GET {baseUrl}/models with a bearer token via WinHTTP. Returns True on
+  HTTP 200 with the body in Body; otherwise Body carries an error message. }
+function HttpGetModels(BaseUrl, ApiKey: string; var Body: string): Boolean;
+var
+  WinHttp: Variant;
+begin
+  Result := False;
+  try
+    WinHttp := CreateOleObject('WinHttp.WinHttpRequest.5.1');
+    WinHttp.Open('GET', BaseUrl + '/models', False);
+    WinHttp.SetRequestHeader('Authorization', 'Bearer ' + ApiKey);
+    WinHttp.Send('');
+    if WinHttp.Status = 200 then
+    begin
+      Body := WinHttp.ResponseText;
+      Result := True;
+    end
+    else
+      Body := 'HTTP ' + IntToStr(WinHttp.Status);
+  except
+    Body := GetExceptionMessage;
+  end;
+end;
+
+{ Scan an OpenAI-style /models response for each "id":"..." value. }
+procedure ParseModelIds(Json: string; List: TStringList);
+var
+  Rest, Id: string;
+  P, Q: Integer;
+begin
+  List.Clear;
+  Rest := Json;
+  repeat
+    P := Pos('"id"', Rest);
+    if P = 0 then
+      Break;
+    Rest := Copy(Rest, P + 4, Length(Rest));
+    P := Pos('"', Rest);
+    if P = 0 then
+      Break;
+    Rest := Copy(Rest, P + 1, Length(Rest));
+    Q := Pos('"', Rest);
+    if Q = 0 then
+      Break;
+    Id := Copy(Rest, 1, Q - 1);
+    Rest := Copy(Rest, Q + 1, Length(Rest));
+    if (Id <> '') and (List.IndexOf(Id) < 0) then
+      List.Add(Id);
+  until False;
+end;
+
+{ Built-in fallback list mirroring config-tool.html's PRESET_MODELS. }
+procedure LoadPresetModels(List: TStringList);
+begin
+  List.Clear;
+  List.Add('auto');
+  List.Add('grok-4-20-reasoning');
+  List.Add('grok-4.3');
+  List.Add('deepseek-v4-flash');
+  List.Add('deepseek-v4-pro');
+  List.Add('glm-5.1');
+  List.Add('MiniMax-M2.5');
+  List.Add('gemini-3.5-flash');
+  List.Add('gemini-3.1-flash-lite');
+  List.Add('gemini-3-flash-preview');
+  List.Add('gemini-3.1-pro-preview');
+  List.Add('Kimi-K2.6');
+  List.Add('gpt-5.3-codex');
+  List.Add('gpt-5.4');
+  List.Add('gpt-5.5');
+  List.Add('claude-sonnet-4-6');
+  List.Add('claude-opus-4-6');
+  List.Add('claude-opus-4-7');
+  List.Add('claude-opus-4-8');
+end;
+
+{ Fill the dropdown from a list of model ids; preselect DefaultModel. }
+procedure PopulateModelCombo(List: TStringList);
+var
+  I, DefIdx: Integer;
+begin
+  ModelCombo.Items.Clear;
+  DefIdx := -1;
+  for I := 0 to List.Count - 1 do
+  begin
+    ModelCombo.Items.Add(List[I]);
+    if List[I] = DefaultModel then
+      DefIdx := I;
+  end;
+  if ModelCombo.Items.Count > 0 then
+  begin
+    if DefIdx >= 0 then
+      ModelCombo.ItemIndex := DefIdx
+    else
+      ModelCombo.ItemIndex := 0;
+  end;
+end;
+
+procedure FetchButtonClick(Sender: TObject);
+var
+  Body, BaseUrl, ApiKey: string;
+  List: TStringList;
+begin
+  BaseUrl := TrimTrailingSlashes(Trim(BaseUrlEdit.Text));
+  ApiKey := Trim(ApiKeyEdit.Text);
+  if (BaseUrl = '') or ((Pos('http://', Lowercase(BaseUrl)) <> 1) and (Pos('https://', Lowercase(BaseUrl)) <> 1)) then
+  begin
+    StatusLabel.Caption := '请先填写正确的 Base URL（需以 http:// 或 https:// 开头）';
+    exit;
+  end;
+  if ApiKey = '' then
+  begin
+    StatusLabel.Caption := '请先填写 API Key';
+    exit;
+  end;
+  StatusLabel.Caption := '正在拉取模型列表…';
+  List := TStringList.Create;
+  try
+    if HttpGetModels(BaseUrl, ApiKey, Body) then
+    begin
+      ParseModelIds(Body, List);
+      if List.Count = 0 then
+        StatusLabel.Caption := '接口返回的模型列表为空，可点「使用内置预设」'
+      else
+      begin
+        PopulateModelCombo(List);
+        StatusLabel.Caption := '✓ 已拉取 ' + IntToStr(List.Count) + ' 个模型';
+      end;
+    end
+    else
+      StatusLabel.Caption := '拉取失败：' + Body + ' —— 可点「使用内置预设」';
+  finally
+    List.Free;
+  end;
+end;
+
+procedure PresetButtonClick(Sender: TObject);
+var
+  List: TStringList;
+begin
+  List := TStringList.Create;
+  try
+    LoadPresetModels(List);
+    PopulateModelCombo(List);
+    StatusLabel.Caption := '已加载内置预设模型列表（' + IntToStr(List.Count) + ' 个）';
+  finally
+    List.Free;
+  end;
+end;
+
+{ ---- Config file generation ------------------------------------------- }
+
+function BuildSudocodeJson(BaseUrl, ApiKey, ModelsBlock: string; EnableSearch: Boolean): string;
+begin
+  Result :=
+    '{' + #13#10 +
+    '  "models": {' + #13#10 +
+    ModelsBlock + #13#10 +
+    '  },' + #13#10 +
+    '  "auth_modes": {' + #13#10 +
+    '    "proxy": {' + #13#10 +
+    '      "sudorouter": { "baseUrl": ' + JsonStr(BaseUrl) + ', "apiKey": ' + JsonStr(ApiKey) + ' }' + #13#10 +
+    '    }' + #13#10 +
+    '  }';
+  if EnableSearch then
+    Result := Result + ',' + #13#10 +
+      '  "web_search": {' + #13#10 +
+      '    "provider": "tavily",' + #13#10 +
+      '    "apiUrl": "https://hk.sudorouter.ai/search/tavily/search",' + #13#10 +
+      '    "apiKey": ""' + #13#10 +
+      '  }';
+  Result := Result + #13#10 + '}' + #13#10;
+end;
+
+function BuildModelsBlock: string;
+var
+  I: Integer;
+  Id, InputArr, Block: string;
+begin
+  Block := '';
+  for I := 0 to ModelCombo.Items.Count - 1 do
+  begin
+    Id := ModelCombo.Items[I];
+    if IsVisionModel(Id) then
+      InputArr := '["text", "image"]'
+    else
+      InputArr := '["text"]';
+    if I > 0 then
+      Block := Block + ',' + #13#10;
+    Block := Block +
+      '    ' + JsonStr(Id) + ': {' + #13#10 +
+      '      "alias": ' + JsonStr(Id) + ',' + #13#10 +
+      '      "name": ' + JsonStr(Id) + ',' + #13#10 +
+      '      "input": ' + InputArr + ',' + #13#10 +
+      '      "providers": {' + #13#10 +
+      '        "proxy": { "provider": "sudorouter", "model": ' + JsonStr(Id) + ', "api": "openai-completions" }' + #13#10 +
+      '      }' + #13#10 +
+      '    }';
+  end;
+  Result := Block;
+end;
+
+procedure WriteConfigFiles;
+var
+  Dir, BaseUrl, ApiKey, Model, SudoJson, SettingsJson: string;
+begin
+  if ModelCombo.Items.Count = 0 then
+    exit;
+  BaseUrl := TrimTrailingSlashes(Trim(BaseUrlEdit.Text));
+  ApiKey := Trim(ApiKeyEdit.Text);
+  if ModelCombo.ItemIndex >= 0 then
+    Model := ModelCombo.Items[ModelCombo.ItemIndex]
+  else
+    Model := DefaultModel;
+
+  Dir := ConfigDir;
+  if not ForceDirectories(Dir) then
+  begin
+    MsgBox('无法创建配置目录：' + Dir, mbError, MB_OK);
+    exit;
+  end;
+
+  SudoJson := BuildSudocodeJson(BaseUrl, ApiKey, BuildModelsBlock, SearchCheck.Checked);
+  SettingsJson := '{ "model": ' + JsonStr(Model) + ' }' + #13#10;
+
+  if not SaveStringToFile(Dir + '\sudocode.json', SudoJson, False) then
+    MsgBox('写入 sudocode.json 失败：' + Dir, mbError, MB_OK);
+  if not SaveStringToFile(Dir + '\settings.json', SettingsJson, False) then
+    MsgBox('写入 settings.json 失败：' + Dir, mbError, MB_OK);
+end;
+
+{ ---- Wizard page wiring ----------------------------------------------- }
+
+procedure CreateConfigPage;
+var
+  Y: Integer;
+  Hint: TNewStaticText;
+begin
+  ConfigPage := CreateCustomPage(wpSelectDir, '配置 scode',
+    '填写 API Key 并拉取模型，安装时将自动生成配置文件到 ~/.nexus/sudocode');
+
+  Y := ScaleY(8);
+
+  { Base URL }
+  Hint := TNewStaticText.Create(WizardForm);
+  Hint.Parent := ConfigPage.Surface;
+  Hint.Top := Y;
+  Hint.Caption := 'Base URL（API 服务地址，通常以 /v1 结尾）';
+  Y := Y + Hint.Height + ScaleY(2);
+
+  BaseUrlEdit := TNewEdit.Create(WizardForm);
+  BaseUrlEdit.Parent := ConfigPage.Surface;
+  BaseUrlEdit.Top := Y;
+  BaseUrlEdit.Width := ConfigPage.SurfaceWidth;
+  BaseUrlEdit.Text := DefaultBaseUrl;
+  Y := Y + BaseUrlEdit.Height + ScaleY(12);
+
+  { API Key }
+  Hint := TNewStaticText.Create(WizardForm);
+  Hint.Parent := ConfigPage.Surface;
+  Hint.Top := Y;
+  Hint.Caption := 'API Key（你的密钥，一般以 sk- 开头）';
+  Y := Y + Hint.Height + ScaleY(2);
+
+  ApiKeyEdit := TPasswordEdit.Create(WizardForm);
+  ApiKeyEdit.Parent := ConfigPage.Surface;
+  ApiKeyEdit.Top := Y;
+  ApiKeyEdit.Width := ConfigPage.SurfaceWidth;
+  Y := Y + ApiKeyEdit.Height + ScaleY(12);
+
+  { Fetch / preset buttons }
+  FetchButton := TNewButton.Create(WizardForm);
+  FetchButton.Parent := ConfigPage.Surface;
+  FetchButton.Top := Y;
+  FetchButton.Width := ScaleX(110);
+  FetchButton.Height := ScaleY(25);
+  FetchButton.Caption := '拉取模型';
+  FetchButton.OnClick := @FetchButtonClick;
+
+  PresetButton := TNewButton.Create(WizardForm);
+  PresetButton.Parent := ConfigPage.Surface;
+  PresetButton.Top := Y;
+  PresetButton.Left := FetchButton.Left + FetchButton.Width + ScaleX(10);
+  PresetButton.Width := ScaleX(130);
+  PresetButton.Height := ScaleY(25);
+  PresetButton.Caption := '使用内置预设';
+  PresetButton.OnClick := @PresetButtonClick;
+  Y := Y + FetchButton.Height + ScaleY(12);
+
+  { Default model dropdown }
+  Hint := TNewStaticText.Create(WizardForm);
+  Hint.Parent := ConfigPage.Surface;
+  Hint.Top := Y;
+  Hint.Caption := '默认模型（拉取或加载预设后从下拉框选择）';
+  Y := Y + Hint.Height + ScaleY(2);
+
+  ModelCombo := TNewComboBox.Create(WizardForm);
+  ModelCombo.Parent := ConfigPage.Surface;
+  ModelCombo.Top := Y;
+  ModelCombo.Width := ConfigPage.SurfaceWidth;
+  ModelCombo.Style := csDropDownList;
+  Y := Y + ModelCombo.Height + ScaleY(12);
+
+  { web_search }
+  SearchCheck := TNewCheckBox.Create(WizardForm);
+  SearchCheck.Parent := ConfigPage.Surface;
+  SearchCheck.Top := Y;
+  SearchCheck.Width := ConfigPage.SurfaceWidth;
+  SearchCheck.Caption := '启用联网搜索 web_search（密钥自动复用上面的 API Key）';
+  SearchCheck.Checked := True;
+  Y := Y + SearchCheck.Height + ScaleY(12);
+
+  { Status line }
+  StatusLabel := TNewStaticText.Create(WizardForm);
+  StatusLabel.Parent := ConfigPage.Surface;
+  StatusLabel.Top := Y;
+  StatusLabel.Width := ConfigPage.SurfaceWidth;
+  StatusLabel.AutoSize := False;
+  StatusLabel.Height := ScaleY(34);
+  StatusLabel.WordWrap := True;
+  StatusLabel.Caption := '';
+end;
+
+procedure InitializeWizard;
+begin
+  ConfigDone := False;
+  CreateConfigPage;
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False;
+  { Skip the wizard entirely if the user already has a sudocode.json. }
+  if (PageID = ConfigPage.ID) and ConfigAlreadyExists then
+    Result := True;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if CurPageID = ConfigPage.ID then
+  begin
+    if Trim(ApiKeyEdit.Text) = '' then
+    begin
+      MsgBox('请填写 API Key。', mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+    if ModelCombo.Items.Count = 0 then
+    begin
+      MsgBox('请先点击「拉取模型」或「使用内置预设」，再选择默认模型。', mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+    ConfigDone := True;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if (CurStep = ssPostInstall) and ConfigDone then
+    WriteConfigFiles;
 end;

--- a/packaging/windows/scode.iss
+++ b/packaging/windows/scode.iss
@@ -159,7 +159,7 @@ end;
 
 { ---- Model list fetching ---------------------------------------------- }
 
-{ GET {baseUrl}/models with a bearer token via WinHTTP. Returns True on
+{ GET BaseUrl + /models with a bearer token via WinHTTP. Returns True on
   HTTP 200 with the body in Body; otherwise Body carries an error message. }
 function HttpGetModels(BaseUrl, ApiKey: string; var Body: string): Boolean;
 var

--- a/packaging/windows/scode.iss
+++ b/packaging/windows/scode.iss
@@ -45,6 +45,12 @@ SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=lowest
 ChangesEnvironment=yes
+ShowLanguageDialog=no
+
+[Languages]
+; Simplified Chinese for the whole wizard (welcome, dir page, tasks, buttons).
+; The .isl ships alongside this script in packaging/windows/.
+Name: "chinesesimp"; MessagesFile: "ChineseSimplified.isl"
 
 [Tasks]
 ; Default-checked: append the install dir to the user's PATH.
@@ -309,6 +315,15 @@ begin
   end;
 end;
 
+{ Auto-fetch when the user finishes entering the API key (focus leaves the
+  field). The manual 拉取模型 button remains available; FetchButtonClick
+  ignores its Sender so passing nil is fine. }
+procedure ApiKeyEditExit(Sender: TObject);
+begin
+  if Trim(ApiKeyEdit.Text) <> '' then
+    FetchButtonClick(nil);
+end;
+
 { ---- Config file generation ------------------------------------------- }
 
 function BuildSudocodeJson(BaseUrl, ApiKey, ModelsBlock: string; EnableSearch: Boolean): string;
@@ -427,6 +442,7 @@ begin
   ApiKeyEdit.Parent := ConfigPage.Surface;
   ApiKeyEdit.Top := Y;
   ApiKeyEdit.Width := ConfigPage.SurfaceWidth;
+  ApiKeyEdit.OnExit := @ApiKeyEditExit;
   Y := Y + ApiKeyEdit.Height + ScaleY(12);
 
   { Fetch / preset buttons }

--- a/packaging/windows/scode.iss
+++ b/packaging/windows/scode.iss
@@ -77,7 +77,6 @@ var
   BaseUrlEdit: TNewEdit;
   ApiKeyEdit: TPasswordEdit;
   FetchButton: TNewButton;
-  PresetButton: TNewButton;
   ModelCombo: TNewComboBox;
   SearchCheck: TNewCheckBox;
   StatusLabel: TNewStaticText;
@@ -216,31 +215,6 @@ begin
   until False;
 end;
 
-{ Built-in fallback list mirroring config-tool.html's PRESET_MODELS. }
-procedure LoadPresetModels(List: TStringList);
-begin
-  List.Clear;
-  List.Add('auto');
-  List.Add('grok-4-20-reasoning');
-  List.Add('grok-4.3');
-  List.Add('deepseek-v4-flash');
-  List.Add('deepseek-v4-pro');
-  List.Add('glm-5.1');
-  List.Add('MiniMax-M2.5');
-  List.Add('gemini-3.5-flash');
-  List.Add('gemini-3.1-flash-lite');
-  List.Add('gemini-3-flash-preview');
-  List.Add('gemini-3.1-pro-preview');
-  List.Add('Kimi-K2.6');
-  List.Add('gpt-5.3-codex');
-  List.Add('gpt-5.4');
-  List.Add('gpt-5.5');
-  List.Add('claude-sonnet-4-6');
-  List.Add('claude-opus-4-6');
-  List.Add('claude-opus-4-7');
-  List.Add('claude-opus-4-8');
-end;
-
 { Fill the dropdown from a list of model ids; preselect DefaultModel. }
 procedure PopulateModelCombo(List: TStringList);
 var
@@ -287,7 +261,7 @@ begin
     begin
       ParseModelIds(Body, List);
       if List.Count = 0 then
-        StatusLabel.Caption := '接口返回的模型列表为空，可点「使用内置预设」'
+        StatusLabel.Caption := '接口返回的模型列表为空，请检查 API Key 后重试'
       else
       begin
         PopulateModelCombo(List);
@@ -295,21 +269,7 @@ begin
       end;
     end
     else
-      StatusLabel.Caption := '拉取失败：' + Body + ' —— 可点「使用内置预设」';
-  finally
-    List.Free;
-  end;
-end;
-
-procedure PresetButtonClick(Sender: TObject);
-var
-  List: TStringList;
-begin
-  List := TStringList.Create;
-  try
-    LoadPresetModels(List);
-    PopulateModelCombo(List);
-    StatusLabel.Caption := '已加载内置预设模型列表（' + IntToStr(List.Count) + ' 个）';
+      StatusLabel.Caption := '拉取失败：' + Body + '，请检查网络与 API Key 后重试';
   finally
     List.Free;
   end;
@@ -445,7 +405,7 @@ begin
   ApiKeyEdit.OnExit := @ApiKeyEditExit;
   Y := Y + ApiKeyEdit.Height + ScaleY(12);
 
-  { Fetch / preset buttons }
+  { Fetch button }
   FetchButton := TNewButton.Create(WizardForm);
   FetchButton.Parent := ConfigPage.Surface;
   FetchButton.Top := Y;
@@ -453,22 +413,13 @@ begin
   FetchButton.Height := ScaleY(25);
   FetchButton.Caption := '拉取模型';
   FetchButton.OnClick := @FetchButtonClick;
-
-  PresetButton := TNewButton.Create(WizardForm);
-  PresetButton.Parent := ConfigPage.Surface;
-  PresetButton.Top := Y;
-  PresetButton.Left := FetchButton.Left + FetchButton.Width + ScaleX(10);
-  PresetButton.Width := ScaleX(130);
-  PresetButton.Height := ScaleY(25);
-  PresetButton.Caption := '使用内置预设';
-  PresetButton.OnClick := @PresetButtonClick;
   Y := Y + FetchButton.Height + ScaleY(12);
 
   { Default model dropdown }
   Hint := TNewStaticText.Create(WizardForm);
   Hint.Parent := ConfigPage.Surface;
   Hint.Top := Y;
-  Hint.Caption := '默认模型（拉取或加载预设后从下拉框选择）';
+  Hint.Caption := '默认模型（拉取后从下拉框选择）';
   Y := Y + Hint.Height + ScaleY(2);
 
   ModelCombo := TNewComboBox.Create(WizardForm);
@@ -525,7 +476,7 @@ begin
     end;
     if ModelCombo.Items.Count = 0 then
     begin
-      MsgBox('请先点击「拉取模型」或「使用内置预设」，再选择默认模型。', mbError, MB_OK);
+      MsgBox('请先点击「拉取模型」，再选择默认模型。', mbError, MB_OK);
       Result := False;
       exit;
     end;

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -733,7 +733,10 @@ pub fn default_config_home() -> PathBuf {
     std::env::var_os("SUDO_CODE_CONFIG_HOME")
         .map(PathBuf::from)
         .or_else(|| {
-            std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".nexus").join("sudocode"))
+            // Windows sets USERPROFILE rather than HOME.
+            std::env::var_os("HOME")
+                .or_else(|| std::env::var_os("USERPROFILE"))
+                .map(|home| PathBuf::from(home).join(".nexus").join("sudocode"))
         })
         .unwrap_or_else(|| PathBuf::from(".nexus/sudocode"))
 }


### PR DESCRIPTION
## Summary
- 新增 CI workflow `installer-preview.yml`：4 个平台（Windows x64/arm64 .exe、macOS arm64/x64 .pkg）构建原生安装包并上传 artifact
- Windows 安装器（Inno Setup，全中文界面）：安装到 `%LocalAppData%\Programs\scode` 并加入用户 PATH；内置首次配置向导——输入 API Key 自动拉取模型列表、选择默认模型、生成 `sudocode.json` + `settings.json`（已移除内置预设模型按钮，拉取为唯一途径）
- macOS 安装器（.pkg）：安装 scode 到 `/usr/local/bin`，postinstall 在终端启动交互式配置向导 `scode-setup`
- 修复 `default_config_home()` 在 Windows 下不读 `USERPROFILE` 的 bug——此前 HOME 未设置时会退到当前目录的 `.nexus/sudocode`，导致安装器写入的配置不生效

## Test plan
- [x] CI 四平台构建通过（run 28580179167）
- [ ] Windows x64 实机安装：验证向导拉取模型、配置写入 `%USERPROFILE%\.nexus\sudocode`、PATH 生效
- [ ] macOS 安装 .pkg 后验证 postinstall 向导及 `scode doctor`
- [ ] 已有 sudocode.json 时向导跳过 / 询问覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)