### PR TITLE
cli: default empty tool-call input to "{}"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "base64",
  "criterion",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "plugins",
  "runtime",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "commands",
  "runtime",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "api",
  "serde_json",
@@ -2059,7 +2059,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3211,7 +3211,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "api",
  "arboard",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "chrono",
  "dirs",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -333,6 +333,11 @@ impl CliStreamState {
                         .map_err(|error| RuntimeError::new(error.to_string()))?;
                 }
                 if let Some((id, name, input, thought_signature)) = self.pending_tool.take() {
+                    let input = if input.is_empty() {
+                        "{}".to_string()
+                    } else {
+                        input
+                    };
                     if let Some(progress_reporter) = &self.progress_reporter {
                         progress_reporter.mark_tool_phase(&name, &input);
                     }

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -331,9 +331,7 @@ impl LineEditor {
         // Matches Claude Code's arrow-key UX.
         editor.bind_sequence(
             KeyEvent(KeyCode::Up, Modifiers::NONE),
-            EventHandler::Conditional(Box::new(UpArrowHandler {
-                dequeue_hook,
-            })),
+            EventHandler::Conditional(Box::new(UpArrowHandler { dequeue_hook })),
         );
         editor.bind_sequence(
             KeyEvent(KeyCode::Down, Modifiers::NONE),

--- a/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
@@ -19,10 +19,7 @@ fn up_arrow_moves_cursor_to_beginning_before_history() {
     let root = env.workspace_root().to_path_buf();
     fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
 
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only"],
-        &[("EDITOR", "true")],
-    );
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[("EDITOR", "true")]);
     sess.set_default_timeout(Duration::from_secs(10));
 
     sess.expect("❯").unwrap_or_else(|e| {
@@ -72,10 +69,7 @@ fn up_arrow_navigates_history_on_empty_buffer() {
     fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
 
     let prompt = env.prompt("say OK", "single_turn_text");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only"],
-        &[("EDITOR", "true")],
-    );
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[("EDITOR", "true")]);
     sess.set_default_timeout(Duration::from_secs(15));
 
     sess.expect("❯").unwrap_or_else(|e| {
@@ -122,10 +116,7 @@ fn down_arrow_moves_cursor_to_end() {
     let root = env.workspace_root().to_path_buf();
     fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
 
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only"],
-        &[("EDITOR", "true")],
-    );
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[("EDITOR", "true")]);
     sess.set_default_timeout(Duration::from_secs(10));
 
     sess.expect("❯").unwrap_or_else(|e| {


### PR DESCRIPTION
## Summary

Default empty tool-call input to `{}` so the downstream consumers of `pending_tool` receive a valid empty JSON object instead of an empty string.

- **fix(cli): default empty tool-call input to "{}"** — A tool call with no parameters leaves the accumulated `input` (built from `InputJsonDelta`) empty. At `ContentBlockStop`, fill it with `{}` so `mark_tool_phase`, `format_tool_call_start`, and `AssistantEvent::ToolUse` each receive a valid empty JSON object rather than an empty string.
- **chore: bump workspace version to 0.1.15** — Bump workspace `version` 0.1.14 -> 0.1.15; `Cargo.lock` synced across all 10 local crates.

## Testing

- `cargo check --workspace` passes locally (all 10 crates resolve at v0.1.15).
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` are enforced by CI on this PR.