### PR TITLE
Add Linux bundle installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,20 @@ jobs:
             --binary target/x86_64-unknown-linux-musl/release/scode \
             --output dist
 
+      - name: Build bundle installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" == v* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0.${GITHUB_RUN_NUMBER}"
+          fi
+          ../packaging/linux/bundle/build-bundle.sh \
+            --version "$version" \
+            --binary target/x86_64-unknown-linux-musl/release/scode \
+            --output dist
+
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
@@ -115,6 +129,12 @@ jobs:
         with:
           name: scode-linux-x64-deb
           path: rust/dist/scode_*_amd64.deb
+
+      - name: Upload bundle workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scode-linux-x64-bundle
+          path: rust/dist/scode-linux-x64-bundle.tar.gz
 
   build:
     name: build-${{ matrix.name }}

--- a/docs/linux-bundle-install.zh-CN.md
+++ b/docs/linux-bundle-install.zh-CN.md
@@ -1,0 +1,352 @@
+# Linux bundle 安装使用说明
+
+本文档说明如何使用 `scode-linux-x64-bundle.tar.gz` 在 Linux 服务器上安装
+`scode`。该方式不依赖 deb、rpm、apt 或 yum，适合客户服务器发行版和版本不确定的场景。
+
+## 适用场景
+
+推荐在以下场景使用 bundle：
+
+- 客户服务器不确定是 Ubuntu、Debian、CentOS、RHEL、Rocky 还是其他发行版。
+- 服务器没有可用的 apt/dpkg。
+- 客户希望离线传包安装。
+- deb 安装包在目标环境不可用。
+
+如果客户明确是 Ubuntu/Debian，仍然可以优先使用 deb 安装包。
+
+## 下载产物
+
+从 GitHub Actions 或 Release 下载：
+
+```text
+scode-linux-x64-bundle.tar.gz
+```
+
+解压后目录结构：
+
+```text
+scode-linux-x64-bundle/
+  scode
+  scode-setup
+  README-install.zh-CN.md
+  VERSION
+  SHA256SUMS.txt
+```
+
+## 上传到服务器
+
+```bash
+scp scode-linux-x64-bundle.tar.gz ubuntu@your-server:/tmp/
+ssh ubuntu@your-server
+```
+
+## 安装
+
+在服务器上执行：
+
+```bash
+cd /tmp
+tar -xzf scode-linux-x64-bundle.tar.gz
+cd scode-linux-x64-bundle
+sudo ./scode-setup install
+```
+
+默认安装到：
+
+```text
+/usr/local/bin/scode
+/usr/local/bin/scode-setup
+/usr/local/lib/scode/install-manifest
+```
+
+说明：
+
+- `/usr/local/bin` 是手工安装软件的推荐路径。
+- 安装后任意目录都可以执行 `scode` 和 `scode-setup`。
+- `install-manifest` 用于记录脚本安装过哪些文件，方便后续卸载。
+
+如果客户明确要求安装到 `/usr/bin`：
+
+```bash
+sudo ./scode-setup install --bin-dir /usr/bin
+```
+
+## 首次配置模型
+
+`sudo ./scode-setup install` 安装完成后，会进入终端配置向导。
+
+向导会询问：
+
+```text
+Base URL
+API Key
+默认模型
+是否启用 web_search
+```
+
+默认 Base URL：
+
+```text
+https://hk.sudorouter.ai/v1
+```
+
+配置文件写入真实登录用户的 home 目录，而不是 root：
+
+```text
+~/.nexus/sudocode/sudocode.json
+~/.nexus/sudocode/settings.json
+```
+
+`sudocode.json` 包含 API Key，不要直接发送给他人。
+
+## 验证安装
+
+```bash
+which scode
+which scode-setup
+scode --version
+```
+
+预期：
+
+```text
+/usr/local/bin/scode
+/usr/local/bin/scode-setup
+```
+
+如果安装到了 `/usr/bin`，预期为：
+
+```text
+/usr/bin/scode
+/usr/bin/scode-setup
+```
+
+检查安装记录：
+
+```bash
+cat /usr/local/lib/scode/install-manifest
+```
+
+运行安装检查：
+
+```bash
+scode-setup doctor
+```
+
+运行配置检查：
+
+```bash
+ls -la ~/.nexus/sudocode
+cat ~/.nexus/sudocode/settings.json
+```
+
+`settings.json` 应类似：
+
+```json
+{ "model": "gpt-5" }
+```
+
+安全查看 `sudocode.json`：
+
+```bash
+sed -E 's/("apiKey"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"***"/g' \
+  ~/.nexus/sudocode/sudocode.json
+```
+
+试跑：
+
+```bash
+scode doctor
+scode -p "你好"
+```
+
+## 后续更新模型配置
+
+安装完成后，直接运行：
+
+```bash
+scode-setup
+```
+
+等价于：
+
+```bash
+scode-setup configure
+```
+
+已有配置时会显示：
+
+```text
+1) 只修改默认模型
+2) 重新拉取模型列表并选择默认模型
+3) 修改 Base URL / API Key 并重建配置
+4) 开启/关闭 web_search
+5) 退出
+```
+
+建议：
+
+- 只切换默认模型：选择 `1`。
+- 服务端模型列表变化：选择 `2`。
+- Base URL 或 API Key 变化：选择 `3`。
+- 调整联网搜索：选择 `4`。
+
+## 非交互配置
+
+自动化部署可以使用：
+
+```bash
+SCODE_BASE_URL=https://hk.sudorouter.ai/v1 \
+SCODE_API_KEY=your-api-key \
+SCODE_MODEL=deepseek-v4-pro \
+SCODE_ENABLE_SEARCH=1 \
+scode-setup configure --non-interactive
+```
+
+如果不希望访问 `/models`，可以提供模型列表：
+
+```bash
+SCODE_API_KEY=your-api-key \
+SCODE_MODEL=gpt-5 \
+SCODE_MODELS=gpt-5,gpt-5-mini,gpt-4.1 \
+scode-setup configure --non-interactive
+```
+
+## 只安装，不配置
+
+自动化场景中，如果只想安装二进制，暂时不生成模型配置：
+
+```bash
+sudo SCODE_SKIP_CONFIG=1 ./scode-setup install
+```
+
+后续由目标用户运行：
+
+```bash
+scode-setup configure
+```
+
+## 升级
+
+下载新的 bundle 后重新执行安装：
+
+```bash
+tar -xzf scode-linux-x64-bundle.tar.gz
+cd scode-linux-x64-bundle
+sudo ./scode-setup install
+```
+
+升级会替换：
+
+```text
+/usr/local/bin/scode
+/usr/local/bin/scode-setup
+```
+
+不会覆盖用户已有模型配置：
+
+```text
+~/.nexus/sudocode/sudocode.json
+~/.nexus/sudocode/settings.json
+```
+
+如需刷新模型列表：
+
+```bash
+scode-setup configure
+```
+
+然后选择：
+
+```text
+2) 重新拉取模型列表并选择默认模型
+```
+
+## 卸载
+
+如果使用默认安装路径：
+
+```bash
+sudo scode-setup uninstall
+```
+
+自动化场景：
+
+```bash
+sudo scode-setup uninstall --yes
+```
+
+如果安装时指定了 `/usr/bin`：
+
+```bash
+sudo scode-setup uninstall --bin-dir /usr/bin
+```
+
+卸载会删除脚本安装的全局文件：
+
+```text
+scode
+scode-setup
+install-manifest
+```
+
+用户配置默认保留：
+
+```text
+~/.nexus/sudocode
+```
+
+如确认不再需要，可手动删除：
+
+```bash
+rm -rf ~/.nexus/sudocode
+```
+
+## 常见问题
+
+### 为什么默认安装到 /usr/local/bin
+
+`/usr/local/bin` 是 Linux 上手工安装软件的推荐位置，不容易和系统包管理器管理的
+`/usr/bin` 文件冲突。
+
+如果客户环境只允许 `/usr/bin`，可以显式指定：
+
+```bash
+sudo ./scode-setup install --bin-dir /usr/bin
+```
+
+### sudo 安装后配置是否会写到 root
+
+不会。安装脚本会尽量识别真实登录用户，并把配置写入该用户的：
+
+```text
+~/.nexus/sudocode
+```
+
+如果无法识别真实用户，会提示用户安装后手动运行：
+
+```bash
+scode-setup configure
+```
+
+### 安装时没有进入配置向导
+
+如果当前不是交互式终端，安装脚本不会阻塞等待输入。安装后运行：
+
+```bash
+scode-setup configure
+```
+
+### settings.json 内容应该是什么
+
+应只包含默认模型：
+
+```json
+{ "model": "gpt-5" }
+```
+
+如果内容异常，重新运行：
+
+```bash
+scode-setup configure
+```

