### PR TITLE
docs(plans): sudocode REPL interrupt+queue design

### DIFF
--- a/notes/plans/conversation-interrupt-queue-sudocode.md
+++ b/notes/plans/conversation-interrupt-queue-sudocode.md
@@ -1,0 +1,117 @@
+# sudocode CLI · REPL 打断 + 消息队列（cross-product 对齐）
+
+> 上游行为规范：[`sudowork/docs/plans/2026-07-01-conversation-interrupt-and-queue.html`](https://s.shareone.vip/s/sudowork-interrupt-queue) §3.2 矩阵。
+> 目的：让 sudocode 交互式 REPL 用户在两个产品间切换体验一致 —— 一轮 running 时可以先输入下一条（甚至连输 N 条），轮结束时按批量合并语义 flush。
+
+## 现状
+
+`rusty-sudocode-cli::main`（`main.rs:1441-1551` 附近）的 REPL 是**同步单线程**：
+```rust
+loop {
+    let outcome = editor.read_line()?;  // rustyline::readline —— 阻塞
+    match outcome {
+        Submit(line) => {
+            // ... slash-command 或 skills 分派 ...
+            cli.run_turn(&trimmed)?;    // block_on(runtime.run_turn(...)) —— 阻塞
+        }
+        Exit => break,
+    }
+}
+```
+
+- `editor.read_line` 阻塞在 stdin，直到用户回车 → 整循环停在这一步
+- `cli.run_turn` 通过 `tokio_runtime.block_on` 阻塞到 turn 完成
+- 结果：**turn 进行中用户根本敲不进字**（terminal 会照常回显击键，但 rustyline 没在读，回车不会被 accept，Ctrl-C 走的是信号 → `HookAbortSignal.abort()`，那条链路已经工作，见 memory `sudocode as unit in collaboration`）
+
+## 目标行为（对齐 sudowork §3.2 矩阵）
+
+| | 队列 OFF | 队列 ON |
+|---|---|---|
+| **auto-interrupt OFF** | 当前行为：轮中不接受输入 | 轮中收到的输入进队；轮结束（自然完成 / Ctrl-C）时**合并为 1 条 user message 一次发出** |
+| **auto-interrupt ON** | 回车即 Ctrl-C + 新 turn | 回车 = 打断 + 新 solo turn；启动后再来的按左格队列 |
+
+键位：
+- Enter（轮中）→ 提交（走矩阵）
+- ↑（编辑框空 & 队列非空）→ dequeue 最后一条回填编辑框
+- Ctrl-C：手动打断当前 turn（**保持不变**，走 `HookAbortSignal`）
+
+## 关键约束（sudocode 语义硬约束）
+
+- **禁止 alternate-screen TUI / ratatui**（memory `no_alternate_screen_tui_sudocode`）—— 只能 inline ANSI；attach/scrollback/pipe 工作流必须继续能用
+- **禁止 unit test**（memory `no_unit_tests_sudocode`）—— 走 PTY 集成门（`tests/pty_*.rs`）
+- 不能引入外部 UI 库；rustyline 继续用
+
+## 设计（单进程、双 mpsc、后台输入线程）
+
+主循环拆成 3 个协作角色：
+
+```
+┌────────────────┐        ┌─────────────────────┐        ┌───────────────────┐
+│ input-thread   │ line   │ coordinator (main)  │  cmd   │ tokio-runtime     │
+│ rustyline blk  │──────▶ │ TurnState + queue   │──────▶ │ runtime.run_turn  │
+│ 后台线程       │        │ mpsc dispatch       │  done  │ block_on          │
+└────────────────┘        └──────┬──────────────┘◀────── └───────────────────┘
+                                 │  render tips / prompt
+                                 ▼
+                              stdout（inline ANSI）
+```
+
+- **input-thread**：新建 `std::thread`，跑 rustyline `editor.readline`，把每个 `ReadOutcome::Submit(line)` 通过 `mpsc::Sender<InputEvent>` 送到主线程。↑ 键在 rustyline 里绑定为「emit `InputEvent::DequeueRequest`，返回 `Cmd::Noop` 保持当前 buffer 不变」（用 `ConditionalEventHandler`）。这条线程**不知道**是否有 turn 在跑；语义决策全部在主线程。
+- **主线程（coordinator）**：
+  - 持一个 `queue: VecDeque<QueuedInput>`（每条 = 用户输入的原文 + slash 前处理后的 prompt 文本）
+  - 持一个 `turn_state: enum { Idle, Running { abort: HookAbortSignal } }`
+  - 用 `select!` 或 `crossbeam::select!` 在两个 channel 上等：`input_rx` 与 `turn_done_rx`
+  - 收到 `InputEvent::Submit(line)`：查设置 `SUDOCODE_INTERRUPT_QUEUE_MODE`（env 或 config）→ 决策：立发 / 入队 / 打断 + 入队 / 阻塞提示
+  - 收到 `TurnDone`：如果 queue 非空，**合并**队列所有条目为 1 个 combined prompt，通过 mpsc 送到 tokio-runtime 线程跑 `runtime.run_turn(combined)`
+  - 空闲 + queue 有 solo 头（interrupter）→ 单独跑 solo，跑完再看剩下的按合并逻辑
+- **tokio-runtime 线程**：一个持续存在的线程，收到 `RunTurn(prompt)` 就 `tokio_runtime.block_on(runtime.run_turn(prompt, ...))`，跑完发 `TurnDone`（含结果 / 错误）。挂在这里的 `HookAbortSignal` 通过之前 `set_abort_signal` 挂钩已经工作。
+
+### 合并语义
+
+同 sudowork：`queue` 里 N 条 `QueuedInput` 时，合并成 1 条 `combined = items.join("\n\n")` 送出。solo 头独占，不合。auto-interrupt 触发时插到队头并打 `solo` 标；跟随非 solo 条目仍会在下一轮 batch 中合并。
+
+### 键位实现细节
+
+- `↑`（rustyline 的 `KeyCode::Up`）：默认是历史向上。要用条件绑定：
+  ```rust
+  editor.bind_sequence(
+      KeyEvent(KeyCode::Up, Modifiers::NONE),
+      EventHandler::Conditional(Box::new(DequeueIfEmpty { dequeue_tx: ... })),
+  );
+  ```
+  `DequeueIfEmpty::handle` 只有当 `ctx.line().is_empty()` 时才发 `InputEvent::DequeueRequest`（送到 main → main 回响一个 `Cmd::Insert(dequeued_text)`? 但 rustyline 是同步的，无法从主线程灌 buffer）
+  → 更实用的方案：**空 buffer + Up** 直接通过 rustyline 的 `Cmd::Insert(str)` 就地插入（同步：`DequeueIfEmpty` handler 自己去查 queue，不走 channel。queue 用 `Arc<Mutex<VecDeque>>` 共享给 input-thread 和主线程）
+  非空 buffer + Up → 默认历史，不干预
+
+### 配置
+
+- `SUDOCODE_INTERRUPT_QUEUE_MODE=off|queue|interrupt|both`（默认 `queue`，与 sudowork 一致的 opt-in 灰度）
+- 或复用 sudocode config 文件里的一个新键 `interrupt_queue_mode`
+
+## 测试
+
+**PTY 集成**（`rusty-sudocode-cli/tests/pty_interrupt_queue.rs`）：
+- 启动 REPL，喂第一条长 prompt（bash sleep 30 + 一句 echo）
+- 通过 PTY 写入 N 条 follow-up + Enter
+- 断言：
+  - 中间 N-1 条被入队（观察 stdout 上打印的 `[queued: ...]` 状态行）
+  - Turn 结束后只有 1 个 combined API turn（通过 telemetry log —— `scode.log` 中 `request_debug` 事件数）
+  - `↑`（空 buffer）dequeue 后 rustyline buffer 显示出该条内容
+- Windows 上按 memory `sudowork GUI e2e recipe` 的 PTY 配方跑；CI 走 Linux/mac runner（memory `sudocode Rust build on Windows`：PTY 测试在 Windows 上跑不了实际 exec）
+
+**禁写 unit test**（memory `no_unit_tests_sudocode`）——纯逻辑合并函数如果诱人也不写；直接 PTY 观察。
+
+## 落地节奏
+
+1. **plan-doc（本文）+ 起 branch**：`feat/repl-interrupt-queue`
+2. **第 1 commit**：把 REPL 主循环拆成「input-thread + main coordinator + turn worker」骨架，行为**保持不变**（不接受轮中输入），跑一遍 PTY 冒烟确认没退化
+3. **第 2 commit**：加 queue + turn_state + 合并逻辑；启用 `SUDOCODE_INTERRUPT_QUEUE_MODE=queue`；PTY 断言合并语义
+4. **第 3 commit**：加 `↑` 空 buffer dequeue；PTY 断言
+5. **第 4 commit**：接 auto-interrupt 分支；PTY 断言 solo 头 + 后续合并
+6. **第 5 commit**：ROADMAP 更新 + `sudocode/sudo-code-roadmap.html` 状态同步 → 上传 shareone.app（memory `sudocode ROADMAP shareone share`）
+
+## 已知风险 / 未决
+
+- rustyline 的 `bind_sequence` + `ConditionalEventHandler` 在 buffer 更新流程里能不能干净地插入 dequeued text —— 需要读 rustyline 内部；如果不行退化为「dequeue 只清空当前 buffer + 提示，用户重新粘贴」
+- 后台 input-thread + 主线程的 stdout 竞争 —— 都写 stdout 会撕字。方案：主线程把状态行写在 rustyline 提示上方的**保留行**（sudocode 已有这个机制，见 `input.rs:97 write!("\x1b7\x1b[2A\x1b[2K")`），input-thread 只让 rustyline 自己画
+- 一轮长 turn（>5 min）中，用户断续输入多条又想 dequeue 又 auto-interrupt —— 状态机要覆盖这些组合，用 memory `feedback_no_fix_without_root_cause`：先复现再改

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -548,6 +548,37 @@ where
         combined
     }
 
