### PR TITLE
docs: clarify model aliases are not the full catalog (sudorouter has 170+ incl Gemini)

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -21,6 +21,12 @@ scode --model sonnet --auth subscription
 
 For the canonical live alias list, run `scode --help`.
 
+> **These are convenience aliases, not the full model list.** `scode`
+> routes through the backend (sudorouter), whose live catalog has 170+
+> models - including Gemini (`gemini-3.5-flash`, ...), GPT-5, DeepSeek,
+> GLM, Kimi, MiniMax, and more. Use any catalog model by its full name,
+> e.g. `scode --model gemini-3.5-flash`.
+
 ## Provider-specific handling
 
 Translating Claude-style messages to OpenAI-compatible chat completion


### PR DESCRIPTION
The Aliases table lists only 4 convenience shortcuts and is easy to misread as the full supported set (an AI concluded Gemini was unsupported from it). Added a note that the full model catalog comes from the sudorouter backend — 170+ models incl Gemini / GPT-5 / DeepSeek / GLM / Kimi / MiniMax — usable by full name (e.g. `scode --model gemini-3.5-flash`).