### PR TITLE
Bump version to 0.1.16

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "base64",
  "criterion",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "plugins",
  "runtime",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "commands",
  "runtime",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "api",
  "serde_json",
@@ -2059,7 +2059,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3211,7 +3211,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "api",
  "arboard",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "chrono",
  "dirs",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
## Summary
- bump workspace package version to 0.1.16
- update Cargo.lock workspace package versions

## Tests
- cargo metadata --offline --format-version 1 --no-deps
- git diff --check