### PR TITLE
feat(cron): wire the /cron slash command (REPL) + e2e

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1120,6 +1120,9 @@ pub enum SlashCommand {
     Skills {
         args: Option<String>,
     },
+    Cron {
+        args: Option<String>,
+    },
     Doctor,
     Login,
     Logout,
@@ -1300,6 +1303,7 @@ impl SlashCommand {
             Self::AddDir { .. } => "/add-dir",
             Self::Sandbox => "/sandbox",
             Self::Mcp { .. } => "/mcp",
+            Self::Cron { .. } => "/cron",
             Self::Export { .. } => "/export",
             Self::Undo => "/undo",
             #[allow(unreachable_patterns)]
@@ -1412,6 +1416,7 @@ pub fn validate_slash_command_input(
         "skills" | "skill" => SlashCommand::Skills {
             args: parse_skills_args(remainder.as_deref())?,
         },
+        "cron" => SlashCommand::Cron { args: remainder },
         "doctor" | "providers" => {
             validate_no_args(command, &args)?;
             SlashCommand::Doctor
@@ -4440,6 +4445,7 @@ pub fn handle_slash_command(
         | SlashCommand::Plugins { .. }
         | SlashCommand::Agents { .. }
         | SlashCommand::Skills { .. }
+        | SlashCommand::Cron { .. }
         | SlashCommand::Doctor
         | SlashCommand::Login
         | SlashCommand::Logout

--- a/rust/crates/rusty-sudocode-cli/src/cli/cron.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/cron.rs
@@ -66,6 +66,141 @@ pub(crate) fn run(args: &[String], output_format: CliOutputFormat) -> CronResult
     }
 }
 
+/// REPL `/cron ...` — CRUD management, returns text for the REPL to show.
+/// Firing (`run`/`tick`/`daemon`) is directed to the shell: a live REPL
+/// session already owns a runtime, so firing an agent turn from inside it is
+/// confusing; `scode cron run/tick/daemon` is the surface for that.
+pub(crate) fn run_slash(args: Option<&str>) -> Result<String, String> {
+    let tokens = tokenize(args.unwrap_or(""));
+    let (sub, rest) = tokens
+        .split_first()
+        .map_or(("list", &[][..]), |(s, r)| (s.as_str(), r));
+    let reg = open_registry();
+    match sub {
+        "" | "list" | "ls" => Ok(list_text(&reg)),
+        "add" | "create" => add_text(&reg, rest),
+        "remove" | "rm" | "delete" => {
+            let id = slash_id(rest)?;
+            reg.delete(id)?;
+            Ok(format!("removed cron {id}"))
+        }
+        "enable" => {
+            let id = slash_id(rest)?;
+            reg.set_enabled(id, true)?;
+            if let Some(e) = reg.get(id) {
+                if let Some(n) = cron_schedule::first_run_at(&e, now_secs()) {
+                    let _ = reg.set_next_run(id, Some(n));
+                }
+            }
+            Ok(format!("enabled cron {id}"))
+        }
+        "disable" => {
+            let id = slash_id(rest)?;
+            reg.set_enabled(id, false)?;
+            Ok(format!("disabled cron {id}"))
+        }
+        "run" | "tick" | "daemon" => Ok(format!(
+            "run `scode cron {sub}` from the shell — firing from inside a REPL session isn't supported"
+        )),
+        other => Err(format!(
+            "unknown /cron subcommand {other:?}; try: list | add | remove | enable | disable"
+        )),
+    }
+}
+
+fn list_text(reg: &CronRegistry) -> String {
+    let entries = reg.list(false);
+    if entries.is_empty() {
+        return "No scheduled tasks. Add one: /cron add --schedule \"0 9 * * *\" --prompt \"…\""
+            .to_owned();
+    }
+    entries
+        .iter()
+        .map(format_entry_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn add_text(reg: &CronRegistry, rest: &[String]) -> Result<String, String> {
+    let opts = FlagMap::parse(rest);
+    let prompt = opts
+        .get("prompt")
+        .ok_or("`/cron add` requires --prompt <text>")?
+        .to_owned();
+    let (kind, schedule) = match (opts.get("schedule"), opts.get("every"), opts.get("at")) {
+        (Some(s), None, None) => (CronKind::Cron, s.to_owned()),
+        (None, Some(s), None) => (CronKind::Every, s.to_owned()),
+        (None, None, Some(s)) => (CronKind::At, s.to_owned()),
+        (None, None, None) => {
+            return Err("`/cron add` requires one of --schedule | --every | --at".to_owned())
+        }
+        _ => {
+            return Err("`/cron add` accepts exactly one of --schedule | --every | --at".to_owned())
+        }
+    };
+    let tz = opts.get("tz").map(str::to_owned);
+    cron_schedule::validate(kind, &schedule, tz.as_deref())?;
+    let entry = reg.create_full(CronCreateParams {
+        schedule,
+        kind,
+        prompt,
+        description: opts.get("description").map(str::to_owned),
+        name: opts.get("name").map(str::to_owned),
+        tz,
+        cwd: opts.get("cwd").map(str::to_owned),
+    });
+    if let Some(n) = cron_schedule::first_run_at(&entry, now_secs()) {
+        let _ = reg.set_next_run(&entry.cron_id, Some(n));
+    }
+    let entry = reg.get(&entry.cron_id).unwrap_or(entry);
+    Ok(format!("created: {}", format_entry_line(&entry)))
+}
+
+fn slash_id(rest: &[String]) -> Result<&str, String> {
+    rest.iter()
+        .find(|a| !a.starts_with('-'))
+        .map(String::as_str)
+        .ok_or_else(|| "expected a <cron_id>".to_owned())
+}
+
+/// Quote-aware tokenizer so `/cron add --schedule "0 9 * * *" --prompt "do X"`
+/// keeps multi-word quoted values intact.
+fn tokenize(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quote: Option<char> = None;
+    let mut has = false;
+    for c in s.chars() {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                } else {
+                    cur.push(c);
+                }
+            }
+            None => {
+                if c == '\'' || c == '"' {
+                    quote = Some(c);
+                    has = true;
+                } else if c.is_whitespace() {
+                    if has {
+                        out.push(std::mem::take(&mut cur));
+                        has = false;
+                    }
+                } else {
+                    cur.push(c);
+                    has = true;
+                }
+            }
+        }
+    }
+    if has {
+        out.push(cur);
+    }
+    out
+}
+
 fn list(reg: &CronRegistry, output_format: CliOutputFormat) -> CronResult {
     let entries = reg.list(false);
     match output_format {
@@ -332,5 +467,37 @@ impl FlagMap {
             .get(key)
             .map(String::as_str)
             .filter(|s| !s.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tokenize;
+
+    #[test]
+    fn tokenize_keeps_quoted_multiword_values() {
+        // The exact `/cron add` shape a user types in the REPL.
+        let t = tokenize("add --schedule \"0 9 * * *\" --prompt 'daily standup' --name s");
+        assert_eq!(
+            t,
+            vec![
+                "add",
+                "--schedule",
+                "0 9 * * *",
+                "--prompt",
+                "daily standup",
+                "--name",
+                "s"
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_plain_and_empty() {
+        assert_eq!(tokenize("list"), vec!["list"]);
+        assert_eq!(tokenize("   "), Vec::<String>::new());
+        assert!(tokenize("").is_empty());
+        // an explicitly empty quoted value is preserved as an empty arg.
+        assert_eq!(tokenize("--prompt \"\""), vec!["--prompt", ""]);
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1278,6 +1278,11 @@ fn run_resume_command(
                 ),
             })
         }
+        SlashCommand::Cron { args } => Ok(ResumeCommandOutcome {
+            session: session.clone(),
+            message: Some(cli::cron::run_slash(args.as_deref()).map_err(std::io::Error::other)?),
+            json: None,
+        }),
         SlashCommand::Skills { args } => {
             if let SkillSlashDispatch::Invoke(_) = classify_skills_slash_command(args.as_deref()) {
                 return Err(
@@ -3477,6 +3482,13 @@ impl LiveCli {
             }
             SlashCommand::Agents { args } => {
                 Self::print_agents(args.as_deref(), CliOutputFormat::Text)?;
+                false
+            }
+            SlashCommand::Cron { args } => {
+                match cli::cron::run_slash(args.as_deref()) {
+                    Ok(text) => println!("{text}"),
+                    Err(e) => println!("cron error: {e}"),
+                }
                 false
             }
             SlashCommand::Skills { args } => {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_cron.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_cron.rs
@@ -127,6 +127,21 @@ impl CronEnv {
     fn crons_json(&self) -> String {
         fs::read_to_string(self.config_home.join("crons.json")).unwrap_or_default()
     }
+
+    /// Spawn the interactive REPL (`scode` with no subcommand) under a PTY
+    /// with this env's isolated config home — for driving the `/cron`
+    /// slash command.
+    fn repl(&self) -> PtySession {
+        let scode = env!("CARGO_BIN_EXE_scode");
+        std::env::set_var("SUDO_CODE_CONFIG_HOME", &self.config_home);
+        std::env::set_var("HOME", &self.home);
+        std::env::set_var("NO_COLOR", "1");
+        let _ = std::env::set_current_dir(&self.workspace);
+        let args = ["--auth", "proxy", "--model", "auto"];
+        let mut sess = PtySession::spawn(scode, &args).expect("spawn scode repl");
+        sess.set_default_timeout(TIMEOUT);
+        sess
+    }
 }
 
 /// Pull the single cron's id straight from the persisted store.
@@ -295,6 +310,40 @@ fn disabled_cron_does_not_fire_on_tick() {
         json.contains("\"enabled\": false"),
         "stays disabled: {json}"
     );
+}
+
+#[test]
+fn repl_cron_slash_add_and_list() {
+    // The `/cron` slash command needs the REPL to boot (real config), so
+    // it is live-gated. Quoted multi-word values exercise the slash
+    // tokenizer end-to-end through the REPL → run_slash path.
+    if !is_live() {
+        eprintln!("skipping repl_cron_slash_add_and_list (set SCODE_TEST_BACKEND=live)");
+        return;
+    }
+    let env = CronEnv::new("repl-slash");
+    let mut s = env.repl();
+    s.expect("❯").expect("REPL prompt");
+
+    s.send("/cron add --every 3600 --prompt \"repl scheduled task\" --name viaslash\r")
+        .expect("send /cron add");
+    s.expect("created").expect("cron created via /cron");
+    s.expect("❯").expect("prompt after add");
+    s.send("/exit\r").expect("send /exit");
+    drop(s);
+    // The store proves the full slash path end-to-end: parse+dispatch reached
+    // run_slash, the quote-aware tokenizer kept the multi-word prompt intact,
+    // FlagMap parsed --name/--every, and it wrote through to crons.json.
+    let json = env.crons_json();
+    assert!(
+        json.contains("repl scheduled task"),
+        "quoted prompt tokenized + persisted: {json}"
+    );
+    assert!(
+        json.contains("\"name\": \"viaslash\""),
+        "name persisted: {json}"
+    );
+    assert!(json.contains("\"kind\": \"every\""), "kind parsed: {json}");
 }
 
 #[test]


### PR DESCRIPTION
Finishes cron to 100% — the one deferred item.

The `/cron` slash command was advertised in help (`[list|add|remove]`) but parsed to `Unknown` and errored in the REPL. Now wired end-to-end:
- `SlashCommand::Cron` variant + parse arm + `/cron` Display + no-auth list (CRUD needs no model) + **both** REPL dispatch sites (resume + interactive).
- `cli::cron::run_slash` — CRUD (list/add/remove/enable/disable) returning text; `run`/`tick`/`daemon` direct to the shell (firing from inside a live REPL session isn't supported).
- A **quote-aware tokenizer** so `/cron add --schedule "0 9 * * *" --prompt "do X"` keeps multi-word values intact.

## Verification (per the e2e standard)
- **Live pty test** driving the **real REPL**: `/cron add` with quoted args → `created` → the persisted store shows the tokenized prompt + `--name` + `--every` kind. All 9 `pty_cron` tests pass live with a real key.
- **Tokenizer unit tests** (CI regression for the tricky quote parsing).

Reuses the persistent registry shared with `scode cron` + the tools, so a cron scheduled via `/cron` is the same entity the CLI/scheduler see.

—— sudocode via sudowork-win-pc-1