### PR TITLE
Add Linux deb installer packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,21 @@ jobs:
           set -euo pipefail
           tar -C dist -czf "dist/${{ matrix.archive_name }}" "${{ matrix.package_dir }}"
 
+      - name: Build deb installer
+        if: matrix.name == 'linux-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" == v* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
+          ../packaging/linux/deb/build-deb.sh \
+            --version "$version" \
+            --binary target/release/scode \
+            --output dist
+
       - name: Archive release payload (zip)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -176,6 +191,13 @@ jobs:
         with:
           name: ${{ matrix.package_dir }}
           path: rust/dist/${{ matrix.archive_name }}
+
+      - name: Upload deb workflow artifact
+        if: matrix.name == 'linux-x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scode-linux-x64-deb
+          path: rust/dist/scode_*_amd64.deb
 
   publish-release:
     name: publish-release
@@ -196,13 +218,14 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
-          sha256sum scode-* > SHA256SUMS.txt
+          sha256sum scode-* scode_*.deb > SHA256SUMS.txt
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/scode-*
+            dist/scode_*.deb
             dist/SHA256SUMS.txt
           fail_on_unmatched_files: true
 
@@ -219,7 +242,7 @@ jobs:
             -s "$TENCENT_SECRET_KEY" \
             -b sudowork-release-1309794936 \
             -e cos.accelerate.myqcloud.com
-          for file in dist/scode-*.tar.gz dist/scode-*.zip; do
+          for file in dist/scode-*.tar.gz dist/scode-*.zip dist/scode_*.deb; do
             [ -f "$file" ] || continue
             filename=$(basename "$file")
             echo "Uploading $filename"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,31 @@ jobs:
           set -euo pipefail
           tar -C dist -czf "dist/scode-linux-x64.tar.gz" "scode-linux-x64"
 
+      - name: Build deb installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" == v* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
+          ../packaging/linux/deb/build-deb.sh \
+            --version "$version" \
+            --binary target/x86_64-unknown-linux-musl/release/scode \
+            --output dist
+
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
           name: scode-linux-x64
           path: rust/dist/scode-linux-x64.tar.gz
+
+      - name: Upload deb workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scode-linux-x64-deb
+          path: rust/dist/scode_*_amd64.deb
 
   build:
     name: build-${{ matrix.name }}
@@ -162,21 +182,6 @@ jobs:
           set -euo pipefail
           tar -C dist -czf "dist/${{ matrix.archive_name }}" "${{ matrix.package_dir }}"
 
-      - name: Build deb installer
-        if: matrix.name == 'linux-x64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" == v* ]]; then
-            version="${GITHUB_REF_NAME#v}"
-          else
-            version="0.0.0.${GITHUB_RUN_NUMBER}"
-          fi
-          ../packaging/linux/deb/build-deb.sh \
-            --version "$version" \
-            --binary target/release/scode \
-            --output dist
-
       - name: Archive release payload (zip)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -191,13 +196,6 @@ jobs:
         with:
           name: ${{ matrix.package_dir }}
           path: rust/dist/${{ matrix.archive_name }}
-
-      - name: Upload deb workflow artifact
-        if: matrix.name == 'linux-x64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: scode-linux-x64-deb
-          path: rust/dist/scode_*_amd64.deb
 
   publish-release:
     name: publish-release

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ the content.
 
 - [`usage.md`](./usage.md) — REPL, one-shot prompts, JSON output,
   session resume, `scode doctor`.
+- [`linux-deb-install.md`](./linux-deb-install.md) — install, configure,
+  validate, upgrade, and uninstall the Ubuntu/Debian package.
 - [`authentication.md`](./authentication.md) — subscription / proxy /
   api-key modes, environment variables, endpoints.
 - [`permissions-and-sandbox.md`](./permissions-and-sandbox.md) —

--- a/docs/linux-deb-install.md
+++ b/docs/linux-deb-install.md
@@ -1,0 +1,227 @@
+# Linux deb install guide
+
+This guide covers installing and validating the Ubuntu/Debian `scode`
+package produced by the `Release binaries` workflow.
+
+## Download the package
+
+For a manual GitHub Actions run, download the `scode-linux-x64-deb`
+artifact. After extracting it, you should have a file named like:
+
+```text
+scode_0.0.0.12345_amd64.deb
+```
+
+For a tagged release, download the versioned package from the GitHub
+Release assets:
+
+```text
+scode_0.1.13_amd64.deb
+```
+
+## Upload to the server
+
+Copy the package to the Ubuntu server:
+
+```bash
+scp scode_*.deb ubuntu@your-server:/tmp/
+```
+
+Then connect to the server:
+
+```bash
+ssh ubuntu@your-server
+```
+
+## Install
+
+Install the package with apt:
+
+```bash
+sudo apt install /tmp/scode_*.deb
+```
+
+The package installs:
+
+```text
+/usr/bin/scode
+/usr/bin/scode-setup
+/usr/lib/scode/scode-setup
+```
+
+If the install is running in an interactive terminal, the package runs
+`scode-setup` automatically. The setup wizard is terminal-only and does
+not require a graphical desktop.
+
+## First-time setup
+
+The installer prompts for:
+
+```text
+Base URL
+API Key
+Default model
+web_search on/off
+```
+
+By default, Base URL is:
+
+```text
+https://hk.sudorouter.ai/v1
+```
+
+The wizard calls the selected Base URL with `/models`, shows the returned
+model IDs, and writes user-level configuration files:
+
+```text
+~/.nexus/sudocode/sudocode.json
+~/.nexus/sudocode/settings.json
+```
+
+The API key is stored in `sudocode.json`, so the file is written with
+user-only permissions.
+
+## Validate the install
+
+Check the global commands:
+
+```bash
+which scode
+which scode-setup
+scode --version
+```
+
+Expected command paths:
+
+```text
+/usr/bin/scode
+/usr/bin/scode-setup
+```
+
+Check generated config:
+
+```bash
+ls -la ~/.nexus/sudocode
+cat ~/.nexus/sudocode/settings.json
+```
+
+Do not print or share the raw `sudocode.json` because it contains the API
+key. To inspect it safely:
+
+```bash
+sed -E 's/("apiKey"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"***"/g' \
+  ~/.nexus/sudocode/sudocode.json
+```
+
+Run a health check:
+
+```bash
+scode doctor
+```
+
+Run a one-shot prompt:
+
+```bash
+scode -p "你好"
+```
+
+## Update model configuration
+
+Run the setup command again:
+
+```bash
+scode-setup
+```
+
+When an existing config is present, the wizard shows:
+
+```text
+1) 只修改默认模型
+2) 重新拉取模型列表并选择默认模型
+3) 修改 Base URL / API Key 并重建配置
+4) 开启/关闭 web_search
+5) 退出
+```
+
+Use option `1` to change only `settings.json`. Use option `2` when the
+remote model list has changed. Use option `3` when the Base URL or API key
+has changed.
+
+## Non-interactive setup
+
+For automated server provisioning, run:
+
+```bash
+SCODE_BASE_URL=https://hk.sudorouter.ai/v1 \
+SCODE_API_KEY=your-api-key \
+SCODE_MODEL=deepseek-v4-pro \
+SCODE_ENABLE_SEARCH=1 \
+scode-setup --non-interactive
+```
+
+If `SCODE_MODEL` is omitted, setup chooses `deepseek-v4-pro` when present
+in the fetched model list, otherwise the first returned model.
+
+You can also avoid the network model fetch by providing a model list:
+
+```bash
+SCODE_API_KEY=your-api-key \
+SCODE_MODEL=gpt-5 \
+SCODE_MODELS=gpt-5,gpt-5-mini,gpt-4.1 \
+scode-setup --non-interactive
+```
+
+## Upgrade
+
+Install the newer package over the existing one:
+
+```bash
+sudo apt install /tmp/scode_0.1.14_amd64.deb
+```
+
+Package upgrades replace `/usr/bin/scode` and `scode-setup`, but do not
+overwrite existing user configuration under `~/.nexus/sudocode`.
+
+## Uninstall
+
+Remove the package:
+
+```bash
+sudo apt remove scode
+```
+
+Confirm the global commands are gone:
+
+```bash
+which scode || echo "scode removed"
+which scode-setup || echo "scode-setup removed"
+```
+
+User configuration is intentionally preserved:
+
+```bash
+ls -la ~/.nexus/sudocode
+```
+
+## Troubleshooting
+
+If `settings.json` contains anything other than a single model ID, rerun
+setup with the latest package:
+
+```bash
+scode-setup
+cat ~/.nexus/sudocode/settings.json
+```
+
+Expected format:
+
+```json
+{ "model": "gpt-5" }
+```
+
+If installation happens in a non-interactive environment, the package does
+not block waiting for input. Run setup manually as the target user:
+
+```bash
+scode-setup
+```

