### PR TITLE
fix(docs): contain matrix tooltip text within its box

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -42,7 +42,9 @@
   .tip{position:relative;border-bottom:1px dotted var(--q);cursor:help;color:var(--q)}
   .tip .tipbox{visibility:hidden;opacity:0;transition:.12s;position:absolute;left:0;top:1.6em;z-index:9;
     width:340px;background:#0b1220;border:1px solid var(--q);border-radius:8px;padding:10px 12px;
-    color:#e2e8f0;font-weight:400;box-shadow:0 8px 30px rgba(0,0,0,.5);font-size:12.5px;line-height:1.5}
+    color:#e2e8f0;font-weight:400;box-shadow:0 8px 30px rgba(0,0,0,.5);font-size:12.5px;line-height:1.5;
+    white-space:normal;overflow-wrap:break-word;word-break:break-word}
+  .tip .tipbox code{white-space:normal;overflow-wrap:break-word;word-break:break-word}
   .tip:hover .tipbox{visibility:visible;opacity:1}
   .qbox{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--q);
     border-radius:8px;padding:8px 14px;margin:10px 0}


### PR DESCRIPTION
Hover tooltips in the agent-context storage matrix inherited white-space:nowrap from td.item, so their text ran off as one long line outside the 340px box and pushed page scrollWidth to ~3111px. Reset white-space:normal + overflow-wrap on .tipbox. Verified via ai-dev-browser: tooltips now wrap inside the box, scrollWidth back to ~1556. ShareOne (remote-url-backed by this file on main) reflects automatically.