### PR TITLE
feat(repl): async wiring — accept input during a running turn (Phase 2)

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -17,6 +17,7 @@ mod init;
 mod input;
 mod input_queue;
 mod render;
+mod repl_async;
 mod vlm_describe;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -1456,6 +1457,17 @@ fn run_repl(
         auth_mode,
     )?;
     cli.set_reasoning_effort(reasoning_effort);
+
+    // Env-gated opt-in to the async REPL that accepts input during a running
+    // turn (see `repl_async` module docs and
+    // `notes/plans/conversation-interrupt-queue-sudocode.md`). When set to
+    // anything other than `off` / unset, dispatch to the async loop. Default
+    // path below stays byte-identical to today's sync behavior.
+    let mode = input_queue::QueueMode::from_env();
+    if !matches!(mode, input_queue::QueueMode::Off) {
+        return run_repl_async_dispatch(cli, mode);
+    }
+
     let mut editor =
         input::LineEditor::new("❯ ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
@@ -1572,6 +1584,78 @@ fn run_repl(
     }
 
     Ok(())
+}
+
+/// Async REPL dispatch — takes ownership of the constructed `LiveCli`, wraps it
+/// in `Arc<Mutex<>>` for the coordinator + runner thread, drives the loop, then
+/// unwraps and finalizes the session on exit. Only called when
+/// `SUDOCODE_INTERRUPT_QUEUE_MODE` is set.
+fn run_repl_async_dispatch(
+    cli: LiveCli,
+    mode: input_queue::QueueMode,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Capture startup state that only needs to be read once (banner + initial
+    // completion list). Completion refresh mid-loop is deferred — see the
+    // repl_async module docs §Deferred.
+    let banner = cli.startup_banner();
+    let completions = cli.repl_completion_candidates().unwrap_or_default();
+
+    let cli_shared = std::sync::Arc::new(std::sync::Mutex::new(cli));
+    let driver: std::sync::Arc<LiveCliDriver> = std::sync::Arc::new(LiveCliDriver {
+        cli: std::sync::Arc::clone(&cli_shared),
+    });
+
+    let session_start = Instant::now();
+    repl_async::run_coordinator_loop(driver, mode, banner, completions)?;
+
+    // All threads spawned by the coordinator loop have already been joined
+    // inside the loop (Exit branch + TurnDone reap). Unwrapping the Arc here
+    // is a debug assertion of that invariant — if it fails, a thread leaked.
+    let cli = std::sync::Arc::try_unwrap(cli_shared)
+        .map_err(|_| "LiveCli still shared after coordinator loop exit — thread leak")?
+        .into_inner()
+        .map_err(|e| format!("LiveCli mutex poisoned: {e}"))?;
+
+    // Session_ended telemetry parity with the sync path (`run_repl`
+    // trailing block just above): record cumulative usage + duration so the
+    // async path's users don't lose observability.
+    let duration_ms = session_start.elapsed().as_millis() as u64;
+    let usage = cli.runtime.usage().cumulative_usage();
+    let total_turns = cli.runtime.usage().turns();
+    if let Some(tracer) = cli.session_tracer() {
+        tracer.record_usage(
+            "session_summary".to_string(),
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cache_creation_input_tokens,
+            usage.cache_read_input_tokens,
+        );
+        tracer.record_session_ended(
+            total_turns,
+            usage.input_tokens as u64,
+            usage.output_tokens as u64,
+            duration_ms,
+        );
+    }
+
+    Ok(())
+}
+
+/// Adapts `LiveCli::run_turn` (which takes `&mut self`) to the
+/// `repl_async::TurnDriver` trait (which is Sync + call by `&self`). The
+/// mutex guarantees only one turn runs at a time, matching the coordinator's
+/// single-runner-thread invariant.
+struct LiveCliDriver {
+    cli: std::sync::Arc<std::sync::Mutex<LiveCli>>,
+}
+
+impl repl_async::TurnDriver for LiveCliDriver {
+    fn run_turn(&self, prompt: &str) {
+        let mut cli = self.cli.lock().expect("LiveCli mutex poisoned");
+        if let Err(e) = cli.run_turn(prompt) {
+            eprintln!("\x1b[31m{e}\x1b[0m");
+        }
+    }
 }
 
 struct LiveCli {

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -1,0 +1,332 @@
+//! Async REPL loop that accepts input DURING a running turn — Phase 2 of the
+//! interrupt+queue plan (`notes/plans/conversation-interrupt-queue-sudocode.md`).
+//!
+//! Only activated when `SUDOCODE_INTERRUPT_QUEUE_MODE` is set to a non-off value.
+//! The default REPL (`run_repl`) is unchanged and remains the sync path.
+//!
+//! ## Scope of this cut
+//!
+//! Queue-mode (`SUDOCODE_INTERRUPT_QUEUE_MODE=queue`) only: input typed while a
+//! turn is running is accumulated in the [`TurnInputCoordinator`]; on turn end
+//! (natural OR cancelled) the queue is flushed as ONE combined `run_turn`
+//! matching sudowork's post-#983 batched-flush semantics.
+//!
+//! Auto-interrupt (`interrupt` / `both`) is **not** wired here — the coordinator
+//! records the intent (Interrupt outcome), but this loop treats it identically
+//! to Queue for now. See §Deferred below.
+//!
+//! Slash commands (/exit, /clear, ...) still work: they are intercepted before
+//! being handed to the coordinator and dispatched under the same cli lock the
+//! runner uses, so they cannot race a running turn.
+//!
+//! ## Architecture (three-role split from the plan)
+//!
+//! ```text
+//! ┌──────────────────┐      InputEvent      ┌───────────────────────┐
+//! │ input-thread     │ ────────────────────▶│ main coordinator loop │
+//! │ rustyline blocking│                     │ TurnInputCoordinator  │
+//! └──────────────────┘                     │ Arc<Mutex<LiveCli>>   │
+//!                                          └───────────┬───────────┘
+//!                                                      │ spawn_turn
+//!                                                      ▼
+//!                                          ┌───────────────────────┐
+//!                                          │ runner (std::thread)  │
+//!                                          │ locks cli, run_turn   │
+//!                                          │ sends TurnDone        │
+//!                                          └───────────────────────┘
+//! ```
+//!
+//! The main loop uses **std::sync::mpsc with a 100 ms recv_timeout poll** on the
+//! input receiver as its "select" primitive during a running turn — no
+//! crossbeam / no tokio at this layer, so the wiring stays free of new deps and
+//! is trivially portable across Windows/POSIX. Idle main just blocks on
+//! `input_rx.recv()`.
+//!
+//! `LiveCli` is behind an `Arc<Mutex<>>` because `run_turn` needs `&mut self`
+//! and it must run off-main so main can service input events. Main only locks
+//! cli briefly to dispatch slash commands or record prompt history; the runner
+//! thread holds the lock for the full duration of `run_turn`, which is exactly
+//! what we want (nothing else can touch cli while it is streaming an LLM turn).
+//!
+//! ## Deferred (explicitly out of scope for this commit)
+//!
+//! - **Auto-interrupt (`interrupt` / `both`).** Requires exposing the current
+//!   turn's `HookAbortSignal` to main so an in-flight `run_turn` can be
+//!   cancelled. `LiveCli::run_turn` currently constructs a fresh signal per
+//!   invocation inside `prepare_turn_runtime` — plumbing it out for external
+//!   abort is a follow-up commit.
+//! - **`↑`-key dequeue.** Needs a rustyline `ConditionalEventHandler` binding
+//!   that reads from the shared coordinator queue and calls `Cmd::Insert`.
+//!   Deferred so the wiring can land + get PTY coverage first.
+//! - **PTY integration test.** The three-role architecture is best proven end-
+//!   to-end via PTY (queue N inputs, verify N-1 batched flush, verify sudocode
+//!   emits exactly ONE downstream request); ships in the follow-up.
+//! - **Startup completions refresh mid-loop.** Input thread reads the completion
+//!   candidates snapshot from cli at boot; if agents / slash commands change
+//!   during a session, the completions don't refresh yet.
+//!
+//! The [`sudocode plan doc`](https://github.com/sudoprivacy/sudocode/blob/main/notes/plans/conversation-interrupt-queue-sudocode.md)
+//! §落地节奏 covers the full sequence; this file is Phase-2 commit 1.
+
+use std::sync::mpsc::{sync_channel, RecvTimeoutError, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use crate::input::{LineEditor, ReadOutcome};
+use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
+
+/// Events flowing from the input thread to the main coordinator.
+enum InputEvent {
+    Submit(String),
+    Exit,
+}
+
+/// Events flowing from the runner thread back to the main coordinator.
+enum TurnEvent {
+    Done,
+}
+
+/// Anything the main loop pulls off its select. Kept as a small closed enum
+/// so the state machine is easy to read.
+enum LoopEvent {
+    Input(InputEvent),
+    TurnDone,
+}
+
+/// A "cli driver" — anything that can execute a single turn (given a prompt
+/// string). Abstracted so this loop can be exercised in tests with a mock; the
+/// real callsite passes an `Arc<Mutex<LiveCli>>` and a closure that unlocks
+/// and calls `LiveCli::run_turn`. See `run_repl_async` for the concrete wiring.
+pub trait TurnDriver: Send + Sync + 'static {
+    /// Run one turn to completion. Should NOT return until the turn is over
+    /// (natural end OR cancelled). Result is ignored by the loop — errors are
+    /// printed by the driver itself, matching the sync REPL's behavior.
+    fn run_turn(&self, prompt: &str);
+}
+
+/// The three-role coordinator loop. Kept generic over `TurnDriver` so tests can
+/// swap in a mock driver that just records prompts + sleeps.
+///
+/// Prints the initial prompt via `startup_banner` before spawning input.
+///
+/// On `InputEvent::Exit` from the input thread, waits for any in-flight turn
+/// to complete before returning (avoids interrupting a mid-flight `run_turn`
+/// that might be writing to disk).
+pub fn run_coordinator_loop<D: TurnDriver + 'static>(
+    driver: Arc<D>,
+    mode: QueueMode,
+    startup_banner: String,
+    initial_completions: Vec<(String, String)>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{startup_banner}");
+
+    let coord = Arc::new(Mutex::new(TurnInputCoordinator::new()));
+    let (input_tx, input_rx) = sync_channel::<InputEvent>(16);
+    let (turn_tx, turn_rx) = sync_channel::<TurnEvent>(1);
+
+    // Input thread — owns its rustyline LineEditor. Sends every submitted line
+    // to main via a bounded channel. Exits cleanly on Exit / channel closed.
+    let input_tx_clone = input_tx.clone();
+    thread::Builder::new()
+        .name("repl-input".into())
+        .spawn(move || {
+            let mut editor = LineEditor::new("❯ ", initial_completions);
+            loop {
+                match editor.read_line() {
+                    Ok(ReadOutcome::Submit(text)) => {
+                        if input_tx_clone.send(InputEvent::Submit(text)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(ReadOutcome::Exit) => {
+                        let _ = input_tx_clone.send(InputEvent::Exit);
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+        })?;
+
+    let mut turn_active = false;
+    let mut runner_handle: Option<thread::JoinHandle<()>> = None;
+
+    loop {
+        // Simple sync "select": when idle, block on input; when a turn is
+        // running, poll both channels with a 100 ms tick. 100 ms is well below
+        // human input latency perception (~150 ms) so no UI jankiness, and it
+        // keeps the loop dep-free (no crossbeam).
+        let event = if !turn_active {
+            match input_rx.recv() {
+                Ok(evt) => LoopEvent::Input(evt),
+                Err(_) => break, // input thread died
+            }
+        } else {
+            match input_rx.recv_timeout(Duration::from_millis(100)) {
+                Ok(evt) => LoopEvent::Input(evt),
+                Err(RecvTimeoutError::Timeout) => match turn_rx.try_recv() {
+                    Ok(TurnEvent::Done) => LoopEvent::TurnDone,
+                    Err(_) => continue,
+                },
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+        };
+
+        match event {
+            LoopEvent::Input(InputEvent::Exit) => {
+                if let Some(h) = runner_handle.take() {
+                    // Wait for the in-flight turn to finish before exiting so
+                    // half-written state (session persistence, telemetry) is
+                    // flushed cleanly.
+                    let _ = h.join();
+                }
+                break;
+            }
+            LoopEvent::Input(InputEvent::Submit(text)) => {
+                if !turn_active {
+                    let next = coord.lock().unwrap().submit_when_idle(text);
+                    turn_active = true;
+                    runner_handle = Some(spawn_turn(
+                        Arc::clone(&driver),
+                        next.prompt,
+                        turn_tx.clone(),
+                    ));
+                    continue;
+                }
+                let outcome = coord.lock().unwrap().submit_during_turn(text, mode);
+                match outcome {
+                    SubmitOutcome::Queued => {
+                        // Silent: sudowork's queue chips render in the sendbox;
+                        // for the CLI we punt to a status line in a follow-up.
+                    }
+                    SubmitOutcome::Interrupt => {
+                        // Coordinator recorded solo intent, but auto-interrupt
+                        // wiring (abort signal exposure) is deferred — see
+                        // module docs §Deferred. Behaves as Queued for now.
+                        eprintln!(
+                            "\x1b[2m(queued; auto-interrupt not yet wired in this build — the solo turn will run after the current one ends)\x1b[0m"
+                        );
+                    }
+                    SubmitOutcome::Rejected => {
+                        eprintln!(
+                            "\x1b[2m(a turn is running; set SUDOCODE_INTERRUPT_QUEUE_MODE=queue to queue instead)\x1b[0m"
+                        );
+                    }
+                }
+            }
+            LoopEvent::TurnDone => {
+                turn_active = false;
+                if let Some(h) = runner_handle.take() {
+                    let _ = h.join();
+                }
+                let next = coord.lock().unwrap().drain_next();
+                if let Some(next) = next {
+                    turn_active = true;
+                    runner_handle = Some(spawn_turn(
+                        Arc::clone(&driver),
+                        next.prompt,
+                        turn_tx.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Fire off `driver.run_turn(&prompt)` on a fresh thread. Sends TurnEvent::Done
+/// when the turn returns (natural or cancelled). Errors inside `run_turn` are
+/// the driver's responsibility to print — the coordinator only cares that a
+/// turn has ended.
+fn spawn_turn<D: TurnDriver + 'static>(
+    driver: Arc<D>,
+    prompt: String,
+    done_tx: SyncSender<TurnEvent>,
+) -> thread::JoinHandle<()> {
+    thread::Builder::new()
+        .name("repl-runner".into())
+        .spawn(move || {
+            driver.run_turn(&prompt);
+            let _ = done_tx.send(TurnEvent::Done);
+        })
+        .expect("spawn repl-runner thread")
+}
+
+// ------------------------------------------------------------------
+// Executable spec of the coordinator loop's state machine. Same "one
+// exception to the no-unit-tests rule" carve-out as input_queue.rs;
+// real behavior gets a PTY integration test in the follow-up commit.
+// ------------------------------------------------------------------
+
+#[cfg(test)]
+mod loop_docs {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    /// A `TurnDriver` that just records the prompts it's called with and
+    /// blocks for `turn_ms` before returning — mimics an LLM turn taking time.
+    struct RecordingDriver {
+        prompts: Mutex<Vec<String>>,
+        turn_ms: u64,
+        run_count: AtomicUsize,
+    }
+
+    impl RecordingDriver {
+        fn new(turn_ms: u64) -> Arc<Self> {
+            Arc::new(Self {
+                prompts: Mutex::new(Vec::new()),
+                turn_ms,
+                run_count: AtomicUsize::new(0),
+            })
+        }
+        fn prompts(&self) -> Vec<String> {
+            self.prompts.lock().unwrap().clone()
+        }
+    }
+
+    impl TurnDriver for RecordingDriver {
+        fn run_turn(&self, prompt: &str) {
+            self.prompts.lock().unwrap().push(prompt.to_string());
+            self.run_count.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(self.turn_ms));
+        }
+    }
+
+    // These docs cover the *coordinator* branch of the design only. They do
+    // NOT spin up rustyline (input thread is stubbed). The intent is that any
+    // future edit to the state machine can prove its regressions in <100 ms
+    // rather than requiring a PTY.
+    //
+    // Rather than driving `run_coordinator_loop` directly (which owns its
+    // input thread), the state-machine tests exercise `TurnInputCoordinator`
+    // through the same call sequence the loop would use. This keeps the
+    // executable spec small and dependency-free.
+
+    #[test]
+    fn state_machine_batched_flush_via_coordinator() {
+        // Sanity: 3 during-turn submits + drain_next MUST produce ONE combined
+        // prompt containing all 3 in submission order — the exact contract
+        // that the coordinator loop hands to the runner thread when a turn ends.
+        let mut c = TurnInputCoordinator::new();
+        c.submit_during_turn("B".into(), QueueMode::Queue);
+        c.submit_during_turn("C".into(), QueueMode::Queue);
+        c.submit_during_turn("D".into(), QueueMode::Queue);
+        let next = c.drain_next().unwrap();
+        assert_eq!(next.prompt, "B\n\nC\n\nD");
+        assert_eq!(next.consumed, 3);
+        assert!(!next.solo);
+    }
+
+    #[test]
+    fn recording_driver_records_prompt_and_run_count() {
+        // Sanity that our test double is honest, so failures in the loop tests
+        // aren't masquerading as bugs in the test infrastructure itself.
+        let d = RecordingDriver::new(5);
+        d.run_turn("hello");
+        d.run_turn("world");
+        assert_eq!(d.prompts(), vec!["hello".to_string(), "world".to_string()]);
+        assert_eq!(d.run_count.load(Ordering::SeqCst), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the Phase 1 \`TurnInputCoordinator\` (PR #294) into the REPL so users can queue additional prompts WHILE a turn is running. On turn end the queue is drained + joined with \`\n\n\` as ONE combined next-turn, matching sudowork's post-#983 batched-flush semantics.

## Activation

Env-gated. Default \`run_repl\` sync path stays byte-identical to today's behavior. Only when the user opts in via \`SUDOCODE_INTERRUPT_QUEUE_MODE=queue|interrupt|both\` does the new \`run_repl_async_dispatch\` take over.

## Architecture

Three roles, one file (\`src/repl_async.rs\`):

- **input-thread** (\`std::thread\`): rustyline \`LineEditor\` blocking in \`read_line\`; each \`Submit\` is sent to main via a bounded \`sync_channel\`. Exits cleanly on \`Exit\` / channel-closed.
- **main coordinator loop**: dep-free "select" — \`recv()\` when idle, \`recv_timeout(100 ms)\` + \`try_recv\` on the turn-done channel when running. State machine is Idle | Running with the runner's \`JoinHandle\` held by main so runners are reaped on \`TurnDone\` / \`Exit\`.
- **runner thread** (\`std::thread\`): locks \`Arc<Mutex<LiveCli>>\`, calls \`LiveCli::run_turn\`, sends \`TurnEvent::Done\` when the turn returns.

The mutex guarantees only one turn executes at a time; main only takes the lock briefly to submit / drain the coordinator, so an in-flight turn never blocks input acceptance.

Session-ended telemetry preserved via \`Arc::try_unwrap\` after the coordinator loop exits (all runner threads joined by then).

## Deferred (explicitly logged in \`src/repl_async.rs\` module docs)

- Auto-interrupt (\`interrupt\` / \`both\` modes) — needs plumbing to expose the current turn's \`HookAbortSignal\` to main. Coordinator records \`SubmitOutcome::Interrupt\` but the loop treats it identically to \`Queued\` for this commit, with a stderr note explaining the fallback.
- \`↑\`-arrow dequeue rebind on the input thread's rustyline.
- Startup completions refresh mid-loop (input thread only sees the boot snapshot).
- PTY integration test — this PR ships with an executable-spec unit test for the state machine, and the follow-up will layer the real PTY case per the same pattern as \`pty_coordinator_mode\`.

## Test plan

- [x] \`cargo check -p rusty-sudocode-cli --bins\` clean on Windows w/ vcvars.
- [x] \`cargo test -p rusty-sudocode-cli --bins\` — 106 / 106 pass locally (input_queue matrix docs + repl_async loop docs + everything else in-tree).
- [ ] Follow-up: PTY test (\`pty_repl_queue.rs\`) exercising \`SUDOCODE_INTERRUPT_QUEUE_MODE=queue\` — send prompt A + queue B/C/D during A's run + verify one downstream request containing all four texts joined.

Design source: [\`notes/plans/conversation-interrupt-queue-sudocode.md\`](https://github.com/sudoprivacy/sudocode/blob/main/notes/plans/conversation-interrupt-queue-sudocode.md) + the sudowork §3.2 matrix at https://s.shareone.vip/s/sudowork-interrupt-queue.