--- a/docs/superpowers/plans/2026-07-21-linux-deb-installer.md
+++ b/docs/superpowers/plans/2026-07-21-linux-deb-installer.md
@@ -1,0 +1,186 @@
+# Linux deb Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and publish a Ubuntu/Debian `.deb` package for `scode` with a terminal-only setup command that can configure and later update model settings.
+
+**Architecture:** Add a focused `packaging/linux/deb` package builder that assembles Debian filesystem layout from an existing release binary. Ship `scode-setup` as a reusable shell wizard, run it from `postinst` only when an interactive terminal exists, and integrate the package artifact into the existing GitHub Release workflow.
+
+**Tech Stack:** POSIX shell/bash, `dpkg-deb`, GitHub Actions, existing Rust release binary.
+
+---
+
+## File Map
+
+- Create `packaging/linux/deb/build-deb.sh`: validates inputs, builds package root, renders `control`, installs files, runs `dpkg-deb --build`.
+- Create `packaging/linux/deb/scode-setup`: terminal setup and update wizard for `~/.nexus/sudocode`.
+- Create `packaging/linux/deb/postinst`: safe install hook that runs setup only for interactive installs.
+- Create `packaging/linux/deb/prerm`: minimal maintainer script.
+- Create `packaging/linux/deb/control.template`: Debian package metadata template.
+- Create `packaging/linux/deb/tests/test_build_deb.sh`: shell tests for package layout and noninteractive postinst behavior.
+- Modify `.github/workflows/release.yml`: produce `scode_0.1.12_amd64.deb` from the linux-x64 matrix build and upload it as an artifact.
+- Keep `docs/superpowers/specs/2026-07-21-linux-deb-installer-design.md` as the design record.
+
+## Task 1: Package Builder Test
+
+**Files:**
+- Create: `packaging/linux/deb/tests/test_build_deb.sh`
+
+- [ ] **Step 1: Write the failing package layout test**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fake_bin="$TMP/scode"
+cat >"$fake_bin" <<'BIN'
+#!/usr/bin/env sh
+printf 'scode test\n'
+BIN
+chmod +x "$fake_bin"
+
+"$ROOT/packaging/linux/deb/build-deb.sh" \
+  --version 0.1.12 \
+  --binary "$fake_bin" \
+  --output "$TMP/dist"
+
+deb="$TMP/dist/scode_0.1.12_amd64.deb"
+test -f "$deb"
+dpkg-deb --contents "$deb" | grep -q './usr/bin/scode$'
+dpkg-deb --contents "$deb" | grep -q './usr/bin/scode-setup$'
+dpkg-deb --contents "$deb" | grep -q './usr/lib/scode/scode-setup$'
+dpkg-deb --info "$deb" | grep -q 'Package: scode'
+dpkg-deb --info "$deb" | grep -q 'Version: 0.1.12'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash packaging/linux/deb/tests/test_build_deb.sh`
+
+Expected: FAIL because `packaging/linux/deb/build-deb.sh` does not exist.
+
+## Task 2: Minimal deb Builder
+
+**Files:**
+- Create: `packaging/linux/deb/build-deb.sh`
+- Create: `packaging/linux/deb/control.template`
+- Create: `packaging/linux/deb/postinst`
+- Create: `packaging/linux/deb/prerm`
+- Create: `packaging/linux/deb/scode-setup`
+
+- [ ] **Step 1: Implement builder and package scripts**
+
+Create executable shell files that install `scode`, `scode-setup`, README, control metadata, and maintainer scripts into a temporary package root, then run `dpkg-deb --build`.
+
+- [ ] **Step 2: Run package layout test**
+
+Run: `bash packaging/linux/deb/tests/test_build_deb.sh`
+
+Expected: PASS.
+
+## Task 3: Setup Script Behavior Test
+
+**Files:**
+- Modify: `packaging/linux/deb/tests/test_build_deb.sh`
+
+- [ ] **Step 1: Extend test for noninteractive setup**
+
+Add assertions:
+
+```bash
+setup_home="$TMP/home"
+mkdir -p "$setup_home"
+HOME="$setup_home" \
+SCODE_BASE_URL="https://example.invalid/v1" \
+SCODE_API_KEY="test-key" \
+SCODE_MODEL="test-model" \
+SCODE_MODELS="test-model,vision-model" \
+SCODE_ENABLE_SEARCH=0 \
+"$ROOT/packaging/linux/deb/scode-setup" --non-interactive
+
+test -f "$setup_home/.nexus/sudocode/sudocode.json"
+test -f "$setup_home/.nexus/sudocode/settings.json"
+grep -q '"test-model"' "$setup_home/.nexus/sudocode/settings.json"
+grep -q '"baseUrl": "https://example.invalid/v1"' "$setup_home/.nexus/sudocode/sudocode.json"
+grep -q '"apiKey": "test-key"' "$setup_home/.nexus/sudocode/sudocode.json"
+! grep -q '"web_search"' "$setup_home/.nexus/sudocode/sudocode.json"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash packaging/linux/deb/tests/test_build_deb.sh`
+
+Expected: FAIL until `scode-setup --non-interactive` supports environment-driven config.
+
+## Task 4: Setup Script Implementation
+
+**Files:**
+- Modify: `packaging/linux/deb/scode-setup`
+
+- [ ] **Step 1: Implement noninteractive config**
+
+Support `SCODE_BASE_URL`, `SCODE_API_KEY`, `SCODE_MODEL`, `SCODE_MODELS`, `SCODE_ENABLE_SEARCH`, and `--non-interactive`.
+
+- [ ] **Step 2: Implement interactive menus**
+
+Support first-run full config and existing-config menu for default model, model refresh, credential rebuild, and web_search toggling.
+
+- [ ] **Step 3: Run setup behavior test**
+
+Run: `bash packaging/linux/deb/tests/test_build_deb.sh`
+
+Expected: PASS.
+
+## Task 5: Release Workflow Integration
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add deb build step for linux-x64**
+
+After tar.gz creation, run `../packaging/linux/deb/build-deb.sh --version "${GITHUB_REF_NAME#v}" --binary target/release/scode --output dist` only when `matrix.name == 'linux-x64'`.
+
+- [ ] **Step 2: Upload deb artifact**
+
+Add a conditional upload-artifact step for `rust/dist/scode_*_amd64.deb`.
+
+- [ ] **Step 3: Include deb in COS mirror upload**
+
+Change the COS loop to include `dist/scode_*.deb` along with tar.gz and zip.
+
+## Task 6: Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run package test**
+
+Run: `bash packaging/linux/deb/tests/test_build_deb.sh`
+
+Expected: PASS.
+
+- [ ] **Step 2: Build local package from existing root `scode` binary**
+
+Run: `packaging/linux/deb/build-deb.sh --version 0.1.12 --binary ./scode --output /tmp/scode-deb-test`
+
+Expected: creates `/tmp/scode-deb-test/scode_0.1.12_amd64.deb`.
+
+- [ ] **Step 3: Inspect package metadata**
+
+Run: `dpkg-deb --info /tmp/scode-deb-test/scode_0.1.12_amd64.deb && dpkg-deb --contents /tmp/scode-deb-test/scode_0.1.12_amd64.deb`
+
+Expected: package metadata and required files are present.
+
+- [ ] **Step 4: Commit and push**
+
+Stage only:
+
+```bash
+git add .github/workflows/release.yml docs/superpowers/specs/2026-07-21-linux-deb-installer-design.md docs/superpowers/plans/2026-07-21-linux-deb-installer.md packaging/linux/deb
+git commit -m "feat: add linux deb installer packaging"
+git push -u origin codex/linux-deb-installer
+```

--- a/docs/superpowers/specs/2026-07-21-linux-deb-installer-design.md
+++ b/docs/superpowers/specs/2026-07-21-linux-deb-installer-design.md
@@ -1,0 +1,585 @@
+# scode Linux deb 安装包设计
+
+日期：2026-07-21
+
+## 背景
+
+当前 Linux 交付物主要是 `scode` 单个可执行二进制和 `tar.gz` 压缩包。客户希望获得一个标准 Linux 软件安装包，安装到 Ubuntu 服务器后可以直接使用：
+
+- 安装完成后在任意路径执行 `scode`。
+- 安装过程中支持配置模型、Base URL、API Key 和联网搜索。
+- 客户服务器可能没有图形界面，安装流程必须支持纯终端交互。
+- 后续用户可以重新更新模型配置。
+- 安装包应作为 GitHub Release 的正式产物发布。
+
+## 目标
+
+为 Ubuntu/Debian 系统新增按版本命名的安装包，例如 `scode_0.1.12_amd64.deb`。
+
+安装后提供两个全局命令：
+
+```bash
+scode
+scode-setup
+```
+
+命令职责：
+
+- `scode`：主 CLI 程序。
+- `scode-setup`：首次配置和后续配置更新向导。
+
+## 非目标
+
+- 不做 GUI 安装器。目标服务器可能无桌面环境。
+- 不在本阶段实现 apt repository。先通过 GitHub Release 发布 `.deb` 文件，客户使用 `apt install ./scode_0.1.12_amd64.deb` 这类命令安装。
+- 不覆盖用户已有配置。升级包时保留用户配置。
+- 不把 API Key 写入系统级 `/etc` 配置。
+
+## 推荐交付形态
+
+Release 产物建议包含：
+
+```text
+scode-linux-x64.tar.gz
+scode-linux-x64-musl.tar.gz
+scode_0.1.12_amd64.deb
+SHA256SUMS.txt
+```
+
+`.deb` 是 Ubuntu 客户的主交付物；`tar.gz` 和 musl 静态包继续保留，用于非 Debian 系、脚本安装或临时排障。
+
+## deb 包文件布局
+
+```text
+/usr/bin/scode
+/usr/bin/scode-setup
+/usr/lib/scode/scode-setup
+/usr/share/doc/scode/README.md
+/DEBIAN/control
+/DEBIAN/postinst
+/DEBIAN/prerm
+```
+
+说明：
+
+- `/usr/bin/scode` 放主二进制，保证任意路径可执行。
+- `/usr/lib/scode/scode-setup` 放配置脚本真实文件。
+- `/usr/bin/scode-setup` 可以是软链接，也可以是一个很薄的 wrapper，方便用户直接运行。
+- `/usr/share/doc/scode/README.md` 放基础使用说明。
+- `postinst` 在安装后触发首次配置向导。
+- `prerm` 暂时不删除用户配置，只处理包管理需要的清理动作。
+
+## 包元数据
+
+`DEBIAN/control` 示例：
+
+```text
+Package: scode
+Version: 0.1.12
+Section: devel
+Priority: optional
+Architecture: amd64
+Maintainer: sudocode
+Depends: ca-certificates, curl
+Description: Sudo Code command line coding agent
+```
+
+依赖保持最小：
+
+- `curl`：安装期拉取模型列表。
+- `ca-certificates`：HTTPS 请求需要证书链。
+
+## 安装体验
+
+客户执行：
+
+```bash
+sudo apt install ./scode_0.1.12_amd64.deb
+```
+
+安装后 `postinst` 自动触发终端向导：
+
+```text
+Sudo Code · scode 首次配置向导
+
+Base URL [https://hk.sudorouter.ai/v1]:
+API Key:
+正在拉取模型列表...
+
+请选择默认模型：
+   1) deepseek-v4-pro
+   2) claude-sonnet-4-6
+   3) gpt-5
+
+启用联网搜索 web_search？[Y/n]
+```
+
+配置写入：
+
+```text
+~/.nexus/sudocode/sudocode.json
+~/.nexus/sudocode/settings.json
+```
+
+安装完成后：
+
+```bash
+scode --version
+scode doctor
+scode -p "你好"
+```
+
+## 真实用户目录解析
+
+安装通常由 `sudo apt install` 执行。如果 `postinst` 直接写 `$HOME`，可能会写到 `/root/.nexus/sudocode`，这不符合用户预期。
+
+`postinst` 和 `scode-setup --install` 应解析真实登录用户：
+
+优先级：
+
+```text
+1. SUDO_USER
+2. logname
+3. 当前有效用户
+```
+
+当解析到真实用户后：
+
+- 配置目录写入该用户的 home，例如 `/home/ubuntu/.nexus/sudocode`。
+- 文件 owner 设置为真实用户。
+- 目录权限为 `0700`。
+- `sudocode.json` 权限为 `0600`，因为包含 API Key。
+
+如果无法可靠解析真实用户，则提示用户安装完成后手动运行：
+
+```bash
+scode-setup
+```
+
+## 图形界面约束
+
+安装包不依赖 GUI。所有配置通过 shell 终端完成。
+
+配置脚本必须只依赖常见基础工具：
+
+- POSIX shell 或 bash
+- curl
+- sed
+- grep
+- awk
+- chmod/chown/mkdir
+
+不依赖：
+
+- Python
+- jq
+- whiptail/dialog
+- X11/Wayland
+
+这样可以在最小化 Ubuntu Server、SSH 会话和云服务器控制台中运行。
+
+## 非交互安装行为
+
+服务器自动化部署可能使用：
+
+```bash
+DEBIAN_FRONTEND=noninteractive apt install ./scode_0.1.12_amd64.deb
+```
+
+也可能由 CI、Ansible、cloud-init 或脚本执行。安装包不能在非交互环境中阻塞。
+
+规则：
+
+- 如果 stdin/stdout 是 TTY，则自动进入 `scode-setup --install`。
+- 如果不是 TTY，则跳过交互配置，安装仍然成功。
+- 跳过时打印明确提示：
+
+```text
+scode installed.
+No interactive terminal detected, skipped setup.
+Run `scode-setup` as the target user to configure models.
+```
+
+## scode-setup 设计
+
+`scode-setup` 是可重复运行的配置管理器，不只是首次安装脚本。
+
+### 首次配置
+
+当未发现 `~/.nexus/sudocode/sudocode.json` 时，直接进入完整配置：
+
+```text
+1. 输入 Base URL，默认 https://hk.sudorouter.ai/v1
+2. 隐藏输入 API Key
+3. 请求用户配置的 Base URL 加 `/models`
+4. 解析模型 id 列表
+5. 选择默认模型
+6. 选择是否启用 web_search
+7. 写入 sudocode.json 和 settings.json
+```
+
+### 已有配置时
+
+检测到已有配置后显示菜单：
+
+```text
+检测到已有配置：~/.nexus/sudocode/sudocode.json
+
+请选择操作：
+  1) 只修改默认模型
+  2) 重新拉取模型列表并选择默认模型
+  3) 修改 Base URL / API Key 并重建配置
+  4) 开启/关闭 web_search
+  5) 退出
+```
+
+默认推荐操作是 `1) 只修改默认模型`。
+
+### 修改默认模型
+
+读取现有 `sudocode.json` 的模型列表，让用户选择默认模型，只更新：
+
+```text
+~/.nexus/sudocode/settings.json
+```
+
+### 重新拉取模型列表
+
+使用现有 Base URL 和 API Key 请求 `/models`，刷新 `sudocode.json` 中的 `models` 块，然后让用户重新选择默认模型。
+
+### 修改 Base URL / API Key
+
+完整重走首次配置流程，并重建：
+
+```text
+sudocode.json
+settings.json
+```
+
+### web_search 更新
+
+允许用户开启或关闭 `web_search` 配置。默认搜索地址保持：
+
+```text
+https://hk.sudorouter.ai/search/tavily/search
+```
+
+## 生成的配置格式
+
+`sudocode.json` 复用现有 macOS/Windows 逻辑：
+
+```json
+{
+  "models": {
+    "deepseek-v4-pro": {
+      "alias": "deepseek-v4-pro",
+      "name": "deepseek-v4-pro",
+      "input": ["text"],
+      "providers": {
+        "proxy": {
+          "provider": "sudorouter",
+          "model": "deepseek-v4-pro",
+          "api": "openai-completions"
+        }
+      }
+    }
+  },
+  "auth_modes": {
+    "proxy": {
+      "sudorouter": {
+        "baseUrl": "https://hk.sudorouter.ai/v1",
+        "apiKey": "example-api-key"
+      }
+    }
+  },
+  "web_search": {
+    "provider": "tavily",
+    "apiUrl": "https://hk.sudorouter.ai/search/tavily/search",
+    "apiKey": ""
+  }
+}
+```
+
+`settings.json` 示例：
+
+```json
+{ "model": "deepseek-v4-pro" }
+```
+
+## 非交互配置能力
+
+为了支持自动化部署，`scode-setup` 应支持：
+
+```bash
+SCODE_BASE_URL=https://hk.sudorouter.ai/v1 \
+SCODE_API_KEY=sk-xxx \
+SCODE_MODEL=deepseek-v4-pro \
+SCODE_ENABLE_SEARCH=1 \
+scode-setup --non-interactive
+```
+
+规则：
+
+- `SCODE_API_KEY` 必填。
+- `SCODE_MODEL` 可选；未提供时优先使用默认模型 `deepseek-v4-pro`，若模型列表不存在该模型，则使用拉取列表中的第一个模型。
+- `SCODE_BASE_URL` 默认 `https://hk.sudorouter.ai/v1`。
+- `SCODE_ENABLE_SEARCH` 默认 `1`。
+- 非交互模式失败时返回非零退出码，并输出可诊断错误。
+
+## 升级和卸载行为
+
+### 升级
+
+执行：
+
+```bash
+sudo apt install ./scode_0.1.13_amd64.deb
+```
+
+或后续 apt repository 支持后：
+
+```bash
+sudo apt upgrade scode
+```
+
+升级规则：
+
+- 替换 `/usr/bin/scode` 和 `scode-setup`。
+- 不覆盖 `~/.nexus/sudocode/sudocode.json`。
+- 不覆盖 `~/.nexus/sudocode/settings.json`。
+- 如果已有配置，`postinst` 只提示：
+
+```text
+Existing scode config detected. It was not modified.
+Run `scode-setup` to update models or credentials.
+```
+
+### 卸载
+
+执行：
+
+```bash
+sudo apt remove scode
+```
+
+卸载规则：
+
+- 删除包安装的系统文件。
+- 默认保留用户目录下的配置和会话数据。
+- 不删除 API Key 配置，避免误删用户数据。
+
+如果未来支持 purge：
+
+```bash
+sudo apt purge scode
+```
+
+可以只删除系统级残留，不建议自动遍历所有用户 home 删除个人配置。
+
+## 构建脚本设计
+
+新增目录：
+
+```text
+packaging/linux/deb/
+  build-deb.sh
+  control.template
+  postinst
+  prerm
+  scode-setup
+```
+
+`build-deb.sh` 输入：
+
+```bash
+packaging/linux/deb/build-deb.sh \
+  --version 0.1.12 \
+  --binary rust/target/release/scode \
+  --output rust/dist
+```
+
+输出：
+
+```text
+rust/dist/scode_0.1.12_amd64.deb
+```
+
+实现方式：
+
+```text
+1. 创建临时 package root
+2. 写入 DEBIAN/control、postinst、prerm
+3. 复制 scode 到 usr/bin/scode
+4. 复制 scode-setup 到 usr/lib/scode/scode-setup
+5. 创建 usr/bin/scode-setup wrapper 或软链接
+6. 复制 README
+7. 设置权限
+8. dpkg-deb --build
+```
+
+## Release 集成
+
+在 `.github/workflows/release.yml` 的 Linux x64 构建完成后新增 deb 打包步骤。
+
+建议新增独立 job：
+
+```text
+build-linux-deb
+```
+
+依赖：
+
+```text
+build-linux-x64
+```
+
+产物：
+
+```text
+scode_0.1.12_amd64.deb
+```
+
+发布时 `publish-release` 下载所有 artifact，生成统一 `SHA256SUMS.txt`，并上传：
+
+```text
+scode-linux-x64.tar.gz
+scode-linux-x64-musl.tar.gz
+scode-linux-arm64.tar.gz
+scode-macos-arm64.tar.gz
+scode-macos-x64.tar.gz
+scode-windows-x64.zip
+scode-windows-arm64.zip
+scode_0.1.12_amd64.deb
+SHA256SUMS.txt
+```
+
+## 测试计划
+
+### 本地包结构测试
+
+```bash
+dpkg-deb --info scode_0.1.12_amd64.deb
+dpkg-deb --contents scode_0.1.12_amd64.deb
+```
+
+检查：
+
+- `/usr/bin/scode` 存在且权限为可执行。
+- `/usr/bin/scode-setup` 存在且权限为可执行。
+- `postinst` 存在且权限为可执行。
+- `control` 元数据合法。
+
+### Ubuntu 容器安装测试
+
+```bash
+docker run --rm -it -v "$PWD/dist:/dist" ubuntu:22.04 bash
+apt-get update
+apt-get install -y /dist/scode_0.1.12_amd64.deb
+scode --version
+scode-setup
+```
+
+检查：
+
+- 安装成功。
+- `scode` 任意路径可执行。
+- 无 GUI 依赖。
+- 交互向导可运行。
+
+### 非交互安装测试
+
+```bash
+DEBIAN_FRONTEND=noninteractive apt-get install -y ./scode_0.1.12_amd64.deb
+```
+
+检查：
+
+- 安装不阻塞。
+- 未配置时给出清晰提示。
+- 返回码为 0。
+
+### 非交互配置测试
+
+```bash
+SCODE_BASE_URL=https://hk.sudorouter.ai/v1 \
+SCODE_API_KEY=sk-test \
+SCODE_MODEL=deepseek-v4-pro \
+SCODE_ENABLE_SEARCH=1 \
+scode-setup --non-interactive
+```
+
+检查：
+
+- 生成 `sudocode.json`。
+- 生成 `settings.json`。
+- 文件权限正确。
+- owner 是目标用户。
+
+### 升级测试
+
+```bash
+sudo apt install ./scode_0.1.12_amd64.deb
+sudo apt install ./scode_0.1.13_amd64.deb
+```
+
+检查：
+
+- 二进制版本更新。
+- 用户已有配置没有被覆盖。
+- `scode-setup` 更新为新版本。
+
+### 卸载测试
+
+```bash
+sudo apt remove scode
+```
+
+检查：
+
+- `/usr/bin/scode` 删除。
+- `/usr/bin/scode-setup` 删除。
+- 用户配置保留。
+
+## 风险和处理
+
+### sudo 安装写入 root 配置
+
+风险：安装时写到 `/root/.nexus/sudocode`。
+
+处理：`postinst` 解析真实用户；无法解析时跳过自动配置并提示手动运行。
+
+### 非交互安装卡住
+
+风险：自动化部署时安装过程等待输入。
+
+处理：只有检测到 TTY 才运行交互向导。
+
+### API Key 泄露
+
+风险：配置文件包含 API Key。
+
+处理：写入用户 home，目录 `0700`，配置文件 `0600`，不打印 API Key。
+
+### 模型列表解析不完整
+
+风险：shell 用 grep/sed 解析 JSON 不如 jq 稳健。
+
+处理：保持与现有 macOS/Windows 逻辑一致，解析 OpenAI 风格 `/models` 中的 `id` 字段；后续如果 CLI 内置配置命令，可迁移到 Rust 实现。
+
+### 安装时网络不可达
+
+风险：服务器不能访问模型接口。
+
+处理：配置向导失败不应破坏包安装；提示用户检查网络/API Key 后运行 `scode-setup` 重试。
+
+## 成功标准
+
+- GitHub Release 中出现 `scode_0.1.12_amd64.deb` 这类版本化 deb 产物。
+- Ubuntu 20.04/22.04/24.04 上可以通过 `apt install ./scode_0.1.12_amd64.deb` 安装。
+- 安装后任意路径可执行 `scode`。
+- 安装后任意路径可执行 `scode-setup`。
+- 有交互终端时安装后自动进入配置向导。
+- 无交互终端时安装不阻塞，并提示后续运行 `scode-setup`。
+- `scode-setup` 可重复运行，用于更新模型、Base URL、API Key 和 web_search。
+- 升级不会覆盖用户已有配置。
+- 卸载不会删除用户配置。

