### PR TITLE
feat(repl): wire auto-interrupt — SubmitOutcome::Interrupt aborts turn

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1614,9 +1614,16 @@ fn run_repl_async_dispatch(
     // wedges the terminal on POSIX (see LiveCli::esc_monitor_enabled docs).
     cli.esc_monitor_enabled = false;
 
+    // Auto-interrupt wiring: install a persistent HookAbortSignal so main can
+    // call `.abort()` mid-turn without ever locking cli. `prepare_turn_runtime`
+    // resets the signal before each turn (see the branch we added there).
+    let abort_signal = runtime::HookAbortSignal::new();
+    cli.persistent_abort_signal = Some(abort_signal.clone());
+
     let cli_shared = std::sync::Arc::new(std::sync::Mutex::new(cli));
     let driver: std::sync::Arc<LiveCliDriver> = std::sync::Arc::new(LiveCliDriver {
         cli: std::sync::Arc::clone(&cli_shared),
+        abort_signal,
     });
 
     let session_start = Instant::now();
@@ -1658,9 +1665,11 @@ fn run_repl_async_dispatch(
 /// Adapts `LiveCli::run_turn` (which takes `&mut self`) to the
 /// `repl_async::TurnDriver` trait (which is Sync + call by `&self`). The
 /// mutex guarantees only one turn runs at a time, matching the coordinator's
-/// single-runner-thread invariant.
+/// single-runner-thread invariant. Holds a clone of the persistent abort
+/// signal so `abort_current_turn` can fire without ever touching the mutex.
 struct LiveCliDriver {
     cli: std::sync::Arc<std::sync::Mutex<LiveCli>>,
+    abort_signal: runtime::HookAbortSignal,
 }
 
 impl repl_async::TurnDriver for LiveCliDriver {
@@ -1681,6 +1690,13 @@ impl repl_async::TurnDriver for LiveCliDriver {
             eprintln!("\x1b[31m{e}\x1b[0m");
         }
     }
+
+    fn abort_current_turn(&self) {
+        // Idempotent by design (HookAbortSignal::abort just sets a bool +
+        // notifies waiters). No cli-lock needed — the runner thread already
+        // holds it while streaming, and would deadlock if we tried.
+        self.abort_signal.abort();
+    }
 }
 
 struct LiveCli {
@@ -1700,6 +1716,12 @@ struct LiveCli {
     /// crossterm listener leaves the terminal wedged after the turn ends
     /// (deadlocked the `/exit` path on POSIX CI runners in PR #298 v1).
     esc_monitor_enabled: bool,
+    /// When `Some`, `prepare_turn_runtime` resets and reuses THIS signal
+    /// instead of creating a fresh one per turn. Set by the async REPL
+    /// dispatch so main can hold a clone and call `.abort()` mid-turn
+    /// without ever locking the `LiveCli` mutex — the runner thread holds
+    /// that lock while `run_turn` streams.
+    persistent_abort_signal: Option<runtime::HookAbortSignal>,
 }
 
 pub(crate) struct RuntimePluginState {
@@ -3031,6 +3053,7 @@ impl LiveCli {
             undone_tool_use_ids: std::collections::HashSet::new(),
             tokio_runtime,
             esc_monitor_enabled: true,
+            persistent_abort_signal: None,
         };
         cli.persist_session()?;
 
@@ -3166,7 +3189,18 @@ impl LiveCli {
         &mut self,
         emit_output: bool,
     ) -> Result<(BuiltRuntime, HookAbortMonitor), Box<dyn std::error::Error>> {
-        let hook_abort_signal = runtime::HookAbortSignal::new();
+        // Async REPL mode installs a persistent abort signal so main can call
+        // `.abort()` mid-turn without racing the runner thread. Reset the flag
+        // here — the previous turn may have aborted it (that's how we got
+        // this new turn scheduled), and the runtime treats `is_aborted() ==
+        // true` as "cancel immediately", which would collapse the fresh turn.
+        let hook_abort_signal = match &self.persistent_abort_signal {
+            Some(sig) => {
+                sig.reset();
+                sig.clone()
+            }
+            None => runtime::HookAbortSignal::new(),
+        };
         // `build_runtime` stamps `prompt_known_date` with today's local date,
         // which is correct only for a freshly-created runtime. The REPL
         // rebuilds the runtime on every turn, so without carrying this date

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -4,16 +4,18 @@
 //! Only activated when `SUDOCODE_INTERRUPT_QUEUE_MODE` is set to a non-off value.
 //! The default REPL (`run_repl`) is unchanged and remains the sync path.
 //!
-//! ## Scope of this cut
+//! ## Modes
 //!
-//! Queue-mode (`SUDOCODE_INTERRUPT_QUEUE_MODE=queue`) only: input typed while a
-//! turn is running is accumulated in the [`TurnInputCoordinator`]; on turn end
-//! (natural OR cancelled) the queue is flushed as ONE combined `run_turn`
-//! matching sudowork's post-#983 batched-flush semantics.
-//!
-//! Auto-interrupt (`interrupt` / `both`) is **not** wired here — the coordinator
-//! records the intent (Interrupt outcome), but this loop treats it identically
-//! to Queue for now. See §Deferred below.
+//! - `queue` — input typed while a turn is running is accumulated in the
+//!   [`TurnInputCoordinator`]; on turn end (natural OR cancelled) the queue is
+//!   flushed as ONE combined `run_turn` matching sudowork's post-#983
+//!   batched-flush semantics.
+//! - `interrupt` / `both` — same as `queue` for the queue side, PLUS the
+//!   coordinator's `SubmitOutcome::Interrupt` calls
+//!   [`TurnDriver::abort_current_turn`]. The runner's in-flight `run_turn`
+//!   observes the aborted [`runtime::HookAbortSignal`] and returns a cancelled
+//!   `TurnSummary`, which propagates as `TurnEvent::Done`; the drain then picks
+//!   up the interrupter as a fresh solo turn per §3.2 row 2.
 //!
 //! Slash commands (/exit, /clear, ...) still work: they are intercepted before
 //! being handed to the coordinator and dispatched under the same cli lock the
@@ -109,6 +111,17 @@ pub trait TurnDriver: Send + Sync + 'static {
     /// `session_ended` telemetry, etc.). Default no-op keeps the loop
     /// self-contained for tests.
     fn on_exit(&self) {}
+
+    /// Auto-interrupt the currently running turn. Called from main when the
+    /// coordinator matrix decides `SubmitOutcome::Interrupt` — the runner
+    /// thread's `run_turn` will observe the abort and return with a
+    /// cancelled `TurnSummary`, then the drain picks up the interrupter
+    /// (already `solo`-tagged at the queue head by `submit_during_turn`).
+    /// Must NOT block on the runner (main is holding the coordinator loop).
+    /// Idempotent: safe to call when no turn is active — the next
+    /// `LiveCli::prepare_turn_runtime` resets the shared signal before use.
+    /// Default no-op for test drivers that don't wire abort.
+    fn abort_current_turn(&self) {}
 }
 
 /// A submitted line that the coordinator loop needs to classify: is it a
@@ -227,11 +240,15 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                         // for the CLI we punt to a status line in a follow-up.
                     }
                     SubmitOutcome::Interrupt => {
-                        // Coordinator recorded solo intent, but auto-interrupt
-                        // wiring (abort signal exposure) is deferred — see
-                        // module docs §Deferred. Behaves as Queued for now.
+                        // Coordinator has already placed the interrupter at the
+                        // queue head with `solo: true`. Now cancel the running
+                        // turn via the driver's abort handle — the runner's
+                        // `run_turn` observes the abort, returns a cancelled
+                        // TurnSummary, sends `TurnEvent::Done`, and the drain
+                        // picks up the interrupter as a fresh solo run.
+                        driver.abort_current_turn();
                         eprintln!(
-                            "\x1b[2m(queued; auto-interrupt not yet wired in this build — the solo turn will run after the current one ends)\x1b[0m"
+                            "\x1b[2m(interrupting current turn; interrupter will run as a solo new turn)\x1b[0m"
                         );
                     }
                     SubmitOutcome::Rejected => {
@@ -294,10 +311,13 @@ mod loop_docs {
 
     /// A `TurnDriver` that just records the prompts it's called with and
     /// blocks for `turn_ms` before returning — mimics an LLM turn taking time.
+    /// Also counts `abort_current_turn` calls so the matrix doc can verify
+    /// the auto-interrupt hook fires as expected.
     struct RecordingDriver {
         prompts: Mutex<Vec<String>>,
         turn_ms: u64,
         run_count: AtomicUsize,
+        abort_count: AtomicUsize,
     }
 
     impl RecordingDriver {
@@ -306,6 +326,7 @@ mod loop_docs {
                 prompts: Mutex::new(Vec::new()),
                 turn_ms,
                 run_count: AtomicUsize::new(0),
+                abort_count: AtomicUsize::new(0),
             })
         }
         fn prompts(&self) -> Vec<String> {
@@ -318,6 +339,10 @@ mod loop_docs {
             self.prompts.lock().unwrap().push(prompt.to_string());
             self.run_count.fetch_add(1, Ordering::SeqCst);
             std::thread::sleep(Duration::from_millis(self.turn_ms));
+        }
+
+        fn abort_current_turn(&self) {
+            self.abort_count.fetch_add(1, Ordering::SeqCst);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the last §3.2 gap in the async REPL: \`SUDOCODE_INTERRUPT_QUEUE_MODE=interrupt\` and \`both\` modes now actually cancel a running turn instead of behaving as \`queue\`.

Design source: https://s.shareone.vip/s/sudowork-interrupt-queue §3.2 row 2 — "第一条立即打断并单独作为新轮启动". Layers on top of PR #298's \`esc_monitor_enabled\` scaffold (that already got the terminal-mode conflict out of the way).

## Plumbing

- \`TurnDriver::abort_current_turn(&self)\` — new trait method with default no-op. Coordinator calls it when \`submit_during_turn\` returns \`SubmitOutcome::Interrupt\` (which already puts the interrupter at the queue head with \`solo: true\`).
- \`LiveCli::persistent_abort_signal: Option<HookAbortSignal>\` — when \`Some\`, \`prepare_turn_runtime\` resets and reuses it instead of building a fresh signal per turn. Reset is essential: the abort flag being true is precisely how this new turn got scheduled, and \`ConversationRuntime::run_turn\` treats \`is_aborted() == true\` as "cancel immediately", so a fresh turn with a stale flag would collapse before running.
- \`LiveCliDriver\` holds a clone of that signal (created in \`run_repl_async_dispatch\`) and implements \`abort_current_turn\` by calling \`.abort()\` on it. No cli-lock needed — the runner thread holds that lock for the whole turn, so an abort path through the lock would deadlock.

## Sync REPL: unchanged

\`persistent_abort_signal\` defaults to \`None\`, so the sync path still builds a fresh signal per turn. Bit-for-bit identical to before this PR.

## Test plan

- [x] \`cargo test -p rusty-sudocode-cli --bins\` — 108 / 108 pass locally on Windows w/ vcvars. \`RecordingDriver\` in the module docs gains an \`abort_count\` so any regression that quietly stops calling \`abort_current_turn\` will fail matrix docs.
- [x] \`cargo test -p rusty-sudocode-cli --test pty_repl_async_queue\` — 1 / 1 pass. Existing smoke still green.
- [ ] Deferred: dedicated auto-interrupt PTY case needs mock scenario with per-request delay so PTY timing has a "during a turn" window to inject the interrupter. Ships behind the same follow-up as the full N-inputs-batched-flush PTY test.

Design source: [\`notes/plans/conversation-interrupt-queue-sudocode.md\`](https://github.com/sudoprivacy/sudocode/blob/main/notes/plans/conversation-interrupt-queue-sudocode.md).