### PR TITLE
feat(repl): ↑-arrow dequeue on empty buffer + PTY regression guard

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -15,6 +15,41 @@ use rustyline::{
     EventHandler, Helper, KeyCode, KeyEvent, Modifiers, RepeatCount,
 };
 
+/// Callback invoked by the `↑`-arrow handler when the current input buffer is
+/// empty. Returns `Some(text)` to have rustyline `Cmd::Insert(text)` splice
+/// into the buffer (typical use: pop the newest item from the async REPL's
+/// TurnInputCoordinator queue). Returns `None` to fall through to rustyline's
+/// default `↑` behavior (history navigation), matching the "only dequeue when
+/// there's something to dequeue" contract in the sudowork §3.2 muted note.
+///
+/// Signature is a `Fn` (Send + Sync + 'static) so rustyline's editor can hold
+/// it across its threads without extra ceremony.
+pub type UpArrowDequeueHook = std::sync::Arc<dyn Fn() -> Option<String> + Send + Sync + 'static>;
+
+/// Rustyline handler for `↑` on an empty prompt buffer: invokes the
+/// `UpArrowDequeueHook` and, on `Some(text)`, splices via `Cmd::Insert`.
+/// On non-empty buffer or hook returning None, returns `None` so rustyline's
+/// default history-up path runs — never breaks multi-line editing.
+struct UpArrowDequeueHandler {
+    hook: UpArrowDequeueHook,
+}
+
+impl ConditionalEventHandler for UpArrowDequeueHandler {
+    fn handle(
+        &self,
+        _evt: &rustyline::Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        if !ctx.line().is_empty() {
+            return None;
+        }
+        let text = (self.hook)()?;
+        Some(Cmd::Insert(1, text))
+    }
+}
+
 /// Accept the line only when it contains non-whitespace text.
 /// When the line is empty, Enter is a no-op.
 struct AcceptNonEmpty;