--- a/packaging/linux/deb/build-deb.sh
+++ b/packaging/linux/deb/build-deb.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: build-deb.sh --version VERSION --binary PATH --output DIR
+
+Build scode_VERSION_amd64.deb from an existing Linux x64 scode binary.
+EOF
+}
+
+VERSION=""
+BINARY=""
+OUTPUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#--version=}"
+      shift
+      ;;
+    --binary)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      BINARY="$2"
+      shift 2
+      ;;
+    --binary=*)
+      BINARY="${1#--binary=}"
+      shift
+      ;;
+    --output)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --output=*)
+      OUTPUT="${1#--output=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$VERSION" ] || { printf 'missing --version\n' >&2; exit 2; }
+[ -n "$BINARY" ] || { printf 'missing --binary\n' >&2; exit 2; }
+[ -n "$OUTPUT" ] || { printf 'missing --output\n' >&2; exit 2; }
+[ -f "$BINARY" ] || { printf 'binary not found: %s\n' "$BINARY" >&2; exit 2; }
+[ -x "$BINARY" ] || { printf 'binary is not executable: %s\n' "$BINARY" >&2; exit 2; }
+DPKG_DEB="${SCODE_DPKG_DEB:-dpkg-deb}"
+command -v "$DPKG_DEB" >/dev/null 2>&1 || { printf 'dpkg-deb is required\n' >&2; exit 2; }
+
+case "$VERSION" in
+  v*) VERSION="${VERSION#v}" ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT INT TERM HUP
+
+pkg="$TMP/scode_${VERSION}_amd64"
+mkdir -p \
+  "$pkg/DEBIAN" \
+  "$pkg/usr/bin" \
+  "$pkg/usr/lib/scode" \
+  "$pkg/usr/share/doc/scode"
+
+sed "s/@VERSION@/$VERSION/g" "$SCRIPT_DIR/control.template" > "$pkg/DEBIAN/control"
+install -m 0755 "$SCRIPT_DIR/postinst" "$pkg/DEBIAN/postinst"
+install -m 0755 "$SCRIPT_DIR/prerm" "$pkg/DEBIAN/prerm"
+install -m 0755 "$BINARY" "$pkg/usr/bin/scode"
+install -m 0755 "$SCRIPT_DIR/scode-setup" "$pkg/usr/lib/scode/scode-setup"
+cat > "$pkg/usr/bin/scode-setup" <<'EOF'
+#!/usr/bin/env sh
+exec /usr/lib/scode/scode-setup "$@"
+EOF
+chmod 0755 "$pkg/usr/bin/scode-setup"
+
+if [ -f "$ROOT/README.md" ]; then
+  install -m 0644 "$ROOT/README.md" "$pkg/usr/share/doc/scode/README.md"
+else
+  printf 'scode\n' > "$pkg/usr/share/doc/scode/README.md"
+  chmod 0644 "$pkg/usr/share/doc/scode/README.md"
+fi
+
+mkdir -p "$OUTPUT"
+"$DPKG_DEB" --build --root-owner-group "$pkg" "$OUTPUT/scode_${VERSION}_amd64.deb" >/dev/null
+printf '%s\n' "$OUTPUT/scode_${VERSION}_amd64.deb"

