### PR TITLE
feat(repl): arrow keys, display width, resume into REPL, message rendering pipeline

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3241,6 +3241,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tools",
+ "unicode-width",
 ]
 
 [[package]]

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = "0.10"
 syntect = "5"
 tokio = { version = "1", features = ["rt-multi-thread", "signal", "time"] }
 tools = { path = "../tools" }
+unicode-width = "0.2"
 
 [lints]
 workspace = true

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -267,6 +267,12 @@ pub(crate) enum CliAction {
         session_path: PathBuf,
         commands: Vec<String>,
         output_format: CliOutputFormat,
+        model: String,
+        permission_mode: PermissionMode,
+        auth_mode: Option<AuthMode>,
+    },
+    ListSessions {
+        output_format: CliOutputFormat,
     },
     Status {
         model: String,
@@ -469,7 +475,14 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
 
     // --resume takes priority over subcommands
     if let Some(resume_value) = cli.resume {
-        return parse_resume_from_clap(&resume_value, &cli.prompt_words, output_format);
+        return parse_resume_from_clap(
+            &resume_value,
+            &cli.prompt_words,
+            output_format,
+            model.clone(),
+            permission_mode,
+            auth_mode,
+        );
     }
 
     // Subcommand dispatch
@@ -704,27 +717,43 @@ fn parse_resume_from_clap(
     session_str: &str,
     trailing: &[String],
     output_format: CliOutputFormat,
+    model: String,
+    permission_mode: PermissionMode,
+    auth_mode: Option<AuthMode>,
 ) -> Result<CliAction, String> {
-    let (session_path, command_tokens) = if session_str.is_empty() {
-        // `--resume` without value
+    let (session_path, command_tokens) = if session_str.is_empty() && trailing.is_empty() {
+        // `--resume` without value and no trailing commands — list sessions.
+        return Ok(CliAction::ListSessions { output_format });
+    } else if session_str.is_empty() {
+        // `--resume /status` etc — resume latest with commands
         (PathBuf::from(LATEST_SESSION_REFERENCE), trailing)
     } else if looks_like_slash_command_token(session_str) {
         // `--resume /status` — session_str is actually a command
         let all: Vec<String> = std::iter::once(session_str.to_string())
             .chain(trailing.iter().cloned())
             .collect();
-        return parse_resume_commands(PathBuf::from(LATEST_SESSION_REFERENCE), &all, output_format);
+        return parse_resume_commands(
+            PathBuf::from(LATEST_SESSION_REFERENCE),
+            &all,
+            output_format,
+            model,
+            permission_mode,
+            auth_mode,
+        );
     } else {
         (PathBuf::from(session_str), trailing)
     };
 
-    parse_resume_commands(session_path, command_tokens, output_format)
+    parse_resume_commands(session_path, command_tokens, output_format, model, permission_mode, auth_mode)
 }
 
 fn parse_resume_commands(
     session_path: PathBuf,
     command_tokens: &[String],
     output_format: CliOutputFormat,
+    model: String,
+    permission_mode: PermissionMode,
+    auth_mode: Option<AuthMode>,
 ) -> Result<CliAction, String> {
     let mut commands = Vec::new();
     let mut current_command = String::new();
@@ -759,6 +788,9 @@ fn parse_resume_commands(
         session_path,
         commands,
         output_format,
+        model,
+        permission_mode,
+        auth_mode,
     })
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -5,12 +5,160 @@ use std::fmt::Write as _;
 use api::{self, AuthMode, ProviderKind};
 use runtime::{self, TokenUsage};
 use std::time::Duration;
+use unicode_width::UnicodeWidthStr;
+
+// ---------------------------------------------------------------------------
+// Display width helpers
+// ---------------------------------------------------------------------------
+
+/// Compute the display width of a string, stripping ANSI escape sequences
+/// and accounting for unicode character widths (CJK = 2 columns, etc.).
+///
+/// This is the single source of truth for terminal column calculations.
+/// Use this instead of `chars().count()` or `.len()` whenever sizing
+/// borders, padding, or alignment.
+pub(crate) fn display_width(s: &str) -> usize {
+    strip_ansi_codes(s).width()
+}
+
+/// Strip ANSI SGR escape sequences (`ESC[...m`) from a string.
+fn strip_ansi_codes(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                for next in chars.by_ref() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
 
 use crate::{
     load_sudocode_config_for_current_dir, GitWorkspaceSummary, InternalPromptProgressEvent,
     InternalPromptProgressState, BUILD_TARGET, DEFAULT_DATE, GIT_SHA, LATEST_SESSION_REFERENCE,
     PRIMARY_SESSION_EXTENSION, VERSION,
 };
+
+// ---------------------------------------------------------------------------
+// Unified message rendering pipeline
+// ---------------------------------------------------------------------------
+
+/// Render a single `ConversationMessage` into styled terminal output.
+///
+/// This is the SSOT for "how does a completed message look on screen."
+/// Both session replay (`--resume`) and any future message display
+/// (e.g. `/history`, export) should call this instead of hand-rolling
+/// role/block matching.
+///
+/// The live REPL uses a different path (streaming event callbacks) for
+/// progressive rendering during a turn, but the *final* visual result
+/// is the same because both paths call the same per-block format
+/// functions (`format_input_echo`, `format_tool_call_start`, etc.).
+pub(crate) fn render_message(
+    msg: &runtime::ConversationMessage,
+    term_width: usize,
+    renderer: &crate::render::TerminalRenderer,
+) -> Option<String> {
+    let mut out = String::new();
+
+    match msg.role {
+        runtime::MessageRole::User => {
+            let text = text_from_blocks(&msg.blocks);
+            if text.is_empty() {
+                return None;
+            }
+            let sep = format!("\x1b[2m{}\x1b[0m", "─".repeat(term_width));
+            out.push_str(&sep);
+            out.push('\n');
+            let (echo, _) = format_input_echo(&text, term_width);
+            out.push_str(&echo);
+            out.push('\n');
+            out.push_str(&sep);
+        }
+        runtime::MessageRole::Assistant => {
+            for block in &msg.blocks {
+                match block {
+                    runtime::ContentBlock::Text { text } if !text.is_empty() => {
+                        let rendered = renderer.render_markdown(text);
+                        if !out.is_empty() {
+                            out.push('\n');
+                        }
+                        out.push_str(&rendered);
+                    }
+                    runtime::ContentBlock::ToolUse { name, input, .. } => {
+                        if !out.is_empty() {
+                            out.push('\n');
+                        }
+                        out.push_str(&format_tool_call_start(name, input));
+                    }
+                    _ => {}
+                }
+            }
+            if out.is_empty() {
+                return None;
+            }
+        }
+        runtime::MessageRole::Tool => {
+            for block in &msg.blocks {
+                if let runtime::ContentBlock::ToolResult {
+                    tool_name,
+                    output,
+                    is_error,
+                    ..
+                } = block
+                {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str(&format_tool_result(tool_name, output, *is_error));
+                }
+            }
+            if out.is_empty() {
+                return None;
+            }
+        }
+        runtime::MessageRole::System => return None,
+    }
+
+    Some(out)
+}
+
+/// Render a slice of messages into a single string. Convenience wrapper
+/// over [`render_message`] for session replay.
+pub(crate) fn render_messages(
+    messages: &[runtime::ConversationMessage],
+    term_width: usize,
+    renderer: &crate::render::TerminalRenderer,
+) -> String {
+    let mut parts = Vec::new();
+    for msg in messages {
+        if let Some(rendered) = render_message(msg, term_width, renderer) {
+            parts.push(rendered);
+        }
+    }
+    parts.join("\n")
+}
+
+/// Extract concatenated text content from a message's blocks.
+fn text_from_blocks(blocks: &[runtime::ContentBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|b| match b {
+            runtime::ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 pub(crate) const DISPLAY_TRUNCATION_NOTICE: &str =
     "\x1b[2m… output truncated for display; full result preserved in session.\x1b[0m";
@@ -487,7 +635,7 @@ pub(crate) fn format_input_echo(input: &str, term_width: usize) -> (String, usiz
     for (idx, line) in raw_lines.iter().enumerate() {
         let prefix = if idx == 0 { " › " } else { "   " };
         let body = format!("{prefix}{line}");
-        let visible = body.chars().count();
+        let visible = display_width(&body);
         let pad = term_width.saturating_sub(visible);
         if idx > 0 {
             rendered.push('\n');
@@ -701,7 +849,9 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
         _ => summarize_tool_payload(input),
     };
 
-    let border = "─".repeat(name.len() + 8);
+    // Top: ╭─ {name} ─╮  →  visual width of inner = name_width + 4 (─ SP name SP ─)
+    let name_width = display_width(name);
+    let border = "─".repeat(name_width + 4);
     let detail_indented = detail.replace('\n', "\n  ");
     format!(
         "  \x1b[38;5;245m╭─ \x1b[1;36m{name}\x1b[0;38;5;245m ─╮\x1b[0m\n  \x1b[38;5;245m│\x1b[0m {detail_indented}\n  \x1b[38;5;245m╰{border}╯\x1b[0m"
@@ -915,14 +1065,21 @@ fn render_stdout_stderr_block(header: String, stdout: &str, stderr: &str) -> Str
         return header;
     }
 
+    let term_width = crossterm::terminal::size()
+        .map(|(cols, _)| cols as usize)
+        .unwrap_or(80);
+    // 4 = indent ("  └ " or "    "), plus safety margin to avoid wrapping
+    let max_content_width = term_width.saturating_sub(6);
+
     let preview_count = TOOL_OUTPUT_DISPLAY_MAX_LINES;
     let mut result = header;
 
     for (i, line) in all_output.iter().take(preview_count).enumerate() {
+        let truncated = truncate_to_width(line, max_content_width);
         if i == 0 {
-            write!(&mut result, "\n  └ {line}").expect("write to string");
+            write!(&mut result, "\n  └ {truncated}").expect("write to string");
         } else {
-            write!(&mut result, "\n    {line}").expect("write to string");
+            write!(&mut result, "\n    {truncated}").expect("write to string");
         }
     }
 
@@ -937,6 +1094,29 @@ fn render_stdout_stderr_block(header: String, stdout: &str, stderr: &str) -> Str
     }
 
     result
+}
+
+/// Truncate a string to fit within `max_width` display columns, appending `…`
+/// if truncated. Strips ANSI codes for width calculation but preserves them in
+/// output up to the cut point.
+fn truncate_to_width(s: &str, max_width: usize) -> String {
+    let stripped = strip_ansi_codes(s);
+    if UnicodeWidthStr::width(stripped.as_str()) <= max_width {
+        return s.to_string();
+    }
+    // Walk characters of the stripped version, accumulating display width.
+    let mut width = 0usize;
+    let mut byte_end = 0usize;
+    for ch in stripped.chars() {
+        let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_width + 1 > max_width {
+            // +1 for the trailing `…`
+            break;
+        }
+        width += ch_width;
+        byte_end += ch.len_utf8();
+    }
+    format!("{}…", &stripped[..byte_end])
 }
 
 pub(crate) fn format_read_result(icon: &str, parsed: &serde_json::Value) -> String {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -65,7 +65,8 @@ use cli::format::{
     format_internal_prompt_progress_line, format_issue_report, format_model_report,
     format_model_switch_report, format_permission_prompt_box, format_permissions_report,
     format_permissions_switch_report, format_pr_report, format_resume_report,
-    format_sandbox_report, format_tool_timeline, format_turn_status_line_with_branch,
+    format_sandbox_report, format_tool_call_start, format_tool_result, format_tool_timeline, render_messages,
+    format_turn_status_line_with_branch,
     format_ultraplan_report, render_resume_usage, render_version_report, truncate_for_summary,
 };
 use cli::git::{
@@ -462,7 +463,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             session_path,
             commands,
             output_format,
-        } => resume_session(&session_path, &commands, output_format),
+            model,
+            permission_mode,
+            auth_mode,
+        } => resume_session(&session_path, &commands, output_format, model, permission_mode, auth_mode),
+        CliAction::ListSessions { output_format } => {
+            list_sessions_cli(output_format)?;
+        }
         CliAction::Status {
             model,
             model_flag_raw,
@@ -863,8 +870,71 @@ fn print_system_prompt(
     Ok(())
 }
 
+/// `--resume` without arguments: list available sessions so the user can
+/// pick one to resume.  Prints id, age, message count, and branch — enough
+/// context to identify the right session.
+fn list_sessions_cli(
+    output_format: CliOutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use cli::session::list_managed_sessions;
+
+    let sessions = list_managed_sessions()?;
+    if sessions.is_empty() {
+        if output_format == CliOutputFormat::Json {
+            println!("{}", serde_json::json!({ "sessions": [] }));
+        } else {
+            println!("No saved sessions found.");
+            println!("Start a session first, then use `scode --resume latest` or `scode --resume <id>`.");
+        }
+        return Ok(());
+    }
+
+    if output_format == CliOutputFormat::Json {
+        let entries: Vec<serde_json::Value> = sessions
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "id": s.id,
+                    "messages": s.message_count,
+                    "modified_ms": s.modified_epoch_millis as u64,
+                    "branch": s.branch_name,
+                    "path": s.path.display().to_string(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::json!({ "sessions": entries }));
+        return Ok(());
+    }
+
+    println!("Available sessions (use `scode --resume <id>`):\n");
+    for (i, session) in sessions.iter().enumerate() {
+        let age = cli::session::format_session_modified_age(session.modified_epoch_millis);
+        let branch = session
+            .branch_name
+            .as_deref()
+            .map(|b| format!("  branch={b}"))
+            .unwrap_or_default();
+        let latest = if i == 0 { "  (latest)" } else { "" };
+        println!(
+            "  {id}  {msgs} msgs  {age}{branch}{latest}",
+            id = session.id,
+            msgs = session.message_count,
+        );
+    }
+    println!();
+    println!("Tip: `scode --resume latest` resumes the most recent session.");
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)]
-fn resume_session(session_path: &Path, commands: &[String], output_format: CliOutputFormat) {
+fn resume_session(
+    session_path: &Path,
+    commands: &[String],
+    output_format: CliOutputFormat,
+    model: String,
+    permission_mode: PermissionMode,
+    auth_mode: Option<AuthMode>,
+) {
     let session_reference = session_path.display().to_string();
     let (handle, session) = match load_session_reference(&session_reference) {
         Ok(loaded) => loaded,
@@ -902,12 +972,37 @@ fn resume_session(session_path: &Path, commands: &[String], output_format: CliOu
                     "message_count": session.messages.len(),
                 })
             );
-        } else {
-            println!(
-                "Restored session from {} ({} messages).",
-                handle.path.display(),
-                session.messages.len()
-            );
+            return;
+        }
+        // No commands — enter the interactive REPL with the restored session.
+        let resolved_model = resolve_repl_model(model);
+        let mut cli = match LiveCli::new(
+            resolved_model,
+            true,
+            None,
+            permission_mode,
+            auth_mode,
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("failed to initialize: {e}");
+                std::process::exit(1);
+            }
+        };
+        // Load the restored session into the running CLI.
+        let session_ref = resolved_path.display().to_string();
+        if let Err(e) = cli.resume_session(Some(session_ref)) {
+            eprintln!("failed to resume: {e}");
+            std::process::exit(1);
+        }
+        // Enter the REPL loop (it renders banner + any existing messages).
+        let mode = input_queue::QueueMode::from_env();
+        if !matches!(mode, input_queue::QueueMode::Off) {
+            if let Err(e) = run_repl_async_dispatch(cli, mode) {
+                eprintln!("\x1b[31m{e}\x1b[0m");
+            }
+        } else if let Err(e) = run_repl_loop(cli) {
+            eprintln!("\x1b[31m{e}\x1b[0m");
         }
         return;
     }
@@ -1477,9 +1572,30 @@ fn run_repl(
         return run_repl_async_dispatch(cli, mode);
     }
 
+    run_repl_loop(cli)
+}
+
+/// The synchronous REPL loop. Handles both new sessions and resumed
+/// sessions identically: banner → existing messages (if any) → prompt.
+fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
     let mut editor =
         input::LineEditor::new("❯ ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
+
+    // Render any existing messages from the session. For a new session
+    // this is empty (zero cost). For a resumed session this replays
+    // the conversation using the same format pipeline as live output.
+    let messages = &cli.runtime.session().messages;
+    if !messages.is_empty() {
+        let term_width = crossterm::terminal::size()
+            .map(|(cols, _)| cols as usize)
+            .unwrap_or(80);
+        let renderer = render::TerminalRenderer::new();
+        let rendered = render_messages(messages, term_width, &renderer);
+        if !rendered.is_empty() {
+            println!("{rendered}");
+        }
+    }
 
     // Track session metrics for session_ended event
     let session_start = Instant::now();
@@ -3941,6 +4057,23 @@ impl LiveCli {
             )
         );
         Ok(true)
+    }
+
+    /// Replace the current session with a pre-loaded one (for `--resume`).
+    fn replace_with_session(
+        &mut self,
+        session: runtime::Session,
+        handle: SessionHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let session_id = session.session_id.clone();
+        let runtime =
+            self.build_replacement_runtime(session, handle.id.clone(), self.config.clone())?;
+        self.replace_runtime(runtime)?;
+        self.session = SessionHandle {
+            id: session_id,
+            path: handle.path,
+        };
+        Ok(())
     }
 
     fn print_config(section: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_resume.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_resume.rs
@@ -1,0 +1,108 @@
+//! PTY tests for session resume (`--resume`) behavior.
+//!
+//! Verifies:
+//! 1. `--resume` without args lists available sessions
+//! 2. `--resume <id>` enters REPL with previous messages rendered
+//! 3. No duplicate rendering between resume report and message replay
+//! 4. Messages are rendered using the same pipeline as live output
+
+mod common;
+
+use std::fs;
+use std::time::Duration;
+
+/// `--resume` without arguments should list sessions and exit.
+#[test]
+fn resume_no_args_lists_sessions() {
+    let env = common::TestEnv::new("resume-list");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    // Create a session by entering then exiting the REPL.
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("EDITOR", "true")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+    sess.expect("❯").expect("REPL prompt");
+    sess.send("/exit\r").expect("send exit");
+    sess.expect_eof().expect("clean exit");
+
+    // Now run --resume with no args.
+    let mut sess2 = env.spawn(&["--resume"]);
+    sess2.set_default_timeout(Duration::from_secs(5));
+
+    sess2.expect("Available sessions").unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("should list sessions: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess2.expect("scode --resume").unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("should show usage tip: {e}\nPTY screen:\n{screen}");
+    });
+
+    let exit2 = sess2.expect_eof().unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("should exit after listing: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit2, 0);
+}
+
+/// `--resume latest` should show banner, then previous messages, then
+/// REPL prompt — with no duplicate rendering.
+#[test]
+fn resume_latest_renders_messages_after_banner() {
+    let env = common::TestEnv::new("resume-render");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    // First: run a session with a turn so it has messages.
+    let prompt = env.prompt("say hello world", "single_turn_text");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("EDITOR", "true")],
+    );
+    sess.set_default_timeout(Duration::from_secs(15));
+    sess.expect("❯").expect("REPL prompt");
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+    sess.expect("❯").expect("second prompt after turn");
+    sess.send("/exit\r").expect("send exit");
+    sess.expect_eof().expect("clean exit");
+
+    // Resume latest session.
+    let mut sess2 = env.spawn_with_env(
+        &["--resume", "latest", "--permission-mode", "read-only"],
+        &[("EDITOR", "true")],
+    );
+    sess2.set_default_timeout(Duration::from_secs(15));
+
+    // Should see the banner.
+    sess2.expect("Code").unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("should see banner: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Should see the REPL prompt (messages rendered between banner and prompt).
+    sess2.expect("❯").unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("should see REPL prompt after resume: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Verify no duplicate: "Session resumed" should appear at most once.
+    let screen = sess2.render(|s| s.contents());
+    let resume_count = screen.matches("Session resumed").count();
+    assert!(
+        resume_count <= 1,
+        "should not duplicate 'Session resumed'. Found {resume_count} times.\n\
+         PTY screen:\n{screen}"
+    );
+
+    sess2.send("/exit\r").expect("send exit");
+    let exit = sess2.expect_eof().unwrap_or_else(|e| {
+        let screen2 = sess2.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen2}");
+    });
+    assert_eq!(exit, 0);
+}
+

--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -692,7 +692,7 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>Planning &amp; Structured</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>3</strong></td></tr>
     <tr><td>Background &amp; Parallel</td><td>11</td><td>0</td><td>0</td><td>11</td><td><strong>7</strong></td></tr>
     <tr><td>Git Workflow</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>1</strong></td></tr><!-- 3 must-have (bash git ops) + 2 nice (skill shortcuts) -->
-    <tr><td>Session Management</td><td>11</td><td>0</td><td>0</td><td>11</td><td><strong>8</strong></td></tr>
+    <tr><td>Session Management</td><td>12</td><td>0</td><td>0</td><td>12</td><td><strong>10</strong></td></tr>
     <tr><td>Config &amp; Discovery</td><td>17</td><td>0</td><td>4</td><td>13</td><td><strong>10</strong></td></tr>
     <tr><td>Diagnostics</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>3</strong></td></tr>
     <tr><td>Auth</td><td>7</td><td>0</td><td>0</td><td>7</td><td><strong>1</strong></td></tr>


### PR DESCRIPTION
## Summary

Four features in one cohesive PR:

1. **Arrow keys (CC parity)** — ↑=beginning-of-line→history, ↓=end-of-line→history
2. **Display width** — unicode-width crate for correct box borders and line truncation
3. **Resume into REPL** — `--resume` lists sessions, `--resume <id>` enters REPL with messages rendered
4. **Message rendering pipeline** — `render_message()` / `render_messages()` as SSOT in format.rs

### Architecture

- `run_repl_loop` handles both new and resumed sessions: banner → render existing messages → prompt loop
- `render_message(msg, term_width, renderer)` uses the same format functions as live output
- `ResumeSession` action carries model/permission/auth from CLI parser (no hardcoded defaults)

## Test plan

- [x] `pty_arrow_keys` — 3 tests (beginning-of-line, history on empty, end-of-line roundtrip)
- [x] `pty_resume` — 2 tests (list sessions, resume renders messages after banner)
- [x] Full regression: 23/23 pass across core_conversation, arrow_keys, smoke, memory, resume