### PR TITLE
feat(repl): arrow keys, display width, resume, cancel

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3226,6 +3226,7 @@ dependencies = [
  "futures",
  "futures-util",
  "mock-anthropic-service",
+ "nix 0.29.0",
  "plugins",
  "pty-expect",
  "pulldown-cmark",

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -18,6 +18,9 @@ clap = { version = "4", features = ["derive"] }
 commands = { path = "../commands" }
 compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["term", "poll"] }
 futures = "0.3"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 pulldown-cmark = "0.13"

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -18,9 +18,6 @@ clap = { version = "4", features = ["derive"] }
 commands = { path = "../commands" }
 compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
-
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["term", "poll"] }
 futures = "0.3"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 pulldown-cmark = "0.13"
@@ -49,4 +46,7 @@ serde_json.workspace = true
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-tungstenite = "0.29"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["term", "poll"] }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3047,21 +3047,19 @@ impl HookAbortMonitor {
 
             runtime.block_on(async move {
                 let esc_abort = abort_signal.clone();
-                let wait_for_esc_or_stop = tokio::task::spawn_blocking(move || {
-                    loop {
-                        if stop_rx.try_recv().is_ok() {
-                            return;
+                let wait_for_esc_or_stop = tokio::task::spawn_blocking(move || loop {
+                    if stop_rx.try_recv().is_ok() {
+                        return;
+                    }
+                    if !raw_enabled {
+                        match stop_rx.recv_timeout(Duration::from_millis(50)) {
+                            Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
+                            Err(RecvTimeoutError::Timeout) => continue,
                         }
-                        if !raw_enabled {
-                            match stop_rx.recv_timeout(Duration::from_millis(50)) {
-                                Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
-                                Err(RecvTimeoutError::Timeout) => continue,
-                            }
-                        }
-                        if poll_abort_key(Duration::from_millis(50)) {
-                            esc_abort.abort();
-                            return;
-                        }
+                    }
+                    if poll_abort_key(Duration::from_millis(50)) {
+                        esc_abort.abort();
+                        return;
                     }
                 });
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -466,7 +466,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             model,
             permission_mode,
             auth_mode,
-        } => resume_session(
+        } => run_resume(
             &session_path,
             &commands,
             output_format,
@@ -934,7 +934,14 @@ fn list_sessions_cli(output_format: CliOutputFormat) -> Result<(), Box<dyn std::
 }
 
 #[allow(clippy::too_many_lines)]
-fn resume_session(
+/// CLI entry point for `--resume <id> [commands...]`.
+///
+/// - With commands: load session, run commands, exit (non-interactive).
+/// - Without commands: load session, enter REPL with messages rendered.
+///
+/// This is the CLI dispatch function; `LiveCli::load_session` handles the
+/// data-only operation (no I/O side effects). Display is the caller's job.
+fn run_resume(
     session_path: &Path,
     commands: &[String],
     output_format: CliOutputFormat,
@@ -992,7 +999,7 @@ fn resume_session(
         };
         // Load the restored session into the running CLI.
         let session_ref = resolved_path.display().to_string();
-        if let Err(e) = cli.resume_session(Some(session_ref)) {
+        if let Err(e) = cli.load_session(Some(session_ref)) {
             eprintln!("failed to resume: {e}");
             std::process::exit(1);
         }
@@ -1583,9 +1590,9 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
         input::LineEditor::new("❯ ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
 
-    // Render any existing messages from the session. For a new session
-    // this is empty (zero cost). For a resumed session this replays
-    // the conversation using the same format pipeline as live output.
+    // Render existing messages and seed editor history from user prompts.
+    // Same code path for new sessions (messages empty → no-op) and resumed
+    // sessions (messages present → render + populate history).
     let messages = &cli.runtime.session().messages;
     if !messages.is_empty() {
         let term_width = crossterm::terminal::size()
@@ -1595,6 +1602,23 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
         let rendered = render_messages(messages, term_width, &renderer);
         if !rendered.is_empty() {
             println!("{rendered}");
+        }
+        // Seed rustyline history so ↑ recalls previous prompts.
+        for msg in messages {
+            if msg.role == runtime::MessageRole::User {
+                let text = msg
+                    .blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        runtime::ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if !text.trim().is_empty() {
+                    editor.push_history(text);
+                }
+            }
         }
     }
 
@@ -3007,18 +3031,23 @@ impl HookAbortMonitor {
                 return;
             };
 
-            // Enable raw mode so crossterm can detect ESC keypresses
-            // during streaming / tool execution (CC parity). The
-            // rendering layer uses ANSI cursor control (not println!)
-            // during a turn, so raw mode is safe here. Restored when
-            // the monitor stops.
             let is_tty = io::stdin().is_terminal();
+
+            // On Unix, bypass crossterm for raw mode and key detection.
+            // Crossterm's lazy global `InternalEventSource` becomes stale
+            // after rustyline (which also uses crossterm internally) toggles
+            // raw mode on the main thread between REPL prompts — causing
+            // `event::poll` to miss keypresses in subsequent turns.
+            // Reading raw bytes via termios + `poll(2)` is immune to this.
+            #[cfg(unix)]
+            let raw_enabled = is_tty && enable_raw_mode_unix();
+
+            #[cfg(not(unix))]
             let raw_enabled = is_tty && crossterm::terminal::enable_raw_mode().is_ok();
 
             runtime.block_on(async move {
                 let esc_abort = abort_signal.clone();
                 let wait_for_esc_or_stop = tokio::task::spawn_blocking(move || {
-                    use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
                     loop {
                         if stop_rx.try_recv().is_ok() {
                             return;
@@ -3029,19 +3058,9 @@ impl HookAbortMonitor {
                                 Err(RecvTimeoutError::Timeout) => continue,
                             }
                         }
-                        if event::poll(Duration::from_millis(50)).unwrap_or(false) {
-                            if let Ok(Event::Key(key)) = event::read() {
-                                if key.kind != KeyEventKind::Press {
-                                    continue;
-                                }
-                                let is_esc = key.code == KeyCode::Esc;
-                                let is_ctrl_c = key.code == KeyCode::Char('c')
-                                    && key.modifiers.contains(event::KeyModifiers::CONTROL);
-                                if is_esc || is_ctrl_c {
-                                    esc_abort.abort();
-                                    return;
-                                }
-                            }
+                        if poll_abort_key(Duration::from_millis(50)) {
+                            esc_abort.abort();
+                            return;
                         }
                     }
                 });
@@ -3056,6 +3075,12 @@ impl HookAbortMonitor {
                 }
             });
 
+            #[cfg(unix)]
+            if raw_enabled {
+                disable_raw_mode_unix();
+            }
+
+            #[cfg(not(unix))]
             if raw_enabled {
                 let _ = crossterm::terminal::disable_raw_mode();
             }
@@ -3083,6 +3108,104 @@ impl HookAbortMonitor {
             let _ = join_handle.join();
         }
     }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Raw-mode helpers for `HookAbortMonitor`
+//
+// On Unix, we manage raw mode via `nix` (safe termios wrappers) instead
+// of crossterm to avoid the stale-event-source bug described in
+// `HookAbortMonitor::spawn`. On Windows, crossterm is used unchanged.
+// ──────────────────────────────────────────────────────────────────────
+
+// Thread-local storage for the original termios settings saved by
+// `enable_raw_mode_unix`. Each monitor thread saves its own copy so
+// concurrent monitors (hypothetical) don't clobber each other.
+#[cfg(unix)]
+std::thread_local! {
+    static ORIGINAL_TERMIOS: std::cell::RefCell<Option<nix::sys::termios::Termios>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Enable raw mode via `nix::sys::termios` — no crossterm involvement.
+/// Returns `true` on success. Call `disable_raw_mode_unix()` to restore.
+#[cfg(unix)]
+fn enable_raw_mode_unix() -> bool {
+    use nix::sys::termios::{self, SetArg, SpecialCharacterIndices};
+    use std::os::fd::AsFd;
+
+    let stdin = std::io::stdin();
+    let Ok(original) = termios::tcgetattr(&stdin) else {
+        return false;
+    };
+    ORIGINAL_TERMIOS.with(|cell| *cell.borrow_mut() = Some(original.clone()));
+
+    let mut raw = original;
+    termios::cfmakeraw(&mut raw);
+    // Non-blocking: VMIN=0, VTIME=0 means read() returns immediately
+    // with 0 bytes if nothing is available — poll() handles the wait.
+    raw.control_chars[SpecialCharacterIndices::VMIN as usize] = 0;
+    raw.control_chars[SpecialCharacterIndices::VTIME as usize] = 0;
+    termios::tcsetattr(&stdin, SetArg::TCSANOW, &raw).is_ok()
+}
+
+/// Restore original terminal settings saved by `enable_raw_mode_unix`.
+#[cfg(unix)]
+fn disable_raw_mode_unix() {
+    use nix::sys::termios::{self, SetArg};
+    use std::os::fd::AsFd;
+
+    let stdin = std::io::stdin();
+    ORIGINAL_TERMIOS.with(|cell| {
+        if let Some(original) = cell.borrow().as_ref() {
+            let _ = termios::tcsetattr(&stdin, SetArg::TCSANOW, original);
+        }
+    });
+}
+
+/// Poll stdin for an abort key (ESC = 0x1b, Ctrl-C = 0x03).
+/// Returns `true` if an abort key was detected within `timeout`.
+#[cfg(unix)]
+fn poll_abort_key(timeout: Duration) -> bool {
+    use nix::poll::{self, PollFd, PollFlags, PollTimeout};
+    use std::os::fd::AsFd;
+    use std::os::unix::io::AsRawFd;
+
+    let stdin = std::io::stdin();
+    let poll_timeout = PollTimeout::try_from(timeout).unwrap_or(PollTimeout::from(50u16));
+    let mut fds = [PollFd::new(stdin.as_fd(), PollFlags::POLLIN)];
+    let ready = poll::poll(&mut fds, poll_timeout).unwrap_or(0);
+    if ready <= 0 {
+        return false;
+    }
+    let revents = fds[0].revents().unwrap_or(PollFlags::empty());
+    if !revents.contains(PollFlags::POLLIN) {
+        return false;
+    }
+    let mut buf = [0u8; 1];
+    match nix::unistd::read(stdin.as_raw_fd(), &mut buf) {
+        Ok(1) => buf[0] == 0x1b || buf[0] == 0x03,
+        _ => false,
+    }
+}
+
+/// Poll stdin for an abort key using crossterm's event system (Windows).
+#[cfg(not(unix))]
+fn poll_abort_key(timeout: Duration) -> bool {
+    use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+    if !event::poll(timeout).unwrap_or(false) {
+        return false;
+    }
+    if let Ok(Event::Key(key)) = event::read() {
+        if key.kind != KeyEventKind::Press {
+            return false;
+        }
+        let is_esc = key.code == KeyCode::Esc;
+        let is_ctrl_c =
+            key.code == KeyCode::Char('c') && key.modifiers.contains(event::KeyModifiers::CONTROL);
+        return is_esc || is_ctrl_c;
+    }
+    false
 }
 
 /// Measure visible string width by stripping ANSI escape sequences.
@@ -3640,7 +3763,20 @@ impl LiveCli {
                 self.print_cost();
                 false
             }
-            SlashCommand::Resume { session_path } => self.resume_session(session_path)?,
+            SlashCommand::Resume { session_path } => {
+                let resumed = self.load_session(session_path)?;
+                if resumed {
+                    println!(
+                        "{}",
+                        format_resume_report(
+                            &self.session.path.display().to_string(),
+                            self.runtime.session().messages.len(),
+                            self.runtime.usage().turns(),
+                        )
+                    );
+                }
+                resumed
+            }
             SlashCommand::Config { section } => {
                 Self::print_config(section.as_deref())?;
                 false
@@ -4014,7 +4150,10 @@ impl LiveCli {
         println!("{}", format_cost_report(cumulative));
     }
 
-    fn resume_session(
+    /// Load a session by reference (id, path, or "latest"), replacing the
+    /// current runtime. Pure data operation — no terminal output.
+    /// Callers decide how to report the result.
+    fn load_session(
         &mut self,
         session_path: Option<String>,
     ) -> Result<bool, Box<dyn std::error::Error>> {
@@ -4034,7 +4173,7 @@ impl LiveCli {
                 .default(0)
                 .interact_opt()?;
             return match selection {
-                Some(idx) => self.resume_session(Some(sessions[idx].id.clone())),
+                Some(idx) => self.load_session(Some(sessions[idx].id.clone())),
                 None => Ok(false),
             };
         };
@@ -4049,14 +4188,6 @@ impl LiveCli {
             id: session_id,
             path: handle.path,
         };
-        println!(
-            "{}",
-            format_resume_report(
-                &self.session.path.display().to_string(),
-                message_count,
-                self.runtime.usage().turns(),
-            )
-        );
         Ok(true)
     }
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_cancel.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_cancel.rs
@@ -1,0 +1,146 @@
+//! PTY tests for ESC / Ctrl-C cancel during streaming in REPL mode.
+//!
+//! These tests verify the direct-termios abort monitor (bypassing crossterm's
+//! event system) works correctly after rustyline has toggled raw mode on the
+//! main thread.
+
+mod common;
+
+use std::fs;
+use std::time::Duration;
+
+/// ESC during a tool call in REPL mode cancels the turn and returns to prompt.
+///
+/// Uses `bash_interrupt_long_running` (mock: `sleep 30` tool call) to create
+/// a window where ESC can be pressed mid-execution. In live mode the model
+/// may call bash or stream text — either way, ESC should cancel and return
+/// to the `❯` prompt.
+#[test]
+#[cfg(unix)]
+fn esc_cancels_turn_in_repl() {
+    let env = common::TestEnv::new("esc-repl");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let prompt = env.prompt(
+        "Run this exact bash command: printf 'esc-start'; sleep 30; printf 'esc-done'",
+        "bash_interrupt_long_running",
+    );
+    let mut sess = env.spawn_with_env(
+        &[
+            "--permission-mode",
+            "danger-full-access",
+            "--allowedTools",
+            "bash",
+        ],
+        &[("EDITOR", "true")],
+    );
+    let timeout = if env.is_live() {
+        Duration::from_secs(30)
+    } else {
+        Duration::from_secs(15)
+    };
+    sess.set_default_timeout(timeout);
+
+    sess.expect("❯").expect("REPL prompt");
+
+    // Submit the prompt — the tool call takes a while (sleep 30).
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+
+    // Wait for an indicator that the turn is in progress.
+    // Mock: "bash" tool call appears. Live: could be thinking indicator
+    // or model name or the tool call.
+    sess.expect("(?i)(bash|thinking|sonnet|auto|claude|❯)")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("should see turn activity: {e}\nPTY screen:\n{screen}");
+        });
+
+    // Small delay to ensure the abort monitor is polling.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Press ESC to cancel the turn.
+    sess.send("\x1b").expect("send ESC");
+
+    // Wait for the cancel to complete and REPL prompt to return.
+    // The cancellation marker or prompt confirms the turn was aborted.
+    sess.set_default_timeout(Duration::from_secs(15));
+    sess.expect("(?i)(cancelled|interrupted|❯)")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("ESC should cancel the turn: {e}\nPTY screen:\n{screen}");
+        });
+
+    // Wait for the REPL prompt specifically.
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should return to prompt after cancel: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Small delay to ensure the REPL is fully ready for input.
+    std::thread::sleep(Duration::from_millis(300));
+
+    sess.send("/exit\r").expect("send exit");
+    sess.set_default_timeout(Duration::from_secs(10));
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}
+
+/// Resume a session, press ↑ — previous prompt should appear from history.
+///
+/// Verifies that `run_repl_loop` seeds the rustyline history from user
+/// messages when entering a resumed session.
+#[test]
+fn resume_seeds_history_for_up_arrow() {
+    let env = common::TestEnv::new("resume-hist");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let prompt = env.prompt("say hello world", "single_turn_text");
+
+    // Session 1: submit a prompt, then exit.
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[("EDITOR", "true")]);
+    sess.set_default_timeout(Duration::from_secs(15));
+    sess.expect("❯").expect("REPL prompt");
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+    sess.expect("❯").expect("second prompt after turn");
+    sess.send("/exit\r").expect("send exit");
+    sess.expect_eof().expect("clean exit");
+
+    // Session 2: resume latest, then press ↑ on empty prompt.
+    let mut sess2 = env.spawn_with_env(
+        &["--resume", "latest", "--permission-mode", "read-only"],
+        &[("EDITOR", "true")],
+    );
+    sess2.set_default_timeout(Duration::from_secs(15));
+
+    // Wait for the resumed REPL prompt.
+    sess2.expect("❯").unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("should see prompt after resume: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Press ↑ on empty prompt — should show the previous user prompt from history.
+    sess2.send("\x1b[A").expect("send Up arrow");
+    std::thread::sleep(Duration::from_millis(500));
+
+    let screen = sess2.render(|s| s.contents());
+    assert!(
+        screen.contains("say hello world") || screen.contains("single_turn_text"),
+        "↑ after resume should recall the previous prompt from history.\n\
+         PTY screen:\n{screen}",
+    );
+
+    // Clean exit.
+    sess2.send("\x15").expect("Ctrl-U clear");
+    std::thread::sleep(Duration::from_millis(100));
+    sess2.send("/exit\r").expect("send exit");
+    let exit = sess2.expect_eof().unwrap_or_else(|e| {
+        let screen = sess2.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}


### PR DESCRIPTION
## Summary

- **Arrow keys ↑/↓ = home/end then history** (CC parity): `UpArrowHandler`/`DownArrowHandler` replace the old `UpArrowDequeueHandler`. First press moves cursor to beginning/end of line; second press cycles history.
- **Display-width-aware truncation**: `unicode-width` crate for ANSI-stripped, unicode-aware column counting in box borders and tool output lines.
- **Resume into REPL** (`--resume <id>`): loads session, enters REPL, renders previous messages through the unified `render_message()` pipeline — same format functions as live output. `--resume` without args lists available sessions. Carries `--model`/`--auth`/`--permission-mode` from CLI args.
- **Message rendering pipeline** (`format.rs`): `render_message(msg, term_width, renderer)` is the SSOT for completed message display; `render_messages()` for batches.
- **ESC/Ctrl-C cancel fix**: replace crossterm's event system with direct termios + `poll(2)` for the abort monitor on Unix. Crossterm's lazy global `InternalEventSource` becomes stale after rustyline toggles raw mode between REPL prompts.
- **History seeding on resume**: rustyline history is populated from user messages so ↑ recalls previous prompts.
- **PTY tests**: `esc_cancels_turn_in_repl` and `resume_seeds_history_for_up_arrow` (dual-mode mock/live).

## Commits

- `649e658` feat(repl): arrow keys, display width, resume into REPL, message rendering pipeline
- `be9da22` fix(repl): ESC/Ctrl-C cancel in REPL mode via direct termios
- `b835c4c` test(repl): PTY tests for ESC cancel + resume history seeding

## Test plan

- [ ] `cargo test` passes (unit tests)
- [ ] PTY tests pass: `pty_arrow_keys`, `pty_resume`, `pty_cancel`
- [ ] Manual: launch REPL, press ↑ at empty prompt → cursor moves to start, press ↑ again → history cycles
- [ ] Manual: `--resume <id>` renders previous messages and enters REPL
- [ ] Manual: ESC during tool execution cancels the turn and returns to prompt
- [ ] Manual: ↑ after resume recalls previous user prompts from history