--- a/packaging/linux/deb/control.template
+++ b/packaging/linux/deb/control.template
@@ -1,0 +1,10 @@
+Package: scode
+Version: @VERSION@
+Section: devel
+Priority: optional
+Architecture: amd64
+Maintainer: sudocode
+Depends: bash, ca-certificates, curl
+Description: Sudo Code command line coding agent
+ scode is a terminal coding agent CLI. This package installs the scode
+ binary and the scode-setup configuration command for Ubuntu/Debian systems.

--- a/packaging/linux/deb/postinst
+++ b/packaging/linux/deb/postinst
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${1:-}" != "configure" ]; then
+  exit 0
+fi
+
+if [ "${DEBIAN_FRONTEND:-}" = "noninteractive" ] || [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; then
+  printf '%s\n' "scode installed."
+  printf '%s\n' "No interactive terminal detected, skipped setup."
+  printf '%s\n' "Run 'scode-setup' as the target user to configure models."
+  exit 0
+fi
+
+target_user=""
+if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+  target_user="$SUDO_USER"
+elif command -v logname >/dev/null 2>&1; then
+  target_user="$(logname 2>/dev/null || true)"
+fi
+
+if [ -n "$target_user" ] && command -v getent >/dev/null 2>&1; then
+  target_home="$(getent passwd "$target_user" | awk -F: '{print $6}' | head -n 1)"
+else
+  target_home=""
+fi
+
+if [ "$(id -u)" -eq 0 ] && [ -n "$target_user" ] && [ "$target_user" != "root" ]; then
+  if [ -z "$target_home" ]; then
+    printf '%s\n' "scode installed."
+    printf '%s\n' "Could not resolve home directory for '$target_user'. Run 'scode-setup' as that user."
+    exit 0
+  fi
+  if command -v runuser >/dev/null 2>&1; then
+    runuser -u "$target_user" -- env HOME="$target_home" USER="$target_user" LOGNAME="$target_user" /usr/lib/scode/scode-setup --install </dev/tty >/dev/tty 2>&1 || true
+  elif command -v su >/dev/null 2>&1; then
+    su "$target_user" -c "HOME='$target_home' USER='$target_user' LOGNAME='$target_user' /usr/lib/scode/scode-setup --install" </dev/tty >/dev/tty 2>&1 || true
+  else
+    printf '%s\n' "scode installed."
+    printf '%s\n' "Could not switch to target user '$target_user'. Run 'scode-setup' as that user."
+  fi
+else
+  /usr/lib/scode/scode-setup --install </dev/tty >/dev/tty 2>&1 || true
+fi
+
+exit 0

--- a/packaging/linux/deb/prerm
+++ b/packaging/linux/deb/prerm
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+exit 0

--- a/packaging/linux/deb/scode-setup
+++ b/packaging/linux/deb/scode-setup
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_BASE_URL="https://hk.sudorouter.ai/v1"
+DEFAULT_MODEL="deepseek-v4-pro"
+SEARCH_API_URL="https://hk.sudorouter.ai/search/tavily/search"
+CONFIG_DIR="${SUDO_CODE_CONFIG_HOME:-$HOME/.nexus/sudocode}"
+NON_INTERACTIVE=0
+INSTALL_MODE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --non-interactive)
+      NON_INTERACTIVE=1
+      shift
+      ;;
+    --install)
+      INSTALL_MODE=1
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scode-setup [--install] [--non-interactive]
+
+Configure scode models, credentials, and web_search.
+
+Environment for --non-interactive:
+  SCODE_BASE_URL       Default: https://hk.sudorouter.ai/v1
+  SCODE_API_KEY        Required
+  SCODE_MODEL          Optional default model
+  SCODE_MODELS         Optional comma or newline separated model list
+  SCODE_ENABLE_SEARCH  1 or 0, default 1
+EOF
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+is_vision() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    *gpt-5*|*gpt-4o*|*gpt-4.1*|*gemini*|*claude-3*|*claude-opus*|*claude-sonnet*|*claude-haiku*|*vision*|*-vl*|*llava*|*pixtral*|*-image*|*multimodal*|*omni*)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_models() {
+  tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF && !seen[$0]++'
+}
+
+fetch_models() {
+  base_url="${1%/}"
+  api_key="$2"
+  curl -fsS -H "Authorization: Bearer $api_key" "$base_url/models" 2>/dev/null \
+    | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | sed -E 's/.*"([^"]*)"$/\1/' \
+    | awk 'NF && !seen[$0]++'
+}
+
+extract_base_url() {
+  [ -f "$CONFIG_DIR/sudocode.json" ] || return 1
+  sed -nE 's/.*"baseUrl"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG_DIR/sudocode.json" | head -n 1
+}
+
+extract_api_key() {
+  [ -f "$CONFIG_DIR/sudocode.json" ] || return 1
+  sed -nE 's/.*"apiKey"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$CONFIG_DIR/sudocode.json" | head -n 1
+}
+
+extract_models() {
+  [ -f "$CONFIG_DIR/sudocode.json" ] || return 1
+  sed -nE 's/^[[:space:]]*"([^"]+)"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/\1/p' "$CONFIG_DIR/sudocode.json" \
+    | awk '$0 != "models" && $0 != "auth_modes" && $0 != "proxy" && $0 != "sudorouter" && $0 != "web_search"'
+}
+
+has_web_search() {
+  [ -f "$CONFIG_DIR/sudocode.json" ] && grep -q '"web_search"' "$CONFIG_DIR/sudocode.json"
+}
+
+choose_model_from_list() {
+  models="$1"
+  preferred="${2:-$DEFAULT_MODEL}"
+  def_index=""
+  i=1
+  while IFS= read -r model; do
+    [ -n "$model" ] || continue
+    printf '  %2d) %s\n' "$i" "$model"
+    if [ "$model" = "$preferred" ]; then
+      def_index="$i"
+    fi
+    i=$((i + 1))
+  done <<EOF
+$models
+EOF
+  total=$((i - 1))
+  [ "$total" -gt 0 ] || return 1
+  printf '编号 [%s]: ' "${def_index:-1}"
+  read -r selected
+  selected="${selected:-${def_index:-1}}"
+  if ! printf '%s' "$selected" | grep -qE '^[0-9]+$' || [ "$selected" -lt 1 ] || [ "$selected" -gt "$total" ]; then
+    selected="${def_index:-1}"
+  fi
+  printf '%s\n' "$models" | awk 'NF' | sed -n "${selected}p"
+}
+
+build_models_block() {
+  models="$1"
+  first=1
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    if is_vision "$id"; then
+      input='["text", "image"]'
+    else
+      input='["text"]'
+    fi
+    eid="$(json_escape "$id")"
+    entry=$(printf '    "%s": {\n      "alias": "%s",\n      "name": "%s",\n      "input": %s,\n      "providers": {\n        "proxy": { "provider": "sudorouter", "model": "%s", "api": "openai-completions" }\n      }\n    }' "$eid" "$eid" "$eid" "$input" "$eid")
+    if [ "$first" -eq 1 ]; then
+      printf '%s' "$entry"
+      first=0
+    else
+      printf ',\n%s' "$entry"
+    fi
+  done <<EOF
+$models
+EOF
+}
+
+write_config() {
+  base_url="${1%/}"
+  api_key="$2"
+  models="$3"
+  chosen_model="$4"
+  enable_search="$5"
+
+  models_block="$(build_models_block "$models")"
+  if [ "$enable_search" = "1" ]; then
+    web_search=$(cat <<EOF
+,
+  "web_search": {
+    "provider": "tavily",
+    "apiUrl": "$SEARCH_API_URL",
+    "apiKey": ""
+  }
+EOF
+)
+  else
+    web_search=""
+  fi
+
+  mkdir -p "$CONFIG_DIR"
+  chmod 700 "$CONFIG_DIR"
+  cat > "$CONFIG_DIR/sudocode.json" <<EOF
+{
+  "models": {
+$models_block
+  },
+  "auth_modes": {
+    "proxy": {
+      "sudorouter": { "baseUrl": "$(json_escape "$base_url")", "apiKey": "$(json_escape "$api_key")" }
+    }
+  }$web_search
+}
+EOF
+  chmod 600 "$CONFIG_DIR/sudocode.json"
+  printf '{ "model": "%s" }\n' "$(json_escape "$chosen_model")" > "$CONFIG_DIR/settings.json"
+  chmod 600 "$CONFIG_DIR/settings.json"
+}
+
+non_interactive_setup() {
+  base_url="${SCODE_BASE_URL:-$DEFAULT_BASE_URL}"
+  api_key="${SCODE_API_KEY:-}"
+  enable_search="${SCODE_ENABLE_SEARCH:-1}"
+  [ -n "$api_key" ] || { printf 'SCODE_API_KEY is required for --non-interactive\n' >&2; exit 2; }
+  case "$enable_search" in
+    1|true|TRUE|yes|YES) enable_search=1 ;;
+    0|false|FALSE|no|NO) enable_search=0 ;;
+    *) printf 'SCODE_ENABLE_SEARCH must be 1 or 0\n' >&2; exit 2 ;;
+  esac
+  if [ -n "${SCODE_MODELS:-}" ]; then
+    models="$(printf '%s\n' "$SCODE_MODELS" | normalize_models)"
+  else
+    models="$(fetch_models "$base_url" "$api_key" || true)"
+  fi
+  [ -n "$models" ] || { printf 'model list is empty\n' >&2; exit 1; }
+  chosen_model="${SCODE_MODEL:-}"
+  if [ -z "$chosen_model" ]; then
+    if printf '%s\n' "$models" | grep -qx "$DEFAULT_MODEL"; then
+      chosen_model="$DEFAULT_MODEL"
+    else
+      chosen_model="$(printf '%s\n' "$models" | awk 'NF' | sed -n '1p')"
+    fi
+  fi
+  if ! printf '%s\n' "$models" | grep -qx "$chosen_model"; then
+    models="$(printf '%s\n%s\n' "$chosen_model" "$models" | awk 'NF && !seen[$0]++')"
+  fi
+  write_config "$base_url" "$api_key" "$models" "$chosen_model" "$enable_search"
+  printf 'scode configuration written to %s\n' "$CONFIG_DIR"
+}
+
+full_interactive_setup() {
+  printf 'Base URL [%s]: ' "$DEFAULT_BASE_URL"
+  read -r base_url
+  base_url="${base_url:-$DEFAULT_BASE_URL}"
+  base_url="${base_url%/}"
+  case "$base_url" in
+    http://*|https://*) ;;
+    *) printf 'Base URL must start with http:// or https://\n' >&2; exit 1 ;;
+  esac
+
+  printf 'API Key: '
+  read -r -s api_key
+  printf '\n'
+  [ -n "$api_key" ] || { printf 'API Key cannot be empty.\n' >&2; exit 1; }
+
+  printf '正在拉取模型列表...\n'
+  models="$(fetch_models "$base_url" "$api_key" || true)"
+  [ -n "$models" ] || { printf '拉取失败或列表为空，请检查网络和 API Key 后重试。\n' >&2; exit 1; }
+  printf '已拉取 %s 个模型\n\n' "$(printf '%s\n' "$models" | awk 'NF' | wc -l | tr -d ' ')"
+
+  printf '请选择默认模型（回车默认 %s）：\n' "$DEFAULT_MODEL"
+  chosen_model="$(choose_model_from_list "$models" "$DEFAULT_MODEL")"
+  printf '默认模型：%s\n' "$chosen_model"
+
+  printf '启用联网搜索 web_search？[Y/n] '
+  read -r search_answer
+  case "$search_answer" in
+    n|N|no|NO) enable_search=0 ;;
+    *) enable_search=1 ;;
+  esac
+
+  write_config "$base_url" "$api_key" "$models" "$chosen_model" "$enable_search"
+  printf '\n配置已写入：\n'
+  printf '  %s/sudocode.json\n' "$CONFIG_DIR"
+  printf '  %s/settings.json\n' "$CONFIG_DIR"
+}
+
+update_default_model() {
+  models="$(extract_models || true)"
+  [ -n "$models" ] || { printf '未找到模型列表，请选择重新拉取模型列表。\n' >&2; return 1; }
+  printf '请选择默认模型：\n'
+  chosen_model="$(choose_model_from_list "$models" "$DEFAULT_MODEL")"
+  printf '{ "model": "%s" }\n' "$(json_escape "$chosen_model")" > "$CONFIG_DIR/settings.json"
+  chmod 600 "$CONFIG_DIR/settings.json"
+  printf '默认模型已更新：%s\n' "$chosen_model"
+}
+
+refresh_models() {
+  base_url="$(extract_base_url || true)"
+  api_key="$(extract_api_key || true)"
+  [ -n "$base_url" ] || base_url="$DEFAULT_BASE_URL"
+  [ -n "$api_key" ] || { printf '未找到 API Key，请选择修改 Base URL / API Key。\n' >&2; return 1; }
+  printf '正在拉取模型列表...\n'
+  models="$(fetch_models "$base_url" "$api_key" || true)"
+  [ -n "$models" ] || { printf '拉取失败或列表为空。\n' >&2; return 1; }
+  printf '请选择默认模型：\n'
+  chosen_model="$(choose_model_from_list "$models" "$DEFAULT_MODEL")"
+  if has_web_search; then enable_search=1; else enable_search=0; fi
+  write_config "$base_url" "$api_key" "$models" "$chosen_model" "$enable_search"
+  printf '模型列表已刷新。\n'
+}
+
+toggle_web_search() {
+  base_url="$(extract_base_url || true)"
+  api_key="$(extract_api_key || true)"
+  models="$(extract_models || true)"
+  [ -n "$base_url" ] || base_url="$DEFAULT_BASE_URL"
+  [ -n "$api_key" ] || { printf '未找到 API Key，请先重建配置。\n' >&2; return 1; }
+  [ -n "$models" ] || { printf '未找到模型列表，请先重建配置。\n' >&2; return 1; }
+  current_model="$(sed -nE 's/.*"model"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG_DIR/settings.json" 2>/dev/null | head -n 1)"
+  [ -n "$current_model" ] || current_model="$(printf '%s\n' "$models" | awk 'NF' | sed -n '1p')"
+  if has_web_search; then
+    printf '当前 web_search 已启用，是否关闭？[y/N] '
+    read -r answer
+    case "$answer" in y|Y|yes|YES) enable_search=0 ;; *) enable_search=1 ;; esac
+  else
+    printf '当前 web_search 未启用，是否开启？[Y/n] '
+    read -r answer
+    case "$answer" in n|N|no|NO) enable_search=0 ;; *) enable_search=1 ;; esac
+  fi
+  write_config "$base_url" "$api_key" "$models" "$current_model" "$enable_search"
+  printf 'web_search 配置已更新。\n'
+}
+
+interactive_menu() {
+  printf '================================================\n'
+  printf '     Sudo Code · scode 配置向导\n'
+  printf '================================================\n\n'
+
+  if [ ! -f "$CONFIG_DIR/sudocode.json" ]; then
+    full_interactive_setup
+    return
+  fi
+
+  if [ "$INSTALL_MODE" -eq 1 ]; then
+    printf '检测到已有配置：%s/sudocode.json\n' "$CONFIG_DIR"
+    printf '安装过程不会覆盖已有配置。如需更新模型，请运行 scode-setup。\n'
+    return
+  fi
+
+  while true; do
+    printf '\n检测到已有配置：%s/sudocode.json\n\n' "$CONFIG_DIR"
+    printf '请选择操作：\n'
+    printf '  1) 只修改默认模型\n'
+    printf '  2) 重新拉取模型列表并选择默认模型\n'
+    printf '  3) 修改 Base URL / API Key 并重建配置\n'
+    printf '  4) 开启/关闭 web_search\n'
+    printf '  5) 退出\n'
+    printf '编号 [1]: '
+    read -r choice
+    choice="${choice:-1}"
+    case "$choice" in
+      1) update_default_model ;;
+      2) refresh_models ;;
+      3) full_interactive_setup ;;
+      4) toggle_web_search ;;
+      5) return ;;
+      *) printf '无效选择。\n' ;;
+    esac
+  done
+}
+
+if [ "$NON_INTERACTIVE" -eq 1 ]; then
+  non_interactive_setup
+else
+  interactive_menu
+fi

