### PR TITLE
feat(mcp): add SSE transport unified behind McpConnection trait

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2910,12 +2910,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3001,6 +3003,7 @@ dependencies = [
  "nix 0.29.0",
  "plugins",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4281,6 +4284,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -38,6 +38,9 @@ keyring = "3"
 nexus-vfs-client = { path = "../nexus-vfs-client" }
 plugins = { path = "../plugins" }
 regex = "1"
+# HTTP client for the MCP SSE transport (mcp_sse.rs). Mirrors the api crate:
+# rustls-tls to avoid an OpenSSL dependency, `stream` for `bytes_stream()`.
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
 telemetry = { path = "../telemetry" }

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -128,21 +128,21 @@ pub use mcp_client::{
     McpClientAuth, McpClientBootstrap, McpClientTransport, McpManagedProxyTransport,
     McpRemoteTransport, McpSdkTransport, McpStdioTransport,
 };
+pub use mcp_connection::McpConnection;
 pub use mcp_lifecycle_hardened::{
     McpDegradedReport, McpErrorSurface, McpFailedServer, McpLifecyclePhase, McpLifecycleState,
     McpLifecycleValidator, McpPhaseResult,
 };
 pub use mcp_server::{McpServer, McpServerSpec, ToolCallHandler, MCP_SERVER_PROTOCOL_VERSION};
-pub use mcp_connection::McpConnection;
-pub use mcp_stdio::{spawn_mcp_stdio_process, McpStdioProcess};
 pub use mcp_server_manager::{
     JsonRpcError, JsonRpcId, JsonRpcRequest, JsonRpcResponse, ManagedMcpTool, McpDiscoveryFailure,
     McpInitializeClientInfo, McpInitializeParams, McpInitializeResult, McpInitializeServerInfo,
     McpListResourcesParams, McpListResourcesResult, McpListToolsParams, McpListToolsResult,
-    McpReadResourceParams, McpReadResourceResult, McpResource, McpResourceContents, McpServerManager,
-    McpServerManagerError, McpTool, McpToolCallContent, McpToolCallParams, McpToolCallResult,
-    McpToolDiscoveryReport, UnsupportedMcpServer,
+    McpReadResourceParams, McpReadResourceResult, McpResource, McpResourceContents,
+    McpServerManager, McpServerManagerError, McpTool, McpToolCallContent, McpToolCallParams,
+    McpToolCallResult, McpToolDiscoveryReport, UnsupportedMcpServer,
 };
+pub use mcp_stdio::{spawn_mcp_stdio_process, McpStdioProcess};
 pub use oauth::{
     clear_oauth_credentials, clear_oauth_credentials_from_keyring, clear_oauth_credentials_with,
     code_challenge_s256, credentials_path, generate_pkce_pair, generate_state,

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -30,9 +30,12 @@ mod lane_events;
 pub mod lsp_client;
 mod mcp;
 mod mcp_client;
+mod mcp_connection;
 pub mod mcp_lifecycle_hardened;
 mod mcp_ndjson_transport;
 pub mod mcp_server;
+mod mcp_server_manager;
+mod mcp_sse;
 mod mcp_stdio;
 pub mod mcp_tool_bridge;
 pub mod memory;
@@ -130,14 +133,15 @@ pub use mcp_lifecycle_hardened::{
     McpLifecycleValidator, McpPhaseResult,
 };
 pub use mcp_server::{McpServer, McpServerSpec, ToolCallHandler, MCP_SERVER_PROTOCOL_VERSION};
-pub use mcp_stdio::{
-    spawn_mcp_stdio_process, JsonRpcError, JsonRpcId, JsonRpcRequest, JsonRpcResponse,
-    ManagedMcpTool, McpDiscoveryFailure, McpInitializeClientInfo, McpInitializeParams,
-    McpInitializeResult, McpInitializeServerInfo, McpListResourcesParams, McpListResourcesResult,
-    McpListToolsParams, McpListToolsResult, McpReadResourceParams, McpReadResourceResult,
-    McpResource, McpResourceContents, McpServerManager, McpServerManagerError, McpStdioProcess,
-    McpTool, McpToolCallContent, McpToolCallParams, McpToolCallResult, McpToolDiscoveryReport,
-    UnsupportedMcpServer,
+pub use mcp_connection::McpConnection;
+pub use mcp_stdio::{spawn_mcp_stdio_process, McpStdioProcess};
+pub use mcp_server_manager::{
+    JsonRpcError, JsonRpcId, JsonRpcRequest, JsonRpcResponse, ManagedMcpTool, McpDiscoveryFailure,
+    McpInitializeClientInfo, McpInitializeParams, McpInitializeResult, McpInitializeServerInfo,
+    McpListResourcesParams, McpListResourcesResult, McpListToolsParams, McpListToolsResult,
+    McpReadResourceParams, McpReadResourceResult, McpResource, McpResourceContents, McpServerManager,
+    McpServerManagerError, McpTool, McpToolCallContent, McpToolCallParams, McpToolCallResult,
+    McpToolDiscoveryReport, UnsupportedMcpServer,
 };
 pub use oauth::{
     clear_oauth_credentials, clear_oauth_credentials_from_keyring, clear_oauth_credentials_with,

--- a/rust/crates/runtime/src/mcp_connection.rs
+++ b/rust/crates/runtime/src/mcp_connection.rs
@@ -1,0 +1,67 @@
+//! Transport-agnostic connection abstraction shared by the stdio and the
+//! remote (SSE) MCP transports, so [`McpServerManager`](crate::McpServerManager)
+//! can drive either one through a single `Box<dyn McpConnection>`.
+//!
+//! The trait deliberately mirrors the inherent methods of `McpStdioProcess`
+//! (the first implementation), so the stdio path delegates with no behavioral
+//! change. Per-transport timeout configuration is intentionally excluded:
+//! `McpStdioProcess` does not carry a timeout, so the manager resolves the
+//! `tools/call` timeout from the bootstrap transport instead (see
+//! `McpServerManager::tool_call_timeout_ms`).
+
+use std::io;
+
+use async_trait::async_trait;
+
+use crate::mcp_server_manager::{
+    JsonRpcId, JsonRpcResponse, McpInitializeParams, McpInitializeResult, McpListResourcesParams,
+    McpListResourcesResult, McpListToolsParams, McpListToolsResult, McpReadResourceParams,
+    McpReadResourceResult, McpToolCallParams, McpToolCallResult,
+};
+
+/// A live MCP transport connection over which JSON-RPC requests can be driven.
+#[async_trait]
+pub trait McpConnection: Send + std::fmt::Debug {
+    /// Send `initialize` and read the handshake response.
+    async fn initialize(
+        &mut self,
+        id: JsonRpcId,
+        params: McpInitializeParams,
+    ) -> io::Result<JsonRpcResponse<McpInitializeResult>>;
+
+    /// Send `tools/list` (optionally paged via `cursor`) and read the response.
+    async fn list_tools(
+        &mut self,
+        id: JsonRpcId,
+        params: Option<McpListToolsParams>,
+    ) -> io::Result<JsonRpcResponse<McpListToolsResult>>;
+
+    /// Send `tools/call` and read the response.
+    async fn call_tool(
+        &mut self,
+        id: JsonRpcId,
+        params: McpToolCallParams,
+    ) -> io::Result<JsonRpcResponse<McpToolCallResult>>;
+
+    /// Send `resources/list` (optionally paged) and read the response.
+    async fn list_resources(
+        &mut self,
+        id: JsonRpcId,
+        params: Option<McpListResourcesParams>,
+    ) -> io::Result<JsonRpcResponse<McpListResourcesResult>>;
+
+    /// Send `resources/read` and read the response.
+    async fn read_resource(
+        &mut self,
+        id: JsonRpcId,
+        params: McpReadResourceParams,
+    ) -> io::Result<JsonRpcResponse<McpReadResourceResult>>;
+
+    /// Whether the underlying transport has already terminated and must be
+    /// re-established before the next request.
+    async fn has_exited(&mut self) -> io::Result<bool>;
+
+    /// Tear down the transport. Best-effort: callers absorb errors, so this
+    /// returns unit rather than `io::Result`.
+    async fn shutdown(&mut self);
+}

--- a/rust/crates/runtime/src/mcp_server.rs
+++ b/rust/crates/runtime/src/mcp_server.rs
@@ -18,7 +18,7 @@ use std::io;
 use serde_json::{json, Value as JsonValue};
 use tokio::io::{stdin, stdout, BufReader, Stdin, Stdout};
 
-use crate::mcp_stdio::{
+use crate::mcp_server_manager::{
     JsonRpcError, JsonRpcId, JsonRpcRequest, JsonRpcResponse, McpInitializeResult,
     McpInitializeServerInfo, McpListToolsResult, McpTool, McpToolCallContent, McpToolCallParams,
     McpToolCallResult,

--- a/rust/crates/runtime/src/mcp_server_manager.rs
+++ b/rust/crates/runtime/src/mcp_server_manager.rs
@@ -562,9 +562,7 @@ impl McpServerManager {
                 unsupported_servers.push(UnsupportedMcpServer {
                     server_name: server_name.clone(),
                     transport,
-                    reason: format!(
-                        "transport {transport:?} is not supported by McpServerManager"
-                    ),
+                    reason: format!("transport {transport:?} is not supported by McpServerManager"),
                 });
             }
         }

--- a/rust/crates/runtime/src/mcp_server_manager.rs
+++ b/rust/crates/runtime/src/mcp_server_manager.rs
@@ -1,0 +1,1288 @@
+//! Transport-agnostic MCP client manager.
+//!
+//! Extracted verbatim from `mcp_stdio.rs` (structural refactor, no logic
+//! change): the JSON-RPC message shapes, the `McpServerManager` that drives
+//! `initialize` / `tools/list` / `tools/call` / `resources/*`, the error
+//! type, and the spawn-attempt / reset retry policy. Transport-specific
+//! connection types (`McpStdioProcess`, the future `McpSseConnection`) live
+//! in their own modules and are attached through `McpStdioProcess` directly
+//! today (to be generalized via a connection trait in a follow-up).
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::io;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tokio::time::timeout;
+
+use crate::config::{McpTransport, RuntimeConfig, ScopedMcpServerConfig};
+use crate::mcp::mcp_tool_name;
+use crate::mcp_client::{McpClientBootstrap, McpClientTransport, DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS};
+use crate::mcp_connection::McpConnection;
+use crate::mcp_lifecycle_hardened::{
+    McpDegradedReport, McpErrorSurface, McpFailedServer, McpLifecyclePhase,
+};
+use crate::mcp_sse::McpSseConnection;
+use crate::mcp_stdio::spawn_mcp_stdio_process;
+
+// Test timeouts must still comfortably cover spawning a fresh Python child and
+// completing the JSON-RPC handshake on a loaded CI runner (macOS is the slowest).
+// They were originally 200/300 ms, which flaked when the *second* (legitimate)
+// spawn in the retry tests raced the timeout. They only bound how long a
+// deliberately-hung child is waited on, so 2 s keeps tests fast while removing
+// the race. Production values are unchanged.
+#[cfg(test)]
+const MCP_INITIALIZE_TIMEOUT_MS: u64 = 2_000;
+#[cfg(not(test))]
+const MCP_INITIALIZE_TIMEOUT_MS: u64 = 10_000;
+
+#[cfg(test)]
+const MCP_LIST_TOOLS_TIMEOUT_MS: u64 = 2_000;
+#[cfg(not(test))]
+const MCP_LIST_TOOLS_TIMEOUT_MS: u64 = 30_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum JsonRpcId {
+    Number(u64),
+    String(String),
+    Null,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcRequest<T = JsonValue> {
+    pub jsonrpc: String,
+    pub id: JsonRpcId,
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<T>,
+}
+
+impl<T> JsonRpcRequest<T> {
+    #[must_use]
+    pub fn new(id: JsonRpcId, method: impl Into<String>, params: Option<T>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcResponse<T = JsonValue> {
+    pub jsonrpc: String,
+    pub id: JsonRpcId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInitializeParams {
+    pub protocol_version: String,
+    pub capabilities: JsonValue,
+    pub client_info: McpInitializeClientInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInitializeClientInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInitializeResult {
+    pub protocol_version: String,
+    pub capabilities: JsonValue,
+    pub server_info: McpInitializeServerInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInitializeServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpListToolsParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpTool {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "inputSchema", skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<JsonValue>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpListToolsResult {
+    pub tools: Vec<McpTool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolCallParams {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<JsonValue>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpToolCallContent {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(flatten)]
+    pub data: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolCallResult {
+    #[serde(default)]
+    pub content: Vec<McpToolCallContent>,
+    #[serde(default)]
+    pub structured_content: Option<JsonValue>,
+    #[serde(default)]
+    pub is_error: Option<bool>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpListResourcesParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpResource {
+    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<JsonValue>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpListResourcesResult {
+    pub resources: Vec<McpResource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpReadResourceParams {
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpResourceContents {
+    pub uri: String,
+    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpReadResourceResult {
+    pub contents: Vec<McpResourceContents>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ManagedMcpTool {
+    pub server_name: String,
+    pub qualified_name: String,
+    pub raw_name: String,
+    pub tool: McpTool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedMcpServer {
+    pub server_name: String,
+    pub transport: McpTransport,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpDiscoveryFailure {
+    pub server_name: String,
+    pub phase: McpLifecyclePhase,
+    pub error: String,
+    pub recoverable: bool,
+    pub context: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpToolDiscoveryReport {
+    pub tools: Vec<ManagedMcpTool>,
+    pub failed_servers: Vec<McpDiscoveryFailure>,
+    pub unsupported_servers: Vec<UnsupportedMcpServer>,
+    pub degraded_startup: Option<McpDegradedReport>,
+}
+
+#[derive(Debug)]
+pub enum McpServerManagerError {
+    Io(io::Error),
+    Transport {
+        server_name: String,
+        method: &'static str,
+        source: io::Error,
+    },
+    JsonRpc {
+        server_name: String,
+        method: &'static str,
+        error: JsonRpcError,
+    },
+    InvalidResponse {
+        server_name: String,
+        method: &'static str,
+        details: String,
+    },
+    Timeout {
+        server_name: String,
+        method: &'static str,
+        timeout_ms: u64,
+    },
+    UnknownTool {
+        qualified_name: String,
+    },
+    UnknownServer {
+        server_name: String,
+    },
+    /// Sticky terminal failure after exceeding the spawn-attempt limit.
+    /// Prevents a broken plugin MCP server from being re-forked indefinitely.
+    PermanentlyFailed {
+        server_name: String,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for McpServerManagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::Transport {
+                server_name,
+                method,
+                source,
+            } => write!(
+                f,
+                "MCP server `{server_name}` transport failed during {method}: {source}"
+            ),
+            Self::JsonRpc {
+                server_name,
+                method,
+                error,
+            } => write!(
+                f,
+                "MCP server `{server_name}` returned JSON-RPC error for {method}: {} ({})",
+                error.message, error.code
+            ),
+            Self::InvalidResponse {
+                server_name,
+                method,
+                details,
+            } => write!(
+                f,
+                "MCP server `{server_name}` returned invalid response for {method}: {details}"
+            ),
+            Self::Timeout {
+                server_name,
+                method,
+                timeout_ms,
+            } => write!(
+                f,
+                "MCP server `{server_name}` timed out after {timeout_ms} ms while handling {method}"
+            ),
+            Self::UnknownTool { qualified_name } => {
+                write!(f, "unknown MCP tool `{qualified_name}`")
+            }
+            Self::UnknownServer { server_name } => write!(f, "unknown MCP server `{server_name}`"),
+            Self::PermanentlyFailed {
+                server_name,
+                reason,
+            } => write!(
+                f,
+                "MCP server `{server_name}` permanently disabled: {reason}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for McpServerManagerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Transport { source, .. } => Some(source),
+            Self::JsonRpc { .. }
+            | Self::InvalidResponse { .. }
+            | Self::Timeout { .. }
+            | Self::UnknownTool { .. }
+            | Self::UnknownServer { .. }
+            | Self::PermanentlyFailed { .. } => None,
+        }
+    }
+}
+
+impl From<io::Error> for McpServerManagerError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl McpServerManagerError {
+    fn lifecycle_phase(&self) -> McpLifecyclePhase {
+        match self {
+            Self::Io(_) => McpLifecyclePhase::SpawnConnect,
+            Self::Transport { method, .. }
+            | Self::JsonRpc { method, .. }
+            | Self::InvalidResponse { method, .. }
+            | Self::Timeout { method, .. } => lifecycle_phase_for_method(method),
+            Self::UnknownTool { .. } => McpLifecyclePhase::ToolDiscovery,
+            Self::UnknownServer { .. } => McpLifecyclePhase::ServerRegistration,
+            // Permanent failure is the sticky version of "couldn't make it
+            // past initialize" — preserve InitializeHandshake so downstream
+            // surfaces (degraded report, doctor) don't misclassify it.
+            Self::PermanentlyFailed { .. } => McpLifecyclePhase::InitializeHandshake,
+        }
+    }
+
+    fn recoverable(&self) -> bool {
+        !matches!(
+            self.lifecycle_phase(),
+            McpLifecyclePhase::InitializeHandshake
+        ) && matches!(self, Self::Transport { .. } | Self::Timeout { .. })
+    }
+
+    fn discovery_failure(&self, server_name: &str) -> McpDiscoveryFailure {
+        let phase = self.lifecycle_phase();
+        let recoverable = self.recoverable();
+        let context = self.error_context();
+
+        McpDiscoveryFailure {
+            server_name: server_name.to_string(),
+            phase,
+            error: self.to_string(),
+            recoverable,
+            context,
+        }
+    }
+
+    fn error_context(&self) -> BTreeMap<String, String> {
+        match self {
+            Self::Io(error) => BTreeMap::from([("kind".to_string(), error.kind().to_string())]),
+            Self::Transport {
+                server_name,
+                method,
+                source,
+            } => BTreeMap::from([
+                ("server".to_string(), server_name.clone()),
+                ("method".to_string(), (*method).to_string()),
+                ("io_kind".to_string(), source.kind().to_string()),
+            ]),
+            Self::JsonRpc {
+                server_name,
+                method,
+                error,
+            } => BTreeMap::from([
+                ("server".to_string(), server_name.clone()),
+                ("method".to_string(), (*method).to_string()),
+                ("jsonrpc_code".to_string(), error.code.to_string()),
+            ]),
+            Self::InvalidResponse {
+                server_name,
+                method,
+                details,
+            } => BTreeMap::from([
+                ("server".to_string(), server_name.clone()),
+                ("method".to_string(), (*method).to_string()),
+                ("details".to_string(), details.clone()),
+            ]),
+            Self::Timeout {
+                server_name,
+                method,
+                timeout_ms,
+            } => BTreeMap::from([
+                ("server".to_string(), server_name.clone()),
+                ("method".to_string(), (*method).to_string()),
+                ("timeout_ms".to_string(), timeout_ms.to_string()),
+            ]),
+            Self::UnknownTool { qualified_name } => {
+                BTreeMap::from([("qualified_tool".to_string(), qualified_name.clone())])
+            }
+            Self::UnknownServer { server_name } => {
+                BTreeMap::from([("server".to_string(), server_name.clone())])
+            }
+            Self::PermanentlyFailed {
+                server_name,
+                reason,
+            } => BTreeMap::from([
+                ("server".to_string(), server_name.clone()),
+                ("reason".to_string(), reason.clone()),
+                // Track the lifecycle method this failure aborted, matching
+                // other variants. PermanentlyFailed always trips in the
+                // spawn → initialize handshake window.
+                ("method".to_string(), "initialize".to_string()),
+            ]),
+        }
+    }
+}
+
+fn lifecycle_phase_for_method(method: &str) -> McpLifecyclePhase {
+    match method {
+        "initialize" => McpLifecyclePhase::InitializeHandshake,
+        "tools/list" => McpLifecyclePhase::ToolDiscovery,
+        "resources/list" => McpLifecyclePhase::ResourceDiscovery,
+        "resources/read" | "tools/call" => McpLifecyclePhase::Invocation,
+        _ => McpLifecyclePhase::ErrorSurfacing,
+    }
+}
+
+pub(crate) fn unsupported_server_failed_server(server: &UnsupportedMcpServer) -> McpFailedServer {
+    McpFailedServer {
+        server_name: server.server_name.clone(),
+        phase: McpLifecyclePhase::ServerRegistration,
+        error: McpErrorSurface::new(
+            McpLifecyclePhase::ServerRegistration,
+            Some(server.server_name.clone()),
+            server.reason.clone(),
+            BTreeMap::from([("transport".to_string(), format!("{:?}", server.transport))]),
+            false,
+        ),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolRoute {
+    server_name: String,
+    raw_name: String,
+}
+
+/// Maximum number of spawn+initialize attempts to make against a single MCP
+/// server within one McpServerManager lifetime. Exceeding this trips a sticky
+/// `permanent_failure` so a broken plugin MCP server cannot loop-fork.
+pub(crate) const MCP_SPAWN_ATTEMPT_LIMIT: u32 = 2;
+
+#[derive(Debug)]
+struct ManagedMcpServer {
+    bootstrap: McpClientBootstrap,
+    process: Option<Box<dyn McpConnection>>,
+    initialized: bool,
+    /// Total spawn attempts (including retries) made against this server.
+    /// Capped at MCP_SPAWN_ATTEMPT_LIMIT to short-circuit the spawn loop.
+    spawn_attempts: u32,
+    /// Sticky terminal failure that disables further spawn attempts and is
+    /// returned verbatim on every future request. Set once spawn_attempts
+    /// reaches the cap.
+    permanent_failure: Option<String>,
+}
+
+impl ManagedMcpServer {
+    fn new(bootstrap: McpClientBootstrap) -> Self {
+        Self {
+            bootstrap,
+            process: None,
+            initialized: false,
+            spawn_attempts: 0,
+            permanent_failure: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct McpServerManager {
+    servers: BTreeMap<String, ManagedMcpServer>,
+    unsupported_servers: Vec<UnsupportedMcpServer>,
+    tool_index: BTreeMap<String, ToolRoute>,
+    next_request_id: u64,
+}
+
+impl McpServerManager {
+    #[must_use]
+    pub fn from_runtime_config(config: &RuntimeConfig) -> Self {
+        Self::from_servers(config.mcp().servers())
+    }
+
+    #[must_use]
+    pub fn from_servers(servers: &BTreeMap<String, ScopedMcpServerConfig>) -> Self {
+        let mut managed_servers = BTreeMap::new();
+        let mut unsupported_servers = Vec::new();
+
+        for (server_name, server_config) in servers {
+            let transport = server_config.transport();
+            if matches!(transport, McpTransport::Stdio | McpTransport::Sse) {
+                let bootstrap = McpClientBootstrap::from_scoped_config(server_name, server_config);
+                managed_servers.insert(server_name.clone(), ManagedMcpServer::new(bootstrap));
+            } else {
+                unsupported_servers.push(UnsupportedMcpServer {
+                    server_name: server_name.clone(),
+                    transport,
+                    reason: format!(
+                        "transport {transport:?} is not supported by McpServerManager"
+                    ),
+                });
+            }
+        }
+
+        Self {
+            servers: managed_servers,
+            unsupported_servers,
+            tool_index: BTreeMap::new(),
+            next_request_id: 1,
+        }
+    }
+
+    #[must_use]
+    pub fn unsupported_servers(&self) -> &[UnsupportedMcpServer] {
+        &self.unsupported_servers
+    }
+
+    #[must_use]
+    pub fn server_names(&self) -> Vec<String> {
+        self.servers.keys().cloned().collect()
+    }
+
+    pub async fn discover_tools(&mut self) -> Result<Vec<ManagedMcpTool>, McpServerManagerError> {
+        let server_names = self.servers.keys().cloned().collect::<Vec<_>>();
+        let mut discovered_tools = Vec::new();
+
+        for server_name in server_names {
+            let server_tools = self.discover_tools_for_server(&server_name).await?;
+            self.clear_routes_for_server(&server_name);
+
+            for tool in server_tools {
+                self.tool_index.insert(
+                    tool.qualified_name.clone(),
+                    ToolRoute {
+                        server_name: tool.server_name.clone(),
+                        raw_name: tool.raw_name.clone(),
+                    },
+                );
+                discovered_tools.push(tool);
+            }
+        }
+
+        Ok(discovered_tools)
+    }
+
+    pub async fn discover_tools_best_effort(&mut self) -> McpToolDiscoveryReport {
+        let server_names = self.server_names();
+        let mut discovered_tools = Vec::new();
+        let mut working_servers = Vec::new();
+        let mut failed_servers = Vec::new();
+
+        for server_name in server_names {
+            match self.discover_tools_for_server(&server_name).await {
+                Ok(server_tools) => {
+                    working_servers.push(server_name.clone());
+                    self.clear_routes_for_server(&server_name);
+                    for tool in server_tools {
+                        self.tool_index.insert(
+                            tool.qualified_name.clone(),
+                            ToolRoute {
+                                server_name: tool.server_name.clone(),
+                                raw_name: tool.raw_name.clone(),
+                            },
+                        );
+                        discovered_tools.push(tool);
+                    }
+                }
+                Err(error) => {
+                    self.clear_routes_for_server(&server_name);
+                    failed_servers.push(error.discovery_failure(&server_name));
+                }
+            }
+        }
+
+        let degraded_failed_servers = failed_servers
+            .iter()
+            .map(|failure| McpFailedServer {
+                server_name: failure.server_name.clone(),
+                phase: failure.phase,
+                error: McpErrorSurface::new(
+                    failure.phase,
+                    Some(failure.server_name.clone()),
+                    failure.error.clone(),
+                    failure.context.clone(),
+                    failure.recoverable,
+                ),
+            })
+            .chain(
+                self.unsupported_servers
+                    .iter()
+                    .map(unsupported_server_failed_server),
+            )
+            .collect::<Vec<_>>();
+        let degraded_startup = (!working_servers.is_empty() && !degraded_failed_servers.is_empty())
+            .then(|| {
+                McpDegradedReport::new(
+                    working_servers,
+                    degraded_failed_servers,
+                    discovered_tools
+                        .iter()
+                        .map(|tool| tool.qualified_name.clone())
+                        .collect(),
+                    Vec::new(),
+                )
+            });
+
+        McpToolDiscoveryReport {
+            tools: discovered_tools,
+            failed_servers,
+            unsupported_servers: self.unsupported_servers.clone(),
+            degraded_startup,
+        }
+    }
+
+    pub async fn call_tool(
+        &mut self,
+        qualified_tool_name: &str,
+        arguments: Option<JsonValue>,
+    ) -> Result<JsonRpcResponse<McpToolCallResult>, McpServerManagerError> {
+        let route = self
+            .tool_index
+            .get(qualified_tool_name)
+            .cloned()
+            .ok_or_else(|| McpServerManagerError::UnknownTool {
+                qualified_name: qualified_tool_name.to_string(),
+            })?;
+
+        let timeout_ms = self.tool_call_timeout_ms(&route.server_name)?;
+
+        self.ensure_server_ready(&route.server_name).await?;
+        let request_id = self.take_request_id();
+        let response =
+            {
+                let server = self.server_mut(&route.server_name)?;
+                let process = server.process.as_mut().ok_or_else(|| {
+                    McpServerManagerError::InvalidResponse {
+                        server_name: route.server_name.clone(),
+                        method: "tools/call",
+                        details: "server process missing after initialization".to_string(),
+                    }
+                })?;
+                Self::run_process_request(
+                    &route.server_name,
+                    "tools/call",
+                    timeout_ms,
+                    process.call_tool(
+                        request_id,
+                        McpToolCallParams {
+                            name: route.raw_name,
+                            arguments,
+                            meta: None,
+                        },
+                    ),
+                )
+                .await
+            };
+
+        if let Err(error) = &response {
+            if Self::should_reset_server(error) {
+                self.reset_server(&route.server_name).await?;
+            }
+        }
+
+        response
+    }
+
+    pub async fn list_resources(
+        &mut self,
+        server_name: &str,
+    ) -> Result<McpListResourcesResult, McpServerManagerError> {
+        let mut attempts = 0;
+
+        loop {
+            match self.list_resources_once(server_name).await {
+                Ok(resources) => return Ok(resources),
+                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
+                    self.reset_server(server_name).await?;
+                    attempts += 1;
+                }
+                Err(error) => {
+                    if Self::should_reset_server(&error) {
+                        self.reset_server(server_name).await?;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    pub async fn read_resource(
+        &mut self,
+        server_name: &str,
+        uri: &str,
+    ) -> Result<McpReadResourceResult, McpServerManagerError> {
+        let mut attempts = 0;
+
+        loop {
+            match self.read_resource_once(server_name, uri).await {
+                Ok(resource) => return Ok(resource),
+                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
+                    self.reset_server(server_name).await?;
+                    attempts += 1;
+                }
+                Err(error) => {
+                    if Self::should_reset_server(&error) {
+                        self.reset_server(server_name).await?;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    pub async fn shutdown(&mut self) -> Result<(), McpServerManagerError> {
+        let server_names = self.servers.keys().cloned().collect::<Vec<_>>();
+        for server_name in server_names {
+            let server = self.server_mut(&server_name)?;
+            if let Some(process) = server.process.as_mut() {
+                process.shutdown().await;
+            }
+            server.process = None;
+            server.initialized = false;
+        }
+        Ok(())
+    }
+
+    fn clear_routes_for_server(&mut self, server_name: &str) {
+        self.tool_index
+            .retain(|_, route| route.server_name != server_name);
+    }
+
+    fn server_mut(
+        &mut self,
+        server_name: &str,
+    ) -> Result<&mut ManagedMcpServer, McpServerManagerError> {
+        self.servers
+            .get_mut(server_name)
+            .ok_or_else(|| McpServerManagerError::UnknownServer {
+                server_name: server_name.to_string(),
+            })
+    }
+
+    fn take_request_id(&mut self) -> JsonRpcId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.saturating_add(1);
+        JsonRpcId::Number(id)
+    }
+
+    fn tool_call_timeout_ms(&self, server_name: &str) -> Result<u64, McpServerManagerError> {
+        let server =
+            self.servers
+                .get(server_name)
+                .ok_or_else(|| McpServerManagerError::UnknownServer {
+                    server_name: server_name.to_string(),
+                })?;
+        match &server.bootstrap.transport {
+            McpClientTransport::Stdio(transport) => Ok(transport.resolved_tool_call_timeout_ms()),
+            // Remote transports (SSE today; HTTP/WS/SDK remain unimplemented)
+            // are not configurable per-server yet — fall back to the default.
+            _ => Ok(DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS),
+        }
+    }
+
+    pub(crate) async fn server_process_exited(
+        &mut self,
+        server_name: &str,
+    ) -> Result<bool, McpServerManagerError> {
+        let server = self.server_mut(server_name)?;
+        match server.process.as_mut() {
+            Some(process) => Ok(process.has_exited().await?),
+            None => Ok(false),
+        }
+    }
+
+    async fn discover_tools_for_server(
+        &mut self,
+        server_name: &str,
+    ) -> Result<Vec<ManagedMcpTool>, McpServerManagerError> {
+        let mut attempts = 0;
+
+        loop {
+            match self.discover_tools_for_server_once(server_name).await {
+                Ok(tools) => return Ok(tools),
+                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
+                    self.reset_server(server_name).await?;
+                    attempts += 1;
+                }
+                Err(error) => {
+                    if Self::should_reset_server(&error) {
+                        self.reset_server(server_name).await?;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    async fn discover_tools_for_server_once(
+        &mut self,
+        server_name: &str,
+    ) -> Result<Vec<ManagedMcpTool>, McpServerManagerError> {
+        self.ensure_server_ready(server_name).await?;
+
+        let mut discovered_tools = Vec::new();
+        let mut cursor = None;
+        loop {
+            let request_id = self.take_request_id();
+            let response = {
+                let server = self.server_mut(server_name)?;
+                let process = server.process.as_mut().ok_or_else(|| {
+                    McpServerManagerError::InvalidResponse {
+                        server_name: server_name.to_string(),
+                        method: "tools/list",
+                        details: "server process missing after initialization".to_string(),
+                    }
+                })?;
+                Self::run_process_request(
+                    server_name,
+                    "tools/list",
+                    MCP_LIST_TOOLS_TIMEOUT_MS,
+                    process.list_tools(
+                        request_id,
+                        Some(McpListToolsParams {
+                            cursor: cursor.clone(),
+                        }),
+                    ),
+                )
+                .await?
+            };
+
+            if let Some(error) = response.error {
+                return Err(McpServerManagerError::JsonRpc {
+                    server_name: server_name.to_string(),
+                    method: "tools/list",
+                    error,
+                });
+            }
+
+            let result = response
+                .result
+                .ok_or_else(|| McpServerManagerError::InvalidResponse {
+                    server_name: server_name.to_string(),
+                    method: "tools/list",
+                    details: "missing result payload".to_string(),
+                })?;
+
+            for tool in result.tools {
+                let qualified_name = mcp_tool_name(server_name, &tool.name);
+                discovered_tools.push(ManagedMcpTool {
+                    server_name: server_name.to_string(),
+                    qualified_name,
+                    raw_name: tool.name.clone(),
+                    tool,
+                });
+            }
+
+            match result.next_cursor {
+                Some(next_cursor) => cursor = Some(next_cursor),
+                None => break,
+            }
+        }
+
+        Ok(discovered_tools)
+    }
+
+    async fn list_resources_once(
+        &mut self,
+        server_name: &str,
+    ) -> Result<McpListResourcesResult, McpServerManagerError> {
+        self.ensure_server_ready(server_name).await?;
+
+        let mut resources = Vec::new();
+        let mut cursor = None;
+        loop {
+            let request_id = self.take_request_id();
+            let response = {
+                let server = self.server_mut(server_name)?;
+                let process = server.process.as_mut().ok_or_else(|| {
+                    McpServerManagerError::InvalidResponse {
+                        server_name: server_name.to_string(),
+                        method: "resources/list",
+                        details: "server process missing after initialization".to_string(),
+                    }
+                })?;
+                Self::run_process_request(
+                    server_name,
+                    "resources/list",
+                    MCP_LIST_TOOLS_TIMEOUT_MS,
+                    process.list_resources(
+                        request_id,
+                        Some(McpListResourcesParams {
+                            cursor: cursor.clone(),
+                        }),
+                    ),
+                )
+                .await?
+            };
+
+            if let Some(error) = response.error {
+                return Err(McpServerManagerError::JsonRpc {
+                    server_name: server_name.to_string(),
+                    method: "resources/list",
+                    error,
+                });
+            }
+
+            let result = response
+                .result
+                .ok_or_else(|| McpServerManagerError::InvalidResponse {
+                    server_name: server_name.to_string(),
+                    method: "resources/list",
+                    details: "missing result payload".to_string(),
+                })?;
+
+            resources.extend(result.resources);
+
+            match result.next_cursor {
+                Some(next_cursor) => cursor = Some(next_cursor),
+                None => break,
+            }
+        }
+
+        Ok(McpListResourcesResult {
+            resources,
+            next_cursor: None,
+        })
+    }
+
+    async fn read_resource_once(
+        &mut self,
+        server_name: &str,
+        uri: &str,
+    ) -> Result<McpReadResourceResult, McpServerManagerError> {
+        self.ensure_server_ready(server_name).await?;
+
+        let request_id = self.take_request_id();
+        let response =
+            {
+                let server = self.server_mut(server_name)?;
+                let process = server.process.as_mut().ok_or_else(|| {
+                    McpServerManagerError::InvalidResponse {
+                        server_name: server_name.to_string(),
+                        method: "resources/read",
+                        details: "server process missing after initialization".to_string(),
+                    }
+                })?;
+                Self::run_process_request(
+                    server_name,
+                    "resources/read",
+                    MCP_LIST_TOOLS_TIMEOUT_MS,
+                    process.read_resource(
+                        request_id,
+                        McpReadResourceParams {
+                            uri: uri.to_string(),
+                        },
+                    ),
+                )
+                .await?
+            };
+
+        if let Some(error) = response.error {
+            return Err(McpServerManagerError::JsonRpc {
+                server_name: server_name.to_string(),
+                method: "resources/read",
+                error,
+            });
+        }
+
+        response
+            .result
+            .ok_or_else(|| McpServerManagerError::InvalidResponse {
+                server_name: server_name.to_string(),
+                method: "resources/read",
+                details: "missing result payload".to_string(),
+            })
+    }
+
+    async fn reset_server(&mut self, server_name: &str) -> Result<(), McpServerManagerError> {
+        let mut process = {
+            let server = self.server_mut(server_name)?;
+            server.initialized = false;
+            server.process.take()
+        };
+
+        if let Some(process) = process.as_mut() {
+            let _ = process.shutdown().await;
+        }
+
+        Ok(())
+    }
+
+    fn is_retryable_error(error: &McpServerManagerError) -> bool {
+        matches!(
+            error,
+            McpServerManagerError::Transport { .. } | McpServerManagerError::Timeout { .. }
+        )
+    }
+
+    fn should_reset_server(error: &McpServerManagerError) -> bool {
+        matches!(
+            error,
+            McpServerManagerError::Transport { .. }
+                | McpServerManagerError::Timeout { .. }
+                | McpServerManagerError::InvalidResponse { .. }
+        )
+    }
+
+    async fn run_process_request<T, F>(
+        server_name: &str,
+        method: &'static str,
+        timeout_ms: u64,
+        future: F,
+    ) -> Result<T, McpServerManagerError>
+    where
+        F: Future<Output = io::Result<T>>,
+    {
+        match timeout(Duration::from_millis(timeout_ms), future).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) if error.kind() == io::ErrorKind::InvalidData => {
+                Err(McpServerManagerError::InvalidResponse {
+                    server_name: server_name.to_string(),
+                    method,
+                    details: error.to_string(),
+                })
+            }
+            Ok(Err(source)) => Err(McpServerManagerError::Transport {
+                server_name: server_name.to_string(),
+                method,
+                source,
+            }),
+            Err(_) => Err(McpServerManagerError::Timeout {
+                server_name: server_name.to_string(),
+                method,
+                timeout_ms,
+            }),
+        }
+    }
+
+    async fn ensure_server_ready(
+        &mut self,
+        server_name: &str,
+    ) -> Result<(), McpServerManagerError> {
+        // Sticky terminal failure short-circuits before any work — prevents
+        // the spawn loop from repeatedly fork()ing a broken plugin server.
+        if let Some(reason) = self
+            .servers
+            .get(server_name)
+            .and_then(|server| server.permanent_failure.clone())
+        {
+            return Err(McpServerManagerError::PermanentlyFailed {
+                server_name: server_name.to_string(),
+                reason,
+            });
+        }
+
+        if self.server_process_exited(server_name).await? {
+            self.reset_server(server_name).await?;
+        }
+
+        let mut attempts = 0;
+        loop {
+            let needs_spawn = self
+                .servers
+                .get(server_name)
+                .map(|server| server.process.is_none())
+                .ok_or_else(|| McpServerManagerError::UnknownServer {
+                    server_name: server_name.to_string(),
+                })?;
+
+            if needs_spawn {
+                let attempt_count = self
+                    .servers
+                    .get(server_name)
+                    .map(|server| server.spawn_attempts)
+                    .unwrap_or(0);
+                if attempt_count >= MCP_SPAWN_ATTEMPT_LIMIT {
+                    let reason = format!(
+                        "MCP server `{server_name}` exceeded {MCP_SPAWN_ATTEMPT_LIMIT} initialize attempts; refusing to retry spawn"
+                    );
+                    if let Some(server) = self.servers.get_mut(server_name) {
+                        server.permanent_failure = Some(reason.clone());
+                    }
+                    return Err(McpServerManagerError::PermanentlyFailed {
+                        server_name: server_name.to_string(),
+                        reason,
+                    });
+                }
+                let bootstrap = {
+                    let server = self.server_mut(server_name)?;
+                    server.spawn_attempts = server.spawn_attempts.saturating_add(1);
+                    server.bootstrap.clone()
+                };
+                let process = match timeout(
+                    Duration::from_millis(MCP_INITIALIZE_TIMEOUT_MS),
+                    spawn_mcp_connection(&bootstrap),
+                )
+                .await
+                {
+                    Ok(result) => result?,
+                    Err(_) => {
+                        return Err(McpServerManagerError::Io(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "MCP spawn timed out",
+                        )));
+                    }
+                };
+                let server = self.server_mut(server_name)?;
+                server.process = Some(process);
+                server.initialized = false;
+            }
+
+            let needs_initialize = self
+                .servers
+                .get(server_name)
+                .map(|server| !server.initialized)
+                .ok_or_else(|| McpServerManagerError::UnknownServer {
+                    server_name: server_name.to_string(),
+                })?;
+
+            if !needs_initialize {
+                return Ok(());
+            }
+
+            let request_id = self.take_request_id();
+            let response = {
+                let server = self.server_mut(server_name)?;
+                let process = server.process.as_mut().ok_or_else(|| {
+                    McpServerManagerError::InvalidResponse {
+                        server_name: server_name.to_string(),
+                        method: "initialize",
+                        details: "server process missing before initialize".to_string(),
+                    }
+                })?;
+                Self::run_process_request(
+                    server_name,
+                    "initialize",
+                    MCP_INITIALIZE_TIMEOUT_MS,
+                    process.initialize(request_id, default_initialize_params()),
+                )
+                .await
+            };
+
+            let response = match response {
+                Ok(response) => response,
+                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
+                    self.reset_server(server_name).await?;
+                    attempts += 1;
+                    continue;
+                }
+                Err(error) => {
+                    if Self::should_reset_server(&error) {
+                        self.reset_server(server_name).await?;
+                    }
+                    return Err(error);
+                }
+            };
+
+            if let Some(error) = response.error {
+                return Err(McpServerManagerError::JsonRpc {
+                    server_name: server_name.to_string(),
+                    method: "initialize",
+                    error,
+                });
+            }
+
+            if response.result.is_none() {
+                let error = McpServerManagerError::InvalidResponse {
+                    server_name: server_name.to_string(),
+                    method: "initialize",
+                    details: "missing result payload".to_string(),
+                };
+                self.reset_server(server_name).await?;
+                return Err(error);
+            }
+
+            let server = self.server_mut(server_name)?;
+            server.initialized = true;
+            // A successful initialize proves the server can start — reset
+            // the spawn counter so a later transport-drop + respawn does
+            // not inherit stale attempts from a prior lifecycle.
+            server.spawn_attempts = 0;
+            return Ok(());
+        }
+    }
+}
+
+fn default_initialize_params() -> McpInitializeParams {
+    McpInitializeParams {
+        protocol_version: "2025-03-26".to_string(),
+        capabilities: JsonValue::Object(serde_json::Map::new()),
+        client_info: McpInitializeClientInfo {
+            name: "runtime".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+    }
+}
+
+/// Spawn (stdio) or connect (SSE) the transport described by `bootstrap` into
+/// a boxed [`McpConnection`]. The JSON-RPC `initialize` handshake itself is
+/// driven later by `McpServerManager::ensure_server_ready`; this only
+/// establishes the transport-level connection (forking the stdio child, or
+/// opening the SSE stream and resolving its POST endpoint).
+async fn spawn_mcp_connection(
+    bootstrap: &McpClientBootstrap,
+) -> io::Result<Box<dyn McpConnection>> {
+    match &bootstrap.transport {
+        McpClientTransport::Stdio(_) => spawn_mcp_stdio_process(bootstrap)
+            .map(|process| Box::new(process) as Box<dyn McpConnection>),
+        McpClientTransport::Sse(transport) => {
+            let connection = McpSseConnection::connect(transport, &bootstrap.server_name).await?;
+            Ok(Box::new(connection))
+        }
+        other => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "MCP bootstrap transport for {} is not supported: {other:?}",
+                bootstrap.server_name
+            ),
+        )),
+    }
+}

--- a/rust/crates/runtime/src/mcp_sse.rs
+++ b/rust/crates/runtime/src/mcp_sse.rs
@@ -1,0 +1,472 @@
+//! MCP SSE transport — legacy HTTP+SSE transport (pre-2025-06-18 MCP spec).
+//!
+//! Wire shape: the client opens a long-lived `GET {url}` Server-Sent-Events
+//! stream; the server emits an `endpoint` event whose data is the URI the
+//! client must POST JSON-RPC requests to; responses travel back on the same
+//! SSE stream. This module implements that shape on top of `reqwest` + the
+//! existing [`IncrementalSseParser`](crate::IncrementalSseParser) and exposes
+//! it through the [`McpConnection`](crate::McpConnection) trait, so
+//! [`McpServerManager`](crate::McpServerManager) drives it exactly like the
+//! stdio transport.
+//!
+//! Per the configured short-lived model, a connection lives for a single
+//! `McpServerManager` request sequence: `connect` opens the stream and resolves
+//! the endpoint, the trait methods POST requests against it, and the connection
+//! is dropped (re-established) on the next call.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE};
+use reqwest::{Client, Url};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+use crate::mcp_client::McpRemoteTransport;
+use crate::mcp_connection::McpConnection;
+use crate::mcp_server_manager::{
+    JsonRpcId, JsonRpcRequest, JsonRpcResponse, McpInitializeParams, McpInitializeResult,
+    McpListResourcesParams, McpListResourcesResult, McpListToolsParams, McpListToolsResult,
+    McpReadResourceParams, McpReadResourceResult, McpToolCallParams, McpToolCallResult,
+};
+use crate::{IncrementalSseParser, SseEvent};
+
+/// Best-effort cap on a `headersHelper` invocation. A helper that cannot
+/// produce headers within this window is treated as failure (static headers
+/// still apply).
+const HEADERS_HELPER_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A live MCP SSE connection: a long-lived GET stream paired with a POST
+/// endpoint, driven over a single [`reqwest::Client`].
+#[derive(Debug)]
+pub struct McpSseConnection {
+    client: Client,
+    endpoint: Url,
+    headers: BTreeMap<String, String>,
+    events: mpsc::Receiver<SseEvent>,
+    closed: Arc<AtomicBool>,
+}
+
+impl McpSseConnection {
+    /// Open the SSE stream at `transport.url`, await the `endpoint` event, and
+    /// return a ready-to-use connection. Static `headers` are merged with the
+    /// dynamic `headersHelper` output (dynamic overrides static); helper
+    /// failures are absorbed so the connection still proceeds with static
+    /// headers alone.
+    pub(crate) async fn connect(
+        transport: &McpRemoteTransport,
+        server_name: &str,
+    ) -> io::Result<Self> {
+        let client = Client::builder().build().map_err(reqwest_error_to_io)?;
+        let headers = resolve_headers(transport, server_name).await;
+
+        let base_url = Url::parse(&transport.url).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid MCP SSE url `{}`: {error}", transport.url),
+            )
+        })?;
+
+        let get_headers = build_header_map(&headers)?;
+        let response = client
+            .get(base_url.clone())
+            .headers(get_headers)
+            .header(ACCEPT, "text/event-stream")
+            .send()
+            .await
+            .map_err(reqwest_error_to_io)?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(io::Error::other(format!(
+                "MCP SSE GET `{}` returned HTTP {status}",
+                transport.url
+            )));
+        }
+
+        let (sender, mut receiver) = mpsc::channel::<SseEvent>(64);
+        let closed = Arc::new(AtomicBool::new(false));
+        let closed_task = closed.clone();
+        let mut stream = Box::pin(response.bytes_stream());
+        tokio::spawn(async move {
+            let mut parser = IncrementalSseParser::new();
+            while let Some(chunk_result) = stream.next().await {
+                match chunk_result {
+                    Ok(bytes) => {
+                        let chunk = String::from_utf8_lossy(&bytes[..]);
+                        for event in parser.push_chunk(&chunk) {
+                            if sender.send(event).await.is_err() {
+                                // Receiver dropped — connection torn down.
+                                closed_task.store(true, Ordering::Relaxed);
+                                return;
+                            }
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            for event in parser.finish() {
+                if sender.send(event).await.is_err() {
+                    break;
+                }
+            }
+            closed_task.store(true, Ordering::Relaxed);
+        });
+
+        let endpoint_event = receiver.recv().await.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "MCP SSE stream closed before endpoint event",
+            )
+        })?;
+        if endpoint_event.event.as_deref() != Some("endpoint") {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "MCP SSE first event was not an `endpoint` event",
+            ));
+        }
+        let endpoint_path = endpoint_event.data.trim();
+        let endpoint = base_url.join(endpoint_path).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("MCP SSE endpoint `{endpoint_path}` is not a valid URL: {error}"),
+            )
+        })?;
+
+        Ok(Self {
+            client,
+            endpoint,
+            headers,
+            events: receiver,
+            closed,
+        })
+    }
+
+    /// POST a JSON-RPC request to the endpoint and read the matching response
+    /// off the SSE stream. Events that fail to parse as a response or carry a
+    /// different id (notifications, progress) are skipped until the matching
+    /// response arrives.
+    async fn post_and_read<TParams, TResult>(
+        &mut self,
+        method: &str,
+        id: JsonRpcId,
+        params: Option<TParams>,
+    ) -> io::Result<JsonRpcResponse<TResult>>
+    where
+        TParams: Serialize,
+        TResult: DeserializeOwned,
+    {
+        let request = JsonRpcRequest::new(id.clone(), method, params);
+        let body = serde_json::to_vec(&request)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+
+        let post_headers = build_header_map(&self.headers)?;
+        let response = self
+            .client
+            .post(self.endpoint.clone())
+            .headers(post_headers)
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, "application/json, text/event-stream")
+            .body(body)
+            .send()
+            .await
+            .map_err(reqwest_error_to_io)?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(io::Error::other(format!(
+                "MCP SSE POST `{}` returned HTTP {status}",
+                self.endpoint
+            )));
+        }
+
+        loop {
+            let event = self.events.recv().await.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "MCP SSE stream closed before response",
+                )
+            })?;
+            let response: JsonRpcResponse<TResult> = match serde_json::from_str(&event.data) {
+                Ok(response) => response,
+                Err(_) => continue,
+            };
+            if response.id == id {
+                return Ok(response);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl McpConnection for McpSseConnection {
+    async fn initialize(
+        &mut self,
+        id: JsonRpcId,
+        params: McpInitializeParams,
+    ) -> io::Result<JsonRpcResponse<McpInitializeResult>> {
+        self.post_and_read("initialize", id, Some(params)).await
+    }
+
+    async fn list_tools(
+        &mut self,
+        id: JsonRpcId,
+        params: Option<McpListToolsParams>,
+    ) -> io::Result<JsonRpcResponse<McpListToolsResult>> {
+        self.post_and_read("tools/list", id, params).await
+    }
+
+    async fn call_tool(
+        &mut self,
+        id: JsonRpcId,
+        params: McpToolCallParams,
+    ) -> io::Result<JsonRpcResponse<McpToolCallResult>> {
+        self.post_and_read("tools/call", id, Some(params)).await
+    }
+
+    async fn list_resources(
+        &mut self,
+        id: JsonRpcId,
+        params: Option<McpListResourcesParams>,
+    ) -> io::Result<JsonRpcResponse<McpListResourcesResult>> {
+        self.post_and_read("resources/list", id, params).await
+    }
+
+    async fn read_resource(
+        &mut self,
+        id: JsonRpcId,
+        params: McpReadResourceParams,
+    ) -> io::Result<JsonRpcResponse<McpReadResourceResult>> {
+        self.post_and_read("resources/read", id, Some(params)).await
+    }
+
+    async fn has_exited(&mut self) -> io::Result<bool> {
+        Ok(self.closed.load(Ordering::Relaxed))
+    }
+
+    async fn shutdown(&mut self) {
+        self.closed.store(true, Ordering::Relaxed);
+        self.events.close();
+    }
+}
+
+/// Merge static `headers` with dynamic `headersHelper` output (dynamic wins).
+/// Helper failures (missing script, non-zero exit, malformed JSON, timeout)
+/// are absorbed — the caller proceeds with static headers alone, matching the
+/// best-effort contract of the helper. No trust gating is applied: this is on
+/// par with the stdio transport, which spawns `command` from the same config
+/// source without a trust check.
+async fn resolve_headers(
+    transport: &McpRemoteTransport,
+    server_name: &str,
+) -> BTreeMap<String, String> {
+    let mut headers = transport.headers.clone();
+    if let Some(helper) = transport.headers_helper.as_deref() {
+        if let Ok(dynamic) = run_headers_helper(helper, server_name, &transport.url).await {
+            for (key, value) in dynamic {
+                headers.insert(key, value);
+            }
+        }
+    }
+    headers
+}
+
+/// Execute the `headersHelper` script and parse its stdout as a JSON object of
+/// string→string. Injects `MCP_SERVER_NAME` / `MCP_SERVER_URL` so a single
+/// helper can serve multiple servers (git credential-helper style).
+async fn run_headers_helper(
+    helper: &str,
+    server_name: &str,
+    server_url: &str,
+) -> io::Result<BTreeMap<String, String>> {
+    let output = timeout(HEADERS_HELPER_TIMEOUT, async {
+        tokio::process::Command::new(helper)
+            .env("MCP_SERVER_NAME", server_name)
+            .env("MCP_SERVER_URL", server_url)
+            .output()
+            .await
+    })
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "headersHelper timed out"))??;
+
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "headersHelper exited with status {}",
+            output.status
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let headers: BTreeMap<String, String> = serde_json::from_str(stdout.trim()).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("headersHelper stdout is not a JSON object of string→string: {error}"),
+        )
+    })?;
+    Ok(headers)
+}
+
+/// Build a [`HeaderMap`] from a string→string table. Header names/values that
+/// fail to parse abort the connection with a clear error rather than being
+/// silently dropped.
+fn build_header_map(headers: &BTreeMap<String, String>) -> io::Result<HeaderMap> {
+    let mut map = HeaderMap::new();
+    for (key, value) in headers {
+        let name = HeaderName::from_bytes(key.as_bytes()).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid MCP SSE header name `{key}`: {error}"),
+            )
+        })?;
+        let value = HeaderValue::from_str(value).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid MCP SSE header value for `{key}`: {error}"),
+            )
+        })?;
+        map.insert(name, value);
+    }
+    Ok(map)
+}
+
+fn reqwest_error_to_io(error: reqwest::Error) -> io::Error {
+    io::Error::other(format!("MCP SSE HTTP error: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp_client::{McpClientAuth, McpRemoteTransport};
+    use crate::mcp_server_manager::{McpInitializeClientInfo, McpInitializeParams};
+    use axum::response::sse::{Event, Sse};
+    use axum::{routing::get, routing::post, Router};
+    use std::sync::Arc;
+
+    /// Spawn a mock MCP-over-SSE server on an ephemeral port.
+    ///
+    /// `GET /sse` emits an `endpoint` event pointing at `/message`, then the
+    /// supplied JSON-RPC responses in order. `POST /message` acknowledges with
+    /// 202; the response is already queued on the GET stream, which mirrors
+    /// how a real server streams responses back over the open SSE connection.
+    async fn spawn_mock_sse(responses: Vec<&'static str>) -> std::net::SocketAddr {
+        let mut events: Vec<Event> = vec![Event::default().event("endpoint").data("/message")];
+        for response in responses {
+            events.push(Event::default().data(response));
+        }
+        let events = Arc::new(events);
+
+        let app = Router::new()
+            .route(
+                "/sse",
+                get({
+                    let events = events.clone();
+                    move || {
+                        let events = events.clone();
+                        async move {
+                            Sse::new(futures::stream::iter(
+                                (*events).clone().into_iter().map(Ok::<Event, io::Error>),
+                            ))
+                        }
+                    }
+                }),
+            )
+            .route("/message", post(|| async { axum::http::StatusCode::ACCEPTED }));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn sse_connects_initializes_lists_and_calls() {
+        let addr = spawn_mock_sse(vec![
+            r#"{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},"serverInfo":{"name":"mock-sse","version":"0.1.0"}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"echo","description":"echo","inputSchema":{"type":"object"}}]}}"#,
+            r#"{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"echo:hi"}],"isError":false}}"#,
+        ])
+        .await;
+
+        let transport = McpRemoteTransport {
+            url: format!("http://{addr}/sse"),
+            headers: BTreeMap::new(),
+            headers_helper: None,
+            auth: McpClientAuth::None,
+        };
+        let mut connection =
+            McpSseConnection::connect(&transport, "mock-sse").await.expect("connect");
+
+        let initialized = connection
+            .initialize(
+                JsonRpcId::Number(1),
+                McpInitializeParams {
+                    protocol_version: "2025-03-26".to_string(),
+                    capabilities: serde_json::json!({}),
+                    client_info: McpInitializeClientInfo {
+                        name: "test".to_string(),
+                        version: "0.1.0".to_string(),
+                    },
+                },
+            )
+            .await
+            .expect("initialize");
+        assert_eq!(initialized.id, JsonRpcId::Number(1));
+        assert_eq!(
+            initialized.result.expect("init result").server_info.name,
+            "mock-sse"
+        );
+
+        let tools = connection
+            .list_tools(JsonRpcId::Number(2), None)
+            .await
+            .expect("list tools");
+        assert_eq!(tools.result.expect("list result").tools.len(), 1);
+
+        let call = connection
+            .call_tool(
+                JsonRpcId::Number(3),
+                McpToolCallParams {
+                    name: "echo".to_string(),
+                    arguments: Some(serde_json::json!({"text": "hi"})),
+                    meta: None,
+                },
+            )
+            .await
+            .expect("call tool");
+        assert!(!call.result.expect("call result").is_error.unwrap_or(true));
+    }
+
+    #[tokio::test]
+    async fn sse_connect_rejects_non_endpoint_first_event() {
+        // First event is a plain message, not `endpoint` → connect must fail.
+        let app = Router::new().route(
+            "/sse",
+            get(|| async {
+                Sse::new(futures::stream::iter(vec![
+                    Ok::<Event, io::Error>(Event::default().event("message").data("hello")),
+                ]))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let transport = McpRemoteTransport {
+            url: format!("http://{addr}/sse"),
+            headers: BTreeMap::new(),
+            headers_helper: None,
+            auth: McpClientAuth::None,
+        };
+        let result = McpSseConnection::connect(&transport, "mock-sse").await;
+        assert!(result.is_err(), "connect should fail without an endpoint event");
+    }
+}

--- a/rust/crates/runtime/src/mcp_sse.rs
+++ b/rust/crates/runtime/src/mcp_sse.rs
@@ -302,12 +302,13 @@ async fn run_headers_helper(
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let headers: BTreeMap<String, String> = serde_json::from_str(stdout.trim()).map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("headersHelper stdout is not a JSON object of string→string: {error}"),
-        )
-    })?;
+    let headers: BTreeMap<String, String> =
+        serde_json::from_str(stdout.trim()).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("headersHelper stdout is not a JSON object of string→string: {error}"),
+            )
+        })?;
     Ok(headers)
 }
 
@@ -375,9 +376,14 @@ mod tests {
                     }
                 }),
             )
-            .route("/message", post(|| async { axum::http::StatusCode::ACCEPTED }));
+            .route(
+                "/message",
+                post(|| async { axum::http::StatusCode::ACCEPTED }),
+            );
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
         let addr = listener.local_addr().expect("local_addr");
         tokio::spawn(async move {
             let _ = axum::serve(listener, app).await;
@@ -400,8 +406,9 @@ mod tests {
             headers_helper: None,
             auth: McpClientAuth::None,
         };
-        let mut connection =
-            McpSseConnection::connect(&transport, "mock-sse").await.expect("connect");
+        let mut connection = McpSseConnection::connect(&transport, "mock-sse")
+            .await
+            .expect("connect");
 
         let initialized = connection
             .initialize(
@@ -449,12 +456,14 @@ mod tests {
         let app = Router::new().route(
             "/sse",
             get(|| async {
-                Sse::new(futures::stream::iter(vec![
-                    Ok::<Event, io::Error>(Event::default().event("message").data("hello")),
-                ]))
+                Sse::new(futures::stream::iter(vec![Ok::<Event, io::Error>(
+                    Event::default().event("message").data("hello"),
+                )]))
             }),
         );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
         let addr = listener.local_addr().expect("local_addr");
         tokio::spawn(async move {
             let _ = axum::serve(listener, app).await;
@@ -467,6 +476,9 @@ mod tests {
             auth: McpClientAuth::None,
         };
         let result = McpSseConnection::connect(&transport, "mock-sse").await;
-        assert!(result.is_err(), "connect should fail without an endpoint event");
+        assert!(
+            result.is_err(),
+            "connect should fail without an endpoint event"
+        );
     }
 }

--- a/rust/crates/runtime/src/mcp_stdio.rs
+++ b/rust/crates/runtime/src/mcp_stdio.rs
@@ -1,1227 +1,28 @@
+//! MCP stdio transport.
+//!
+//! Owns only the stdio-specific connection: `McpStdioProcess` (child process +
+//! NDJSON-framed JSON-RPC over stdin/stdout) and `spawn_mcp_stdio_process`.
+//! The transport-agnostic manager (`McpServerManager`), JSON-RPC message
+//! shapes, and error type live in `mcp_server_manager.rs`.
+
 use std::collections::BTreeMap;
-use std::future::Future;
 use std::io;
 use std::process::Stdio;
-use std::time::Duration;
 
+use async_trait::async_trait;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde::Serialize;
+
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::time::timeout;
 
-use crate::config::{McpTransport, RuntimeConfig, ScopedMcpServerConfig};
-use crate::mcp::mcp_tool_name;
 use crate::mcp_client::{McpClientBootstrap, McpClientTransport, McpStdioTransport};
-use crate::mcp_lifecycle_hardened::{
-    McpDegradedReport, McpErrorSurface, McpFailedServer, McpLifecyclePhase,
+use crate::mcp_connection::McpConnection;
+use crate::mcp_server_manager::{
+    JsonRpcId, JsonRpcRequest, JsonRpcResponse, McpInitializeParams, McpInitializeResult,
+    McpListResourcesParams, McpListResourcesResult, McpListToolsParams, McpListToolsResult,
+    McpReadResourceParams, McpReadResourceResult, McpToolCallParams, McpToolCallResult,
 };
-
-// Test timeouts must still comfortably cover spawning a fresh Python child and
-// completing the JSON-RPC handshake on a loaded CI runner (macOS is the slowest).
-// They were originally 200/300 ms, which flaked when the *second* (legitimate)
-// spawn in the retry tests raced the timeout. They only bound how long a
-// deliberately-hung child is waited on, so 2 s keeps tests fast while removing
-// the race. Production values are unchanged.
-#[cfg(test)]
-const MCP_INITIALIZE_TIMEOUT_MS: u64 = 2_000;
-#[cfg(not(test))]
-const MCP_INITIALIZE_TIMEOUT_MS: u64 = 10_000;
-
-#[cfg(test)]
-const MCP_LIST_TOOLS_TIMEOUT_MS: u64 = 2_000;
-#[cfg(not(test))]
-const MCP_LIST_TOOLS_TIMEOUT_MS: u64 = 30_000;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum JsonRpcId {
-    Number(u64),
-    String(String),
-    Null,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct JsonRpcRequest<T = JsonValue> {
-    pub jsonrpc: String,
-    pub id: JsonRpcId,
-    pub method: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub params: Option<T>,
-}
-
-impl<T> JsonRpcRequest<T> {
-    #[must_use]
-    pub fn new(id: JsonRpcId, method: impl Into<String>, params: Option<T>) -> Self {
-        Self {
-            jsonrpc: "2.0".to_string(),
-            id,
-            method: method.into(),
-            params,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct JsonRpcError {
-    pub code: i64,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct JsonRpcResponse<T = JsonValue> {
-    pub jsonrpc: String,
-    pub id: JsonRpcId,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<JsonRpcError>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpInitializeParams {
-    pub protocol_version: String,
-    pub capabilities: JsonValue,
-    pub client_info: McpInitializeClientInfo,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpInitializeClientInfo {
-    pub name: String,
-    pub version: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpInitializeResult {
-    pub protocol_version: String,
-    pub capabilities: JsonValue,
-    pub server_info: McpInitializeServerInfo,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpInitializeServerInfo {
-    pub name: String,
-    pub version: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpListToolsParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct McpTool {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(rename = "inputSchema", skip_serializing_if = "Option::is_none")]
-    pub input_schema: Option<JsonValue>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<JsonValue>,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpListToolsResult {
-    pub tools: Vec<McpTool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpToolCallParams {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arguments: Option<JsonValue>,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct McpToolCallContent {
-    #[serde(rename = "type")]
-    pub kind: String,
-    #[serde(flatten)]
-    pub data: BTreeMap<String, JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpToolCallResult {
-    #[serde(default)]
-    pub content: Vec<McpToolCallContent>,
-    #[serde(default)]
-    pub structured_content: Option<JsonValue>,
-    #[serde(default)]
-    pub is_error: Option<bool>,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpListResourcesParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct McpResource {
-    pub uri: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
-    pub mime_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<JsonValue>,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpListResourcesResult {
-    pub resources: Vec<McpResource>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct McpReadResourceParams {
-    pub uri: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct McpResourceContents {
-    pub uri: String,
-    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
-    pub mime_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub blob: Option<String>,
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    pub meta: Option<JsonValue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct McpReadResourceResult {
-    pub contents: Vec<McpResourceContents>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct ManagedMcpTool {
-    pub server_name: String,
-    pub qualified_name: String,
-    pub raw_name: String,
-    pub tool: McpTool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UnsupportedMcpServer {
-    pub server_name: String,
-    pub transport: McpTransport,
-    pub reason: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct McpDiscoveryFailure {
-    pub server_name: String,
-    pub phase: McpLifecyclePhase,
-    pub error: String,
-    pub recoverable: bool,
-    pub context: BTreeMap<String, String>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct McpToolDiscoveryReport {
-    pub tools: Vec<ManagedMcpTool>,
-    pub failed_servers: Vec<McpDiscoveryFailure>,
-    pub unsupported_servers: Vec<UnsupportedMcpServer>,
-    pub degraded_startup: Option<McpDegradedReport>,
-}
-
-#[derive(Debug)]
-pub enum McpServerManagerError {
-    Io(io::Error),
-    Transport {
-        server_name: String,
-        method: &'static str,
-        source: io::Error,
-    },
-    JsonRpc {
-        server_name: String,
-        method: &'static str,
-        error: JsonRpcError,
-    },
-    InvalidResponse {
-        server_name: String,
-        method: &'static str,
-        details: String,
-    },
-    Timeout {
-        server_name: String,
-        method: &'static str,
-        timeout_ms: u64,
-    },
-    UnknownTool {
-        qualified_name: String,
-    },
-    UnknownServer {
-        server_name: String,
-    },
-    /// Sticky terminal failure after exceeding the spawn-attempt limit.
-    /// Prevents a broken plugin MCP server from being re-forked indefinitely.
-    PermanentlyFailed {
-        server_name: String,
-        reason: String,
-    },
-}
-
-impl std::fmt::Display for McpServerManagerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(error) => write!(f, "{error}"),
-            Self::Transport {
-                server_name,
-                method,
-                source,
-            } => write!(
-                f,
-                "MCP server `{server_name}` transport failed during {method}: {source}"
-            ),
-            Self::JsonRpc {
-                server_name,
-                method,
-                error,
-            } => write!(
-                f,
-                "MCP server `{server_name}` returned JSON-RPC error for {method}: {} ({})",
-                error.message, error.code
-            ),
-            Self::InvalidResponse {
-                server_name,
-                method,
-                details,
-            } => write!(
-                f,
-                "MCP server `{server_name}` returned invalid response for {method}: {details}"
-            ),
-            Self::Timeout {
-                server_name,
-                method,
-                timeout_ms,
-            } => write!(
-                f,
-                "MCP server `{server_name}` timed out after {timeout_ms} ms while handling {method}"
-            ),
-            Self::UnknownTool { qualified_name } => {
-                write!(f, "unknown MCP tool `{qualified_name}`")
-            }
-            Self::UnknownServer { server_name } => write!(f, "unknown MCP server `{server_name}`"),
-            Self::PermanentlyFailed {
-                server_name,
-                reason,
-            } => write!(
-                f,
-                "MCP server `{server_name}` permanently disabled: {reason}"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for McpServerManagerError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(error) => Some(error),
-            Self::Transport { source, .. } => Some(source),
-            Self::JsonRpc { .. }
-            | Self::InvalidResponse { .. }
-            | Self::Timeout { .. }
-            | Self::UnknownTool { .. }
-            | Self::UnknownServer { .. }
-            | Self::PermanentlyFailed { .. } => None,
-        }
-    }
-}
-
-impl From<io::Error> for McpServerManagerError {
-    fn from(value: io::Error) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl McpServerManagerError {
-    fn lifecycle_phase(&self) -> McpLifecyclePhase {
-        match self {
-            Self::Io(_) => McpLifecyclePhase::SpawnConnect,
-            Self::Transport { method, .. }
-            | Self::JsonRpc { method, .. }
-            | Self::InvalidResponse { method, .. }
-            | Self::Timeout { method, .. } => lifecycle_phase_for_method(method),
-            Self::UnknownTool { .. } => McpLifecyclePhase::ToolDiscovery,
-            Self::UnknownServer { .. } => McpLifecyclePhase::ServerRegistration,
-            // Permanent failure is the sticky version of "couldn't make it
-            // past initialize" — preserve InitializeHandshake so downstream
-            // surfaces (degraded report, doctor) don't misclassify it.
-            Self::PermanentlyFailed { .. } => McpLifecyclePhase::InitializeHandshake,
-        }
-    }
-
-    fn recoverable(&self) -> bool {
-        !matches!(
-            self.lifecycle_phase(),
-            McpLifecyclePhase::InitializeHandshake
-        ) && matches!(self, Self::Transport { .. } | Self::Timeout { .. })
-    }
-
-    fn discovery_failure(&self, server_name: &str) -> McpDiscoveryFailure {
-        let phase = self.lifecycle_phase();
-        let recoverable = self.recoverable();
-        let context = self.error_context();
-
-        McpDiscoveryFailure {
-            server_name: server_name.to_string(),
-            phase,
-            error: self.to_string(),
-            recoverable,
-            context,
-        }
-    }
-
-    fn error_context(&self) -> BTreeMap<String, String> {
-        match self {
-            Self::Io(error) => BTreeMap::from([("kind".to_string(), error.kind().to_string())]),
-            Self::Transport {
-                server_name,
-                method,
-                source,
-            } => BTreeMap::from([
-                ("server".to_string(), server_name.clone()),
-                ("method".to_string(), (*method).to_string()),
-                ("io_kind".to_string(), source.kind().to_string()),
-            ]),
-            Self::JsonRpc {
-                server_name,
-                method,
-                error,
-            } => BTreeMap::from([
-                ("server".to_string(), server_name.clone()),
-                ("method".to_string(), (*method).to_string()),
-                ("jsonrpc_code".to_string(), error.code.to_string()),
-            ]),
-            Self::InvalidResponse {
-                server_name,
-                method,
-                details,
-            } => BTreeMap::from([
-                ("server".to_string(), server_name.clone()),
-                ("method".to_string(), (*method).to_string()),
-                ("details".to_string(), details.clone()),
-            ]),
-            Self::Timeout {
-                server_name,
-                method,
-                timeout_ms,
-            } => BTreeMap::from([
-                ("server".to_string(), server_name.clone()),
-                ("method".to_string(), (*method).to_string()),
-                ("timeout_ms".to_string(), timeout_ms.to_string()),
-            ]),
-            Self::UnknownTool { qualified_name } => {
-                BTreeMap::from([("qualified_tool".to_string(), qualified_name.clone())])
-            }
-            Self::UnknownServer { server_name } => {
-                BTreeMap::from([("server".to_string(), server_name.clone())])
-            }
-            Self::PermanentlyFailed {
-                server_name,
-                reason,
-            } => BTreeMap::from([
-                ("server".to_string(), server_name.clone()),
-                ("reason".to_string(), reason.clone()),
-                // Track the lifecycle method this failure aborted, matching
-                // other variants. PermanentlyFailed always trips in the
-                // spawn → initialize handshake window.
-                ("method".to_string(), "initialize".to_string()),
-            ]),
-        }
-    }
-}
-
-fn lifecycle_phase_for_method(method: &str) -> McpLifecyclePhase {
-    match method {
-        "initialize" => McpLifecyclePhase::InitializeHandshake,
-        "tools/list" => McpLifecyclePhase::ToolDiscovery,
-        "resources/list" => McpLifecyclePhase::ResourceDiscovery,
-        "resources/read" | "tools/call" => McpLifecyclePhase::Invocation,
-        _ => McpLifecyclePhase::ErrorSurfacing,
-    }
-}
-
-fn unsupported_server_failed_server(server: &UnsupportedMcpServer) -> McpFailedServer {
-    McpFailedServer {
-        server_name: server.server_name.clone(),
-        phase: McpLifecyclePhase::ServerRegistration,
-        error: McpErrorSurface::new(
-            McpLifecyclePhase::ServerRegistration,
-            Some(server.server_name.clone()),
-            server.reason.clone(),
-            BTreeMap::from([("transport".to_string(), format!("{:?}", server.transport))]),
-            false,
-        ),
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ToolRoute {
-    server_name: String,
-    raw_name: String,
-}
-
-/// Maximum number of spawn+initialize attempts to make against a single MCP
-/// server within one McpServerManager lifetime. Exceeding this trips a sticky
-/// `permanent_failure` so a broken plugin MCP server cannot loop-fork.
-const MCP_SPAWN_ATTEMPT_LIMIT: u32 = 2;
-
-#[derive(Debug)]
-struct ManagedMcpServer {
-    bootstrap: McpClientBootstrap,
-    process: Option<McpStdioProcess>,
-    initialized: bool,
-    /// Total spawn attempts (including retries) made against this server.
-    /// Capped at MCP_SPAWN_ATTEMPT_LIMIT to short-circuit the spawn loop.
-    spawn_attempts: u32,
-    /// Sticky terminal failure that disables further spawn attempts and is
-    /// returned verbatim on every future request. Set once spawn_attempts
-    /// reaches the cap.
-    permanent_failure: Option<String>,
-}
-
-impl ManagedMcpServer {
-    fn new(bootstrap: McpClientBootstrap) -> Self {
-        Self {
-            bootstrap,
-            process: None,
-            initialized: false,
-            spawn_attempts: 0,
-            permanent_failure: None,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct McpServerManager {
-    servers: BTreeMap<String, ManagedMcpServer>,
-    unsupported_servers: Vec<UnsupportedMcpServer>,
-    tool_index: BTreeMap<String, ToolRoute>,
-    next_request_id: u64,
-}
-
-impl McpServerManager {
-    #[must_use]
-    pub fn from_runtime_config(config: &RuntimeConfig) -> Self {
-        Self::from_servers(config.mcp().servers())
-    }
-
-    #[must_use]
-    pub fn from_servers(servers: &BTreeMap<String, ScopedMcpServerConfig>) -> Self {
-        let mut managed_servers = BTreeMap::new();
-        let mut unsupported_servers = Vec::new();
-
-        for (server_name, server_config) in servers {
-            if server_config.transport() == McpTransport::Stdio {
-                let bootstrap = McpClientBootstrap::from_scoped_config(server_name, server_config);
-                managed_servers.insert(server_name.clone(), ManagedMcpServer::new(bootstrap));
-            } else {
-                unsupported_servers.push(UnsupportedMcpServer {
-                    server_name: server_name.clone(),
-                    transport: server_config.transport(),
-                    reason: format!(
-                        "transport {:?} is not supported by McpServerManager",
-                        server_config.transport()
-                    ),
-                });
-            }
-        }
-
-        Self {
-            servers: managed_servers,
-            unsupported_servers,
-            tool_index: BTreeMap::new(),
-            next_request_id: 1,
-        }
-    }
-
-    #[must_use]
-    pub fn unsupported_servers(&self) -> &[UnsupportedMcpServer] {
-        &self.unsupported_servers
-    }
-
-    #[must_use]
-    pub fn server_names(&self) -> Vec<String> {
-        self.servers.keys().cloned().collect()
-    }
-
-    pub async fn discover_tools(&mut self) -> Result<Vec<ManagedMcpTool>, McpServerManagerError> {
-        let server_names = self.servers.keys().cloned().collect::<Vec<_>>();
-        let mut discovered_tools = Vec::new();
-
-        for server_name in server_names {
-            let server_tools = self.discover_tools_for_server(&server_name).await?;
-            self.clear_routes_for_server(&server_name);
-
-            for tool in server_tools {
-                self.tool_index.insert(
-                    tool.qualified_name.clone(),
-                    ToolRoute {
-                        server_name: tool.server_name.clone(),
-                        raw_name: tool.raw_name.clone(),
-                    },
-                );
-                discovered_tools.push(tool);
-            }
-        }
-
-        Ok(discovered_tools)
-    }
-
-    pub async fn discover_tools_best_effort(&mut self) -> McpToolDiscoveryReport {
-        let server_names = self.server_names();
-        let mut discovered_tools = Vec::new();
-        let mut working_servers = Vec::new();
-        let mut failed_servers = Vec::new();
-
-        for server_name in server_names {
-            match self.discover_tools_for_server(&server_name).await {
-                Ok(server_tools) => {
-                    working_servers.push(server_name.clone());
-                    self.clear_routes_for_server(&server_name);
-                    for tool in server_tools {
-                        self.tool_index.insert(
-                            tool.qualified_name.clone(),
-                            ToolRoute {
-                                server_name: tool.server_name.clone(),
-                                raw_name: tool.raw_name.clone(),
-                            },
-                        );
-                        discovered_tools.push(tool);
-                    }
-                }
-                Err(error) => {
-                    self.clear_routes_for_server(&server_name);
-                    failed_servers.push(error.discovery_failure(&server_name));
-                }
-            }
-        }
-
-        let degraded_failed_servers = failed_servers
-            .iter()
-            .map(|failure| McpFailedServer {
-                server_name: failure.server_name.clone(),
-                phase: failure.phase,
-                error: McpErrorSurface::new(
-                    failure.phase,
-                    Some(failure.server_name.clone()),
-                    failure.error.clone(),
-                    failure.context.clone(),
-                    failure.recoverable,
-                ),
-            })
-            .chain(
-                self.unsupported_servers
-                    .iter()
-                    .map(unsupported_server_failed_server),
-            )
-            .collect::<Vec<_>>();
-        let degraded_startup = (!working_servers.is_empty() && !degraded_failed_servers.is_empty())
-            .then(|| {
-                McpDegradedReport::new(
-                    working_servers,
-                    degraded_failed_servers,
-                    discovered_tools
-                        .iter()
-                        .map(|tool| tool.qualified_name.clone())
-                        .collect(),
-                    Vec::new(),
-                )
-            });
-
-        McpToolDiscoveryReport {
-            tools: discovered_tools,
-            failed_servers,
-            unsupported_servers: self.unsupported_servers.clone(),
-            degraded_startup,
-        }
-    }
-
-    pub async fn call_tool(
-        &mut self,
-        qualified_tool_name: &str,
-        arguments: Option<JsonValue>,
-    ) -> Result<JsonRpcResponse<McpToolCallResult>, McpServerManagerError> {
-        let route = self
-            .tool_index
-            .get(qualified_tool_name)
-            .cloned()
-            .ok_or_else(|| McpServerManagerError::UnknownTool {
-                qualified_name: qualified_tool_name.to_string(),
-            })?;
-
-        let timeout_ms = self.tool_call_timeout_ms(&route.server_name)?;
-
-        self.ensure_server_ready(&route.server_name).await?;
-        let request_id = self.take_request_id();
-        let response =
-            {
-                let server = self.server_mut(&route.server_name)?;
-                let process = server.process.as_mut().ok_or_else(|| {
-                    McpServerManagerError::InvalidResponse {
-                        server_name: route.server_name.clone(),
-                        method: "tools/call",
-                        details: "server process missing after initialization".to_string(),
-                    }
-                })?;
-                Self::run_process_request(
-                    &route.server_name,
-                    "tools/call",
-                    timeout_ms,
-                    process.call_tool(
-                        request_id,
-                        McpToolCallParams {
-                            name: route.raw_name,
-                            arguments,
-                            meta: None,
-                        },
-                    ),
-                )
-                .await
-            };
-
-        if let Err(error) = &response {
-            if Self::should_reset_server(error) {
-                self.reset_server(&route.server_name).await?;
-            }
-        }
-
-        response
-    }
-
-    pub async fn list_resources(
-        &mut self,
-        server_name: &str,
-    ) -> Result<McpListResourcesResult, McpServerManagerError> {
-        let mut attempts = 0;
-
-        loop {
-            match self.list_resources_once(server_name).await {
-                Ok(resources) => return Ok(resources),
-                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
-                    self.reset_server(server_name).await?;
-                    attempts += 1;
-                }
-                Err(error) => {
-                    if Self::should_reset_server(&error) {
-                        self.reset_server(server_name).await?;
-                    }
-                    return Err(error);
-                }
-            }
-        }
-    }
-
-    pub async fn read_resource(
-        &mut self,
-        server_name: &str,
-        uri: &str,
-    ) -> Result<McpReadResourceResult, McpServerManagerError> {
-        let mut attempts = 0;
-
-        loop {
-            match self.read_resource_once(server_name, uri).await {
-                Ok(resource) => return Ok(resource),
-                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
-                    self.reset_server(server_name).await?;
-                    attempts += 1;
-                }
-                Err(error) => {
-                    if Self::should_reset_server(&error) {
-                        self.reset_server(server_name).await?;
-                    }
-                    return Err(error);
-                }
-            }
-        }
-    }
-
-    pub async fn shutdown(&mut self) -> Result<(), McpServerManagerError> {
-        let server_names = self.servers.keys().cloned().collect::<Vec<_>>();
-        for server_name in server_names {
-            let server = self.server_mut(&server_name)?;
-            if let Some(process) = server.process.as_mut() {
-                process.shutdown().await?;
-            }
-            server.process = None;
-            server.initialized = false;
-        }
-        Ok(())
-    }
-
-    fn clear_routes_for_server(&mut self, server_name: &str) {
-        self.tool_index
-            .retain(|_, route| route.server_name != server_name);
-    }
-
-    fn server_mut(
-        &mut self,
-        server_name: &str,
-    ) -> Result<&mut ManagedMcpServer, McpServerManagerError> {
-        self.servers
-            .get_mut(server_name)
-            .ok_or_else(|| McpServerManagerError::UnknownServer {
-                server_name: server_name.to_string(),
-            })
-    }
-
-    fn take_request_id(&mut self) -> JsonRpcId {
-        let id = self.next_request_id;
-        self.next_request_id = self.next_request_id.saturating_add(1);
-        JsonRpcId::Number(id)
-    }
-
-    fn tool_call_timeout_ms(&self, server_name: &str) -> Result<u64, McpServerManagerError> {
-        let server =
-            self.servers
-                .get(server_name)
-                .ok_or_else(|| McpServerManagerError::UnknownServer {
-                    server_name: server_name.to_string(),
-                })?;
-        match &server.bootstrap.transport {
-            McpClientTransport::Stdio(transport) => Ok(transport.resolved_tool_call_timeout_ms()),
-            other => Err(McpServerManagerError::InvalidResponse {
-                server_name: server_name.to_string(),
-                method: "tools/call",
-                details: format!("unsupported MCP transport for stdio manager: {other:?}"),
-            }),
-        }
-    }
-
-    fn server_process_exited(&mut self, server_name: &str) -> Result<bool, McpServerManagerError> {
-        let server = self.server_mut(server_name)?;
-        match server.process.as_mut() {
-            Some(process) => Ok(process.has_exited()?),
-            None => Ok(false),
-        }
-    }
-
-    async fn discover_tools_for_server(
-        &mut self,
-        server_name: &str,
-    ) -> Result<Vec<ManagedMcpTool>, McpServerManagerError> {
-        let mut attempts = 0;
-
-        loop {
-            match self.discover_tools_for_server_once(server_name).await {
-                Ok(tools) => return Ok(tools),
-                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
-                    self.reset_server(server_name).await?;
-                    attempts += 1;
-                }
-                Err(error) => {
-                    if Self::should_reset_server(&error) {
-                        self.reset_server(server_name).await?;
-                    }
-                    return Err(error);
-                }
-            }
-        }
-    }
-
-    async fn discover_tools_for_server_once(
-        &mut self,
-        server_name: &str,
-    ) -> Result<Vec<ManagedMcpTool>, McpServerManagerError> {
-        self.ensure_server_ready(server_name).await?;
-
-        let mut discovered_tools = Vec::new();
-        let mut cursor = None;
-        loop {
-            let request_id = self.take_request_id();
-            let response = {
-                let server = self.server_mut(server_name)?;
-                let process = server.process.as_mut().ok_or_else(|| {
-                    McpServerManagerError::InvalidResponse {
-                        server_name: server_name.to_string(),
-                        method: "tools/list",
-                        details: "server process missing after initialization".to_string(),
-                    }
-                })?;
-                Self::run_process_request(
-                    server_name,
-                    "tools/list",
-                    MCP_LIST_TOOLS_TIMEOUT_MS,
-                    process.list_tools(
-                        request_id,
-                        Some(McpListToolsParams {
-                            cursor: cursor.clone(),
-                        }),
-                    ),
-                )
-                .await?
-            };
-
-            if let Some(error) = response.error {
-                return Err(McpServerManagerError::JsonRpc {
-                    server_name: server_name.to_string(),
-                    method: "tools/list",
-                    error,
-                });
-            }
-
-            let result = response
-                .result
-                .ok_or_else(|| McpServerManagerError::InvalidResponse {
-                    server_name: server_name.to_string(),
-                    method: "tools/list",
-                    details: "missing result payload".to_string(),
-                })?;
-
-            for tool in result.tools {
-                let qualified_name = mcp_tool_name(server_name, &tool.name);
-                discovered_tools.push(ManagedMcpTool {
-                    server_name: server_name.to_string(),
-                    qualified_name,
-                    raw_name: tool.name.clone(),
-                    tool,
-                });
-            }
-
-            match result.next_cursor {
-                Some(next_cursor) => cursor = Some(next_cursor),
-                None => break,
-            }
-        }
-
-        Ok(discovered_tools)
-    }
-
-    async fn list_resources_once(
-        &mut self,
-        server_name: &str,
-    ) -> Result<McpListResourcesResult, McpServerManagerError> {
-        self.ensure_server_ready(server_name).await?;
-
-        let mut resources = Vec::new();
-        let mut cursor = None;
-        loop {
-            let request_id = self.take_request_id();
-            let response = {
-                let server = self.server_mut(server_name)?;
-                let process = server.process.as_mut().ok_or_else(|| {
-                    McpServerManagerError::InvalidResponse {
-                        server_name: server_name.to_string(),
-                        method: "resources/list",
-                        details: "server process missing after initialization".to_string(),
-                    }
-                })?;
-                Self::run_process_request(
-                    server_name,
-                    "resources/list",
-                    MCP_LIST_TOOLS_TIMEOUT_MS,
-                    process.list_resources(
-                        request_id,
-                        Some(McpListResourcesParams {
-                            cursor: cursor.clone(),
-                        }),
-                    ),
-                )
-                .await?
-            };
-
-            if let Some(error) = response.error {
-                return Err(McpServerManagerError::JsonRpc {
-                    server_name: server_name.to_string(),
-                    method: "resources/list",
-                    error,
-                });
-            }
-
-            let result = response
-                .result
-                .ok_or_else(|| McpServerManagerError::InvalidResponse {
-                    server_name: server_name.to_string(),
-                    method: "resources/list",
-                    details: "missing result payload".to_string(),
-                })?;
-
-            resources.extend(result.resources);
-
-            match result.next_cursor {
-                Some(next_cursor) => cursor = Some(next_cursor),
-                None => break,
-            }
-        }
-
-        Ok(McpListResourcesResult {
-            resources,
-            next_cursor: None,
-        })
-    }
-
-    async fn read_resource_once(
-        &mut self,
-        server_name: &str,
-        uri: &str,
-    ) -> Result<McpReadResourceResult, McpServerManagerError> {
-        self.ensure_server_ready(server_name).await?;
-
-        let request_id = self.take_request_id();
-        let response =
-            {
-                let server = self.server_mut(server_name)?;
-                let process = server.process.as_mut().ok_or_else(|| {
-                    McpServerManagerError::InvalidResponse {
-                        server_name: server_name.to_string(),
-                        method: "resources/read",
-                        details: "server process missing after initialization".to_string(),
-                    }
-                })?;
-                Self::run_process_request(
-                    server_name,
-                    "resources/read",
-                    MCP_LIST_TOOLS_TIMEOUT_MS,
-                    process.read_resource(
-                        request_id,
-                        McpReadResourceParams {
-                            uri: uri.to_string(),
-                        },
-                    ),
-                )
-                .await?
-            };
-
-        if let Some(error) = response.error {
-            return Err(McpServerManagerError::JsonRpc {
-                server_name: server_name.to_string(),
-                method: "resources/read",
-                error,
-            });
-        }
-
-        response
-            .result
-            .ok_or_else(|| McpServerManagerError::InvalidResponse {
-                server_name: server_name.to_string(),
-                method: "resources/read",
-                details: "missing result payload".to_string(),
-            })
-    }
-
-    async fn reset_server(&mut self, server_name: &str) -> Result<(), McpServerManagerError> {
-        let mut process = {
-            let server = self.server_mut(server_name)?;
-            server.initialized = false;
-            server.process.take()
-        };
-
-        if let Some(process) = process.as_mut() {
-            let _ = process.shutdown().await;
-        }
-
-        Ok(())
-    }
-
-    fn is_retryable_error(error: &McpServerManagerError) -> bool {
-        matches!(
-            error,
-            McpServerManagerError::Transport { .. } | McpServerManagerError::Timeout { .. }
-        )
-    }
-
-    fn should_reset_server(error: &McpServerManagerError) -> bool {
-        matches!(
-            error,
-            McpServerManagerError::Transport { .. }
-                | McpServerManagerError::Timeout { .. }
-                | McpServerManagerError::InvalidResponse { .. }
-        )
-    }
-
-    async fn run_process_request<T, F>(
-        server_name: &str,
-        method: &'static str,
-        timeout_ms: u64,
-        future: F,
-    ) -> Result<T, McpServerManagerError>
-    where
-        F: Future<Output = io::Result<T>>,
-    {
-        match timeout(Duration::from_millis(timeout_ms), future).await {
-            Ok(Ok(value)) => Ok(value),
-            Ok(Err(error)) if error.kind() == io::ErrorKind::InvalidData => {
-                Err(McpServerManagerError::InvalidResponse {
-                    server_name: server_name.to_string(),
-                    method,
-                    details: error.to_string(),
-                })
-            }
-            Ok(Err(source)) => Err(McpServerManagerError::Transport {
-                server_name: server_name.to_string(),
-                method,
-                source,
-            }),
-            Err(_) => Err(McpServerManagerError::Timeout {
-                server_name: server_name.to_string(),
-                method,
-                timeout_ms,
-            }),
-        }
-    }
-
-    async fn ensure_server_ready(
-        &mut self,
-        server_name: &str,
-    ) -> Result<(), McpServerManagerError> {
-        // Sticky terminal failure short-circuits before any work — prevents
-        // the spawn loop from repeatedly fork()ing a broken plugin server.
-        if let Some(reason) = self
-            .servers
-            .get(server_name)
-            .and_then(|server| server.permanent_failure.clone())
-        {
-            return Err(McpServerManagerError::PermanentlyFailed {
-                server_name: server_name.to_string(),
-                reason,
-            });
-        }
-
-        if self.server_process_exited(server_name)? {
-            self.reset_server(server_name).await?;
-        }
-
-        let mut attempts = 0;
-        loop {
-            let needs_spawn = self
-                .servers
-                .get(server_name)
-                .map(|server| server.process.is_none())
-                .ok_or_else(|| McpServerManagerError::UnknownServer {
-                    server_name: server_name.to_string(),
-                })?;
-
-            if needs_spawn {
-                let attempt_count = self
-                    .servers
-                    .get(server_name)
-                    .map(|server| server.spawn_attempts)
-                    .unwrap_or(0);
-                if attempt_count >= MCP_SPAWN_ATTEMPT_LIMIT {
-                    let reason = format!(
-                        "MCP server `{server_name}` exceeded {MCP_SPAWN_ATTEMPT_LIMIT} initialize attempts; refusing to retry spawn"
-                    );
-                    if let Some(server) = self.servers.get_mut(server_name) {
-                        server.permanent_failure = Some(reason.clone());
-                    }
-                    return Err(McpServerManagerError::PermanentlyFailed {
-                        server_name: server_name.to_string(),
-                        reason,
-                    });
-                }
-                let server = self.server_mut(server_name)?;
-                server.spawn_attempts = server.spawn_attempts.saturating_add(1);
-                server.process = Some(spawn_mcp_stdio_process(&server.bootstrap)?);
-                server.initialized = false;
-            }
-
-            let needs_initialize = self
-                .servers
-                .get(server_name)
-                .map(|server| !server.initialized)
-                .ok_or_else(|| McpServerManagerError::UnknownServer {
-                    server_name: server_name.to_string(),
-                })?;
-
-            if !needs_initialize {
-                return Ok(());
-            }
-
-            let request_id = self.take_request_id();
-            let response = {
-                let server = self.server_mut(server_name)?;
-                let process = server.process.as_mut().ok_or_else(|| {
-                    McpServerManagerError::InvalidResponse {
-                        server_name: server_name.to_string(),
-                        method: "initialize",
-                        details: "server process missing before initialize".to_string(),
-                    }
-                })?;
-                Self::run_process_request(
-                    server_name,
-                    "initialize",
-                    MCP_INITIALIZE_TIMEOUT_MS,
-                    process.initialize(request_id, default_initialize_params()),
-                )
-                .await
-            };
-
-            let response = match response {
-                Ok(response) => response,
-                Err(error) if attempts == 0 && Self::is_retryable_error(&error) => {
-                    self.reset_server(server_name).await?;
-                    attempts += 1;
-                    continue;
-                }
-                Err(error) => {
-                    if Self::should_reset_server(&error) {
-                        self.reset_server(server_name).await?;
-                    }
-                    return Err(error);
-                }
-            };
-
-            if let Some(error) = response.error {
-                return Err(McpServerManagerError::JsonRpc {
-                    server_name: server_name.to_string(),
-                    method: "initialize",
-                    error,
-                });
-            }
-
-            if response.result.is_none() {
-                let error = McpServerManagerError::InvalidResponse {
-                    server_name: server_name.to_string(),
-                    method: "initialize",
-                    details: "missing result payload".to_string(),
-                };
-                self.reset_server(server_name).await?;
-                return Err(error);
-            }
-
-            let server = self.server_mut(server_name)?;
-            server.initialized = true;
-            // A successful initialize proves the server can start — reset
-            // the spawn counter so a later transport-drop + respawn does
-            // not inherit stale attempts from a prior lifecycle.
-            server.spawn_attempts = 0;
-            return Ok(());
-        }
-    }
-}
 
 #[derive(Debug)]
 pub struct McpStdioProcess {
@@ -1417,7 +218,7 @@ impl McpStdioProcess {
         Ok(self.child.try_wait()?.is_some())
     }
 
-    async fn shutdown(&mut self) -> io::Result<()> {
+    pub(crate) async fn shutdown(&mut self) -> io::Result<()> {
         if self.child.try_wait()?.is_none() {
             match self.child.kill().await {
                 Ok(()) => {}
@@ -1427,6 +228,57 @@ impl McpStdioProcess {
         }
         let _ = self.child.wait().await?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl McpConnection for McpStdioProcess {
+    async fn initialize(
+        &mut self,
+        id: JsonRpcId,
+        params: McpInitializeParams,
+    ) -> io::Result<JsonRpcResponse<McpInitializeResult>> {
+        Self::initialize(self, id, params).await
+    }
+
+    async fn list_tools(
+        &mut self,
+        id: JsonRpcId,
+        params: Option<McpListToolsParams>,
+    ) -> io::Result<JsonRpcResponse<McpListToolsResult>> {
+        Self::list_tools(self, id, params).await
+    }
+
+    async fn call_tool(
+        &mut self,
+        id: JsonRpcId,
+        params: McpToolCallParams,
+    ) -> io::Result<JsonRpcResponse<McpToolCallResult>> {
+        Self::call_tool(self, id, params).await
+    }
+
+    async fn list_resources(
+        &mut self,
+        id: JsonRpcId,
+        params: Option<McpListResourcesParams>,
+    ) -> io::Result<JsonRpcResponse<McpListResourcesResult>> {
+        Self::list_resources(self, id, params).await
+    }
+
+    async fn read_resource(
+        &mut self,
+        id: JsonRpcId,
+        params: McpReadResourceParams,
+    ) -> io::Result<JsonRpcResponse<McpReadResourceResult>> {
+        Self::read_resource(self, id, params).await
+    }
+
+    async fn has_exited(&mut self) -> io::Result<bool> {
+        Self::has_exited(self)
+    }
+
+    async fn shutdown(&mut self) {
+        let _ = Self::shutdown(self).await;
     }
 }
 
@@ -1449,17 +301,6 @@ fn apply_env(command: &mut Command, env: &BTreeMap<String, String>) {
     }
 }
 
-fn default_initialize_params() -> McpInitializeParams {
-    McpInitializeParams {
-        protocol_version: "2025-03-26".to_string(),
-        capabilities: JsonValue::Object(serde_json::Map::new()),
-        client_info: McpInitializeClientInfo {
-            name: "runtime".to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
-        },
-    }
-}
-
 // `#[cfg(unix)]` because every test in this module builds a POSIX
 // shell or python script and spawns it as a mock MCP stdio server,
 // using `chmod +x` via `std::os::unix::fs::PermissionsExt::set_mode`.
@@ -1469,7 +310,7 @@ fn default_initialize_params() -> McpInitializeParams {
 // no chmod) is a follow-up.
 #[cfg(all(test, unix))]
 mod tests {
-    use super::MCP_SPAWN_ATTEMPT_LIMIT;
+    use crate::mcp_server_manager::MCP_SPAWN_ATTEMPT_LIMIT;
     use std::collections::BTreeMap;
     use std::fs;
     use std::io::ErrorKind;
@@ -1488,11 +329,12 @@ mod tests {
     use crate::mcp::mcp_tool_name;
     use crate::mcp_client::McpClientBootstrap;
 
-    use super::{
-        spawn_mcp_stdio_process, unsupported_server_failed_server, JsonRpcId, JsonRpcRequest,
-        JsonRpcResponse, McpInitializeClientInfo, McpInitializeParams, McpInitializeResult,
-        McpInitializeServerInfo, McpListToolsResult, McpReadResourceParams, McpReadResourceResult,
-        McpServerManager, McpServerManagerError, McpStdioProcess, McpTool, McpToolCallParams,
+    use super::{spawn_mcp_stdio_process, McpStdioProcess};
+    use crate::mcp_server_manager::{
+        unsupported_server_failed_server, JsonRpcId, JsonRpcRequest, JsonRpcResponse,
+        McpInitializeClientInfo, McpInitializeParams, McpInitializeResult, McpInitializeServerInfo,
+        McpListToolsResult, McpReadResourceParams, McpReadResourceResult, McpResourceContents,
+        McpServerManager, McpServerManagerError, McpTool, McpToolCallParams,
     };
     use crate::McpLifecyclePhase;
 
@@ -2153,7 +995,7 @@ mod tests {
             assert_eq!(
                 read.result,
                 Some(McpReadResourceResult {
-                    contents: vec![super::McpResourceContents {
+                    contents: vec![McpResourceContents {
                         uri: "file://guide.txt".to_string(),
                         mime_type: Some("text/plain".to_string()),
                         text: Some("contents for file://guide.txt".to_string()),
@@ -2442,6 +1284,7 @@ mod tests {
             let mut waited = Duration::ZERO;
             while !manager
                 .server_process_exited("alpha")
+                .await
                 .expect("query child exit status")
             {
                 assert!(

--- a/rust/crates/runtime/src/mcp_tool_bridge.rs
+++ b/rust/crates/runtime/src/mcp_tool_bridge.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::mcp::mcp_tool_name;
-use crate::mcp_stdio::McpServerManager;
+use crate::mcp_server_manager::McpServerManager;
 use serde::{Deserialize, Serialize};
 
 /// Status of a managed MCP server connection.


### PR DESCRIPTION
- Extract the transport-agnostic McpServerManager, JSON-RPC message
  types, and error type out of mcp_stdio.rs into mcp_server_manager.rs
  (structural refactor, no logic change); route the SSE transport
  through the manager's spawn path alongside stdio.
- Add the McpConnection trait abstracting the JSON-RPC connection
  surface so the manager drives stdio and SSE through a single
  Box<dyn McpConnection>.
- Implement the legacy HTTP+SSE transport (mcp_sse.rs) on reqwest: open
  a long-lived GET stream, resolve the `endpoint` event, POST JSON-RPC
  requests, and read responses off the stream; support headersHelper
  for dynamic per-request headers.
- Add reqwest (rustls-tls + stream) as a runtime dependency for the
  SSE HTTP client; update imports/re-exports in lib.rs, mcp_server.rs,
  and mcp_tool_bridge.rs.