--- a/docs/superpowers/plans/2026-07-22-linux-bundle-installer.md
+++ b/docs/superpowers/plans/2026-07-22-linux-bundle-installer.md
@@ -1,0 +1,125 @@
+# Linux Bundle Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a cross-distribution Linux bundle artifact that lets customers run `sudo ./scode-setup install` to install `scode` globally and then reuse `scode-setup` to update model configuration.
+
+**Architecture:** Reuse the existing static musl `scode` binary and `packaging/linux/deb/scode-setup` script. Add a bundle builder that stages `scode`, `scode-setup`, and Chinese install docs into a tarball; extend `scode-setup` with explicit `install`, `configure`, `doctor`, and `uninstall` commands while preserving the existing configuration behavior.
+
+**Tech Stack:** Bash, tar, GitHub Actions, existing Rust Linux musl release binary.
+
+---
+
+## File Map
+
+- Create `packaging/linux/bundle/build-bundle.sh`: builds `scode-linux-x64-bundle.tar.gz` from an existing binary and setup script.
+- Create `packaging/linux/bundle/tests/test_bundle.sh`: verifies bundle layout and `scode-setup install` behavior with a fake install root.
+- Modify `packaging/linux/deb/scode-setup`: adds install/configure/doctor/uninstall commands without changing existing config flows.
+- Modify `.github/workflows/release.yml`: uploads `scode-linux-x64-bundle.tar.gz` from the Linux x64 job.
+- Create `docs/linux-bundle-install.zh-CN.md`: customer-facing Chinese install and update guide.
+
+## Task 1: Bundle Test
+
+**Files:**
+- Create: `packaging/linux/bundle/tests/test_bundle.sh`
+
+- [ ] **Step 1: Write failing bundle layout and install test**
+
+The test creates a fake `scode`, runs `build-bundle.sh`, inspects the tarball, extracts it, and runs `scode-setup install` into a temporary install root.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash packaging/linux/bundle/tests/test_bundle.sh`
+
+Expected: FAIL because `packaging/linux/bundle/build-bundle.sh` does not exist.
+
+## Task 2: Bundle Builder
+
+**Files:**
+- Create: `packaging/linux/bundle/build-bundle.sh`
+
+- [ ] **Step 1: Implement `build-bundle.sh`**
+
+Support `--version`, `--binary`, and `--output`. Stage `scode`, `scode-setup`, `README-install.zh-CN.md`, and `SHA256SUMS.txt`, then write `scode-linux-x64-bundle.tar.gz`.
+
+- [ ] **Step 2: Run bundle test**
+
+Run: `bash packaging/linux/bundle/tests/test_bundle.sh`
+
+Expected: FAIL at install command until `scode-setup install` exists.
+
+## Task 3: scode-setup Install Commands
+
+**Files:**
+- Modify: `packaging/linux/deb/scode-setup`
+
+- [ ] **Step 1: Add command parser**
+
+Support `install`, `configure`, `doctor`, and `uninstall`. Keep no subcommand as `configure`.
+
+- [ ] **Step 2: Add install root testing hooks**
+
+Support `SCODE_INSTALL_ROOT` and `SCODE_SKIP_CONFIG=1` so tests can install under a temp directory without touching `/usr/local/bin` or user configs.
+
+- [ ] **Step 3: Add installer behavior**
+
+Install sibling `scode` and `scode-setup` to `/usr/local/bin` by default, write `/usr/local/lib/scode/install-manifest`, and optionally run config for the real user.
+
+- [ ] **Step 4: Run bundle test**
+
+Run: `bash packaging/linux/bundle/tests/test_bundle.sh`
+
+Expected: PASS.
+
+## Task 4: Workflow Integration
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Build bundle from Linux x64 job**
+
+After staging the static Linux x64 binary, call `../packaging/linux/bundle/build-bundle.sh`.
+
+- [ ] **Step 2: Upload bundle artifact**
+
+Upload `rust/dist/scode-linux-x64-bundle.tar.gz`.
+
+- [ ] **Step 3: Include bundle in release assets and COS mirror**
+
+Existing `dist/scode-*` release upload already matches the bundle name; verify the COS upload loop includes `.tar.gz`.
+
+## Task 5: Documentation
+
+**Files:**
+- Create: `docs/linux-bundle-install.zh-CN.md`
+
+- [ ] **Step 1: Write Chinese customer guide**
+
+Include download, upload, `sudo ./scode-setup install`, validation, model updates, non-interactive config, upgrade, uninstall, and troubleshooting.
+
+## Task 6: Verification and Git
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run script syntax checks**
+
+Run: `bash -n packaging/linux/bundle/build-bundle.sh packaging/linux/bundle/tests/test_bundle.sh packaging/linux/deb/scode-setup`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run tests**
+
+Run: `bash packaging/linux/deb/tests/test_build_deb.sh && bash packaging/linux/bundle/tests/test_bundle.sh`
+
+Expected: PASS.
+
+- [ ] **Step 3: Validate workflow YAML**
+
+Run: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'`
+
+Expected: `workflow yaml ok`.
+
+- [ ] **Step 4: Commit and push**
+
+Stage only the bundle feature files and push `codex/linux-bundle-installer`.

