### PR TITLE
chore(release): bump workspace version to 0.1.13

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "base64",
  "criterion",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "plugins",
  "runtime",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "commands",
  "runtime",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "api",
  "serde_json",
@@ -2059,7 +2059,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3211,7 +3211,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "api",
  "arboard",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "chrono",
  "dirs",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Cuts scode v0.1.13 so the cron tool gate (#305, 6ffb7ef3) reaches a released binary.

## Why now

sudowork pins scode `0.1.12` in `src/shared/runtime-versions.json`. The released v0.1.12 binary:

- **has** `CronCreate` / `CronDelete` / `CronList`
- **does not have** the `SUDOCODE_DISABLE_CRON_TOOLS` gate

So sudowork injects the gate env at ACP spawn and the shipped engine ignores it — an agent inside sudowork can still create a scode cron that persists in `crons.json` but is never ticked (sudowork runs its own CronService). The gate is merged but not live until a release carries it.

Verified against the actual v0.1.12 release asset (`scode-windows-x64.zip`), not just source.

## Contents

Workspace version 0.1.12 -> 0.1.13. No code changes; the release picks up everything already on main, notably #305.

## After merge

1. Tag `v0.1.13` on main -> `release.yml` builds the platform assets.
2. Bump sudowork's `runtime-versions.json` scode pin to 0.1.13.