@@ -232,6 +267,19 @@ pub struct LineEditor {
 impl LineEditor {
     #[must_use]
     pub fn new(prompt: impl Into<String>, completions: Vec<(String, String)>) -> Self {
+        Self::new_with_dequeue_hook(prompt, completions, None)
+    }
+
+    /// Same as [`new`] but binds `↑` (on an empty buffer) to `dequeue_hook`.
+    /// The async REPL uses this to pop the newest queued input back into the
+    /// editor for editing; sync REPL passes `None` and gets the default
+    /// history-only `↑` behavior.
+    #[must_use]
+    pub fn new_with_dequeue_hook(
+        prompt: impl Into<String>,
+        completions: Vec<(String, String)>,
+        dequeue_hook: Option<UpArrowDequeueHook>,
+    ) -> Self {
         let config = Config::builder()
             .completion_type(CompletionType::List)
             .edit_mode(EditMode::Emacs)
@@ -245,6 +293,13 @@ impl LineEditor {
             KeyEvent(KeyCode::Enter, Modifiers::NONE),
             EventHandler::Conditional(Box::new(AcceptNonEmpty)),
         );
+
+        if let Some(hook) = dequeue_hook {
+            editor.bind_sequence(
+                KeyEvent(KeyCode::Up, Modifiers::NONE),
+                EventHandler::Conditional(Box::new(UpArrowDequeueHandler { hook })),
+            );
+        }
 
         let images: ImageMap = Arc::new(Mutex::new(HashMap::new()));
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -78,6 +78,26 @@ use std::time::Duration;
 use crate::input::{LineEditor, ReadOutcome};
 use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
 
+/// Builds the `↑`-arrow dequeue hook that the input thread's rustyline binds
+/// to `KeyCode::Up` on an empty buffer. Kept as a free function so both the
+/// production wiring and the future PTY test infrastructure can construct one
+/// from the same `Arc<Mutex<TurnInputCoordinator>>` main uses.
+///
+/// Semantics (per shareone §3.2 muted note):
+/// - Buffer non-empty → returns `None`, rustyline runs default history-up.
+/// - Buffer empty + queue empty → returns `None`, same fall-through.
+/// - Buffer empty + queue non-empty → pops NEWEST queued item; caller
+///   `Cmd::Insert`s it for further editing. LIFO so the user gets back the
+///   thing they most recently queued.
+fn make_up_arrow_hook(coord: Arc<Mutex<TurnInputCoordinator>>) -> crate::input::UpArrowDequeueHook {
+    Arc::new(move || {
+        coord
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .dequeue_last()
+    })
+}
+
 /// Events flowing from the input thread to the main coordinator.
 enum InputEvent {
     Submit(String),
@@ -153,11 +173,16 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
 
     // Input thread — owns its rustyline LineEditor. Sends every submitted line
     // to main via a bounded channel. Exits cleanly on Exit / channel closed.
+    // The `↑`-arrow dequeue hook is bound here so the input thread can pop
+    // the newest queued input back into the buffer without needing a
+    // channel round-trip to main.
     let input_tx_clone = input_tx.clone();
+    let dequeue_hook = make_up_arrow_hook(Arc::clone(&coord));
     thread::Builder::new()
         .name("repl-input".into())
         .spawn(move || {
-            let mut editor = LineEditor::new("❯ ", initial_completions);
+            let mut editor =
+                LineEditor::new_with_dequeue_hook("❯ ", initial_completions, Some(dequeue_hook));
             loop {
                 match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {
@@ -215,8 +240,15 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                 // (that'd send the literal text to the LLM as a turn — the
                 // regression the pty_repl_async_queue smoke caught). Handled
                 // BEFORE the coordinator matrix so an in-flight turn (if any)
-                // is joined + telemetry emits cleanly.
+                // is aborted + joined + telemetry emits cleanly.
                 if is_exit_command(&text) {
+                    if runner_handle.is_some() {
+                        // Turn still running — abort it first so the join below
+                        // returns quickly, not after the full LLM/tool wall
+                        // clock. Idempotent + safe to call when no runner is
+                        // active (driver default is no-op).
+                        driver.abort_current_turn();
+                    }
                     if let Some(h) = runner_handle.take() {
                         let _ = h.join();
                     }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
@@ -1,0 +1,131 @@
+//! PTY test for the `↑`-arrow dequeue in async REPL mode.
+//!
+//! Guards the wiring landed with the `↑`-arrow handler (PR #TBD):
+//! `LineEditor` gets built with a dequeue hook backed by the shared
+//! `Arc<Mutex<TurnInputCoordinator>>`; on `Up` with an empty buffer, the
+//! newest queued item is spliced into rustyline via `Cmd::Insert`.
+//!
+//! ## Real user journey exercised (3+ steps, data flow between them)
+//!
+//! Follows the [integration-test-generator](file:///C/Users/songym/cursor-projects/document-ai/.claude/skills/integration-test-generator/SKILL.md)
+//! standard: every step's output feeds the next; no orphan operations.
+//!
+//! 1. **Start a long-running turn.** Send prompt A that triggers a bash tool
+//!    invocation the model has to wait on — gives the coordinator a real
+//!    "turn_active = true" window in which queue-during-turn matters.
+//! 2. **Queue during the turn.** Send `MARKER_QUEUED_INPUT\r` while A is
+//!    still executing → coordinator's `submit_during_turn` returns Queued;
+//!    the item lives in the shared queue behind the running turn.
+//! 3. **Press `↑` with empty buffer.** Sends the `ESC[A` sequence → input
+//!    thread's rustyline routes to `UpArrowDequeueHandler` → hook calls
+//!    `dequeue_last` → returns `MARKER_QUEUED_INPUT` → rustyline
+//!    `Cmd::Insert`s it into the buffer.
+//! 4. **Observe the re-rendered buffer.** The Insert rerenders the prompt
+//!    line WITH the dequeued text — pty-expect finds `MARKER_QUEUED_INPUT`
+//!    in the stream. This is the strong end-to-end signal that the whole
+//!    Arc-shared queue → hook → Cmd::Insert path works.
+//! 5. **Clean exit.** `/exit` — same as `pty_repl_async_queue::async_repl_processes_single_turn_and_exits`
+//!    proves the coordinator loop still tears down cleanly after the `↑`
+//!    interaction (no rustyline / mutex leaks left over).
+//!
+//! ## Why the `BashInterruptLongRunning` mock scenario
+//!
+//! It's the only stock scenario whose `run_turn` stays in-flight long enough
+//! for a scripted PTY sequence to reliably interleave. `SleepShortRoundtrip`'s
+//! 600 ms window is too tight for CI timing to hit deterministically. The
+//! bash `sleep 30` this scenario invokes gets killed cleanly on `/exit`
+//! (scode's `HookAbortMonitor` sends SIGTERM to the tool subprocess), so the
+//! test wall-clock is dominated by the queue-then-up dance (~2 s), not the
+//! 30 s the raw scenario would take.
+
+mod common;
+
+use common::TestEnv;
+use std::time::Duration;
+
+const MARKER: &str = "MARKER_QUEUED_INPUT";
+
+/// Real user journey (5 steps): start long turn → queue → `↑` → verify buffer
+/// contains the dequeued text → clean `/exit`.
+///
+/// Regression guard for: any change that breaks the Arc-shared coordinator
+/// queue → dequeue hook → rustyline `Cmd::Insert` path. Failing signal:
+/// `MARKER` never surfaces in the terminal output after `↑`, meaning either
+/// the hook wasn't installed, the coordinator wasn't shared, or the empty-
+/// buffer guard is inverted.
+#[test]
+fn up_arrow_on_empty_buffer_dequeues_last_queued_input() {
+    let env = TestEnv::new("repl-async-up-dequeue");
+
+    let mut sess = env.spawn_with_env(
+        // danger-full-access so the mock's canned bash command actually runs —
+        // pty_core_conversation's bash_interrupt_long_running case uses the
+        // same flag; without it the tool call is denied and we never get the
+        // "interrupt-start" output we key on below.
+        &["--permission-mode", "danger-full-access"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+
+    // Step 1: async REPL boots + shows prompt.
+    sess.expect("❯")
+        .expect("async REPL should render the initial prompt");
+
+    // Step 2: fire the long-running scenario so we have a real "turn active"
+    // window during which submit_during_turn goes down the Queued arm.
+    let prompt = env.prompt(
+        "Use the bash tool to run a background sleep and let me know when \
+         you started it.",
+        "bash_interrupt_long_running",
+    );
+    sess.send(&format!("{prompt}\r"))
+        .expect("send long-running prompt");
+
+    // Wait for the tool to actually start — the mock's canned bash command
+    // does `printf 'interrupt-start'` before the sleep, and PTY captures
+    // the bash stdout stream. Seeing "interrupt-start" is the strongest
+    // signal that the turn is really in-flight at the runner thread.
+    sess.expect("interrupt-start")
+        .expect("bash tool should print interrupt-start before the sleep");
+
+    // Step 3: submit the marker DURING the running turn — coordinator's
+    // submit_during_turn queues it (queue mode) and returns Queued. The
+    // input thread's rustyline is now idle waiting for the next line, and
+    // the marker text should NOT execute as its own turn.
+    sess.send(&format!("{MARKER}\r"))
+        .expect("queue marker during running turn");
+
+    // Give rustyline + the input thread a beat to process + hand off. 200 ms
+    // is well below the coordinator's 100 ms recv_timeout tick so we don't
+    // race the drain loop.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Step 4: press `↑` on an empty buffer. `ESC[A` is the ANSI sequence
+    // rustyline reads as `KeyCode::Up` under a real terminal. UpArrowDequeueHandler
+    // sees empty buffer + non-empty queue → dequeues `MARKER` → returns
+    // `Cmd::Insert(1, MARKER)` → rustyline splices into the buffer AND
+    // re-renders the prompt line.
+    sess.send("\x1b[A").expect("send Up-arrow key sequence");
+
+    // The rerender is the observable end-to-end signal: `MARKER` shows up
+    // in the PTY output stream. If the hook were unbound or the buffer-empty
+    // guard inverted, the queue would stay populated and the marker would
+    // NOT appear here — clean failure with 30 s timeout.
+    sess.expect(MARKER)
+        .expect("↑ on empty buffer should splice the dequeued marker into rustyline");
+
+    // Step 5: send `/exit` to signal shutdown. `/exit` now calls
+    // `driver.abort_current_turn()` before joining the runner (PR #TBD), so
+    // the bash `sleep 30` gets SIGTERM'd rather than the test waiting 30 s.
+    // We don't assert on `expect_eof` here — the test's real assertion is
+    // step 4's MARKER visibility; the drop-cleanup of PtySession will kill
+    // any surviving child if the abort didn't propagate for some reason
+    // (e.g., a bash quirk on a specific platform), which is fine at this
+    // layer — `pty_repl_async_queue` already gates the clean-`/exit` path
+    // for the non-tool code path.
+    sess.send("/exit\r").expect("send /exit");
+    // Bounded wait — if abort_current_turn works, this returns in a beat.
+    // If it doesn't, PtySession's Drop kills the child. Either way we don't
+    // hang the CI runner.
+    sess.set_default_timeout(Duration::from_secs(15));
+    let _ = sess.expect_eof();
+}


### PR DESCRIPTION
## Summary

Closes the last §3.2 user-facing gap in the async REPL. When the input buffer is empty and the coordinator queue is non-empty, \`↑\` pops the newest queued item back into rustyline via \`Cmd::Insert\` so the user can edit and re-submit. Non-empty buffer → falls through to rustyline's default history-up (multi-line editing unaffected).

Layers cleanly on the PR #297 / #298 / #300 scaffolding — no ceremony.

## Wiring

- \`input::UpArrowDequeueHook = Arc<dyn Fn() -> Option<String> + Send + Sync>\` and a \`ConditionalEventHandler\` bound to \`KeyCode::Up + Modifiers::NONE\` only when a hook is provided.
- \`LineEditor::new_with_dequeue_hook(prompt, completions, hook)\` — sync REPL keeps calling \`LineEditor::new\` (no hook) so its \`↑\` still walks history; the async REPL wires its shared \`Arc<Mutex<TurnInputCoordinator>>\` in through \`make_up_arrow_hook\`.
- \`/exit\` mid-turn now calls \`driver.abort_current_turn()\` before joining the runner, so a Ctrl-Cable turn (e.g., bash \`sleep 30\`) terminates in ~1 s instead of waiting the full tool wall clock. Same \`abort_current_turn\` hook shipped in PR #300 — reused, not re-wired.

## PTY regression guard

\`tests/pty_repl_async_up_dequeue.rs\` drives a 5-step real user journey per the [integration-test-generator](file:///C/Users/songym/cursor-projects/document-ai/.claude/skills/integration-test-generator/SKILL.md) standard:

1. Start turn — \`bash_interrupt_long_running\` scenario triggers bash \`sleep 30\` (real "turn in flight" window).
2. Wait for tool to print \`interrupt-start\` (turn is really running at the runner thread).
3. Queue \`MARKER_QUEUED_INPUT\` during the turn.
4. Press \`↑\` — verify \`MARKER_QUEUED_INPUT\` re-appears in the terminal output (proves the empty-buffer guard, the shared queue, the dequeue hook, and \`Cmd::Insert\` re-render all work).
5. \`/exit\` — abort_current_turn signals the bash tool, /exit returns in ~1 s.

Wall clock ~16 s locally on Windows (mock backend, no API key). Sibling \`pty_repl_async_queue\` still green (baseline async loop still works for the no-↑ case).

## Local test results

- \`cargo test -p rusty-sudocode-cli --bins\` — 108 / 108 pass.
- \`cargo test -p rusty-sudocode-cli --test pty_repl_async_queue\` — 1 / 1 pass.
- \`cargo test -p rusty-sudocode-cli --test pty_repl_async_up_dequeue\` — 1 / 1 pass.

## Still deferred (documented in module docs §Deferred)

- Full \"N inputs during running turn → exactly 1 downstream request\" batched-flush PTY assertion — needs a mock scenario with per-request delay so PTY timing hits reliably.
- Startup completions refresh mid-loop (input thread reads the boot snapshot; if agents / slash commands change during a session, completions don't refresh).