### PR TITLE
docs(readme): translate remaining Chinese mermaid label to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ flowchart LR
       F1 --> F2 --> F3 --> F4 --> F5
     end
 
-    Today ==>|"hydra 底层改, becomes thin"| Future
+    Today ==>|"hydra internals rewritten, becomes thin"| Future
 ```
 
 Sudo Code is the agent unit underneath that whole future picture.


### PR DESCRIPTION
The sudocode README is an English-only doc for a public repo. One Chinese fragment remained inside a mermaid edge label (line 224):

- Before: `hydra 底层改, becomes thin`
- After: `hydra internals rewritten, becomes thin`

No other CJK remains in the file (verified). Docs-only, no code impact.