--- a/packaging/linux/deb/scode-setup
+++ b/packaging/linux/deb/scode-setup
@@ -77,8 +77,8 @@ extract_api_key() {
 
 extract_models() {
   [ -f "$CONFIG_DIR/sudocode.json" ] || return 1
-  sed -nE 's/^[[:space:]]*"([^"]+)"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/\1/p' "$CONFIG_DIR/sudocode.json" \
-    | awk '$0 != "models" && $0 != "auth_modes" && $0 != "proxy" && $0 != "sudorouter" && $0 != "web_search"'
+  sed -n '/^[[:space:]]*"models"[[:space:]]*:[[:space:]]*{[[:space:]]*$/,/^[[:space:]]*"auth_modes"[[:space:]]*:/p' "$CONFIG_DIR/sudocode.json" \
+    | sed -nE 's/^    "([^"]+)"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/\1/p'
 }
 
 has_web_search() {
@@ -92,7 +92,7 @@ choose_model_from_list() {
   i=1
   while IFS= read -r model; do
     [ -n "$model" ] || continue
-    printf '  %2d) %s\n' "$i" "$model"
+    printf '  %2d) %s\n' "$i" "$model" >&2
     if [ "$model" = "$preferred" ]; then
       def_index="$i"
     fi
@@ -102,7 +102,7 @@ $models
 EOF
   total=$((i - 1))
   [ "$total" -gt 0 ] || return 1
-  printf '编号 [%s]: ' "${def_index:-1}"
+  printf '编号 [%s]: ' "${def_index:-1}" >&2
   read -r selected
   selected="${selected:-${def_index:-1}}"
   if ! printf '%s' "$selected" | grep -qE '^[0-9]+$' || [ "$selected" -lt 1 ] || [ "$selected" -gt "$total" ]; then

--- a/packaging/linux/deb/tests/test_build_deb.sh
+++ b/packaging/linux/deb/tests/test_build_deb.sh
@@ -75,3 +75,30 @@ postinst_output="$(
   "$ROOT/packaging/linux/deb/postinst" configure
 )"
 printf '%s\n' "$postinst_output" | grep -q 'No interactive terminal detected, skipped setup.'
+
+interactive_home="$TMP/interactive-home"
+fake_path="$TMP/fake-path"
+mkdir -p "$interactive_home" "$fake_path"
+cat > "$fake_path/curl" <<'BIN'
+#!/usr/bin/env sh
+cat <<'JSON'
+{"data":[{"id":"codex-auto-review"},{"id":"gpt-5"}]}
+JSON
+BIN
+chmod +x "$fake_path/curl"
+
+printf '\ntest-api-key\n2\nn\n' | \
+  HOME="$interactive_home" \
+  PATH="$fake_path:$PATH" \
+  "$ROOT/packaging/linux/deb/scode-setup"
+
+test -f "$interactive_home/.nexus/sudocode/settings.json"
+grep -qx '{ "model": "gpt-5" }' "$interactive_home/.nexus/sudocode/settings.json"
+! grep -q '编号' "$interactive_home/.nexus/sudocode/settings.json"
+! grep -q 'providers' "$interactive_home/.nexus/sudocode/settings.json"
+
+printf '1\n2\n5\n' | \
+  HOME="$setup_home" \
+  "$ROOT/packaging/linux/deb/scode-setup" >/dev/null
+grep -qx '{ "model": "vision-model" }' "$setup_home/.nexus/sudocode/settings.json"
+! grep -q '"model": "providers"' "$setup_home/.nexus/sudocode/settings.json"

--- a/packaging/linux/deb/tests/test_build_deb.sh
+++ b/packaging/linux/deb/tests/test_build_deb.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fake_bin="$TMP/scode"
+cat >"$fake_bin" <<'BIN'
+#!/usr/bin/env sh
+printf 'scode test\n'
+BIN
+chmod +x "$fake_bin"
+
+fake_dpkg="$TMP/fake-dpkg-deb"
+cat >"$fake_dpkg" <<'BIN'
+#!/usr/bin/env bash
+set -euo pipefail
+pkg_root="$3"
+out="$4"
+mkdir -p "$(dirname "$out")" "$SCODE_TEST_CAPTURE_ROOT"
+cp -a "$pkg_root"/. "$SCODE_TEST_CAPTURE_ROOT"/
+printf 'fake deb\n' > "$out"
+BIN
+chmod +x "$fake_dpkg"
+
+SCODE_DPKG_DEB="$fake_dpkg" \
+SCODE_TEST_CAPTURE_ROOT="$TMP/package-root" \
+"$ROOT/packaging/linux/deb/build-deb.sh" \
+  --version 0.1.12 \
+  --binary "$fake_bin" \
+  --output "$TMP/dist"
+
+deb="$TMP/dist/scode_0.1.12_amd64.deb"
+test -f "$deb"
+test -x "$TMP/package-root/usr/bin/scode"
+test -x "$TMP/package-root/usr/bin/scode-setup"
+test -x "$TMP/package-root/usr/lib/scode/scode-setup"
+grep -q 'Package: scode' "$TMP/package-root/DEBIAN/control"
+grep -q 'Version: 0.1.12' "$TMP/package-root/DEBIAN/control"
+
+if command -v dpkg-deb >/dev/null 2>&1; then
+  "$ROOT/packaging/linux/deb/build-deb.sh" \
+    --version 0.1.12 \
+    --binary "$fake_bin" \
+    --output "$TMP/real-dist"
+  real_deb="$TMP/real-dist/scode_0.1.12_amd64.deb"
+  dpkg-deb --contents "$real_deb" | grep -q './usr/bin/scode$'
+  dpkg-deb --contents "$real_deb" | grep -q './usr/bin/scode-setup$'
+  dpkg-deb --contents "$real_deb" | grep -q './usr/lib/scode/scode-setup$'
+  dpkg-deb --info "$real_deb" | grep -q 'Package: scode'
+  dpkg-deb --info "$real_deb" | grep -q 'Version: 0.1.12'
+fi
+
+setup_home="$TMP/home"
+mkdir -p "$setup_home"
+HOME="$setup_home" \
+SCODE_BASE_URL="https://example.invalid/v1" \
+SCODE_API_KEY="test-key" \
+SCODE_MODEL="test-model" \
+SCODE_MODELS="test-model,vision-model" \
+SCODE_ENABLE_SEARCH=0 \
+"$ROOT/packaging/linux/deb/scode-setup" --non-interactive
+
+test -f "$setup_home/.nexus/sudocode/sudocode.json"
+test -f "$setup_home/.nexus/sudocode/settings.json"
+grep -q '"test-model"' "$setup_home/.nexus/sudocode/settings.json"
+grep -q '"baseUrl": "https://example.invalid/v1"' "$setup_home/.nexus/sudocode/sudocode.json"
+grep -q '"apiKey": "test-key"' "$setup_home/.nexus/sudocode/sudocode.json"
+grep -q '"vision-model"' "$setup_home/.nexus/sudocode/sudocode.json"
+! grep -q '"web_search"' "$setup_home/.nexus/sudocode/sudocode.json"
+
+postinst_output="$(
+  DEBIAN_FRONTEND=noninteractive \
+  "$ROOT/packaging/linux/deb/postinst" configure
+)"
+printf '%s\n' "$postinst_output" | grep -q 'No interactive terminal detected, skipped setup.'


### PR DESCRIPTION
## Summary
- add Ubuntu/Debian deb packaging for scode with scode-setup
- publish the deb artifact from the linux-x64 release workflow
- document install, validation, setup updates, non-interactive config, upgrade, and uninstall flows

## Test Plan
- bash -n packaging/linux/deb/build-deb.sh packaging/linux/deb/scode-setup packaging/linux/deb/tests/test_build_deb.sh && sh -n packaging/linux/deb/postinst packaging/linux/deb/prerm
- bash packaging/linux/deb/tests/test_build_deb.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'
- GitHub Actions manual run verified linux deb artifact after workflow fix