### PR TITLE
docs(design): unified agent-context/image/profile storage matrix

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Agent Context / Image / Profile — Unified Storage Matrix</title>
+<style>
+  :root{
+    --bg:#0f172a; --panel:#1e293b; --panel2:#172033; --line:#334155;
+    --fg:#e2e8f0; --muted:#94a3b8; --accent:#60a5fa; --accent2:#38bdf8;
+    --ok:#34d399; --partial:#fbbf24; --miss:#f87171; --q:#c084fc; --dup:#fb923c;
+    --code:#0b1220;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);
+    font:14px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif}
+  .wrap{max-width:1500px;margin:0 auto;padding:28px 22px 80px}
+  h1{font-size:24px;margin:0 0 4px}
+  h2{font-size:18px;margin:34px 0 10px;color:var(--accent);border-bottom:1px solid var(--line);padding-bottom:6px}
+  .sub{color:var(--muted);margin:0 0 18px}
+  code,.mono{font-family:"SF Mono",ui-monospace,Menlo,Consolas,monospace;font-size:12.5px}
+  code{background:var(--code);padding:1px 5px;border-radius:4px;color:#cbd5e1}
+  .lead{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);
+    border-radius:8px;padding:14px 16px;margin:0 0 18px}
+  .lead b{color:var(--accent2)}
+  .legend{display:flex;flex-wrap:wrap;gap:14px;margin:8px 0 18px;color:var(--muted);font-size:12.5px}
+  .b{display:inline-block;padding:1px 7px;border-radius:20px;font-size:11.5px;font-weight:600;white-space:nowrap}
+  .b.ok{background:rgba(52,211,153,.15);color:var(--ok)}
+  .b.partial{background:rgba(251,191,36,.15);color:var(--partial)}
+  .b.miss{background:rgba(248,113,113,.15);color:var(--miss)}
+  .b.q{background:rgba(192,132,252,.16);color:var(--q)}
+  .b.dup{background:rgba(251,146,60,.15);color:var(--dup)}
+  .b.na{background:rgba(148,163,184,.12);color:var(--muted)}
+  table{border-collapse:collapse;width:100%;margin:6px 0 6px;font-size:13px}
+  th,td{border:1px solid var(--line);padding:8px 10px;vertical-align:top;text-align:left}
+  th{background:var(--panel2);color:#cbd5e1;position:sticky;top:0;z-index:2;font-weight:600}
+  tbody tr:nth-child(odd){background:rgba(30,41,59,.35)}
+  td.mega{font-weight:700;color:var(--accent2);white-space:nowrap;background:rgba(23,32,51,.6)}
+  td.item{font-weight:600;color:#f1f5f9;white-space:nowrap}
+  .path{color:#a5b4fc}
+  /* hover tooltip for uncertain / notes */
+  .tip{position:relative;border-bottom:1px dotted var(--q);cursor:help;color:var(--q)}
+  .tip .tipbox{visibility:hidden;opacity:0;transition:.12s;position:absolute;left:0;top:1.6em;z-index:9;
+    width:340px;background:#0b1220;border:1px solid var(--q);border-radius:8px;padding:10px 12px;
+    color:#e2e8f0;font-weight:400;box-shadow:0 8px 30px rgba(0,0,0,.5);font-size:12.5px;line-height:1.5}
+  .tip:hover .tipbox{visibility:visible;opacity:1}
+  .qbox{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--q);
+    border-radius:8px;padding:8px 14px;margin:10px 0}
+  .qbox .qn{color:var(--q);font-weight:700;margin-right:6px}
+  small{color:var(--muted)}
+  .note{color:var(--muted);font-size:12px;margin-top:2px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Agent Context / Image / Profile — Unified Storage Matrix</h1>
+<p class="sub">A 1:1 mapping of Claude Code's on-disk context model onto the Nexus <code>/agents/{name}/</code>+<code>/proc/{pid}/</code> design, tracked through to sudocode &amp; sudowork. Draft for consensus — not yet merged into the doc.</p>
+
+<div class="lead">
+<b>The one principle.</b> Nexus splits an agent the way an OS splits an <i>executable on disk</i> from a <i>running process</i>:
+<b>image / static / class layer = <code>/agents/{name}/</code></b> (config · prompts · skills · memory · sessions — persistent, Metastore, the addressable identity; one name → many pids) vs
+<b>runtime / dynamic / object layer = <code>/proc/{pid}/</code></b> (status · agent-link · chat-with-me · workspace/ — ephemeral, stamped at <code>start_session</code>, reaped on exit; <code>pid</code> = AgentRegistry SSOT = the session id).
+<br><br>
+<b>Claude Code is a flat special case of this:</b> its <code>~/.claude/projects/&lt;sanitized-cwd&gt;/</code> collapses image+runtime into one cwd-keyed folder — one implicit agent per project. Everything CC persists therefore has a home in our two-layer model. This table is that map, and the SSOT for the <span class="b dup">dup</span> that sudowork &amp; sudocode carry today and must merge long-term.
+</div>
+
+<div class="legend">
+  <span><span class="b ok">done</span> implemented</span>
+  <span><span class="b partial">partial</span> partially / differently</span>
+  <span><span class="b miss">missing</span> not built</span>
+  <span><span class="b q">open?</span> design question (hover for detail)</span>
+  <span><span class="b dup">dup</span> duplicated, long-term merge</span>
+  <span><span class="b na">n/a</span> not applicable</span>
+</div>
+
+<h2>The matrix</h2>
+<table>
+<thead><tr>
+  <th style="width:9%">mega-type</th>
+  <th style="width:15%">CC item (source of truth)</th>
+  <th style="width:24%">Nexus end-state (concrete path)</th>
+  <th style="width:26%">sudocode (current → target)</th>
+  <th style="width:26%">sudowork (current, dedup-track)</th>
+</tr></thead>
+<tbody>
+
+<!-- IDENTITY & LAYERING -->
+<tr>
+  <td class="mega" rowspan="2">Identity<br>&amp; layering</td>
+  <td class="item">Primary key</td>
+  <td>Sanitized <b>cwd</b> → <span class="path">~/.claude/projects/&lt;C--Users-…&gt;/</span> (Win) / <span class="path">-Users-…</span> (POSIX). One implicit agent per project.</td>
+  <td><b>agent-name</b> (image) + <b>pid</b> (runtime). <span class="path">/agents/{name}/</span> · <span class="path">/proc/{pid}/</span>. One name → many pids across repos. <span class="b ok">done (design)</span></td>
+  <td>cwd fingerprint. <span class="path">&lt;cwd&gt;/.scode/sessions/&lt;fp&gt;/</span> (flat, local FS). Nexus-managed layer scaffolded but dormant (CLI uses StdFsBackend). <span class="b partial">partial</span></td>
+  <td>conversation-id (SQLite row); <code>extra.workspace</code> + <code>extra.acpSessionId</code> point at the engine. <span class="b partial">partial</span></td>
+</tr>
+<tr>
+  <td class="item">Image vs runtime split</td>
+  <td>None — flat. (bridge-pointer is the only "runtime pointer".)</td>
+  <td><b>image</b>=<span class="path">/agents/{name}/</span> (config/prompts/skills/memory/sessions); <b>runtime</b>=<span class="path">/proc/{pid}/</span> (status/agent→link/chat-with-me/workspace). <span class="b ok">done (design)</span></td>
+  <td>No explicit split yet — sessions on disk, config in <span class="path">~/.scode/</span> + AGENTS.md. Target: fold into <span class="path">/agents/{name}/</span>. <span class="b miss">gap</span></td>
+  <td>All in SQLite <code>conversations.extra</code> (mixes static+runtime). <span class="b dup">dup</span></td>
+</tr>
+
+<!-- SESSION -->
+<tr>
+  <td class="mega" rowspan="2">Session /<br>transcript</td>
+  <td class="item">Transcript file</td>
+  <td><span class="path">~/.claude/projects/&lt;key&gt;/&lt;uuid&gt;.jsonl</span> (JSONL, up to multi-GB; parentUuid DAG)</td>
+  <td><span class="path">/agents/{name}/sessions/&lt;workspace_hash&gt;/&lt;session-id&gt;.jsonl</span> (same FNV-1a hash) <span class="b ok">done (design)</span></td>
+  <td><span class="path">&lt;cwd&gt;/.scode/sessions/&lt;FNV-16hex&gt;/&lt;id&gt;.jsonl</span> (session_meta/compaction/prompt_history/message; 256KB rotate×3) — <b>the local precursor</b>. <span class="b ok">done</span></td>
+  <td><code>messages</code> table = full UI copy of the same conversation, joined by <code>acpSessionId</code>. <span class="b dup">dup — primary</span></td>
+</tr>
+<tr>
+  <td class="item">Cross-agent session search
+    <span class="tip">?<span class="tipbox">CC stores every agent's sessions under one <code>projects/&lt;cwd&gt;/</code> path — flat, so the user can search across sessions. In our per-agent model, can we DT_LINK each <code>/agents/{name}/sessions/…</code> into a shared <code>/agents/sessions/</code> (or <code>/sessions/</code>) index for cross-agent search, keeping per-agent SSOT? (needs cross-node DT_LINK — see Workspace row.)</span></span>
+  </td>
+  <td>Implicit — all sessions flat under project dir; easy cross-session listing.</td>
+  <td><span class="b q">open?</span> DT_LINK per-agent <span class="path">/agents/{name}/sessions/</span> → shared <span class="path">/agents/sessions/</span> for cross-agent search?</td>
+  <td>SessionStore per workspace-fp; <code>latest</code>/<code>list</code>. <span class="b partial">partial</span></td>
+  <td>sudowork lists conversations from SQLite (its own index). <span class="b dup">dup</span></td>
+</tr>
+
+<!-- SUBAGENT / FORK -->
+<tr>
+  <td class="mega" rowspan="2">Subagent /<br>fork</td>
+  <td class="item">Subagent transcript + meta</td>
+  <td><span class="path">&lt;uuid&gt;/subagents/agent-&lt;id&gt;.jsonl</span> + <span class="path">.meta.json</span> (sidechain; <code>agentType</code>/<code>worktreePath</code>)</td>
+  <td>Each subagent = its own <b>pid</b> sharing the agent profile (<span class="path">/proc/{pid'}/</span>, session under <span class="path">/agents/{name}/sessions/</span>). <span class="b ok">done (design)</span></td>
+  <td><span class="path">&lt;cwd&gt;/.sudocode-agents/&lt;id&gt;.md</span> + <span class="path">&lt;id&gt;.json</span> — <b>NOT</b> CC's jsonl+.meta.json; no per-subagent jsonl transcript. <span class="b partial">partial — storage differs</span></td>
+  <td>—<span class="b na"> n/a</span> (relies on engine)</td>
+</tr>
+<tr>
+  <td class="item">Fork inheritance + spawn path
+    <span class="tip">?<span class="tipbox">Two design directions: (1) CC's fork inherits the FULL parent transcript; scode's fork inherits only the last-assistant cache-prefix — do we want full-transcript parity? (2) scode spawns subagents INTERNALLY today; the end-state likely makes them real nexus-managed pids, i.e. <b>sudocode calls <code>ManagedAgentService::start_session</code></b> to spawn a child (this is the legit "sudocode → nexus service" call the layering allows).</span></span>
+  </td>
+  <td>Fork inherits full parent transcript + rendered system-prompt bytes (<code>agentType:'fork'</code>).</td>
+  <td>Subagent = real pid via <b>sudocode → MAS::start_session</b> (spawn child). <span class="b q">open? (direction)</span></td>
+  <td>scode fork inherits <b>last-assistant cache-prefix only</b> (not full); internal spawn, not MAS. <span class="b partial">partial</span></td>
+  <td>—<span class="b na"> n/a</span></td>
+</tr>
+
+<!-- TOOL OUTPUT -->
+<tr>
+  <td class="mega">Oversized<br>tool output</td>
+  <td class="item">Offload + replacement
+    <span class="tip">?<span class="tipbox">CC spills any tool result over ~50k chars to <code>tool-results/&lt;toolUseId&gt;.txt|.json</code> and injects a <code>&lt;persisted-output&gt;</code> replacement + a <code>content-replacement</code> transcript record so resume rebuilds a byte-identical prompt-cache prefix. scode has the schema fields (<code>persistedOutputPath/Size</code>) but always None — 16KB truncate + compact only. Do we adopt CC's disk-offload? Where on VFS — <code>/agents/{name}/sessions/&lt;hash&gt;/tool-results/</code>?</span></span>
+  </td>
+  <td><span class="path">&lt;uuid&gt;/tool-results/&lt;toolUseId&gt;.txt|.json</span> + <code>content-replacement</code> record (byte-identical resume)</td>
+  <td><span class="b q">open?</span> proposed <span class="path">/agents/{name}/sessions/&lt;hash&gt;/tool-results/</span></td>
+  <td><b>Missing</b> — fields exist, always <code>None</code>; 16KB truncate + compaction only. <span class="b miss">gap</span></td>
+  <td>—<span class="b na"> n/a</span> (relies on engine)</td>
+</tr>
+
+<!-- MEMORY (one row each) -->
+<tr>
+  <td class="mega" rowspan="8">Memory</td>
+  <td class="item">Auto-memory (4 types)</td>
+  <td><span class="path">projects/&lt;git-root&gt;/memory/</span> — user/feedback/project/reference + MEMORY.md index (keyed by <b>git root</b>)</td>
+  <td><span class="path">/agents/{name}/memory/</span> (agent-keyed)</td>
+  <td><span class="path">~/.scode/projects/&lt;slug&gt;/memory/</span> + MEMORY.md, 4 types, prompt-driven Write (PR #229/236). <span class="b ok">done</span></td>
+  <td><b>None.</b> <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">Agent memory (per agent-type)</td>
+  <td><span class="path">agent-memory/&lt;type&gt;/</span> (user) · <span class="path">.claude/agent-memory[-local]/&lt;type&gt;/</span> (project/local) + git-distributable snapshots</td>
+  <td><span class="path">/agents/{name}/memory/</span> is already per-agent; scopes via workspace-mount. <span class="b ok">done (design)</span></td>
+  <td><span class="path">&lt;base&gt;/agent-memory/&lt;agent_type&gt;/</span> wired into per-agent system prompt. <span class="b ok">done</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">extractMemories (turn-end auto-writer)</td>
+  <td>Forked subagent at <code>handleStopHooks</code> writes durable memories; cursor + mutual-exclusion with main agent.</td>
+  <td><span class="path">/proc/{pid}/</span> fork writing to <span class="path">/agents/{name}/memory/</span>. <span class="b q">open?</span></td>
+  <td><b>Missing</b> — memory is prompt-driven only, no auto-fork writer. <span class="b miss">gap</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">Session memory (running summary)</td>
+  <td><code>getSessionMemoryDir()</code> markdown notes for <i>this</i> convo → feeds compaction; <code>/summary</code>.</td>
+  <td><span class="path">/proc/{pid}/</span> or session sidecar under <span class="path">/agents/{name}/sessions/&lt;hash&gt;/</span>. <span class="b q">open?</span></td>
+  <td><b>Missing</b> (roadmap "gap — needs forked-agent infra"). <span class="b miss">gap</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">Team memory (org-shared)</td>
+  <td><span class="path">&lt;mem&gt;/team/</span> + server <code>/api/…/team_memory</code>; keyed by GitHub repo slug; server-authoritative, ETag, secret-scan.</td>
+  <td><span class="path">/agents/{name}/memory/team/</span> replicated via <b>zone raft / federation</b> (native — no API needed). <span class="b q">open?</span></td>
+  <td><b>Missing</b> (roadmap "gap — enterprise"). <span class="b miss">gap</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">Auto-dream (consolidation)</td>
+  <td>Nightly forked <code>/dream</code> rewrites memory topic files + MEMORY.md; gates ≥24h &amp; ≥5 sessions; <code>.consolidate-lock</code>.</td>
+  <td>Background <span class="path">/proc/{pid}/</span> job over <span class="path">/agents/{name}/sessions/</span> → <span class="path">memory/</span>. <span class="b q">open?</span></td>
+  <td><b>Missing.</b> <span class="b miss">gap</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">Daily logs (KAIROS)</td>
+  <td><span class="path">&lt;mem&gt;/logs/YYYY/MM/YYYY-MM-DD.md</span> append-only; nightly <code>/dream</code> distills.</td>
+  <td><span class="path">/agents/{name}/memory/logs/YYYY/MM/…</span> (append-only DT_FILE or DT_STREAM). <span class="b q">open?</span></td>
+  <td><b>Missing.</b> <span class="b miss">gap</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+<tr>
+  <td class="item">Manual layer (/remember, CLAUDE.md)</td>
+  <td><code>CLAUDE.md</code>/<code>CLAUDE.local.md</code> static; <code>/remember</code> reviews+promotes across layers.</td>
+  <td>Repo-mounted files under <span class="path">/proc/{pid}/workspace/{repo}/</span>. <span class="b ok">design</span></td>
+  <td><code>AGENTS.md</code> scan (repo cwd). <code>/remember</code>? <span class="b partial">partial</span></td>
+  <td>None. <span class="b miss">gap</span></td>
+</tr>
+
+<!-- RESUME / POINTER -->
+<tr>
+  <td class="mega">Resume /<br>live pointer</td>
+  <td class="item">Persistent-assistant pointer
+    <span class="tip">?<span class="tipbox">CC's Kairos <code>bridge-pointer.json {sessionId,environmentId,source}</code> answers "which session is the live persistent assistant" for crash-recovery, with an mtime-TTL heartbeat (4h) and a cross-worktree "pick the freshest" scan. Nexus's AgentRegistry (pid FSM) is the SSOT for "which pid is live". Do we adopt CC's mtime-heartbeat + cross-worktree-freshest for the STANDALONE/offline scode case (no nexus)? A zero-infra file pointer is nice offline.</span></span>
+  </td>
+  <td><span class="path">&lt;cwd&gt;/bridge-pointer.json</span> — <code>{sessionId,environmentId,source}</code>, mtime TTL 4h heartbeat, cross-worktree freshest.</td>
+  <td><b>AgentRegistry</b> (pid FSM, kernel SSOT) = "which pid is live"; <span class="path">/proc/{pid}/</span> is the live session. <span class="b ok">done (design)</span></td>
+  <td><code>--resume &lt;id&gt;</code> / <code>latest</code> (SessionStore.latest_session). Standalone file-pointer? <span class="b q">open?</span> <span class="b partial">partial</span></td>
+  <td><code>extra.acpSessionId</code> = sudowork's resume pointer (its bridge-pointer analogue). <span class="b dup">dup</span></td>
+</tr>
+
+<!-- A2A -->
+<tr>
+  <td class="mega">A2A /<br>mailbox</td>
+  <td class="item">Agent-to-agent messaging</td>
+  <td><span class="b na">n/a</span> (single machine, no native A2A)</td>
+  <td><b>chat-with-me DT_STREAM</b> + kernel-tier <code>a2a</code> substrate (MailboxStampingHook = unforgeable <code>from</code>) + raft cross-node wake. Substrate <span class="b ok">done</span>; agent-binding pending.</td>
+  <td><span class="path">/proc/{pid}/chat-with-me</span> (nexus-managed, spawn_task) + <span class="path">&lt;ws&gt;/.sudocode-inbox/&lt;recipient&gt;.jsonl</span> (standalone). <span class="b ok">done</span></td>
+  <td>IM channels (Telegram/Lark/DingTalk) — separate surface. <span class="b na">n/a</span></td>
+</tr>
+
+<!-- WORKSPACE (finalize after DT_LINK dive) -->
+<tr>
+  <td class="mega">Workspace</td>
+  <td class="item">Workspace &amp; multi-path
+    <span class="tip">?<span class="tipbox">DT_LINK follow = full syscall re-entry on the target, so a link to a <b>federation-mounted</b> path resolves cross-node for FREE (inherits DT_FILE <code>try_remote_fetch</code> via <code>last_writer_address</code>). So workspace/ linking repos across a distributed VFS works today for mounted targets; default-mount the launch path (project root) as workspace[0] is trivially local. Only a target on a node with NO local mount/zone needs genuinely-new owner-discovery (none of DT_STREAM/PIPE/FILE provide "who owns X") — see Q6.</span></span>
+  </td>
+  <td>cwd IS the (single) workspace.</td>
+  <td><span class="path">/proc/{pid}/workspace/</span> (DT_DIR) + <span class="path">workspace/{alias}</span> → DT_LINK → mount_path. <b>Multi-repo cross-node works today</b> for federation-mounted targets (syscall re-entry). Default mount launch-path (≈ project root) as first. <span class="b ok">done (design)</span></td>
+  <td>cwd = workspace (single); <code>workspace_fingerprint</code>. <span class="b partial">partial</span></td>
+  <td><code>extra.workspace</code> / <code>customWorkspace</code> / <code>mossWorkDir</code>. <span class="b dup">dup</span></td>
+</tr>
+
+<!-- CROSS-MACHINE -->
+<tr>
+  <td class="mega">Cross-<br>machine</td>
+  <td class="item">Sync</td>
+  <td><span class="b na">n/a</span> (single machine)</td>
+  <td><b>Native</b> — distributed VFS: zone raft replication + federation mounts + LocalConnector (write) + FUSE (unified read) over Tailscale (Mac↔Win verified byte-exact). <span class="b ok">done</span></td>
+  <td>Inherits nexus VFS when embedded; standalone = local FS only. <span class="b partial">partial</span></td>
+  <td>—<span class="b na"> n/a</span></td>
+</tr>
+
+<!-- DEPENDENCY DIRECTION -->
+<tr>
+  <td class="mega">Dependency<br>direction</td>
+  <td class="item">Who calls whom</td>
+  <td><span class="b na">n/a</span></td>
+  <td colspan="1"><b>sudocode → nexus</b> for VFS syscalls (<code>KernelAbi</code> sys_*) and for services (A2A write; spawn-child via <code>MAS::start_session</code>). <b>nexus → sudocode</b> only via the <code>SpawnTask&lt;K&gt;</code> DI trait (sudocode-host registers the adapter at boot — no compile-edge reversal). <b>Self lifecycle state</b>: sudocode reports up via a <code>state_callback</code>; MAS (owns AgentRegistry) writes it — the kernel owns its task table (FSM enforced), like a process not editing its own task_struct. <span class="b ok">clean</span></td>
+  <td colspan="2"><small>Confirmed on origin/main v0.1.15: no <code>AgentRegistry</code>/<code>ManagedAgentService</code> type refs in sudocode; only <code>KernelAbi</code> + <code>AgentDescriptor</code>. CLI still runs StdFsBackend (seam dormant).</small></td>
+</tr>
+
+<!-- MIGRATION -->
+<tr>
+  <td class="mega">Migration</td>
+  <td class="item">Path to end-state</td>
+  <td><span class="b na">n/a</span></td>
+  <td><b>Nexus end-state</b> = the superset all others migrate toward.</td>
+  <td>flat <span class="path">.scode/sessions/</span> (StdFsBackend) → <span class="path">/agents/{name}/sessions/&lt;hash&gt;/</span> (KernelFsBackend). Seam scaffolded, dormant → wire it. <span class="b q">open? (priority)</span></td>
+  <td><code>messages</code> table → view over engine JSONL keyed by <code>acpSessionId</code>; keep only UI-unique fields (position/status/pin/cron/channel/user_id). <span class="b dup">dup → merge</span></td>
+</tr>
+
+</tbody>
+</table>
+
+<h2>Open questions (for consensus)</h2>
+<div class="qbox"><span class="qn">Q1</span> Adopt <b>agent-name as primary key</b> (Nexus superset) as canonical — a real shift from CC/scode's cwd-primary? <small>(§ Identity)</small></div>
+<div class="qbox"><span class="qn">Q2</span> <b>Memory tiers</b>: agent-memory (<code>/agents/{name}/memory/</code>) + project-memory. Given workspace can DT_LINK multiple repos, where does <b>project-memory</b> live — at the workspace's primary mount root (≈ launch path)? Which of the 6 missing memory rows do we build, and in what order?</div>
+<div class="qbox"><span class="qn">Q3</span> <b>Cross-agent session search</b> via DT_LINK <code>/agents/{name}/sessions/</code> → shared <code>/agents/sessions/</code>? <small>(depends on Q6)</small></div>
+<div class="qbox"><span class="qn">Q4</span> <b>Oversized tool-output offload</b> (CC's tool-results/ + content-replacement) into scode — adopt? Path under <code>/agents/{name}/sessions/&lt;hash&gt;/tool-results/</code>?</div>
+<div class="qbox"><span class="qn">Q5</span> <b>Subagent</b>: full-transcript fork parity (vs cache-prefix)? Move subagents to nexus-managed pids (sudocode → <code>MAS::start_session</code>)? Storage → <code>agent-&lt;id&gt;.jsonl</code>+<code>.meta.json</code> parity?</div>
+<div class="qbox"><span class="qn">Q6</span> <b>Workspace &amp; DT_LINK</b> — confirm default-mount of the launch path (≈ project root) as <code>workspace[0]</code> + multi-repo via <code>workspace/{alias}</code>→DT_LINK→mount_path. Cross-node resolved: a link to a <b>federation-mounted</b> target already resolves cross-node <b>today, zero change</b> (the follow is a syscall re-entry that inherits DT_FILE's <code>try_remote_fetch</code>/<code>last_writer_address</code>; DT_STREAM/PIPE similarly "just work" as replicate-everywhere). The <i>only</i> new work is a link to a target on a node with <b>no local mount/zone</b> → needs genuinely-new <b>owner-discovery</b> ("who owns path X"), which no primitive provides (read-miss path contractually refuses peer fan-out). <b>Decision:</b> constrain workspace/link targets to federation-mounted paths (ship now, zero change), or invest in owner-discovery for arbitrary remote targets (separate design)?</div>
+<div class="qbox"><span class="qn">Q7</span> <b>Persistent-assistant pointer</b>: adopt CC's mtime-heartbeat + cross-worktree-freshest for the standalone/offline scode case (AgentRegistry is SSOT when nexus present)?</div>
+<div class="qbox"><span class="qn">Q8</span> <b>Doc drift</b>: nexus-integration §3.3 says the mailbox stamp hook is "owned by ManagedAgentService" — code moved it to the kernel-tier <code>a2a</code> substrate (armed at boot, for all writers incl. matrix humans). Update §3.3.</div>
+<div class="qbox"><span class="qn">Q9</span> <b>Migration &amp; dedup sequencing</b> — priority/order of: (a) wire scode's dormant nexus <code>KernelFsBackend</code> seam (flat <code>.scode/sessions/</code> → <code>/agents/{name}/</code> layered); (b) collapse sudowork <code>messages</code> → a view over the engine JSONL keyed by <code>acpSessionId</code> (keep only UI-unique fields); (c) build the missing memory features. Which first?</div>
+
+<p class="note"><b>Repo SSOT:</b> <code>sudoprivacy/sudocode : docs/design/agent-context-storage-matrix.html</code> — this ShareOne view is remote-url-backed by that file, so comment here and the repo file is updated. Once consensus lands, this table gets tracked into <code>nexus-integration-architecture</code>.</p>
+<p class="note">Sources: Claude Code src/ (session/memory/bridge), sudocode origin/main v0.1.15 (runtime/tools), nexus-integration-architecture.html, nexus-vfs a2a/kernel, hydra (copilot/worker/planner roles). Draft 2026-07 — sudowork-win-pc-4.</p>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Comparison matrix mapping Claude Code's on-disk context model onto the Nexus /agents/{name}/ (image) + /proc/{pid}/ (runtime) design, tracked through to sudocode + sudowork (dedup/merge SSOT). Living design doc for consensus (open questions Q1-Q9); ShareOne (s.shareone.vip/s/agent-context-storage-matrix) is remote-url-backed by this file. To be tracked into nexus-integration-architecture after consensus.