### PR TITLE
style(pty): apply cargo fmt to pty_memory tests

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -782,7 +782,9 @@ fn memory_readonly_blocks_writes() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("auto memory") || stdout.contains("memory system") || stdout.contains("MEMORY.md"),
+        stdout.contains("auto memory")
+            || stdout.contains("memory system")
+            || stdout.contains("MEMORY.md"),
         "system prompt should include memory instructions even for read-only mode"
     );
 
@@ -880,8 +882,7 @@ fn memory_multi_type_single_session() {
     // Verify at least two different types appear across the files.
     let mut types_seen = std::collections::HashSet::new();
     for file_name in &non_index {
-        let content =
-            fs::read_to_string(memory_dir.join(file_name)).unwrap_or_default();
+        let content = fs::read_to_string(memory_dir.join(file_name)).unwrap_or_default();
         for t in ["user", "feedback", "reference", "project"] {
             if content.contains(&format!("type: {t}")) {
                 types_seen.insert(t);


### PR DESCRIPTION
## Why

`main` 上 CI `cargo fmt --all --check` job 挂了 (commit f7ee01c from PR #308)。两处 fmt 违规:

- `rust/crates/rusty-sudocode-cli/tests/pty_memory.rs:782` — 三段 `||` boolean 未按 rustfmt 换行
- `rust/crates/rusty-sudocode-cli/tests/pty_memory.rs:880` — `let content = ...` 应单行

Fix = 跑 `cargo fmt --all`,只动这一个文件,4+/3-。

## Verification

本地 `cargo fmt --all --check` 现在 CLEAN。

## Test plan

- [x] `cargo fmt --all --check` passes locally
- [ ] CI `cargo fmt` job green