### PR TITLE
feat(repl): double Ctrl-C exit + /config set runtime toggle

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1095,6 +1095,11 @@ pub enum SlashCommand {
     Config {
         section: Option<String>,
     },
+    /// `/config set <key> <value>` — runtime toggle for REPL settings.
+    ConfigSet {
+        key: String,
+        value: String,
+    },
     Mcp {
         action: Option<String>,
         target: Option<String>,
@@ -1243,7 +1248,7 @@ impl SlashCommand {
             Self::Compact { .. } => "/compact",
             Self::Cost => "/cost",
             Self::Doctor => "/doctor",
-            Self::Config { .. } => "/config",
+            Self::Config { .. } | Self::ConfigSet { .. } => "/config",
             Self::Memory { .. } => "/memory",
             Self::History { .. } => "/history",
             Self::Diff => "/diff",
@@ -1383,9 +1388,25 @@ pub fn validate_slash_command_input(
         "resume" => SlashCommand::Resume {
             session_path: Some(require_remainder(command, remainder, "<session-path>")?),
         },
-        "config" => SlashCommand::Config {
-            section: parse_config_section(&args)?,
-        },
+        "config" => {
+            if args.first().map(|s| s.to_ascii_lowercase()) == Some("set".into()) {
+                if args.len() < 3 {
+                    return Err(command_error(
+                        "Usage: /config set <key> <value>",
+                        "config",
+                        "/config set <key> <value>",
+                    ));
+                }
+                SlashCommand::ConfigSet {
+                    key: args[1].to_string(),
+                    value: args[2..].join(" "),
+                }
+            } else {
+                SlashCommand::Config {
+                    section: parse_config_section(&args)?,
+                }
+            }
+        }
         "mcp" => parse_mcp_command(&args)?,
         "memory" => {
             validate_no_args(command, &args)?;
@@ -1614,15 +1635,19 @@ fn parse_clear_args(args: &[&str]) -> Result<bool, SlashCommandParseError> {
 }
 
 fn parse_config_section(args: &[&str]) -> Result<Option<String>, SlashCommandParseError> {
-    let section = optional_single_arg("config", args, "[env|hooks|model|plugins]")?;
+    let section = optional_single_arg(
+        "config",
+        args,
+        "[env|hooks|model|plugins|set <key> <value>]",
+    )?;
     if let Some(section) = section {
         if matches!(section.as_str(), "env" | "hooks" | "model" | "plugins") {
             return Ok(Some(section));
         }
         return Err(command_error(
-            &format!("Unsupported /config section '{section}'. Use env, hooks, model, or plugins."),
+            &format!("Unsupported /config section '{section}'. Use env, hooks, model, plugins, or `set <key> <value>`."),
             "config",
-            "/config [env|hooks|model|plugins]",
+            "/config [env|hooks|model|plugins|set <key> <value>]",
         ));
     }
 
@@ -4488,6 +4513,7 @@ pub fn handle_slash_command(
         | SlashCommand::AddDir { .. }
         | SlashCommand::History { .. }
         | SlashCommand::Undo
+        | SlashCommand::ConfigSet { .. }
         | SlashCommand::Unknown(_) => None,
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -287,11 +287,16 @@ impl Highlighter for SlashCommandHelper {
 impl Validator for SlashCommandHelper {}
 impl Helper for SlashCommandHelper {}
 
+/// CC-parity timeout for double Ctrl-C exit (800ms).
+const DOUBLE_CTRLC_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(800);
+
 pub struct LineEditor {
     prompt: String,
     editor: Editor<SlashCommandHelper, DefaultHistory>,
-    /// Whether the previous read returned a Ctrl-C on an empty prompt.
-    pending_exit: bool,
+    /// Timestamp of the first Ctrl-C on an empty prompt. `None` when no
+    /// pending exit. A second Ctrl-C within [`DOUBLE_CTRLC_TIMEOUT`] triggers
+    /// exit; after that the pending state resets automatically.
+    pending_exit_at: Option<std::time::Instant>,
     /// Shared image map populated by the `ImagePasteHandler`.
     images: ImageMap,
 }
@@ -363,7 +368,7 @@ impl LineEditor {
         Self {
             prompt: prompt.into(),
             editor,
-            pending_exit: false,
+            pending_exit_at: None,
             images,
         }
     }
@@ -402,7 +407,7 @@ impl LineEditor {
         loop {
             match self.editor.readline(&self.prompt) {
                 Ok(line) => {
-                    self.pending_exit = false;
+                    self.pending_exit_at = None;
                     return Ok(ReadOutcome::Submit(line));
                 }
                 Err(ReadlineError::Interrupted) => {
@@ -415,14 +420,17 @@ impl LineEditor {
 
                     if has_input {
                         // Had text — clear it and restart the prompt.
-                        self.pending_exit = false;
-                    } else if self.pending_exit {
-                        // Second Ctrl-C — clear remaining chrome and exit.
+                        self.pending_exit_at = None;
+                    } else if self
+                        .pending_exit_at
+                        .is_some_and(|t| t.elapsed() <= DOUBLE_CTRLC_TIMEOUT)
+                    {
+                        // Second Ctrl-C within 800ms — exit.
                         writeln!(stdout, "\x1b[J")?;
                         stdout.flush()?;
                         return Ok(ReadOutcome::Exit);
                     } else {
-                        self.pending_exit = true;
+                        self.pending_exit_at = Some(std::time::Instant::now());
                         // Show exit hint in the footer area (2 lines below prompt).
                         write!(
                             stdout,

--- a/rust/crates/rusty-sudocode-cli/src/input_queue.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_queue.rs
@@ -48,9 +48,11 @@ pub enum QueueMode {
 }
 
 impl QueueMode {
-    /// Resolve from `SUDOCODE_INTERRUPT_QUEUE_MODE`. Case-insensitive; anything
-    /// unrecognized (including unset) → `Off` so the default REPL path stays
-    /// bit-for-bit identical to today's behavior until a user explicitly opts in.
+    /// Resolve from `SUDOCODE_INTERRUPT_QUEUE_MODE`. Case-insensitive.
+    /// Default is `Off` for now — the async REPL's ESC cancel mechanism
+    /// is not yet wired (the input thread owns stdin, the ESC monitor is
+    /// disabled). Switching the default to `Queue` requires making ESC
+    /// cancel work in async mode first.
     #[must_use]
     pub fn from_env() -> Self {
         std::env::var("SUDOCODE_INTERRUPT_QUEUE_MODE")
@@ -66,6 +68,27 @@ impl QueueMode {
             "interrupt" => Some(Self::Interrupt),
             "both" => Some(Self::Both),
             _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Self::Off => 0,
+            Self::Queue => 1,
+            Self::Interrupt => 2,
+            Self::Both => 3,
+        }
+    }
+
+    #[must_use]
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Off,
+            1 => Self::Queue,
+            2 => Self::Interrupt,
+            3 => Self::Both,
+            _ => Self::Queue,
         }
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1266,6 +1266,11 @@ fn run_resume_command(
                 json: Some(json),
             })
         }
+        SlashCommand::ConfigSet { .. } => Ok(ResumeCommandOutcome {
+            session: session.clone(),
+            message: Some("/config set is only available in interactive REPL mode".to_string()),
+            json: None,
+        }),
         SlashCommand::Mcp { action, target } => {
             let cwd = env::current_dir()?;
             let args = match (action.as_deref(), target.as_deref()) {
@@ -1744,22 +1749,18 @@ fn run_repl_async_dispatch(
     mut cli: LiveCli,
     mode: input_queue::QueueMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Capture startup state that only needs to be read once (banner + initial
-    // completion list). Completion refresh mid-loop is deferred — see the
-    // repl_async module docs §Deferred.
     let banner = cli.startup_banner();
     let completions = cli.repl_completion_candidates().unwrap_or_default();
 
-    // In async REPL mode the input thread's rustyline is the sole stdin
-    // consumer — the runner-thread's ESC listener must be disabled or it
-    // wedges the terminal on POSIX (see LiveCli::esc_monitor_enabled docs).
     cli.esc_monitor_enabled = false;
 
-    // Auto-interrupt wiring: install a persistent HookAbortSignal so main can
-    // call `.abort()` mid-turn without ever locking cli. `prepare_turn_runtime`
-    // resets the signal before each turn (see the branch we added there).
     let abort_signal = runtime::HookAbortSignal::new();
     cli.persistent_abort_signal = Some(abort_signal.clone());
+
+    // Shared atomic queue mode — the coordinator reads it each turn,
+    // and `/config set auto-interrupt on|off` writes to it.
+    let shared_mode = repl_async::shared_queue_mode(mode);
+    cli.shared_queue_mode = Some(Arc::clone(&shared_mode));
 
     let cli_shared = std::sync::Arc::new(std::sync::Mutex::new(cli));
     let driver: std::sync::Arc<LiveCliDriver> = std::sync::Arc::new(LiveCliDriver {
@@ -1768,7 +1769,7 @@ fn run_repl_async_dispatch(
     });
 
     let session_start = Instant::now();
-    repl_async::run_coordinator_loop(driver, mode, banner, completions)?;
+    repl_async::run_coordinator_loop(driver, shared_mode, banner, completions)?;
 
     // All threads spawned by the coordinator loop have already been joined
     // inside the loop (Exit branch + TurnDone reap). Unwrapping the Arc here
@@ -1863,6 +1864,9 @@ struct LiveCli {
     /// without ever locking the `LiveCli` mutex — the runner thread holds
     /// that lock while `run_turn` streams.
     persistent_abort_signal: Option<runtime::HookAbortSignal>,
+    /// Shared atomic queue mode for the async REPL. `/config set auto-interrupt`
+    /// writes to this; the coordinator reads it each `submit_during_turn`.
+    shared_queue_mode: Option<repl_async::SharedQueueMode>,
 }
 
 pub(crate) struct RuntimePluginState {
@@ -2540,6 +2544,9 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             }
             SlashCommand::Config { section } => render_config_report(section.as_deref())
                 .map_err(|e| runtime::AcpError::internal(e.to_string()))?,
+            SlashCommand::ConfigSet { .. } => {
+                "/config set is only available in interactive REPL mode".to_string()
+            }
             SlashCommand::Diff => {
                 let output = std::process::Command::new("git")
                     .args(["diff", "--cached", "--no-color"])
@@ -3025,6 +3032,21 @@ struct HookAbortMonitor {
     join_handle: Option<JoinHandle<()>>,
 }
 
+/// CC-parity timeout for double Ctrl-C force exit (800ms).
+const DOUBLE_CTRLC_TIMEOUT_MS: u64 = 800;
+
+/// Shared timestamp (millis since process start) of the last Ctrl-C that
+/// cancelled a turn. Persists across `HookAbortMonitor` lifetimes so a
+/// fast second Ctrl-C on the *next* turn's monitor (or between turns)
+/// triggers process exit. `0` means no pending exit.
+static LAST_CTRLC_CANCEL_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Monotonic reference point for [`LAST_CTRLC_CANCEL_MS`].
+fn process_uptime_ms() -> u64 {
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_millis() as u64
+}
+
 impl HookAbortMonitor {
     fn spawn(abort_signal: runtime::HookAbortSignal) -> Self {
         Self::spawn_with_waiter(abort_signal, move |stop_rx, abort_signal| {
@@ -3061,15 +3083,49 @@ impl HookAbortMonitor {
                             Err(RecvTimeoutError::Timeout) => continue,
                         }
                     }
-                    if poll_abort_key(Duration::from_millis(50)) {
-                        esc_abort.abort();
-                        return;
+                    match poll_abort_key(Duration::from_millis(50)) {
+                        AbortKey::None => {}
+                        AbortKey::Esc => {
+                            esc_abort.abort();
+                            return;
+                        }
+                        AbortKey::CtrlC => {
+                            let now = process_uptime_ms();
+                            let prev =
+                                LAST_CTRLC_CANCEL_MS.load(std::sync::atomic::Ordering::Relaxed);
+                            if prev > 0 && now.saturating_sub(prev) <= DOUBLE_CTRLC_TIMEOUT_MS {
+                                // Double Ctrl-C within 800ms — force exit.
+                                // Restore terminal before exiting.
+                                #[cfg(unix)]
+                                disable_raw_mode_unix();
+                                #[cfg(not(unix))]
+                                let _ = crossterm::terminal::disable_raw_mode();
+                                eprintln!();
+                                std::process::exit(0);
+                            }
+                            LAST_CTRLC_CANCEL_MS.store(now, std::sync::atomic::Ordering::Relaxed);
+                            esc_abort.abort();
+                            return;
+                        }
                     }
                 });
 
                 tokio::select! {
                     result = tokio::signal::ctrl_c() => {
                         if result.is_ok() {
+                            let now = process_uptime_ms();
+                            let prev = LAST_CTRLC_CANCEL_MS
+                                .load(std::sync::atomic::Ordering::Relaxed);
+                            if prev > 0 && now.saturating_sub(prev) <= DOUBLE_CTRLC_TIMEOUT_MS {
+                                #[cfg(unix)]
+                                disable_raw_mode_unix();
+                                #[cfg(not(unix))]
+                                let _ = crossterm::terminal::disable_raw_mode();
+                                eprintln!();
+                                std::process::exit(0);
+                            }
+                            LAST_CTRLC_CANCEL_MS
+                                .store(now, std::sync::atomic::Ordering::Relaxed);
                             abort_signal.abort();
                         }
                     }
@@ -3165,10 +3221,21 @@ fn disable_raw_mode_unix() {
     });
 }
 
+/// Which abort key was detected by `poll_abort_key`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AbortKey {
+    /// No abort key pressed within the poll window.
+    None,
+    /// ESC (0x1b) — cancels the current turn but never triggers exit.
+    Esc,
+    /// Ctrl-C (0x03) — cancels the current turn; double-press within
+    /// 800ms exits the process (CC parity).
+    CtrlC,
+}
+
 /// Poll stdin for an abort key (ESC = 0x1b, Ctrl-C = 0x03).
-/// Returns `true` if an abort key was detected within `timeout`.
 #[cfg(unix)]
-fn poll_abort_key(timeout: Duration) -> bool {
+fn poll_abort_key(timeout: Duration) -> AbortKey {
     use nix::poll::{self, PollFd, PollFlags, PollTimeout};
     use std::os::fd::AsFd;
     use std::os::unix::io::AsRawFd;
@@ -3178,36 +3245,39 @@ fn poll_abort_key(timeout: Duration) -> bool {
     let mut fds = [PollFd::new(stdin.as_fd(), PollFlags::POLLIN)];
     let ready = poll::poll(&mut fds, poll_timeout).unwrap_or(0);
     if ready <= 0 {
-        return false;
+        return AbortKey::None;
     }
     let revents = fds[0].revents().unwrap_or(PollFlags::empty());
     if !revents.contains(PollFlags::POLLIN) {
-        return false;
+        return AbortKey::None;
     }
     let mut buf = [0u8; 1];
     match nix::unistd::read(stdin.as_raw_fd(), &mut buf) {
-        Ok(1) => buf[0] == 0x1b || buf[0] == 0x03,
-        _ => false,
+        Ok(1) if buf[0] == 0x03 => AbortKey::CtrlC,
+        Ok(1) if buf[0] == 0x1b => AbortKey::Esc,
+        _ => AbortKey::None,
     }
 }
 
 /// Poll stdin for an abort key using crossterm's event system (Windows).
 #[cfg(not(unix))]
-fn poll_abort_key(timeout: Duration) -> bool {
+fn poll_abort_key(timeout: Duration) -> AbortKey {
     use crossterm::event::{self, Event, KeyCode, KeyEventKind};
     if !event::poll(timeout).unwrap_or(false) {
-        return false;
+        return AbortKey::None;
     }
     if let Ok(Event::Key(key)) = event::read() {
         if key.kind != KeyEventKind::Press {
-            return false;
+            return AbortKey::None;
         }
-        let is_esc = key.code == KeyCode::Esc;
-        let is_ctrl_c =
-            key.code == KeyCode::Char('c') && key.modifiers.contains(event::KeyModifiers::CONTROL);
-        return is_esc || is_ctrl_c;
+        if key.code == KeyCode::Esc {
+            return AbortKey::Esc;
+        }
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(event::KeyModifiers::CONTROL) {
+            return AbortKey::CtrlC;
+        }
     }
-    false
+    AbortKey::None
 }
 
 /// Measure visible string width by stripping ANSI escape sequences.
@@ -3312,6 +3382,7 @@ impl LiveCli {
             tokio_runtime,
             esc_monitor_enabled: true,
             persistent_abort_signal: None,
+            shared_queue_mode: None,
         };
         cli.persist_session()?;
 
@@ -3783,6 +3854,10 @@ impl LiveCli {
                 Self::print_config(section.as_deref())?;
                 false
             }
+            SlashCommand::ConfigSet { key, value } => {
+                self.handle_config_set(&key, &value)?;
+                false
+            }
             SlashCommand::Mcp { action, target } => {
                 let args = match (action.as_deref(), target.as_deref()) {
                     (None, None) => None,
@@ -4208,6 +4283,82 @@ impl LiveCli {
             path: handle.path,
         };
         Ok(())
+    }
+
+    fn handle_config_set(
+        &mut self,
+        key: &str,
+        value: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match key {
+            "auto-interrupt" | "autoInterrupt" => {
+                let on = match value.to_ascii_lowercase().as_str() {
+                    "on" | "true" | "1" => true,
+                    "off" | "false" | "0" => false,
+                    _ => {
+                        eprintln!("Usage: /config set auto-interrupt on|off");
+                        return Ok(());
+                    }
+                };
+                if let Some(shared) = &self.shared_queue_mode {
+                    use std::sync::atomic::Ordering;
+                    let current = input_queue::QueueMode::from_u8(shared.load(Ordering::Relaxed));
+                    let new_mode = if on {
+                        if current.queue_enabled() {
+                            input_queue::QueueMode::Both
+                        } else {
+                            input_queue::QueueMode::Interrupt
+                        }
+                    } else if current.queue_enabled() {
+                        input_queue::QueueMode::Queue
+                    } else {
+                        input_queue::QueueMode::Off
+                    };
+                    shared.store(new_mode.to_u8(), Ordering::Relaxed);
+                    println!(
+                        "\x1b[2mauto-interrupt: {}\x1b[0m",
+                        if on { "on" } else { "off" }
+                    );
+                } else {
+                    eprintln!("auto-interrupt is only available in async REPL mode");
+                }
+                Ok(())
+            }
+            "queue" | "messageQueue" => {
+                let on = match value.to_ascii_lowercase().as_str() {
+                    "on" | "true" | "1" => true,
+                    "off" | "false" | "0" => false,
+                    _ => {
+                        eprintln!("Usage: /config set queue on|off");
+                        return Ok(());
+                    }
+                };
+                if let Some(shared) = &self.shared_queue_mode {
+                    use std::sync::atomic::Ordering;
+                    let current = input_queue::QueueMode::from_u8(shared.load(Ordering::Relaxed));
+                    let new_mode = if on {
+                        if current.interrupt_enabled() {
+                            input_queue::QueueMode::Both
+                        } else {
+                            input_queue::QueueMode::Queue
+                        }
+                    } else if current.interrupt_enabled() {
+                        input_queue::QueueMode::Interrupt
+                    } else {
+                        input_queue::QueueMode::Off
+                    };
+                    shared.store(new_mode.to_u8(), Ordering::Relaxed);
+                    println!("\x1b[2mqueue: {}\x1b[0m", if on { "on" } else { "off" });
+                } else {
+                    eprintln!("queue is only available in async REPL mode");
+                }
+                Ok(())
+            }
+            _ => {
+                eprintln!("Unknown config key '{key}'. Available: auto-interrupt, queue");
+                Ok(())
+            }
+        }
     }
 
     fn print_config(section: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -70,6 +70,7 @@
 //! The [`sudocode plan doc`](https://github.com/sudoprivacy/sudocode/blob/main/notes/plans/conversation-interrupt-queue-sudocode.md)
 //! §落地节奏 covers the full sequence; this file is Phase-2 commit 1.
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc::{sync_channel, RecvTimeoutError, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -77,6 +78,21 @@ use std::time::Duration;
 
 use crate::input::{LineEditor, ReadOutcome};
 use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
+
+/// Shared queue mode that can be toggled at runtime via `/config set`.
+pub type SharedQueueMode = Arc<AtomicU8>;
+
+/// Create a shared queue mode from the initial value.
+#[must_use]
+pub fn shared_queue_mode(mode: QueueMode) -> SharedQueueMode {
+    Arc::new(AtomicU8::new(mode.to_u8()))
+}
+
+/// Read the current queue mode from the shared atomic.
+#[must_use]
+pub fn load_queue_mode(shared: &SharedQueueMode) -> QueueMode {
+    QueueMode::from_u8(shared.load(Ordering::Relaxed))
+}
 
 /// Builds the `↑`-arrow dequeue hook that the input thread's rustyline binds
 /// to `KeyCode::Up` on an empty buffer. Kept as a free function so both the
@@ -161,7 +177,7 @@ fn is_exit_command(text: &str) -> bool {
 /// that might be writing to disk).
 pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     driver: Arc<D>,
-    mode: QueueMode,
+    mode: SharedQueueMode,
     startup_banner: String,
     initial_completions: Vec<(String, String)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -265,7 +281,10 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                     ));
                     continue;
                 }
-                let outcome = coord.lock().unwrap().submit_during_turn(text, mode);
+                let outcome = coord
+                    .lock()
+                    .unwrap()
+                    .submit_during_turn(text, load_queue_mode(&mode));
                 match outcome {
                     SubmitOutcome::Queued => {
                         // Silent: sudowork's queue chips render in the sendbox;


### PR DESCRIPTION
## Summary
- **Double Ctrl-C force exit** (CC parity): 800ms window. First Ctrl-C cancels turn, second exits process. ESC only cancels, never exits. Shared `AtomicU64` timestamp persists across `HookAbortMonitor` lifetimes.
- **`/config set`**: Runtime toggle for `auto-interrupt on|off` and `queue on|off`. Uses `SharedQueueMode` (`Arc<AtomicU8>`) that the coordinator reads each `submit_during_turn`.
- **`QueueMode::to_u8/from_u8`** for atomic encoding
- **`AbortKey` enum** replaces `bool` return from `poll_abort_key` to distinguish ESC vs Ctrl-C
- **`LineEditor.pending_exit_at`** replaces `pending_exit: bool` — adds 800ms timeout (was infinite window)

## What's NOT in this PR
- Queue ON as default — blocked on ESC cancel in async REPL mode (the input thread owns stdin, the raw-mode ESC monitor is disabled). Will be a follow-up PR.

## Test plan
- [x] All 12 existing PTY tests pass (cancel, core_conversation, resume, arrow_keys, repl_async_queue, repl_async_interrupt)
- [x] Live ESC cancel test passes
- [x] `cargo fmt --all --check` clean