--- a/packaging/linux/bundle/build-bundle.sh
+++ b/packaging/linux/bundle/build-bundle.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: build-bundle.sh --version VERSION --binary PATH --output DIR
+
+Build scode-linux-x64-bundle.tar.gz from an existing Linux x64 scode binary.
+EOF
+}
+
+VERSION=""
+BINARY=""
+OUTPUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#--version=}"
+      shift
+      ;;
+    --binary)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      BINARY="$2"
+      shift 2
+      ;;
+    --binary=*)
+      BINARY="${1#--binary=}"
+      shift
+      ;;
+    --output)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --output=*)
+      OUTPUT="${1#--output=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$VERSION" ] || { printf 'missing --version\n' >&2; exit 2; }
+[ -n "$BINARY" ] || { printf 'missing --binary\n' >&2; exit 2; }
+[ -n "$OUTPUT" ] || { printf 'missing --output\n' >&2; exit 2; }
+[ -f "$BINARY" ] || { printf 'binary not found: %s\n' "$BINARY" >&2; exit 2; }
+[ -x "$BINARY" ] || { printf 'binary is not executable: %s\n' "$BINARY" >&2; exit 2; }
+command -v tar >/dev/null 2>&1 || { printf 'tar is required\n' >&2; exit 2; }
+
+case "$VERSION" in
+  v*) VERSION="${VERSION#v}" ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT INT TERM HUP
+
+bundle_dir="$TMP/scode-linux-x64-bundle"
+mkdir -p "$bundle_dir" "$OUTPUT"
+
+install -m 0755 "$BINARY" "$bundle_dir/scode"
+install -m 0755 "$ROOT/packaging/linux/deb/scode-setup" "$bundle_dir/scode-setup"
+
+if [ -f "$ROOT/docs/linux-bundle-install.zh-CN.md" ]; then
+  install -m 0644 "$ROOT/docs/linux-bundle-install.zh-CN.md" "$bundle_dir/README-install.zh-CN.md"
+else
+  cat > "$bundle_dir/README-install.zh-CN.md" <<EOF
+# scode Linux bundle
+
+解压后运行：
+
+\`\`\`bash
+sudo ./scode-setup install
+\`\`\`
+EOF
+fi
+
+cat > "$bundle_dir/VERSION" <<EOF
+$VERSION
+EOF
+
+(
+  cd "$bundle_dir"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum scode scode-setup README-install.zh-CN.md VERSION > SHA256SUMS.txt
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 scode scode-setup README-install.zh-CN.md VERSION > SHA256SUMS.txt
+  else
+    printf 'sha256sum or shasum is required\n' >&2
+    exit 2
+  fi
+)
+
+tar -C "$TMP" -czf "$OUTPUT/scode-linux-x64-bundle.tar.gz" "scode-linux-x64-bundle"
+printf '%s\n' "$OUTPUT/scode-linux-x64-bundle.tar.gz"

--- a/packaging/linux/bundle/tests/test_bundle.sh
+++ b/packaging/linux/bundle/tests/test_bundle.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fake_bin="$TMP/scode"
+cat > "$fake_bin" <<'BIN'
+#!/usr/bin/env sh
+if [ "${1:-}" = "--version" ]; then
+  printf 'scode test version\n'
+else
+  printf 'scode test\n'
+fi
+BIN
+chmod +x "$fake_bin"
+
+"$ROOT/packaging/linux/bundle/build-bundle.sh" \
+  --version 0.1.12 \
+  --binary "$fake_bin" \
+  --output "$TMP/dist"
+
+bundle="$TMP/dist/scode-linux-x64-bundle.tar.gz"
+test -f "$bundle"
+tar -tzf "$bundle" | grep -qx 'scode-linux-x64-bundle/scode'
+tar -tzf "$bundle" | grep -qx 'scode-linux-x64-bundle/scode-setup'
+tar -tzf "$bundle" | grep -qx 'scode-linux-x64-bundle/README-install.zh-CN.md'
+tar -tzf "$bundle" | grep -qx 'scode-linux-x64-bundle/SHA256SUMS.txt'
+
+tar -xzf "$bundle" -C "$TMP"
+bundle_dir="$TMP/scode-linux-x64-bundle"
+test -x "$bundle_dir/scode"
+test -x "$bundle_dir/scode-setup"
+
+SCODE_INSTALL_ROOT="$TMP/install-root" \
+SCODE_SKIP_CONFIG=1 \
+"$bundle_dir/scode-setup" install --bin-dir /usr/local/bin
+
+test -x "$TMP/install-root/usr/local/bin/scode"
+test -x "$TMP/install-root/usr/local/bin/scode-setup"
+test -f "$TMP/install-root/usr/local/lib/scode/install-manifest"
+grep -q 'bin_dir=/usr/local/bin' "$TMP/install-root/usr/local/lib/scode/install-manifest"
+grep -q '/usr/local/bin/scode' "$TMP/install-root/usr/local/lib/scode/install-manifest"
+grep -q '/usr/local/bin/scode-setup' "$TMP/install-root/usr/local/lib/scode/install-manifest"
+
+SCODE_INSTALL_ROOT="$TMP/install-root" \
+"$TMP/install-root/usr/local/bin/scode-setup" doctor
+
+SCODE_INSTALL_ROOT="$TMP/install-root" \
+"$TMP/install-root/usr/local/bin/scode-setup" uninstall --yes
+
+test ! -e "$TMP/install-root/usr/local/bin/scode"
+test ! -e "$TMP/install-root/usr/local/bin/scode-setup"

--- a/packaging/linux/deb/scode-setup
+++ b/packaging/linux/deb/scode-setup
@@ -5,11 +5,18 @@ DEFAULT_BASE_URL="https://hk.sudorouter.ai/v1"
 DEFAULT_MODEL="deepseek-v4-pro"
 SEARCH_API_URL="https://hk.sudorouter.ai/search/tavily/search"
 CONFIG_DIR="${SUDO_CODE_CONFIG_HOME:-$HOME/.nexus/sudocode}"
+COMMAND="configure"
 NON_INTERACTIVE=0
 INSTALL_MODE=0
+INSTALL_BIN_DIR="/usr/local/bin"
+ASSUME_YES=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    install|configure|doctor|uninstall)
+      COMMAND="$1"
+      shift
+      ;;
     --non-interactive)
       NON_INTERACTIVE=1
       shift
@@ -18,11 +25,35 @@ while [ $# -gt 0 ]; do
       INSTALL_MODE=1
       shift
       ;;
+    --bin-dir)
+      [ $# -ge 2 ] || { printf '%s\n' "--bin-dir requires a directory" >&2; exit 2; }
+      INSTALL_BIN_DIR="${2%/}"
+      shift 2
+      ;;
+    --bin-dir=*)
+      INSTALL_BIN_DIR="${1#--bin-dir=}"
+      INSTALL_BIN_DIR="${INSTALL_BIN_DIR%/}"
+      shift
+      ;;
+    --yes|-y)
+      ASSUME_YES=1
+      shift
+      ;;
     -h|--help)
       cat <<'EOF'
-Usage: scode-setup [--install] [--non-interactive]
+Usage: scode-setup [command] [options]
 
-Configure scode models, credentials, and web_search.
+Commands:
+  install      Install sibling scode + scode-setup globally, then configure
+  configure    Configure or update models, credentials, and web_search
+  doctor       Check installed scode/scode-setup files
+  uninstall    Remove files installed by `scode-setup install`
+
+Options:
+  --bin-dir DIR        Install directory for install command, default /usr/local/bin
+  --yes, -y           Do not prompt before uninstall
+  --install           Debian package post-install configure mode
+  --non-interactive   Generate config from environment variables
 
 Environment for --non-interactive:
   SCODE_BASE_URL       Default: https://hk.sudorouter.ai/v1
@@ -30,6 +61,10 @@ Environment for --non-interactive:
   SCODE_MODEL          Optional default model
   SCODE_MODELS         Optional comma or newline separated model list
   SCODE_ENABLE_SEARCH  1 or 0, default 1
+
+Environment for install tests/automation:
+  SCODE_INSTALL_ROOT   Prefix filesystem root for installed files
+  SCODE_SKIP_CONFIG    Set to 1 to skip post-install configuration
 EOF
       exit 0
       ;;
@@ -328,8 +363,160 @@ interactive_menu() {
   done
 }
 
-if [ "$NON_INTERACTIVE" -eq 1 ]; then
-  non_interactive_setup
-else
-  interactive_menu
-fi
+install_root() {
+  printf '%s' "${SCODE_INSTALL_ROOT:-}"
+}
+
+rooted_path() {
+  root="$(install_root)"
+  path="$1"
+  if [ -n "$root" ]; then
+    printf '%s/%s' "${root%/}" "${path#/}"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+manifest_path() {
+  rooted_path "/usr/local/lib/scode/install-manifest"
+}
+
+script_dir() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+resolve_target_user() {
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    printf '%s' "$SUDO_USER"
+  elif command -v logname >/dev/null 2>&1; then
+    logname 2>/dev/null || true
+  else
+    id -un 2>/dev/null || true
+  fi
+}
+
+home_for_user() {
+  user="$1"
+  if command -v getent >/dev/null 2>&1; then
+    getent passwd "$user" | awk -F: '{print $6}' | head -n 1
+  else
+    eval "printf '%s' ~$(printf '%s' "$user")" 2>/dev/null || true
+  fi
+}
+
+install_files() {
+  src_dir="$(script_dir)"
+  src_scode="$src_dir/scode"
+  src_setup="$src_dir/scode-setup"
+  [ -f "$src_scode" ] || { printf 'scode binary not found next to scode-setup: %s\n' "$src_scode" >&2; exit 1; }
+  [ -x "$src_scode" ] || { printf 'scode binary is not executable: %s\n' "$src_scode" >&2; exit 1; }
+  [ -f "$src_setup" ] || { printf 'scode-setup script not found: %s\n' "$src_setup" >&2; exit 1; }
+
+  dest_bin_dir="$(rooted_path "$INSTALL_BIN_DIR")"
+  dest_lib_dir="$(rooted_path "/usr/local/lib/scode")"
+  mkdir -p "$dest_bin_dir" "$dest_lib_dir"
+  cp "$src_scode" "$dest_bin_dir/scode"
+  cp "$src_setup" "$dest_bin_dir/scode-setup"
+  chmod 0755 "$dest_bin_dir/scode" "$dest_bin_dir/scode-setup"
+
+  manifest="$(manifest_path)"
+  mkdir -p "$(dirname "$manifest")"
+  cat > "$manifest" <<EOF
+version=$(cat "$src_dir/VERSION" 2>/dev/null || printf 'unknown')
+installed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+bin_dir=$INSTALL_BIN_DIR
+installed_files=$INSTALL_BIN_DIR/scode $INSTALL_BIN_DIR/scode-setup
+manifest=/usr/local/lib/scode/install-manifest
+EOF
+  chmod 0644 "$manifest"
+
+  printf 'scode installed to %s\n' "$INSTALL_BIN_DIR"
+}
+
+run_post_install_config() {
+  [ "${SCODE_SKIP_CONFIG:-}" != "1" ] || return 0
+  if [ -n "$(install_root)" ]; then
+    return 0
+  fi
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
+    printf 'No interactive terminal detected, skipped setup. Run scode-setup configure later.\n'
+    return 0
+  fi
+
+  target_user="$(resolve_target_user)"
+  if [ "$(id -u)" -eq 0 ] && [ -n "$target_user" ] && [ "$target_user" != "root" ]; then
+    target_home="$(home_for_user "$target_user")"
+    if [ -n "$target_home" ] && command -v runuser >/dev/null 2>&1; then
+      runuser -u "$target_user" -- env HOME="$target_home" USER="$target_user" LOGNAME="$target_user" "$INSTALL_BIN_DIR/scode-setup" configure
+      return 0
+    fi
+    printf 'Could not switch to target user. Run scode-setup configure as the target user.\n'
+    return 0
+  fi
+
+  "$INSTALL_BIN_DIR/scode-setup" configure
+}
+
+install_command() {
+  case "$INSTALL_BIN_DIR" in
+    /*) ;;
+    *) printf '%s\n' '--bin-dir must be an absolute path' >&2; exit 2 ;;
+  esac
+  install_files
+  run_post_install_config
+}
+
+doctor_command() {
+  scode_path="$(rooted_path "$INSTALL_BIN_DIR/scode")"
+  setup_path="$(rooted_path "$INSTALL_BIN_DIR/scode-setup")"
+  manifest="$(manifest_path)"
+  status=0
+  if [ -x "$scode_path" ]; then
+    printf 'ok: %s\n' "$scode_path"
+  else
+    printf 'missing: %s\n' "$scode_path" >&2
+    status=1
+  fi
+  if [ -x "$setup_path" ]; then
+    printf 'ok: %s\n' "$setup_path"
+  else
+    printf 'missing: %s\n' "$setup_path" >&2
+    status=1
+  fi
+  if [ -f "$manifest" ]; then
+    printf 'ok: %s\n' "$manifest"
+  else
+    printf 'missing: %s\n' "$manifest" >&2
+    status=1
+  fi
+  return "$status"
+}
+
+uninstall_command() {
+  manifest="$(manifest_path)"
+  [ -f "$manifest" ] || { printf 'install manifest not found: %s\n' "$manifest" >&2; exit 1; }
+  if [ "$ASSUME_YES" -ne 1 ]; then
+    printf 'Remove files installed by scode-setup? [y/N] '
+    read -r answer
+    case "$answer" in y|Y|yes|YES) ;; *) printf 'Canceled.\n'; return 0 ;; esac
+  fi
+  rm -f "$(rooted_path "$INSTALL_BIN_DIR/scode")" "$(rooted_path "$INSTALL_BIN_DIR/scode-setup")"
+  rm -f "$manifest"
+  printf 'scode uninstalled from %s\n' "$INSTALL_BIN_DIR"
+}
+
+configure_command() {
+  if [ "$NON_INTERACTIVE" -eq 1 ]; then
+    non_interactive_setup
+  else
+    interactive_menu
+  fi
+}
+
+case "$COMMAND" in
+  install) install_command ;;
+  configure) configure_command ;;
+  doctor) doctor_command ;;
+  uninstall) uninstall_command ;;
+  *) printf 'unknown command: %s\n' "$COMMAND" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary
- add a cross-distribution Linux bundle artifact with scode and scode-setup
- extend scode-setup with install/configure/doctor/uninstall commands
- publish scode-linux-x64-bundle from the linux-x64 release workflow
- add Chinese installation documentation for the bundle flow

## Test Plan
- bash -n packaging/linux/bundle/build-bundle.sh packaging/linux/bundle/tests/test_bundle.sh packaging/linux/deb/scode-setup packaging/linux/deb/tests/test_build_deb.sh && sh -n packaging/linux/deb/postinst packaging/linux/deb/prerm
- bash packaging/linux/deb/tests/test_build_deb.sh
- bash packaging/linux/bundle/tests/test_bundle.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'