### PR TITLE
feat: model discovery SSOT — capabilities-first architecture

### DIFF
--- a/rust/crates/runtime/src/model_capabilities.rs
+++ b/rust/crates/runtime/src/model_capabilities.rs
@@ -140,6 +140,14 @@ pub fn per_model_image_cap(model_id: &str) -> (Option<u32>, Option<u32>) {
     }
 }
 
+/// All known model IDs from the capabilities SSOT.
+/// Used by discovery surfaces (`/model`, tab completion, `get_model_info`).
+#[must_use]
+pub fn all_model_ids() -> Vec<String> {
+    let caps = CAPABILITIES.get_or_init(ModelCapabilitiesFile::default);
+    caps.models.keys().cloned().collect()
+}
+
 /// Context window for a wire model ID, falling back to the SSOT file's
 /// `default` entry when the model is unknown. The single source of truth for
 /// both per-model values and the unknown-model default is this capabilities
@@ -337,6 +345,17 @@ mod tests {
         assert!(
             file.default.context_window > 0,
             "bundled JSON must define a non-zero default context window"
+        );
+    }
+
+    #[test]
+    fn all_model_ids_returns_bundled_models() {
+        // all_model_ids() should return at least the bundled model set.
+        let ids = all_model_ids();
+        assert!(
+            ids.len() >= 30,
+            "expected ≥30 bundled model IDs, got {}",
+            ids.len()
         );
     }
 

--- a/rust/crates/runtime/src/model_capabilities.rs
+++ b/rust/crates/runtime/src/model_capabilities.rs
@@ -148,6 +148,28 @@ pub fn all_model_ids() -> Vec<String> {
     caps.models.keys().cloned().collect()
 }
 
+/// Merge config alias keys with capabilities SSOT model IDs into a single
+/// discovery list: config keys first (preserving order), then capabilities
+/// IDs not already covered (case-insensitive dedup).
+///
+/// This is the DRY helper for all flat-list discovery surfaces
+/// (`get_model_info`, FuzzySelect picker). Call sites that need two-phase
+/// formatting (config aliases with rich display vs. capabilities wire IDs)
+/// should use [`all_model_ids`] directly.
+#[inline]
+#[must_use]
+pub fn merge_discovery_ids(config_keys: &[String]) -> Vec<String> {
+    let mut merged: Vec<String> = config_keys.to_vec();
+    let seen: std::collections::BTreeSet<String> =
+        config_keys.iter().map(|k| k.to_ascii_lowercase()).collect();
+    for id in all_model_ids() {
+        if !seen.contains(&id.to_ascii_lowercase()) {
+            merged.push(id);
+        }
+    }
+    merged
+}
+
 /// Context window for a wire model ID, falling back to the SSOT file's
 /// `default` entry when the model is unknown. The single source of truth for
 /// both per-model values and the unknown-model default is this capabilities