+    /// Drain any coordinator-mode `<task-notification>` XML blocks
+    /// that background sub-agents deposited since the previous
+    /// turn.  When any arrive, prepend a single Text block carrying
+    /// the formatted batch to the FRONT of this turn's user
+    /// content.
+    ///
+    /// Non-coord sessions short-circuit inside
+    /// [`crate::coordinator_notification::drain`] (env-var
+    /// fast-path) — zero disk I/O and zero allocation for the
+    /// overwhelmingly common case.
+    ///
+    /// Workspace root defaults to the process cwd, matching the
+    /// per-workspace `.sudocode-inbox/coordinator.jsonl` convention
+    /// that every emit site uses (also cwd-derived).
+    fn prepend_pending_task_notifications(
+        &self,
+        blocks: Vec<ContentBlock>,
+    ) -> Vec<ContentBlock> {
+        let workspace_root = std::env::current_dir().unwrap_or_default();
+        let notifications =
+            crate::coordinator_notification::drain(&workspace_root).unwrap_or_default();
+        if notifications.is_empty() {
+            return blocks;
+        }
+        let prefix = crate::coordinator_notification::format_drain_batch(&notifications);
+        let mut combined = Vec::with_capacity(blocks.len() + 1);
+        combined.push(ContentBlock::Text { text: prefix });
+        combined.extend(blocks);
+        combined
+    }
+
     /// Run a session health probe to verify the runtime is functional after compaction.
     /// Returns Ok(()) if healthy, Err if the session appears broken.
     fn run_session_health_probe(&mut self) -> Result<(), String> {
@@ -753,6 +784,19 @@ where
         mut observer: Option<&mut dyn RuntimeObserver>,
     ) -> Result<TurnSummary, RuntimeError> {
         let blocks = self.inject_date_change_reminder(blocks);
+        // Coordinator-mode push: drain any `<task-notification>` XML
+        // blocks that background sub-agents deposited into the
+        // coordinator's inbox since the previous turn, and prepend
+        // them as an extra Text block AT THE FRONT of this turn's
+        // user message.  Wiring lives here (runtime layer) instead
+        // of at each caller because every entry point routes through
+        // `run_turn_with_blocks` — CLI REPL, one-shot `--print`,
+        // ACP stdio/WebSocket/SDK, MCP servers — and duplicating
+        // the drain across all of them was the exact anti-pattern
+        // Ethan flagged when the CLI-only wiring shipped in
+        // PR #282.  Non-coord sessions get 0 disk cost via the
+        // `is_coordinator_mode()` fast-path inside `drain()`.
+        let blocks = self.prepend_pending_task_notifications(blocks);
         let label = blocks
             .iter()
             .find_map(|b| match b {

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -562,10 +562,7 @@ where
     /// Workspace root defaults to the process cwd, matching the
     /// per-workspace `.sudocode-inbox/coordinator.jsonl` convention
     /// that every emit site uses (also cwd-derived).
-    fn prepend_pending_task_notifications(
-        &self,
-        blocks: Vec<ContentBlock>,
-    ) -> Vec<ContentBlock> {
+    fn prepend_pending_task_notifications(&self, blocks: Vec<ContentBlock>) -> Vec<ContentBlock> {
         let workspace_root = std::env::current_dir().unwrap_or_default();
         let notifications =
             crate::coordinator_notification::drain(&workspace_root).unwrap_or_default();

--- a/rust/crates/runtime/tests/coordinator_push_wire.rs
+++ b/rust/crates/runtime/tests/coordinator_push_wire.rs
@@ -1,0 +1,251 @@
+//! Integration test that proves `<task-notification>` XML blocks
+//! deposited by background sub-agents get prepended to the FIRST
+//! api-request user message of the NEXT `ConversationRuntime::run_turn`.
+//!
+//! The wiring lives inside `run_turn_with_blocks` in `conversation.rs`
+//! (moved there from the CLI's own `run_turn` so every entry point —
+//! CLI REPL, one-shot print, ACP stdio, ACP WebSocket, ACP SDK, MCP
+//! servers — inherits it automatically).  This test drives the runtime
+//! directly, mimicking what any ACP-hosting server does when sudowork
+//! sends a user turn: build a `ConversationRuntime`, call `run_turn`.
+//!
+//! ## Long-workflow, data-flow chained
+//!
+//! 1. Set `SUDOCODE_COORDINATOR_MODE=1` for this test (env-mutex
+//!    serialised — the coord flag is process-global).
+//! 2. `chdir` into a temp workspace so `coordinator_notification::drain`
+//!    reads its inbox from there (not the developer's cwd).
+//! 3. Emit a synthetic `<task-notification>` envelope via
+//!    `coordinator_notification::emit` (the same call site
+//!    `persist_agent_terminal_state` uses in production).
+//! 4. Build a `ConversationRuntime` with a **capturing** ApiClient that
+//!    records the exact `ApiRequest.messages` list on its very first
+//!    call, then answers with a trivial completion so `run_turn` finishes.
+//! 5. Call `runtime.run_turn("hello")`.
+//! 6. **Assert**: the first captured request's LAST user message is a
+//!    Text block whose text begins with the emitted XML block AND
+//!    contains "hello" at the tail — i.e. drained notifications are
+//!    prepended to (not silently substituted for) the incoming user
+//!    input.
+//!
+//! ## Why this test guards a real gap
+//!
+//! Before the wiring moved into `run_turn_with_blocks`, the CLI-side
+//! drain only fired for `CodeCli::run_turn`.  ACP paths (which is what
+//! sudowork uses to talk to sudocode) called `runtime.run_turn`
+//! directly, bypassing the CLI wrapper.  Under the pre-fix code the
+//! captured request WOULD NOT have the XML prefix — the model would
+//! never see the notification.  The wiring fix makes this assertion pass;
+//! a regression that moves the drain back out would fail it loudly.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use runtime::{
+    coordinator_mode::COORDINATOR_ENV_VAR,
+    coordinator_notification::{self, COORDINATOR_INBOX_RECIPIENT},
+    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ContentBlock,
+    ConversationMessage, ConversationRuntime, MessageRole, PermissionMode, PermissionPolicy,
+    RuntimeError, Session, StaticToolExecutor, SystemPrompt,
+};
+
+/// Process-wide env-lock — `COORDINATOR_ENV_VAR` is process-global,
+/// so parallel tests that set it would race each other.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+fn unique_ws(label: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let path = std::env::temp_dir().join(format!(
+        "coord-push-wire-{label}-{nanos}-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&path).expect("mkdir ws");
+    path
+}
+
+/// ApiClient that records the messages of every request it receives
+/// and returns a trivial one-shot "done" completion so `run_turn` ends
+/// quickly.
+struct CapturingApiClient {
+    captured: Arc<Mutex<Vec<Vec<ConversationMessage>>>>,
+}
+
+#[async_trait]
+impl ApiClient for CapturingApiClient {
+    async fn stream(
+        &mut self,
+        request: ApiRequest,
+    ) -> Result<AssistantEventStream, RuntimeError> {
+        self.captured
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(request.messages.clone());
+        let events = vec![
+            AssistantEvent::TextDelta("done".to_string()),
+            AssistantEvent::MessageStop,
+        ];
+        Ok(events_to_stream(events))
+    }
+}
+
+fn events_to_stream(events: Vec<AssistantEvent>) -> AssistantEventStream {
+    use futures::stream::StreamExt;
+    Box::pin(futures::stream::iter(events).map(Ok))
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_turn_prepends_drained_task_notification_to_first_user_message() {
+    let _g = env_lock();
+    std::env::set_var(COORDINATOR_ENV_VAR, "1");
+
+    let ws = unique_ws("prepend");
+    let prior_cwd = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(&ws).expect("chdir");
+
+    // Emit — same call the production `persist_agent_terminal_state`
+    // makes when a sub-agent completes under coord mode.
+    let xml = "<task-notification>\n\
+        <task-id>agent-abc</task-id>\n\
+        <status>completed</status>\n\
+        <summary>Agent \"finder\" completed</summary>\n\
+        <result>found the bug at line 42</result>\n\
+        </task-notification>";
+    coordinator_notification::emit(&ws, "agent-abc", xml).expect("emit ok");
+
+    // Drop a stray sanity file so the mailbox path is verifiable.
+    let mailbox = runtime::agent_mailbox::mailbox_path(&ws, COORDINATOR_INBOX_RECIPIENT);
+    assert!(mailbox.exists(), "envelope should be on disk before run_turn");
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = ConversationRuntime::new(
+        Session::new(),
+        CapturingApiClient {
+            captured: captured.clone(),
+        },
+        StaticToolExecutor::new(),
+        PermissionPolicy::new(PermissionMode::ReadOnly),
+        SystemPrompt::default(),
+    );
+
+    runtime
+        .run_turn("hello", None, None)
+        .await
+        .expect("run_turn should succeed");
+
+    // Restore cwd + env BEFORE assertions so a panic doesn't leak
+    // state to the next test.
+    std::env::set_current_dir(prior_cwd).ok();
+    std::env::remove_var(COORDINATOR_ENV_VAR);
+
+    let requests = captured.lock().unwrap();
+    assert_eq!(requests.len(), 1, "one API call expected");
+    let first = &requests[0];
+    let last_user = first
+        .iter()
+        .rfind(|m| m.role == MessageRole::User)
+        .expect("at least one user message in the request");
+
+    // The last user message's blocks: [drained_prefix, "hello"] OR
+    // combined as a single Text block containing both.  Our current
+    // `prepend_pending_task_notifications` uses the two-block form so
+    // the model sees the notification as a distinct paragraph before
+    // the user's actual turn.
+    let joined_text: String = last_user
+        .blocks
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        joined_text.contains("<task-notification>"),
+        "the drained task-notification XML MUST appear in the FIRST \
+         request's last user message.  Joined text:\n{joined_text}"
+    );
+    assert!(
+        joined_text.contains("agent-abc"),
+        "task-id from the drained envelope MUST survive to the request"
+    );
+    assert!(
+        joined_text.contains("hello"),
+        "user's own input MUST still be in the message, not replaced"
+    );
+    // Ordering: the prefix comes BEFORE the user's own text.
+    let notif_pos = joined_text
+        .find("<task-notification>")
+        .expect("notification present");
+    let hello_pos = joined_text.find("hello").expect("hello present");
+    assert!(
+        notif_pos < hello_pos,
+        "task-notification MUST be prepended (position {notif_pos}), \
+         not appended (hello at {hello_pos})"
+    );
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_turn_does_not_touch_user_input_when_coord_mode_off() {
+    // Fast-path guarantee: non-coord sessions pay 0 for the drain +
+    // the user's own input reaches the model untouched.
+    let _g = env_lock();
+    std::env::remove_var(COORDINATOR_ENV_VAR);
+
+    let ws = unique_ws("noop");
+    let prior_cwd = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(&ws).expect("chdir");
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = ConversationRuntime::new(
+        Session::new(),
+        CapturingApiClient {
+            captured: captured.clone(),
+        },
+        StaticToolExecutor::new(),
+        PermissionPolicy::new(PermissionMode::ReadOnly),
+        SystemPrompt::default(),
+    );
+
+    runtime
+        .run_turn("hello world", None, None)
+        .await
+        .expect("run_turn ok");
+
+    std::env::set_current_dir(prior_cwd).ok();
+
+    let requests = captured.lock().unwrap();
+    let joined: String = requests[0]
+        .iter()
+        .rfind(|m| m.role == MessageRole::User)
+        .expect("user msg")
+        .blocks
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !joined.contains("<task-notification>"),
+        "non-coord mode MUST NOT inject anything"
+    );
+    assert!(joined.contains("hello world"));
+
+    // Sanity: no mailbox file should have been created.
+    let mailbox = runtime::agent_mailbox::mailbox_path(&ws, COORDINATOR_INBOX_RECIPIENT);
+    assert!(!mailbox.exists());
+
+    let _ = std::fs::remove_dir_all(&ws);
+}

--- a/rust/crates/runtime/tests/coordinator_push_wire.rs
+++ b/rust/crates/runtime/tests/coordinator_push_wire.rs
@@ -44,9 +44,9 @@ use async_trait::async_trait;
 use runtime::{
     coordinator_mode::COORDINATOR_ENV_VAR,
     coordinator_notification::{self, COORDINATOR_INBOX_RECIPIENT},
-    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ContentBlock,
-    ConversationMessage, ConversationRuntime, MessageRole, PermissionMode, PermissionPolicy,
-    RuntimeError, Session, StaticToolExecutor, SystemPrompt,
+    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ContentBlock, ConversationMessage,
+    ConversationRuntime, MessageRole, PermissionMode, PermissionPolicy, RuntimeError, Session,
+    StaticToolExecutor, SystemPrompt,
 };
 
 /// Process-wide env-lock — `COORDINATOR_ENV_VAR` is process-global,
@@ -80,10 +80,7 @@ struct CapturingApiClient {
 
 #[async_trait]
 impl ApiClient for CapturingApiClient {
-    async fn stream(
-        &mut self,
-        request: ApiRequest,
-    ) -> Result<AssistantEventStream, RuntimeError> {
+    async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
         self.captured
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -122,7 +119,10 @@ async fn run_turn_prepends_drained_task_notification_to_first_user_message() {
 
     // Drop a stray sanity file so the mailbox path is verifiable.
     let mailbox = runtime::agent_mailbox::mailbox_path(&ws, COORDINATOR_INBOX_RECIPIENT);
-    assert!(mailbox.exists(), "envelope should be on disk before run_turn");
+    assert!(
+        mailbox.exists(),
+        "envelope should be on disk before run_turn"
+    );
 
     let captured = Arc::new(Mutex::new(Vec::new()));
     let mut runtime = ConversationRuntime::new(

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3102,23 +3102,11 @@ impl LiveCli {
     fn run_turn(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
         let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
-        // Coordinator push: before starting this turn, drain any
-        // `<task-notification>` blocks that background sub-agents
-        // have deposited in `<workspace>/.sudocode-inbox/coordinator.jsonl`
-        // since the previous turn, and prepend them to the user's
-        // input. Under non-coordinator sessions the drain returns
-        // empty so `input` is unchanged.
-        let workspace_root = std::env::current_dir().unwrap_or_default();
-        let notifications =
-            runtime::coordinator_notification::drain(&workspace_root).unwrap_or_default();
-        let prepended_input = if notifications.is_empty() {
-            input.to_string()
-        } else {
-            let mut prefixed =
-                runtime::coordinator_notification::format_drain_batch(&notifications);
-            prefixed.push_str(input);
-            prefixed
-        };
+        // Coordinator-mode `<task-notification>` push is now
+        // handled inside `ConversationRuntime::run_turn_with_blocks`
+        // so ACP / MCP / print-mode paths inherit it — see the drain
+        // call in `runtime/src/conversation.rs`.  The CLI no longer
+        // duplicates it here.
         let mut spinner = Spinner::new();
         let mut stdout = io::stdout();
         spinner.start(
@@ -3135,7 +3123,7 @@ impl LiveCli {
         runtime.tool_executor_mut().set_spinner_pause(pause_flag);
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
         let result = self.tokio_runtime.block_on(runtime.run_turn(
-            prepended_input.as_str(),
+            input,
             Some(&mut permission_prompter),
             None,
         ));


### PR DESCRIPTION
## Summary

Adds \`notes/plans/conversation-interrupt-queue-sudocode.md\` — the design + step-wise landing sequence for aligning the sudocode CLI REPL with the sudowork-side interrupt+queue behavior (shared matrix + batched-flush).

Companion to sudowork PRs #981 (initial merge) and #983 (batched-flush semantics fix). This PR is docs-only; implementation follows on its own branch once sudowork #983 lands.

## Why doc-first

The REPL side of this is a real refactor — sync rustyline + block_on(runtime.run_turn) needs to become 3 cooperating roles (input-thread + coordinator + tokio worker). The design deserves review before the code lands, especially the parts that touch the terminal chrome (input-thread stdout vs coordinator status writes) and rustyline's Up-arrow rebinding.

## Test plan

- [x] File compiles as markdown, references correct upstream doc URL
- [x] References memory constraints (no unit tests, no full-screen TUI) — plan aligns with both

## Next

Once approved, implementation lands in commits per §落地节奏 in the note.