### PR TITLE
fix(test): PTY audit follow-ups — Windows passthrough harness, model_compat vacuity, lint

### DIFF
--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -881,7 +881,7 @@ fn format_hook_start_error(
 
 fn shell_command(command: &str) -> CommandWithStdin {
     #[cfg(windows)]
-    let mut command_builder = {
+    let command_builder = {
         let mut command_builder = Command::new("cmd");
         command_builder.arg("/C").arg(command);
         CommandWithStdin::new(command_builder)

--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -417,32 +417,32 @@ pub fn spawn_scode_in_dir(
     let bin_str = bin.to_string_lossy().to_string();
     let dir_str = dir.display().to_string();
 
-    #[cfg(unix)]
-    {
-        let mut cmd = format!(
-            "cd {} && exec {}",
-            shell_quote(&dir_str),
-            shell_quote(&bin_str)
-        );
-        for arg in args {
-            cmd.push_str(&format!(" {}", shell_quote(arg)));
-        }
-        let sh = resolve_sh();
-        let mut sess = PtySession::spawn(&sh, &["-c", &cmd])?;
-        sess.set_default_timeout(timeout);
-        Ok(sess)
+    // Run `sh -c "cd <dir> && exec /usr/bin/env <scode> <args>"` on ALL
+    // platforms. On Windows this uses Git Bash's `sh.exe` (via `resolve_sh`) —
+    // the same mechanism `spawn_with_workspace` already relies on.
+    //
+    // The previous `#[cfg(windows)]` branch spawned `cmd /c "cd /d \"dir\" &&
+    // \"scode\" ..."`, which portable_pty passes to `CreateProcessW` with
+    // MSVC-style quoting — embedded quotes become `\"`. `cmd.exe` does NOT
+    // understand backslash-escaped quotes, so it saw `cd /d \"dir\"` as an
+    // invalid path, printed "the filename, directory name, or volume label
+    // syntax is incorrect", and exited 1 WITHOUT ever launching scode. Tests
+    // then saw a non-zero exit (and a false "4" match on the `ESC[?1004h`
+    // terminal escape). Routing through `sh -c` + `/usr/bin/env` quotes
+    // reliably and resolves the scode path identically on Linux, macOS, and
+    // Git Bash (see the note in `spawn_with_workspace`).
+    let mut cmd = format!(
+        "cd {} && exec /usr/bin/env {}",
+        shell_quote(&dir_str),
+        shell_quote(&bin_str)
+    );
+    for arg in args {
+        cmd.push_str(&format!(" {}", shell_quote(arg)));
     }
-
-    #[cfg(windows)]
-    {
-        let mut cmd = format!("cd /d \"{}\" && \"{}\"", dir_str, bin_str);
-        for arg in args {
-            cmd.push_str(&format!(" \"{}\"", arg));
-        }
-        let mut sess = PtySession::spawn("cmd", &["/c", &cmd])?;
-        sess.set_default_timeout(timeout);
-        Ok(sess)
-    }
+    let sh = resolve_sh();
+    let mut sess = PtySession::spawn(&sh, &["-c", &cmd])?;
+    sess.set_default_timeout(timeout);
+    Ok(sess)
 }
 
 fn shell_quote(s: &str) -> String {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_model_compat.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_model_compat.rs
@@ -2,8 +2,11 @@
 //! served by sudorouter can be used via proxy passthrough.
 //!
 //! The model list is read from the `SCODE_COMPAT_MODELS` environment
-//! variable (comma-separated model IDs). When the variable is unset
-//! or empty, no models are tested and the test passes vacuously.
+//! variable (comma-separated model IDs). When the variable is unset or
+//! empty, a small built-in default set (`DEFAULT_COMPAT_MODELS`) is used
+//! so a bare live run still exercises real passthrough instead of passing
+//! vacuously. CI's `model-compat.yml` overrides the default with the full
+//! model list fetched from sudorouter's `/v1/models` endpoint.
 //!
 //! These are **live-only** tests — passthrough requires a real proxy.
 //! In mock mode the test exits immediately (no mock scenario needed).
@@ -150,15 +153,32 @@ fn test_one_model(model: &str) -> ModelResult {
     }
 }
 
-/// Parse the `SCODE_COMPAT_MODELS` env var into a list of model IDs.
+/// Model IDs exercised when `SCODE_COMPAT_MODELS` is unset or empty, so a
+/// bare `SCODE_TEST_BACKEND=live cargo test --test pty_model_compat` run
+/// verifies real passthrough instead of passing vacuously. Both are
+/// unconfigured-in-`sudocode.json` IDs that sudorouter serves (spanning two
+/// model families), so `--auth proxy` genuinely goes down the passthrough
+/// path. CI's `model-compat.yml` overrides this with the full endpoint list.
+const DEFAULT_COMPAT_MODELS: &[&str] = &["o3-mini", "doubao-seed-1-6-251015"];
+
+/// Parse the `SCODE_COMPAT_MODELS` env var into a list of model IDs,
+/// falling back to [`DEFAULT_COMPAT_MODELS`] when it is unset or empty.
 fn compat_models() -> Vec<String> {
-    std::env::var("SCODE_COMPAT_MODELS")
+    let from_env: Vec<String> = std::env::var("SCODE_COMPAT_MODELS")
         .unwrap_or_default()
         .split(',')
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(ToString::to_string)
-        .collect()
+        .collect();
+    if from_env.is_empty() {
+        DEFAULT_COMPAT_MODELS
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    } else {
+        from_env
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -181,11 +201,9 @@ fn model_compat_sweep() {
         return;
     }
 
+    // Never empty: falls back to DEFAULT_COMPAT_MODELS when the env is unset,
+    // so a live run always exercises at least the built-in default set.
     let models = compat_models();
-    if models.is_empty() {
-        eprintln!("model_compat_sweep: SCODE_COMPAT_MODELS is empty, skipping");
-        return;
-    }
 
     eprintln!(
         "model_compat_sweep: testing {} model(s): {}",

--- a/rust/crates/rusty-sudocode-cli/tests/pty_proxy_passthrough.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_proxy_passthrough.rs
@@ -13,7 +13,7 @@ mod common;
 
 use std::time::Duration;
 
-use common::{spawn_scode_in_dir, HarnessWorkspace, TestEnv, DEFAULT_TIMEOUT};
+use common::{spawn_scode_in_dir, HarnessWorkspace, TestEnv};
 
 /// Returns true if a proxy provider is configured (live mode with
 /// sudorouter). Passthrough tests only make sense in this mode.


### PR DESCRIPTION
Fixes the findings from the *PTY roadmap drift audit (2026-07-17)* handoff plus a doc-drift item found while x-verifying the interrupt-queue design doc.

## P0 — `pty_proxy_passthrough` 2/3 live failures (real, root-caused live)
`unconfigured_model_works_via_proxy` (doubao-seed-1-6-251015) and `another_unconfigured_model_via_proxy` (o3-mini) failed with exit=1 on Windows. **Not a scode regression** — the proxy serves both models and scode answers correctly outside the harness.

Root cause (captured from the raw PTY buffer under a live run): `spawn_scode_in_dir`'s Windows branch spawned `cmd /c "cd /d \"dir\" && \"scode\" ..."`. portable_pty MSVC-escapes the embedded quotes as `\"`, which cmd.exe treats literally, so `cd /d \"dir\"` was rejected as an invalid path (`the filename, directory name, or volume label syntax is incorrect`) and scode never launched. The `expect("4")` then false-matched the `4` inside the `ESC[?1004h` terminal escape. `configured_model_still_works` passed only because it uses the `sh -c` harness.

Fix: route `spawn_scode_in_dir` through `sh -c "cd <dir> && exec /usr/bin/env <scode> ..."` on all platforms — the same mechanism `spawn_with_workspace` already relies on (and the intent already documented at `pty_session_management.rs`'s `// spawn_scode_in_dir uses sh -c`). **Verified live: all 3 pass (17s, real doubao/o3-mini calls); mock still green.**

## P1 — `model_compat_sweep` vacuous pass
Returned a green PASS while exercising nothing when `SCODE_COMPAT_MODELS` was unset. Added `DEFAULT_COMPAT_MODELS` (`o3-mini`, `doubao-seed-1-6-251015` — both live-verified served) as a fallback so a bare live run tests real passthrough; `model-compat.yml` still overrides with the full endpoint list. **Verified live: "2 pass, 0 skip, 0 fail".**

The other P1 item (`pty_presets_e2e` doc/code drift, "only 2 of 6 gated") is **already resolved** in current code — all 6 preset tests route through `run_preset()` → `require_live()`. No change needed.

## P2 — lint
- `hooks.rs`: dropped an unused `mut` on the Windows arm's outer `command_builder` (only the inner one is mutated).
- `pty_proxy_passthrough.rs`: removed the unused `DEFAULT_TIMEOUT` import.

## Systemic follow-up (not in this PR)
The report's suggestion of a CI check that flags new `pty_*.rs` files missing a roadmap row is a roadmap-tooling concern; deferring to the roadmap owner to avoid overlapping the in-flight roadmap work (#315).