@@ -350,12 +372,32 @@ mod tests {
 
     #[test]
     fn all_model_ids_returns_bundled_models() {
-        // all_model_ids() should return at least the bundled model set.
         let ids = all_model_ids();
         assert!(
             ids.len() >= 30,
             "expected ≥30 bundled model IDs, got {}",
             ids.len()
+        );
+    }
+
+    #[test]
+    fn merge_discovery_ids_deduplicates_case_insensitive() {
+        // Config key "claude-opus-4-6" overlaps with capabilities — should not appear twice.
+        let config_keys = vec!["claude-opus-4-6".to_string(), "custom-alias".to_string()];
+        let merged = merge_discovery_ids(&config_keys);
+        // Config keys come first, in order.
+        assert_eq!(&merged[0], "claude-opus-4-6");
+        assert_eq!(&merged[1], "custom-alias");
+        // No duplicates of config keys.
+        let count = merged
+            .iter()
+            .filter(|id| id.eq_ignore_ascii_case("claude-opus-4-6"))
+            .count();
+        assert_eq!(count, 1, "claude-opus-4-6 should appear exactly once");
+        // Capabilities models are appended.
+        assert!(
+            merged.len() > config_keys.len(),
+            "should have more models than just config keys"
         );
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -236,13 +236,13 @@ pub(crate) fn format_connected_line_with_config(
 
 pub(crate) fn format_model_report(model: &str, message_count: usize, turns: u32) -> String {
     let config = load_sudocode_config_for_current_dir();
+    let model_lower = model.to_ascii_lowercase();
+
+    // Config aliases with display names + provider info.
     let mut available_lines = String::new();
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for (alias, entry) in &config.models {
-        let marker = if alias == &model.to_ascii_lowercase() {
-            " *"
-        } else {
-            ""
-        };
+        let marker = if alias == &model_lower { " *" } else { "" };
         let provider_modes: Vec<&str> = entry.providers.keys().map(String::as_str).collect();
         write!(
             available_lines,
@@ -252,16 +252,25 @@ pub(crate) fn format_model_report(model: &str, message_count: usize, turns: u32)
             provider_modes.join(", ")
         )
         .expect("write to string");
+        seen.insert(alias.to_ascii_lowercase());
     }
-    let available = if available_lines.is_empty() {
-        String::from("opus, sonnet, haiku")
-    } else {
-        available_lines
-    };
+
+    // Capabilities SSOT models not already covered by config aliases.
+    for id in runtime::model_capabilities::all_model_ids() {
+        if !seen.contains(&id.to_ascii_lowercase()) {
+            let marker = if id.eq_ignore_ascii_case(model) {
+                " *"
+            } else {
+                ""
+            };
+            write!(available_lines, "\n    {id}{marker}").expect("write to string");
+        }
+    }
+
     format!(
         "Model
   Current model    {model}
-  Available models{available}
+  Available models{available_lines}
   Session messages {message_count}
   Session turns    {turns}
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2623,7 +2623,10 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         let config_keys: Vec<String> = config.models.keys().cloned().collect();
         let mut models = runtime::model_capabilities::merge_discovery_ids(&config_keys);
         // Ensure the current model is always present.
-        if !models.iter().any(|m| m.eq_ignore_ascii_case(&self.inner.model)) {
+        if !models
+            .iter()
+            .any(|m| m.eq_ignore_ascii_case(&self.inner.model))
+        {
             models.insert(0, self.inner.model.clone());
         }
         (self.inner.model.clone(), models)

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2621,8 +2621,14 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
     fn get_model_info(&self) -> (String, Vec<String>) {
         let config = load_sudocode_config_for_current_dir();
         let mut models: Vec<String> = config.models.keys().cloned().collect();
+        // Merge capabilities SSOT models not already covered by config aliases.
+        for id in runtime::model_capabilities::all_model_ids() {
+            if !models.iter().any(|m| m.eq_ignore_ascii_case(&id)) {
+                models.push(id);
+            }
+        }
         // Ensure the current model is always present.
-        if !models.contains(&self.inner.model) {
+        if !models.iter().any(|m| m.eq_ignore_ascii_case(&self.inner.model)) {
             models.insert(0, self.inner.model.clone());
         }
         (self.inner.model.clone(), models)
@@ -3997,10 +4003,14 @@ impl LiveCli {
     fn set_model(&mut self, model: Option<String>) -> Result<bool, Box<dyn std::error::Error>> {
         let Some(model) = model else {
             let sudocode_config = load_sudocode_config_for_current_dir();
-            let models: Vec<String> = sudocode_config.models.keys().cloned().collect();
-            if models.is_empty() {
-                println!("No models configured in sudocode.json");
-                return Ok(false);
+            let mut models: Vec<String> = sudocode_config.models.keys().cloned().collect();
+            // Merge capabilities SSOT models not already covered by config aliases.
+            let seen: std::collections::BTreeSet<String> =
+                models.iter().map(|m| m.to_ascii_lowercase()).collect();
+            for id in runtime::model_capabilities::all_model_ids() {
+                if !seen.contains(&id.to_ascii_lowercase()) {
+                    models.push(id);
+                }
             }
             let selection = FuzzySelect::new()
                 .with_prompt("Select model")
@@ -5575,9 +5585,6 @@ fn slash_command_completion_candidates_with_sessions(
         "/export ",
         "/issue ",
         "/model ",
-        "/model opus",
-        "/model sonnet",
-        "/model haiku",
         "/permissions ",
         "/permissions read-only",
         "/permissions workspace-write",
@@ -5614,6 +5621,12 @@ fn slash_command_completion_candidates_with_sessions(
     for alias in sudocode_config.models.keys() {
         completions
             .entry(format!("/model {alias}"))
+            .or_insert_with(String::new);
+    }
+    // Add capabilities SSOT model IDs to /model completions.
+    for id in runtime::model_capabilities::all_model_ids() {
+        completions
+            .entry(format!("/model {id}"))
             .or_insert_with(String::new);
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2620,13 +2620,8 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
     fn get_model_info(&self) -> (String, Vec<String>) {
         let config = load_sudocode_config_for_current_dir();
-        let mut models: Vec<String> = config.models.keys().cloned().collect();
-        // Merge capabilities SSOT models not already covered by config aliases.
-        for id in runtime::model_capabilities::all_model_ids() {
-            if !models.iter().any(|m| m.eq_ignore_ascii_case(&id)) {
-                models.push(id);
-            }
-        }
+        let config_keys: Vec<String> = config.models.keys().cloned().collect();
+        let mut models = runtime::model_capabilities::merge_discovery_ids(&config_keys);
         // Ensure the current model is always present.
         if !models.iter().any(|m| m.eq_ignore_ascii_case(&self.inner.model)) {
             models.insert(0, self.inner.model.clone());
@@ -4003,15 +3998,8 @@ impl LiveCli {
     fn set_model(&mut self, model: Option<String>) -> Result<bool, Box<dyn std::error::Error>> {
         let Some(model) = model else {
             let sudocode_config = load_sudocode_config_for_current_dir();
-            let mut models: Vec<String> = sudocode_config.models.keys().cloned().collect();
-            // Merge capabilities SSOT models not already covered by config aliases.
-            let seen: std::collections::BTreeSet<String> =
-                models.iter().map(|m| m.to_ascii_lowercase()).collect();
-            for id in runtime::model_capabilities::all_model_ids() {
-                if !seen.contains(&id.to_ascii_lowercase()) {
-                    models.push(id);
-                }
-            }
+            let config_keys: Vec<String> = sudocode_config.models.keys().cloned().collect();
+            let models = runtime::model_capabilities::merge_discovery_ids(&config_keys);
             let selection = FuzzySelect::new()
                 .with_prompt("Select model")
                 .items(&models)

--- a/rust/crates/rusty-sudocode-cli/tests/pty_config_discovery.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_config_discovery.rs
@@ -83,6 +83,53 @@ fn model_switch_in_repl() {
 }
 
 // ──────────────────────────────────────────────────────────────────────
+// 2b. /model report shows capabilities SSOT models
+// ──────────────────────────────────────────────────────────────────────
+
+/// After entering the REPL, `/model sonnet` switches (or confirms)
+/// the model, then `/model sonnet` again triggers the model report
+/// (no-op switch — same model). The report should list not just the
+/// config aliases but also capabilities SSOT models (e.g. deepseek).
+///
+/// This validates the model-discovery SSOT merge:
+/// - Config aliases appear with display name + provider info.
+/// - Capabilities models not in config appear as wire IDs.
+#[test]
+fn model_report_shows_capabilities_models() {
+    let env = TestEnv::new("model-report-caps");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+
+    sess.expect("❯").expect("should see REPL prompt");
+
+    // First /model sonnet — ensures we are on sonnet (may switch or confirm).
+    sess.send("/model sonnet\r")
+        .expect("send /model sonnet (first)");
+    sess.expect("(?i)(sonnet|model)")
+        .expect("should see model confirmation");
+
+    sess.expect("❯").expect("prompt after first /model");
+
+    // Second /model sonnet — same model, triggers report with full list.
+    sess.send("/model sonnet\r")
+        .expect("send /model sonnet (second, triggers report)");
+
+    // Should see the "Available models" section.
+    sess.expect("Available models")
+        .expect("should see Available models header");
+
+    // Should include capabilities-only models (not in config aliases).
+    sess.expect("deepseek-v4")
+        .expect("should see deepseek capabilities model");
+
+    // Clean exit.
+    sess.expect("❯").expect("prompt after report");
+    sess.send("/exit\r").expect("exit");
+    sess.set_default_timeout(Duration::from_secs(15));
+    let exit = sess.expect_eof().expect("should exit");
+    assert_eq!(exit, 0);
+}
+
+// ──────────────────────────────────────────────────────────────────────
 // 3. /permissions switches mode in REPL
 // ──────────────────────────────────────────────────────────────────────
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_model_compat.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_model_compat.rs
@@ -60,6 +60,28 @@ impl std::fmt::Display for ModelStatus {
     }
 }
 
+/// Check if the PTY screen contains patterns indicating the model is
+/// unavailable (as opposed to genuinely incompatible). These are
+/// transient/group-membership errors that should be skipped, not failed.
+fn is_availability_error(screen: &str) -> bool {
+    screen.contains("429")
+        || screen.contains("rate limit")
+        || screen.contains("Rate limit")
+        || screen.contains("overloaded")
+        || screen.contains("503")
+        || screen.contains("502")
+        || screen.contains("404")
+        || screen.contains("model_not_found")
+        || screen.contains("not supported")
+        || screen.contains("timed out")
+        || screen.contains("timeout")
+        || screen.contains("ETIMEDOUT")
+        || screen.contains("ECONNREFUSED")
+        || screen.contains("connection refused")
+        || screen.contains("upstream")
+        || screen.contains("saturated")
+}
+
 /// Run a single model through a "What is 2+2?" smoke test.
 ///
 /// Returns `Pass` if the model responds with "4", `Skip` if the model
@@ -106,11 +128,25 @@ fn test_one_model(model: &str) -> ModelResult {
                     status: ModelStatus::Pass,
                     detail: "responded with 4, exit 0".to_string(),
                 },
-                Ok(code) => ModelResult {
-                    model: model.to_string(),
-                    status: ModelStatus::Fail,
-                    detail: format!("responded with 4 but exit code {code}"),
-                },
+                Ok(code) => {
+                    // Non-zero exit despite matching "4" — could be a false
+                    // positive (e.g. "404" contains "4"). Check the screen
+                    // for availability errors before calling it a failure.
+                    let screen = sess.render(|s| s.contents());
+                    if is_availability_error(&screen) {
+                        ModelResult {
+                            model: model.to_string(),
+                            status: ModelStatus::Skip,
+                            detail: format!("upstream unavailable (exit {code})"),
+                        }
+                    } else {
+                        ModelResult {
+                            model: model.to_string(),
+                            status: ModelStatus::Fail,
+                            detail: format!("responded with 4 but exit code {code}"),
+                        }
+                    }
+                }
                 Err(e) => ModelResult {
                     model: model.to_string(),
                     status: ModelStatus::Pass,
@@ -122,21 +158,8 @@ fn test_one_model(model: &str) -> ModelResult {
             // Capture the PTY screen to distinguish availability errors
             // from genuine incompatibility.
             let screen = sess.render(|s| s.contents());
-            let is_availability_error = screen.contains("429")
-                || screen.contains("rate limit")
-                || screen.contains("Rate limit")
-                || screen.contains("overloaded")
-                || screen.contains("503")
-                || screen.contains("502")
-                || screen.contains("timed out")
-                || screen.contains("timeout")
-                || screen.contains("ETIMEDOUT")
-                || screen.contains("ECONNREFUSED")
-                || screen.contains("connection refused")
-                || screen.contains("upstream")
-                || screen.contains("saturated");
 
-            if is_availability_error {
+            if is_availability_error(&screen) {
                 ModelResult {
                     model: model.to_string(),
                     status: ModelStatus::Skip,


### PR DESCRIPTION
## Summary

- Make `model-capabilities.json` the single source of truth for model discovery. Config aliases remain for routing only.
- All discovery surfaces (`/model`, tab completion, `get_model_info()`, FuzzySelect) now merge config aliases + capabilities SSOT models.
- Users see ~178 models (after sudorouter refresh) instead of only 12 config aliases.

## Changes

- **`all_model_ids()`** — new public function in `model_capabilities.rs`, returns all wire model IDs from the `OnceLock<BTreeMap>`.
- **`merge_discovery_ids()`** — `#[inline]` DRY helper: config keys first, then capabilities IDs (case-insensitive BTreeSet dedup). Used by `get_model_info()` and `set_model()` FuzzySelect.
- **`format_model_report()`** — two-phase output: config aliases with display name + provider info, then capabilities wire IDs. Removed hardcoded "opus, sonnet, haiku" fallback.
- **Tab completion** — removed hardcoded `/model opus/sonnet/haiku`, added capabilities loop.
- **Compat test fix** — `is_availability_error()` extracted as DRY helper; added 404/model_not_found to skip list; fixed false-positive where `expect("4")` matched "404".

## What does NOT change

- `config.models` structure (routing table)
- `model-capabilities.json` structure (still refreshed from sudorouter every 24h)
- Auth/routing logic, proxy passthrough
- ABI: `get_model_info()` return type `(String, Vec<String>)` unchanged
- `resolve_model_alias()` hardcoded fallback in `args.rs` (offline resilience)

## Test plan

- [x] 4 unit tests in `model_capabilities::tests` (bundled parse, all_model_ids ≥30, merge_discovery_ids dedup, parse_api_response)
- [x] PTY test `model_report_shows_capabilities_models` — mock + live pass
- [x] Full `pty_config_discovery` suite — 9/9 pass (mock + live)
- [x] 30-model live compat sweep — 4 PASS, 26 SKIP (group membership), 0 FAIL
- [x] `cargo check --workspace` clean