### PR TITLE
fix(tools): locale-stable io errors; guard interrupt/up-dequeue PTY as mock-only

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_interrupt.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_interrupt.rs
@@ -52,6 +52,19 @@ const INTERRUPT_MARKER: &str = "INTERRUPT_TRIGGER_MARKER";
 fn submit_during_turn_in_interrupt_mode_aborts_running_turn() {
     let env = TestEnv::new("repl-async-interrupt");
 
+    // Mock-only: the in-flight signal this test waits for ("interrupt-start")
+    // is printed by the mock's canned bash command. A live model has no reason
+    // to emit it, and there's no deterministic way to hold a real turn in-flight
+    // for a fixed window — so run this only under the mock backend. (Same shape
+    // as pty_repl_async_batched_flush's mock-only guard.)
+    if !env.is_mock() {
+        eprintln!(
+            "SKIP: interrupt-during-turn assertion is mock-only \
+             (needs the mock's deterministic in-flight bash window)."
+        );
+        return;
+    }
+
     let mut sess = env.spawn_with_env(
         // danger-full-access so the mock's canned bash command actually runs
         // (the tool call is denied under read-only). Same flag the sibling

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
@@ -57,6 +57,18 @@ const MARKER: &str = "MARKER_QUEUED_INPUT";
 fn up_arrow_on_empty_buffer_dequeues_last_queued_input() {
     let env = TestEnv::new("repl-async-up-dequeue");
 
+    // Mock-only: this journey keys on "interrupt-start" (printed by the mock's
+    // canned bash command) to know the turn is in-flight before queuing. A live
+    // model won't emit it and can't be held in-flight deterministically, so run
+    // only under the mock backend. (Same guard as pty_repl_async_batched_flush.)
+    if !env.is_mock() {
+        eprintln!(
+            "SKIP: up-arrow-dequeue journey is mock-only \
+             (needs the mock's deterministic in-flight bash window)."
+        );
+        return;
+    }
+
     let mut sess = env.spawn_with_env(
         // danger-full-access so the mock's canned bash command actually runs —
         // pty_core_conversation's bash_interrupt_long_running case uses the

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -3071,7 +3071,19 @@ fn to_pretty_json<T: serde::Serialize>(value: T) -> Result<String, String> {
 
 #[allow(clippy::needless_pass_by_value)]
 fn io_to_string(error: std::io::Error) -> String {
-    error.to_string()
+    // `std::io::Error::to_string()` is the OS-localized message (e.g. on a
+    // zh_CN Windows a missing file reads "系统找不到指定的文件"), which is
+    // unstable across locales for both the model and tests. Prefix a stable,
+    // English kind label for the common cases so the error is recognizable
+    // regardless of OS locale; keep the OS detail after it for specifics.
+    use std::io::ErrorKind;
+    let label = match error.kind() {
+        ErrorKind::NotFound => "file not found",
+        ErrorKind::PermissionDenied => "permission denied",
+        ErrorKind::AlreadyExists => "already exists",
+        _ => return error.to_string(),
+    };
+    format!("{label}: {error}")
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Surfaced by running the PTY suite on a **zh_CN Windows** box + in **live** backend (`SCODE_TEST_BACKEND=live`) — neither of which CI's en_US Linux/Windows exercises.

## 1. `io_to_string` returned OS-localized text (SSOT fix)

`std::io::Error::to_string()` is the localized OS message. On zh_CN Windows a missing file reads `系统找不到指定的文件`, so any English-text matcher breaks by locale — the model's own reasoning, and `pty_error_paths::edit_file_not_found` (English-only regex) which **passes in CI (en_US) but fails on a Chinese box**.

Fix prefixes a stable English kind label (`file not found` / `permission denied` / `already exists`) and keeps the OS detail after. `io_to_string` is the single tool-error stringifier, so **every** tool (read_file/edit_file/…) now emits consistent, locale-independent errors — better for the model too.

## 2. `interrupt` / `up_dequeue` PTY are mock-only but weren't guarded

Both key on `interrupt-start` — printed by the **mock's** canned bash command — to know the turn is in-flight before queuing. A live model never emits it and can't be held in-flight for a fixed window, so both **FAILED (not skipped) under live**. They're mock-only by nature (like `batched_flush`, which *does* guard). Added the same `if !env.is_mock() { skip }`.

This means the roadmap's "live-verified" for these PTY was misleading: only `queue` passes live; the other three are mock-only. The **feature's** live verification is the sudowork ai-dev-browser smokes (`batched_flush_live_smoke.py` / `auto_interrupt_live_smoke.py`), which drive the real product against a real backend.

## Verified locally (real runs, both backends)

| | mock | live |
|---|---|---|
| edit_file_not_found | ok (was FAIL on zh_CN) | — |
| write_file_denied_in_read_only | ok (no regression) | — |
| queue | ok | ok |
| batched_flush | ok | SKIP |
| interrupt | ok | SKIP (was FAIL) |
| up_dequeue | ok | SKIP (was FAIL) |