### PR TITLE
test(pty): make interrupt + up-dequeue live-capable, not mock-only-skipped

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_interrupt.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_interrupt.rs
@@ -52,19 +52,6 @@ const INTERRUPT_MARKER: &str = "INTERRUPT_TRIGGER_MARKER";
 fn submit_during_turn_in_interrupt_mode_aborts_running_turn() {
     let env = TestEnv::new("repl-async-interrupt");
 
-    // Mock-only: the in-flight signal this test waits for ("interrupt-start")
-    // is printed by the mock's canned bash command. A live model has no reason
-    // to emit it, and there's no deterministic way to hold a real turn in-flight
-    // for a fixed window — so run this only under the mock backend. (Same shape
-    // as pty_repl_async_batched_flush's mock-only guard.)
-    if !env.is_mock() {
-        eprintln!(
-            "SKIP: interrupt-during-turn assertion is mock-only \
-             (needs the mock's deterministic in-flight bash window)."
-        );
-        return;
-    }
-
     let mut sess = env.spawn_with_env(
         // danger-full-access so the mock's canned bash command actually runs
         // (the tool call is denied under read-only). Same flag the sibling
@@ -78,19 +65,27 @@ fn submit_during_turn_in_interrupt_mode_aborts_running_turn() {
     sess.expect("❯")
         .expect("async REPL should render the initial prompt");
 
-    // Step 2: fire the long-running bash prompt.
+    // Step 2: fire the long-running bash prompt. The natural-language text is
+    // EXPLICIT about the exact command so this works in BOTH backends: under
+    // mock the `bash_interrupt_long_running` scenario returns the canned
+    // `printf 'interrupt-start'; sleep 30` tool_use (prompt text ignored);
+    // under live the real model runs the command we spell out here, so it
+    // emits the same "interrupt-start" marker. (The env drops the scenario
+    // token in live — see TestEnv::prompt.) Same "Run this exact bash command"
+    // shape pty_bash_execution uses to drive live models deterministically.
     let prompt = env.prompt(
-        "Use the bash tool to run a background sleep and let me know when \
-         you started it.",
+        "Run exactly this bash command, nothing else: \
+         printf 'interrupt-start'; sleep 30",
         "bash_interrupt_long_running",
     );
     sess.send(&format!("{prompt}\r"))
         .expect("send long-running prompt");
 
-    // Step 3: wait for the tool to actually start. The mock's canned command
-    // does `printf 'interrupt-start'` before the sleep, and PTY captures the
-    // bash stdout. Seeing this string proves the runner thread reached the
-    // tool execution + subprocess is actually sleeping.
+    // Step 3: wait for the tool to actually start. The command prints
+    // `interrupt-start` before the sleep, and PTY captures the bash stdout.
+    // Seeing this string proves the runner thread reached tool execution +
+    // the subprocess is actually sleeping — the real in-flight window we
+    // interrupt into. Works identically mock and live.
     sess.expect("interrupt-start")
         .expect("bash tool should print interrupt-start before the sleep");
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
@@ -57,18 +57,6 @@ const MARKER: &str = "MARKER_QUEUED_INPUT";
 fn up_arrow_on_empty_buffer_dequeues_last_queued_input() {
     let env = TestEnv::new("repl-async-up-dequeue");
 
-    // Mock-only: this journey keys on "interrupt-start" (printed by the mock's
-    // canned bash command) to know the turn is in-flight before queuing. A live
-    // model won't emit it and can't be held in-flight deterministically, so run
-    // only under the mock backend. (Same guard as pty_repl_async_batched_flush.)
-    if !env.is_mock() {
-        eprintln!(
-            "SKIP: up-arrow-dequeue journey is mock-only \
-             (needs the mock's deterministic in-flight bash window)."
-        );
-        return;
-    }
-
     let mut sess = env.spawn_with_env(
         // danger-full-access so the mock's canned bash command actually runs —
         // pty_core_conversation's bash_interrupt_long_running case uses the
@@ -82,20 +70,24 @@ fn up_arrow_on_empty_buffer_dequeues_last_queued_input() {
     sess.expect("❯")
         .expect("async REPL should render the initial prompt");
 
-    // Step 2: fire the long-running scenario so we have a real "turn active"
-    // window during which submit_during_turn goes down the Queued arm.
+    // Step 2: fire the long-running command so we have a real "turn active"
+    // window during which submit_during_turn goes down the Queued arm. The
+    // prompt spells out the exact command so it works in BOTH backends: mock
+    // returns the canned tool_use (prompt ignored), live runs what we spell
+    // out — both emit "interrupt-start" then sleep. (Env drops the scenario
+    // token in live; same explicit shape pty_bash_execution uses.)
     let prompt = env.prompt(
-        "Use the bash tool to run a background sleep and let me know when \
-         you started it.",
+        "Run exactly this bash command, nothing else: \
+         printf 'interrupt-start'; sleep 30",
         "bash_interrupt_long_running",
     );
     sess.send(&format!("{prompt}\r"))
         .expect("send long-running prompt");
 
-    // Wait for the tool to actually start — the mock's canned bash command
-    // does `printf 'interrupt-start'` before the sleep, and PTY captures
-    // the bash stdout stream. Seeing "interrupt-start" is the strongest
-    // signal that the turn is really in-flight at the runner thread.
+    // Wait for the tool to actually start — the command prints `interrupt-start`
+    // before the sleep, and PTY captures the bash stdout. Seeing it is the
+    // strongest signal the turn is really in-flight at the runner thread.
+    // Works identically mock and live.
     sess.expect("interrupt-start")
         .expect("bash tool should print interrupt-start before the sleep");
 


### PR DESCRIPTION
## Corrects the cop-out in #311

#311 made `pty_repl_async_interrupt` and `pty_repl_async_up_dequeue` **skip** under `SCODE_TEST_BACKEND=live`, because their in-flight signal (`interrupt-start`) was printed only by the mock's canned bash command. But skipping **removes** live coverage — the opposite of the harness's mock/live-parity design (`TestEnv::prompt` drops the scenario token and sends the natural prompt under live, precisely so tests run both ways).

## The real fix

Spell out the exact command in the natural-language prompt, so **both** backends produce the marker:
- **mock**: `bash_interrupt_long_running` still returns the canned tool_use (prompt ignored).
- **live**: the real model runs `printf 'interrupt-start'; sleep 30` verbatim → same marker.

Same explicit "Run this exact bash command" shape `pty_bash_execution` already uses to drive live models deterministically. Guards removed.

## Verified locally, both backends

| | mock | live (real deepseek-v4-flash) |
|---|---|---|
| interrupt | ok 2.3s | **ok 2.3s** |
| up_dequeue | ok 16.4s | **ok 16.4s** |

Now `queue` / `interrupt` / `up_dequeue` all have genuine live coverage. `batched_flush` stays mock-only for a real reason (`captured_message_count` is a mock-server request counter with no live equivalent) — the one 'live is meaningless' case. #311's `io_to_string` locale fix is untouched.