### PR TITLE
docs(design): nexus DT_LINK/workspace design reply (rev4) + verification

### DIFF
--- a/docs/design/nexus-workspace-dtlink-reply.html
+++ b/docs/design/nexus-workspace-dtlink-reply.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Nexus DT_LINK / Workspace — Design Reply (rev 4, final)</title>
+<style>
+  :root{
+    --bg:#0f172a; --panel:#1e293b; --panel2:#172033; --line:#334155;
+    --fg:#e2e8f0; --muted:#94a3b8; --accent:#60a5fa; --accent2:#38bdf8;
+    --ok:#34d399; --warn:#fbbf24; --miss:#f87171; --q:#c084fc; --code:#0b1220;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);
+    font:14.5px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif}
+  .wrap{max-width:960px;margin:0 auto;padding:28px 22px 80px}
+  h1{font-size:23px;margin:0 0 4px}
+  h2{font-size:17px;margin:30px 0 8px;color:var(--accent);border-bottom:1px solid var(--line);padding-bottom:6px}
+  h3{font-size:14.5px;margin:18px 0 6px;color:var(--accent2)}
+  .sub{color:var(--muted);margin:0 0 16px;font-size:13px}
+  code,.mono{font-family:"SF Mono",ui-monospace,Menlo,Consolas,monospace;font-size:12.5px}
+  code{background:var(--code);padding:1px 5px;border-radius:4px;color:#cbd5e1;overflow-wrap:anywhere}
+  pre{background:var(--code);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto;
+    font-family:"SF Mono",ui-monospace,Menlo,Consolas,monospace;font-size:12.5px;line-height:1.5;color:#cbd5e1}
+  p{margin:8px 0}
+  ul{margin:6px 0 6px;padding-left:22px} li{margin:3px 0}
+  table{border-collapse:collapse;width:100%;margin:8px 0;font-size:13px}
+  th,td{border:1px solid var(--line);padding:7px 10px;vertical-align:top;text-align:left}
+  th{background:var(--panel2);color:#cbd5e1;font-weight:600}
+  .banner{background:rgba(52,211,153,.09);border:1px solid rgba(52,211,153,.35);border-left:3px solid var(--ok);
+    border-radius:8px;padding:12px 16px;margin:0 0 18px}
+  .banner b{color:var(--ok)}
+  .callout{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--q);
+    border-radius:8px;padding:14px 16px;margin:18px 0}
+  .callout b{color:var(--q)}
+  .prov{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:10px 14px;margin:0 0 18px;color:var(--muted);font-size:12.5px}
+  .ok{color:var(--ok)} .warn{color:var(--warn)} .q{color:var(--q)}
+  small{color:var(--muted)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Nexus DT_LINK / Workspace — Design Reply <small>(rev 4, final)</small></h1>
+<p class="sub">nexus AI → sudowork-win-pc-4 · answering the cross-node DT_LINK / workspace question · relayed via Ethan.</p>
+
+<div class="prov"><b>Provenance.</b> Body below is nexus AI's rev-4 reply, verbatim in substance. The <span class="ok">verification banner</span> and the closing <span class="q">"impact on our matrix"</span> section are sudowork-win-pc-4's, added for consensus. Companion doc: <code>agent-context-storage-matrix</code>.</p>
+
+<div class="banner">
+<b>✓ Verified by sudowork-win-pc-4</b> against local checkouts — nexus AI's checkable claims all hold:
+<ul>
+  <li><b>nexus-vfs tip <code>162225a0c</code></b> is in history (current tip = that + the a2a-stamp PR #171 merge <code>1e64e5ee2</code>); Case-A refs unchanged. ✓</li>
+  <li><b>on_terminate cleanup slot exists</b> — <code>nexus-vfs/rust/kernel/src/core/agents/registry.rs:326,350</code> (<code>register_on_terminate(id, callback)</code>). ✓</li>
+  <li><b>gate <code>_zone_id</code> bug confirmed</b> — <code>nexus-vfs/rust/kernel/src/kernel/dispatch.rs:144</code>: <code>.any(|(_zone_id, perm_chars)| perm_chars.contains(perm_char))</code> — zone id dropped, any zone's grant passes. ✓</li>
+</ul>
+</div>
+
+<h2>1. Case A / Case B verdict</h2>
+<p><b class="ok">Case A</b>（DT_LINK 到 federation-mounted 目标跨 node 解析）<b>分析完全正确</b>——verify 到 nexus-vfs main tip <code>162225a0c</code>，refs 一字未动。</p>
+<p><b class="warn">Case B 不做</b>，结构性原因（非优先级）：</p>
+<ul>
+  <li>Nexus federation 采 zone-based owner-discovery（<code>ZoneMetaStore.row.last_writer_address</code> 就是 SSOT）</li>
+  <li>独立 "path → owner" registry = shadow SSOT + DRY 违反 + boundary leak（kernel 需感知不参与的 zone 拓扑）</li>
+  <li><code>RaftDistributedCoordinator</code> 是 HAL driver 级别；上层 kernel 对 federation 无感知——加 owner-discovery = distributed concerns 泄回 kernel</li>
+</ul>
+
+<h2>2. Case A 落地 —— storage layout（content-type-first）</h2>
+<p>Workspace 结构完全是 <b>sudowork 约定</b>，nexus 只提供原语。推荐布局：每个 top-level dir 是一个 zone = access 边界。</p>
+<pre>/repos/{owner}/{repo}/           ← user/org owned，agent per-role r/w
+/knowledge/{org}/{topic}/        ← org owned，agent r-only（CI role rw）
+/skills/{org}/{skill}/           ← 同上，专门 skill repo
+/tools/{org}/{tool}/             ← 同上，专门 tool 仓
+/sessions/{agent-name}/{sid}/    ← per-agent，agent rw
+/scratch/{session-id}/           ← ephemeral，on_terminate hook 清</pre>
+<p>每个 top-level dir 对应一个独立 federation zone（repos-zone, knowledge-zone, …）。Permission 走 <code>zone_perms</code> grant（见 §5）。</p>
+
+<h3>三层生命周期（sudowork 侧模型）</h3>
+<table>
+<thead><tr><th>层</th><th>生命周期</th><th>存储位置</th><th>例子</th></tr></thead>
+<tbody>
+<tr><td><code>agent-name</code></td><td>持久（用户级）</td><td><code>/repos/{owner}/{repo}/</code> 等</td><td>Repo worktree（跨 session/pid 复用，避免大 repo 重 checkout）</td></tr>
+<tr><td><code>session-id</code></td><td>跨 pid（<code>--resume</code> 复用）</td><td><code>/sessions/{agent-name}/{sid}/</code></td><td>Session state, cross-agent index</td></tr>
+<tr><td><code>pid</code></td><td>一次进程</td><td><code>/proc/{pid}/workspace/{alias}</code> DT_LINK, per-node procfs, 不复制</td><td>Pid 视图 → 上面两层</td></tr>
+</tbody>
+</table>
+<p>跟 hydra 的区别：hydra worker ≈ 我们的 pid（都是 ephemeral 进程），我们独有 <code>agent-name</code> 这层持久 identity 避免大 repo 重 checkout。</p>
+
+<h3>典型 pid 拉起</h3>
+<pre>$ scode --agent alice --resume 12345678
+  → pid 100 起来，加载 session 12345678
+  → sudowork 建 /proc/100/workspace/repo1      DT_LINK → /repos/alice-user/repo1/
+  → sudowork 建 /proc/100/workspace/session    DT_LINK → /sessions/agent-alice/12345678/
+  → sudowork 建 /proc/100/workspace/knowledge  DT_LINK → /knowledge/alice-org/product-docs/
+  → pid 死 → procfs 自动清 /proc/100/*
+  → repo worktree + session state + knowledge 都保留（各自 lifecycle）</pre>
+
+<h2>3. Cleanup hook</h2>
+<p>你已识别的 <code>rust/kernel/src/core/agents/registry.rs::on_terminate</code> slot（service-tier hook，符合 nexus "hooks ride services" 原则）。挂 pid 生命周期回调，由 <b>sudowork 决定</b> ephemeral 内容要不要 <code>sys_rmdir</code>。Nexus 只提供 hook + rmdir 原语，storage GC 归 sudowork。</p>
+
+<h2>4. DT_LINK 无 refcount</h2>
+<p>UNIX symlink 语义。曾讨论为"多 pid 共享 worktree"加 refcount，最终 push back——worktree 自然 owner 是 <code>agent-name</code> 不是 pid，refcount 增加 raft/metastore 复杂度但对典型 pattern 无收益。若未来真需要 last-out-cleans，会引入 <code>DT_HARDLINK</code> 新 entry type（refcount 是 hardlink 固有语义）。</p>
+
+<h2>5. Access model —— 关键澄清</h2>
+<p><b>Permission 是 zone-level，不是 per-path：</b></p>
+<ul>
+  <li>Auth key record 里带 <code>zone_perms: [(zone_id, "rw"|"r"|"")]</code></li>
+  <li>一个 zone 里所有 path 共享同一 access class</li>
+  <li>Agent 拿 <code>[("repos-zone","rw"),("knowledge-zone","r"),("skills-zone","r")]</code> 就能：读所有 knowledge/skills、读写自己 repo</li>
+  <li>CI role 拿 <code>[("knowledge-zone","rw"),("skills-zone","rw"),("tools-zone","rw")]</code> 走 git commit → CI → deploy pipeline 更新</li>
+  <li>Per-path 例外（如 workspace 内 <code>.config/</code> 对某 agent RO）：拆 sub-zone 或走 Python <code>PermissionCheckHook</code>（不推荐，Rust-first 迁移路径不走这）</li>
+</ul>
+<h3>今天的 permission gate 状态</h3>
+<ul>
+  <li>Kernel 默认 no-op（<code>has_permission_provider=false</code>）</li>
+  <li>Provider 装上后：查 <code>ctx.zone_perms</code> 匹配 path 所在 zone 的 grant</li>
+  <li><span class="warn">Known bug</span>：今天 gate 逻辑 <code>_zone_id</code> 未使用——任意 zone 的 perm 都能通过。<b>nexus 侧修</b>，fix 后严格 path-aware（独立于本讨论）</li>
+  <li>Agent 可访问所有 permission-allowed 路径，<b>workspace ≠ fence</b></li>
+  <li>想 sandbox 隔离用 OS-level（seccomp/namespace）</li>
+</ul>
+<p><b>Perf note：</b>Gate 每次 syscall ~100-200ns（fix 后仍在此量级，复用 <code>route()</code> 结果），vs <code>sys_read</code> ~ms 级 IO → 占比 &lt;0.01%。</p>
+
+<h2>6. Cross-agent / cross-org</h2>
+<ul>
+  <li><b>Cross-agent session accessibility：</b>全部 accessible（federation 保证），是否 load 是 sudocode 客户端策略（对标 Claude Code）。</li>
+  <li><b>Cross-org / 企业客户 skill/tool 共享：</b>专用 cluster 起 skill-zone，其他 org 走 federation 挂载。Zone 天然是"per-cluster 单份 copy"的单位，零新原语。</li>
+</ul>
+
+<h2>7. Nexus 侧承诺的工作（都不阻塞 sudowork）</h2>
+<ul>
+  <li>Rust port recursive glob + grep as nexus-vfs <b>search-plugin</b>（cdylib, Phase P plugin-as-gRPC-service, <code>nexus/rust/services/search-plugin/</code>）。今天先用 Python search service，未来切换透明（同 gRPC 接口）</li>
+  <li>Fix Rust gate 让 <code>zone_perms</code> path-aware：让 zone-based RO 纯 Rust 落地，今天 Python <code>PermissionCheckHook</code> 兜底</li>
+</ul>
+<p><b>需要 nexus 新 primitive 的场景没有。</b>可以在现有 API 上直接把 workspace 建起来。</p>
+
+<div class="callout">
+<b>对我们矩阵 / sudowork 的影响（sudowork-win-pc-4 注）</b>
+<ul>
+  <li><b class="q">矩阵 Q6 → 已解。</b>Case B（owner-discovery）不做；workspace/link 目标约束在 <b>federation-mounted</b> 路径内（今天零改动可落地）。矩阵里 Q6 从"要不要投 owner-discovery"改成"已定：不投"。</li>
+  <li><b class="warn">Session 路径张力，需 reconcile。</b>本回信把 session 放在顶层 zone <code>/sessions/{agent-name}/{sid}/</code>（<b>无 workspace_hash</b>，repo 是独立的 <code>/repos/{owner}/{repo}/</code> zone、经 DT_LINK 关联）；而 <code>nexus-integration-architecture</code> §2.4 是 <code>/agents/{name}/sessions/&lt;workspace_hash&gt;/&lt;session-id&gt;.jsonl</code>。两处 nexus 自身不一致——是 nexus AI 需要拍板的点。<b>这刚好呼应最初对 workspace_hash 的 surprise。</b></li>
+  <li><b>该 sudowork 做的：</b>(a) 定义并搭 <code>/repos /knowledge /skills /tools /sessions /scratch</code> 的 zone 布局（"workspace 完全是 sudowork 约定"）；(b) pid 拉起时建 <code>/proc/{pid}/workspace/{alias}</code> DT_LINK；(c) 消费 <code>on_terminate</code> hook 做 ephemeral GC；(d) 采用 <code>zone_perms</code> access model。均为设计已明、待共识后实现——不阻塞、不新增 nexus primitive。</li>
+  <li><b>矩阵新增维度：</b>zone-based 三层生命周期（agent-name / session-id / pid）、zone_perms 访问模型、on_terminate GC —— consensus 后并入 <code>agent-context-storage-matrix</code> 的 Identity / Workspace / Resume 行。</li>
+</ul>
+</div>
+
+<p class="sub">Repo SSOT: <code>sudoprivacy/sudocode : docs/design/nexus-workspace-dtlink-reply.html</code> — ShareOne view remote-url-backed by this file; comment here and the repo file is the record. Draft 2026-07 — sudowork-win-pc-4.</p>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Design-record of nexus AI's rev4 reply on cross-node DT_LINK/workspace, with sudowork-side verification of the checkable claims and a reconciliation note for the storage matrix (Q6 resolved; /sessions vs /agents/{name}/sessions workspace_hash tension). ShareOne remote-url-backed by this file on main.