### PR TITLE
feat(cli): systemic cancel architecture + Queue default

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cancel.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cancel.rs
@@ -20,12 +20,16 @@ static LAST_CTRLC_CANCEL_MS: AtomicU64 = AtomicU64::new(0);
 /// Monotonic milliseconds since process start. Used as the time-base for
 /// `LAST_CTRLC_CANCEL_MS` so the timestamp survives across monitor lifetimes
 /// without wall-clock drift concerns.
+///
+/// Returns at least 1 — zero is reserved as the "no previous Ctrl-C"
+/// sentinel in [`LAST_CTRLC_CANCEL_MS`].
 pub fn process_uptime_ms() -> u64 {
     static START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
-    START
+    let elapsed = START
         .get_or_init(std::time::Instant::now)
         .elapsed()
-        .as_millis() as u64
+        .as_millis() as u64;
+    elapsed.max(1)
 }
 
 /// Record a Ctrl-C cancel. Call this every time a Ctrl-C fires (whether it

--- a/rust/crates/rusty-sudocode-cli/src/cancel.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cancel.rs
@@ -1,0 +1,47 @@
+//! Single source of truth for the double Ctrl-C exit mechanism.
+//!
+//! Both the sync REPL (via `HookAbortMonitor` in `main.rs`) and the async REPL
+//! (via `LineEditor` in `input.rs`) need to track "was the last Ctrl-C recent
+//! enough that a second one means exit?". This module owns the shared constant,
+//! the cross-turn timestamp, and the helpers that read/write it.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// CC-parity timeout for double Ctrl-C force exit.
+pub const DOUBLE_CTRLC_WINDOW: Duration = Duration::from_millis(800);
+
+/// Shared timestamp (millis since process start) of the last Ctrl-C that
+/// cancelled a turn. Persists across `HookAbortMonitor` lifetimes so a
+/// fast second Ctrl-C on the *next* turn's monitor (or between turns)
+/// triggers process exit. `0` means no pending exit.
+static LAST_CTRLC_CANCEL_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Monotonic milliseconds since process start. Used as the time-base for
+/// `LAST_CTRLC_CANCEL_MS` so the timestamp survives across monitor lifetimes
+/// without wall-clock drift concerns.
+pub fn process_uptime_ms() -> u64 {
+    static START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    START
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_millis() as u64
+}
+
+/// Record a Ctrl-C cancel. Call this every time a Ctrl-C fires (whether it
+/// actually cancels a turn or just resets the prompt).
+pub fn record_ctrlc() {
+    LAST_CTRLC_CANCEL_MS.store(process_uptime_ms(), Ordering::Relaxed);
+}
+
+/// Returns `true` when the previous `record_ctrlc()` was within
+/// [`DOUBLE_CTRLC_WINDOW`] of now — meaning the user double-pressed Ctrl-C
+/// and wants to exit.
+pub fn is_double_ctrlc() -> bool {
+    let prev = LAST_CTRLC_CANCEL_MS.load(Ordering::Relaxed);
+    if prev == 0 {
+        return false;
+    }
+    let now = process_uptime_ms();
+    now.saturating_sub(prev) <= DOUBLE_CTRLC_WINDOW.as_millis() as u64
+}

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -287,14 +287,13 @@ impl Highlighter for SlashCommandHelper {
 impl Validator for SlashCommandHelper {}
 impl Helper for SlashCommandHelper {}
 
-/// CC-parity timeout for double Ctrl-C exit (800ms).
-const DOUBLE_CTRLC_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(800);
+use crate::cancel;
 
 pub struct LineEditor {
     prompt: String,
     editor: Editor<SlashCommandHelper, DefaultHistory>,
     /// Timestamp of the first Ctrl-C on an empty prompt. `None` when no
-    /// pending exit. A second Ctrl-C within [`DOUBLE_CTRLC_TIMEOUT`] triggers
+    /// pending exit. A second Ctrl-C within [`cancel::DOUBLE_CTRLC_WINDOW`] triggers
     /// exit; after that the pending state resets automatically.
     pending_exit_at: Option<std::time::Instant>,
     /// Shared image map populated by the `ImagePasteHandler`.
@@ -423,7 +422,7 @@ impl LineEditor {
                         self.pending_exit_at = None;
                     } else if self
                         .pending_exit_at
-                        .is_some_and(|t| t.elapsed() <= DOUBLE_CTRLC_TIMEOUT)
+                        .is_some_and(|t| t.elapsed() <= cancel::DOUBLE_CTRLC_WINDOW)
                     {
                         // Second Ctrl-C within 800ms — exit.
                         writeln!(stdout, "\x1b[J")?;

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -324,6 +324,11 @@ pub struct LineEditor {
     pending_exit_at: Option<std::time::Instant>,
     /// Shared image map populated by the `ImagePasteHandler`.
     images: ImageMap,
+    /// Optional abort hook called on Ctrl-C with empty buffer (async REPL).
+    /// Cancels the running turn so Ctrl-C works the same as ESC for
+    /// turn cancellation, plus integrates with `cancel::record_ctrlc()`
+    /// for double-press exit.
+    abort_hook: Option<EscAbortHook>,
 }
 
 impl LineEditor {
@@ -373,10 +378,13 @@ impl LineEditor {
 
         // ESC: cancel the running turn (async REPL only). In sync mode the
         // HookAbortMonitor handles ESC on its own raw-mode stdin thread.
-        if let Some(abort_hook) = esc_abort_hook {
+        // Clone the hook so the same callback is available for Ctrl-C too.
+        if let Some(ref abort_hook) = esc_abort_hook {
             editor.bind_sequence(
                 KeyEvent(KeyCode::Esc, Modifiers::NONE),
-                EventHandler::Conditional(Box::new(EscCancelHandler { abort_hook })),
+                EventHandler::Conditional(Box::new(EscCancelHandler {
+                    abort_hook: Arc::clone(abort_hook),
+                })),
             );
         }
 
@@ -407,6 +415,7 @@ impl LineEditor {
             editor,
             pending_exit_at: None,
             images,
+            abort_hook: esc_abort_hook,
         }
     }
 
@@ -458,11 +467,27 @@ impl LineEditor {
                     if has_input {
                         // Had text — clear it and restart the prompt.
                         self.pending_exit_at = None;
+                    } else if let Some(ref hook) = self.abort_hook {
+                        // Async REPL: Ctrl-C cancels the running turn (same
+                        // as ESC) AND checks for double-press exit via the
+                        // shared cancel module.
+                        if cancel::is_double_ctrlc() {
+                            writeln!(stdout, "\x1b[J")?;
+                            stdout.flush()?;
+                            return Ok(ReadOutcome::Exit);
+                        }
+                        cancel::record_ctrlc();
+                        (hook)();
+                        // Show exit hint.
+                        write!(
+                            stdout,
+                            "\x1b[2E\x1b[2K  \x1b[2mPress Ctrl-C again to exit\x1b[0m\x1b[2F"
+                        )?;
                     } else if self
                         .pending_exit_at
                         .is_some_and(|t| t.elapsed() <= cancel::DOUBLE_CTRLC_WINDOW)
                     {
-                        // Second Ctrl-C within 800ms — exit.
+                        // Sync REPL: second Ctrl-C within 800ms — exit.
                         writeln!(stdout, "\x1b[J")?;
                         stdout.flush()?;
                         return Ok(ReadOutcome::Exit);

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -20,6 +20,32 @@ use rustyline::{
 /// returns `None` to fall through to history navigation.
 pub type UpArrowDequeueHook = std::sync::Arc<dyn Fn() -> Option<String> + Send + Sync + 'static>;
 
+/// Callback invoked on ESC press to cancel the currently-running turn.
+/// The async REPL passes `abort_signal.abort()` here; the sync REPL
+/// leaves it `None` (ESC is handled by `HookAbortMonitor` on a separate
+/// thread in sync mode).
+pub type EscAbortHook = Arc<dyn Fn() + Send + Sync + 'static>;
+
+/// Rustyline handler for ESC: calls the abort hook (cancels the running
+/// turn) and consumes the key. Only bound in async REPL mode — the sync
+/// REPL uses `HookAbortMonitor`'s raw-mode stdin listener instead.
+struct EscCancelHandler {
+    abort_hook: EscAbortHook,
+}
+
+impl ConditionalEventHandler for EscCancelHandler {
+    fn handle(
+        &self,
+        _evt: &rustyline::Event,
+        _n: RepeatCount,
+        _positive: bool,
+        _ctx: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        (self.abort_hook)();
+        Some(Cmd::Noop)
+    }
+}
+
 /// Rustyline handler for `↑`: moves cursor to the line above (or to the
 /// beginning of the current line on single-line input), and only navigates
 /// history when the cursor is already at the top-left.  When an async REPL
@@ -303,18 +329,21 @@ pub struct LineEditor {
 impl LineEditor {
     #[must_use]
     pub fn new(prompt: impl Into<String>, completions: Vec<(String, String)>) -> Self {
-        Self::new_with_dequeue_hook(prompt, completions, None)
+        Self::new_with_dequeue_hook(prompt, completions, None, None)
     }
 
-    /// Same as [`new`] but binds `↑` (on an empty buffer) to `dequeue_hook`.
-    /// The async REPL uses this to pop the newest queued input back into the
-    /// editor for editing; sync REPL passes `None` and gets the default
-    /// history-only `↑` behavior.
+    /// Same as [`new`] but binds `↑` (on an empty buffer) to `dequeue_hook`
+    /// and optionally binds ESC to `esc_abort_hook`.
+    ///
+    /// The async REPL uses the dequeue hook to pop the newest queued input
+    /// back into the editor for editing, and the ESC hook to cancel the
+    /// currently-running turn. The sync REPL passes `None` for both.
     #[must_use]
     pub fn new_with_dequeue_hook(
         prompt: impl Into<String>,
         completions: Vec<(String, String)>,
         dequeue_hook: Option<UpArrowDequeueHook>,
+        esc_abort_hook: Option<EscAbortHook>,
     ) -> Self {
         let config = Config::builder()
             .completion_type(CompletionType::List)
@@ -341,6 +370,15 @@ impl LineEditor {
             KeyEvent(KeyCode::Down, Modifiers::NONE),
             EventHandler::Conditional(Box::new(DownArrowHandler)),
         );
+
+        // ESC: cancel the running turn (async REPL only). In sync mode the
+        // HookAbortMonitor handles ESC on its own raw-mode stdin thread.
+        if let Some(abort_hook) = esc_abort_hook {
+            editor.bind_sequence(
+                KeyEvent(KeyCode::Esc, Modifiers::NONE),
+                EventHandler::Conditional(Box::new(EscCancelHandler { abort_hook })),
+            );
+        }
 
         let images: ImageMap = Arc::new(Mutex::new(HashMap::new()));
 

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -350,10 +350,16 @@ impl LineEditor {
         dequeue_hook: Option<UpArrowDequeueHook>,
         esc_abort_hook: Option<EscAbortHook>,
     ) -> Self {
-        let config = Config::builder()
+        let mut config_builder = Config::builder()
             .completion_type(CompletionType::List)
-            .edit_mode(EditMode::Emacs)
-            .build();
+            .edit_mode(EditMode::Emacs);
+        // When an ESC abort hook is installed (async REPL), set a keyseq
+        // timeout so rustyline recognizes standalone ESC after 50ms instead
+        // of blocking indefinitely for a follow-up key (Emacs Meta prefix).
+        if esc_abort_hook.is_some() {
+            config_builder = config_builder.keyseq_timeout(Some(50));
+        }
+        let config = config_builder.build();
         let mut editor = Editor::<SlashCommandHelper, DefaultHistory>::with_config(config)
             .expect("rustyline editor should initialize");
         editor.set_helper(Some(SlashCommandHelper::new(completions)));

--- a/rust/crates/rusty-sudocode-cli/src/input_queue.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_queue.rs
@@ -23,11 +23,12 @@
 //! The auto-interrupter, if any, always runs alone as a fresh solo turn (§3.2
 //! row 2: "第一条立即打断并单独作为新轮启动") — its follow-ups then batch normally.
 //!
-//! ## Env-gated opt-in
+//! ## Environment override
 //!
 //! Reads `SUDOCODE_INTERRUPT_QUEUE_MODE`:
-//! - unset / `off` — current sync behavior, no queue, no interrupt
-//! - `queue` — queue ON, auto-interrupt OFF
+//! - unset — defaults to `queue` (CC parity)
+//! - `off` — sync behavior, no queue, no interrupt
+//! - `queue` — queue ON, auto-interrupt OFF (default)
 //! - `interrupt` — auto-interrupt ON, queue OFF (interrupt-then-send)
 //! - `both` — both ON (sudowork-parity default)
 //!
@@ -49,16 +50,15 @@ pub enum QueueMode {
 
 impl QueueMode {
     /// Resolve from `SUDOCODE_INTERRUPT_QUEUE_MODE`. Case-insensitive.
-    /// Default is `Off` for now — the async REPL's ESC cancel mechanism
-    /// is not yet wired (the input thread owns stdin, the ESC monitor is
-    /// disabled). Switching the default to `Queue` requires making ESC
-    /// cancel work in async mode first.
+    /// Default is `Queue` — message queue ON, matching Claude Code parity.
+    /// ESC and Ctrl-C cancel are wired in the async REPL via
+    /// `EscCancelHandler` and the `abort_hook` in `LineEditor`.
     #[must_use]
     pub fn from_env() -> Self {
         std::env::var("SUDOCODE_INTERRUPT_QUEUE_MODE")
             .ok()
             .and_then(|v| Self::from_str(&v))
-            .unwrap_or(Self::Off)
+            .unwrap_or(Self::Queue)
     }
 
     fn from_str(s: &str) -> Option<Self> {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1744,8 +1744,8 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
 
 /// Async REPL dispatch — takes ownership of the constructed `LiveCli`, wraps it
 /// in `Arc<Mutex<>>` for the coordinator + runner thread, drives the loop, then
-/// unwraps and finalizes the session on exit. Only called when
-/// `SUDOCODE_INTERRUPT_QUEUE_MODE` is set.
+/// unwraps and finalizes the session on exit. Called by default (queue mode)
+/// or when `SUDOCODE_INTERRUPT_QUEUE_MODE` is explicitly set to a non-off value.
 fn run_repl_async_dispatch(
     mut cli: LiveCli,
     mode: input_queue::QueueMode,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1763,6 +1763,13 @@ fn run_repl_async_dispatch(
     let shared_mode = repl_async::shared_queue_mode(mode);
     cli.shared_queue_mode = Some(Arc::clone(&shared_mode));
 
+    // ESC abort hook — wired into rustyline's ConditionalEventHandler so ESC
+    // cancels the running turn without a separate raw-mode stdin thread.
+    let esc_abort_hook: input::EscAbortHook = {
+        let sig = abort_signal.clone();
+        Arc::new(move || sig.abort())
+    };
+
     let cli_shared = std::sync::Arc::new(std::sync::Mutex::new(cli));
     let driver: std::sync::Arc<LiveCliDriver> = std::sync::Arc::new(LiveCliDriver {
         cli: std::sync::Arc::clone(&cli_shared),
@@ -1770,7 +1777,13 @@ fn run_repl_async_dispatch(
     });
 
     let session_start = Instant::now();
-    repl_async::run_coordinator_loop(driver, shared_mode, banner, completions)?;
+    repl_async::run_coordinator_loop(
+        driver,
+        shared_mode,
+        banner,
+        completions,
+        Some(esc_abort_hook),
+    )?;
 
     // All threads spawned by the coordinator loop have already been joined
     // inside the loop (Exit branch + TurnDone reap). Unwrapping the Arc here

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3032,6 +3032,16 @@ impl AcpSdkDelegate {
     }
 }
 
+/// Parse an on/off toggle value. Accepts `on|true|1` and `off|false|0`
+/// (case-insensitive). Returns `None` for unrecognized input.
+fn parse_on_off(value: &str) -> Option<bool> {
+    match value.to_ascii_lowercase().as_str() {
+        "on" | "true" | "1" => Some(true),
+        "off" | "false" | "0" => Some(false),
+        _ => None,
+    }
+}
+
 struct HookAbortMonitor {
     stop_tx: Option<Sender<()>>,
     join_handle: Option<JoinHandle<()>>,
@@ -4270,13 +4280,9 @@ impl LiveCli {
     ) -> Result<(), Box<dyn std::error::Error>> {
         match key {
             "auto-interrupt" | "autoInterrupt" => {
-                let on = match value.to_ascii_lowercase().as_str() {
-                    "on" | "true" | "1" => true,
-                    "off" | "false" | "0" => false,
-                    _ => {
-                        eprintln!("Usage: /config set auto-interrupt on|off");
-                        return Ok(());
-                    }
+                let Some(on) = parse_on_off(value) else {
+                    eprintln!("Usage: /config set auto-interrupt on|off");
+                    return Ok(());
                 };
                 if let Some(shared) = &self.shared_queue_mode {
                     use std::sync::atomic::Ordering;
@@ -4303,13 +4309,9 @@ impl LiveCli {
                 Ok(())
             }
             "queue" | "messageQueue" => {
-                let on = match value.to_ascii_lowercase().as_str() {
-                    "on" | "true" | "1" => true,
-                    "off" | "false" | "0" => false,
-                    _ => {
-                        eprintln!("Usage: /config set queue on|off");
-                        return Ok(());
-                    }
+                let Some(on) = parse_on_off(value) else {
+                    eprintln!("Usage: /config set queue on|off");
+                    return Ok(());
                 };
                 if let Some(shared) = &self.shared_queue_mode {
                     use std::sync::atomic::Ordering;

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -12,6 +12,7 @@
     clippy::unnecessary_wraps,
     clippy::unused_self
 )]
+mod cancel;
 mod cli;
 mod init;
 mod input;
@@ -3036,21 +3037,6 @@ struct HookAbortMonitor {
     join_handle: Option<JoinHandle<()>>,
 }
 
-/// CC-parity timeout for double Ctrl-C force exit (800ms).
-const DOUBLE_CTRLC_TIMEOUT_MS: u64 = 800;
-
-/// Shared timestamp (millis since process start) of the last Ctrl-C that
-/// cancelled a turn. Persists across `HookAbortMonitor` lifetimes so a
-/// fast second Ctrl-C on the *next* turn's monitor (or between turns)
-/// triggers process exit. `0` means no pending exit.
-static LAST_CTRLC_CANCEL_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Monotonic reference point for [`LAST_CTRLC_CANCEL_MS`].
-fn process_uptime_ms() -> u64 {
-    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
-    START.get_or_init(Instant::now).elapsed().as_millis() as u64
-}
-
 impl HookAbortMonitor {
     fn spawn(abort_signal: runtime::HookAbortSignal) -> Self {
         Self::spawn_with_waiter(abort_signal, move |stop_rx, abort_signal| {
@@ -3094,12 +3080,7 @@ impl HookAbortMonitor {
                             return;
                         }
                         AbortKey::CtrlC => {
-                            let now = process_uptime_ms();
-                            let prev =
-                                LAST_CTRLC_CANCEL_MS.load(std::sync::atomic::Ordering::Relaxed);
-                            if prev > 0 && now.saturating_sub(prev) <= DOUBLE_CTRLC_TIMEOUT_MS {
-                                // Double Ctrl-C within 800ms — force exit.
-                                // Restore terminal before exiting.
+                            if cancel::is_double_ctrlc() {
                                 #[cfg(unix)]
                                 disable_raw_mode_unix();
                                 #[cfg(not(unix))]
@@ -3107,7 +3088,7 @@ impl HookAbortMonitor {
                                 eprintln!();
                                 std::process::exit(0);
                             }
-                            LAST_CTRLC_CANCEL_MS.store(now, std::sync::atomic::Ordering::Relaxed);
+                            cancel::record_ctrlc();
                             esc_abort.abort();
                             return;
                         }
@@ -3117,10 +3098,7 @@ impl HookAbortMonitor {
                 tokio::select! {
                     result = tokio::signal::ctrl_c() => {
                         if result.is_ok() {
-                            let now = process_uptime_ms();
-                            let prev = LAST_CTRLC_CANCEL_MS
-                                .load(std::sync::atomic::Ordering::Relaxed);
-                            if prev > 0 && now.saturating_sub(prev) <= DOUBLE_CTRLC_TIMEOUT_MS {
+                            if cancel::is_double_ctrlc() {
                                 #[cfg(unix)]
                                 disable_raw_mode_unix();
                                 #[cfg(not(unix))]
@@ -3128,8 +3106,7 @@ impl HookAbortMonitor {
                                 eprintln!();
                                 std::process::exit(0);
                             }
-                            LAST_CTRLC_CANCEL_MS
-                                .store(now, std::sync::atomic::Ordering::Relaxed);
+                            cancel::record_ctrlc();
                             abort_signal.abort();
                         }
                     }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1831,6 +1831,30 @@ struct LiveCliDriver {
 impl repl_async::TurnDriver for LiveCliDriver {
     fn run_turn(&self, prompt: &str) {
         let mut cli = self.cli.lock().expect("LiveCli mutex poisoned");
+        // Dispatch slash commands the same way the sync REPL does — parse
+        // before reaching the LLM. `/exit` and `/quit` are already handled
+        // in the coordinator loop; everything else (config set, model, clear,
+        // help, etc.) is dispatched here.
+        let trimmed = prompt.trim();
+        match SlashCommand::parse(trimmed) {
+            Ok(Some(command)) => {
+                match cli.handle_repl_command(command) {
+                    Ok(true) => {
+                        if let Err(e) = cli.persist_session() {
+                            eprintln!("\x1b[31m{e}\x1b[0m");
+                        }
+                    }
+                    Ok(false) => {}
+                    Err(e) => eprintln!("\x1b[31m{e}\x1b[0m"),
+                }
+                return;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("\x1b[31m{error}\x1b[0m");
+                return;
+            }
+        }
         if let Err(e) = cli.run_turn(prompt) {
             eprintln!("\x1b[31m{e}\x1b[0m");
         }

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -76,7 +76,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use crate::input::{LineEditor, ReadOutcome};
+use crate::input::{EscAbortHook, LineEditor, ReadOutcome};
 use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
 
 /// Shared queue mode that can be toggled at runtime via `/config set`.
@@ -180,6 +180,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     mode: SharedQueueMode,
     startup_banner: String,
     initial_completions: Vec<(String, String)>,
+    esc_abort_hook: Option<EscAbortHook>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("{startup_banner}");
 
@@ -191,14 +192,20 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     // to main via a bounded channel. Exits cleanly on Exit / channel closed.
     // The `↑`-arrow dequeue hook is bound here so the input thread can pop
     // the newest queued input back into the buffer without needing a
-    // channel round-trip to main.
+    // channel round-trip to main. The ESC abort hook cancels the running
+    // turn directly from rustyline's event handler — no raw-mode conflict
+    // because rustyline already owns stdin.
     let input_tx_clone = input_tx.clone();
     let dequeue_hook = make_up_arrow_hook(Arc::clone(&coord));
     thread::Builder::new()
         .name("repl-input".into())
         .spawn(move || {
-            let mut editor =
-                LineEditor::new_with_dequeue_hook("❯ ", initial_completions, Some(dequeue_hook));
+            let mut editor = LineEditor::new_with_dequeue_hook(
+                "❯ ",
+                initial_completions,
+                Some(dequeue_hook),
+                esc_abort_hook,
+            );
             loop {
                 match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -1,8 +1,8 @@
 //! Async REPL loop that accepts input DURING a running turn — Phase 2 of the
 //! interrupt+queue plan (`notes/plans/conversation-interrupt-queue-sudocode.md`).
 //!
-//! Only activated when `SUDOCODE_INTERRUPT_QUEUE_MODE` is set to a non-off value.
-//! The default REPL (`run_repl`) is unchanged and remains the sync path.
+//! Active by default (`QueueMode::Queue`). Set `SUDOCODE_INTERRUPT_QUEUE_MODE=off`
+//! to fall back to the sync REPL.
 //!
 //! ## Modes
 //!

--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -363,6 +363,12 @@ fn spawn_with_workspace(
         " GIT_COMMITTER_EMAIL={}",
         shell_quote("scode-test@example.com")
     ));
+    // Default to sync REPL for tests — the async REPL doesn't reprint `❯`
+    // after each turn (the prompt is persistent from the input thread), which
+    // breaks tests that `expect("❯")` to detect turn completion. Tests that
+    // want async mode set SUDOCODE_INTERRUPT_QUEUE_MODE explicitly in
+    // `env_vars`, which appears later and overrides this default.
+    cmd.push_str(" SUDOCODE_INTERRUPT_QUEUE_MODE=off");
     for (k, v) in env_vars {
         cmd.push_str(&format!(" {}={}", k, shell_quote(v)));
     }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_async_esc_cancel.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_async_esc_cancel.rs
@@ -1,0 +1,91 @@
+//! PTY test: ESC cancels a running turn in the async REPL.
+//!
+//! Verifies that the `EscCancelHandler` wired in commit 3 (ESC bound as a
+//! rustyline `ConditionalEventHandler`) successfully aborts a turn and returns
+//! to the `❯` prompt. Same contract as `pty_cancel::esc_cancels_turn_in_repl`
+//! but exercised through the async REPL path (queue mode).
+
+mod common;
+
+use std::fs;
+use std::time::Duration;
+
+/// Submit a long-running bash prompt under async REPL (queue mode), press ESC
+/// mid-turn, verify the turn is cancelled and the prompt returns.
+#[test]
+#[cfg(unix)]
+fn esc_cancels_turn_in_async_repl() {
+    let env = common::TestEnv::new("async-esc-cancel");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let prompt = env.prompt(
+        "Run this exact bash command: printf 'esc-start'; sleep 30; printf 'esc-done'",
+        "bash_interrupt_long_running",
+    );
+    let mut sess = env.spawn_with_env(
+        &[
+            "--permission-mode",
+            "danger-full-access",
+            "--allowedTools",
+            "bash",
+        ],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    let timeout = if env.is_live() {
+        Duration::from_secs(30)
+    } else {
+        Duration::from_secs(15)
+    };
+    sess.set_default_timeout(timeout);
+
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+
+    // Wait for an indicator that the turn is in progress.
+    sess.expect("(?i)(bash|thinking|sonnet|auto|claude|❯)")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("should see turn activity: {e}\nPTY screen:\n{screen}");
+        });
+
+    // In live mode, wait longer for the API stream to actually start.
+    let pre_esc_delay = if env.is_live() {
+        Duration::from_secs(8)
+    } else {
+        Duration::from_millis(500)
+    };
+    std::thread::sleep(pre_esc_delay);
+
+    // Press ESC to cancel the turn.
+    sess.send("\x1b").expect("send ESC");
+
+    // Wait for cancel + prompt return.
+    let cancel_timeout = if env.is_live() {
+        Duration::from_secs(30)
+    } else {
+        Duration::from_secs(15)
+    };
+    sess.set_default_timeout(cancel_timeout);
+    sess.expect("(?i)(cancelled|interrupted|❯)")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("ESC should cancel the turn: {e}\nPTY screen:\n{screen}");
+        });
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should return to prompt after cancel: {e}\nPTY screen:\n{screen}");
+    });
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    sess.send("/exit\r").expect("send exit");
+    sess.set_default_timeout(Duration::from_secs(10));
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_config_set.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_config_set.rs
@@ -1,0 +1,79 @@
+//! PTY test: `/config set` toggles work in async REPL mode.
+//!
+//! Exercises `handle_config_set` through the async REPL, verifying that
+//! `/config set auto-interrupt on|off` and `/config set queue on|off` produce
+//! the expected output. This also implicitly tests the `parse_on_off` helper.
+
+mod common;
+
+use std::time::Duration;
+
+/// `/config set auto-interrupt on` then `off` in async REPL.
+#[test]
+fn config_set_auto_interrupt_toggles() {
+    let env = common::TestEnv::new("config-set-interrupt");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send("/config set auto-interrupt on\r")
+        .expect("send config set auto-interrupt on");
+    sess.expect("auto-interrupt: on").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should confirm auto-interrupt on: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/config set auto-interrupt off\r")
+        .expect("send config set auto-interrupt off");
+    sess.expect("auto-interrupt: off").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should confirm auto-interrupt off: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}
+
+/// `/config set queue off` then `on` in async REPL.
+#[test]
+fn config_set_queue_toggles() {
+    let env = common::TestEnv::new("config-set-queue");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send("/config set queue off\r")
+        .expect("send config set queue off");
+    sess.expect("queue: off").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should confirm queue off: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/config set queue on\r")
+        .expect("send config set queue on");
+    sess.expect("queue: on").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should confirm queue on: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_config_set.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_config_set.rs
@@ -28,6 +28,11 @@ fn config_set_auto_interrupt_toggles() {
         panic!("should confirm auto-interrupt on: {e}\nPTY screen:\n{screen}");
     });
 
+    // Small delay so the coordinator loop processes TurnDone from the
+    // slash command before the next input arrives (slash commands return
+    // instantly — no LLM call — so the race window is tight).
+    std::thread::sleep(Duration::from_millis(300));
+
     sess.send("/config set auto-interrupt off\r")
         .expect("send config set auto-interrupt off");
     sess.expect("auto-interrupt: off").unwrap_or_else(|e| {
@@ -62,6 +67,10 @@ fn config_set_queue_toggles() {
         let screen = sess.render(|s| s.contents());
         panic!("should confirm queue off: {e}\nPTY screen:\n{screen}");
     });
+
+    // Small delay so the coordinator loop processes TurnDone before the
+    // next slash command arrives.
+    std::thread::sleep(Duration::from_millis(300));
 
     sess.send("/config set queue on\r")
         .expect("send config set queue on");

--- a/rust/crates/rusty-sudocode-cli/tests/pty_double_ctrlc_exit.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_double_ctrlc_exit.rs
@@ -1,0 +1,66 @@
+//! PTY test: double Ctrl-C within 800ms exits the process.
+//!
+//! Covers both the sync REPL (queue=off) and async REPL (queue=queue) paths.
+//! The sync REPL uses `HookAbortMonitor`'s raw-mode stdin thread for the
+//! double-press check; the async REPL routes through `cancel.rs` via the
+//! `abort_hook` in `LineEditor`. Both should produce a clean exit code 0.
+
+mod common;
+
+use std::time::Duration;
+
+/// Sync REPL: two rapid Ctrl-C on an empty prompt exits the process.
+#[test]
+fn double_ctrlc_exits_sync_repl() {
+    let env = common::TestEnv::new("double-ctrlc-sync");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "off")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    sess.expect("❯").expect("REPL prompt");
+
+    // First Ctrl-C — clears prompt, shows "Press Ctrl-C again to exit".
+    sess.send("\x03").expect("send first Ctrl-C");
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Second Ctrl-C within 800ms — should exit.
+    sess.send("\x03").expect("send second Ctrl-C");
+
+    sess.set_default_timeout(Duration::from_secs(10));
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("double Ctrl-C should exit (sync): {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "sync REPL should exit cleanly on double Ctrl-C");
+}
+
+/// Async REPL: two rapid Ctrl-C on an empty prompt exits the process.
+#[test]
+fn double_ctrlc_exits_async_repl() {
+    let env = common::TestEnv::new("double-ctrlc-async");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    sess.expect("❯").expect("async REPL prompt");
+
+    // First Ctrl-C — cancels (no-op since no turn), records timestamp.
+    sess.send("\x03").expect("send first Ctrl-C");
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Second Ctrl-C within 800ms — should exit.
+    sess.send("\x03").expect("send second Ctrl-C");
+
+    sess.set_default_timeout(Duration::from_secs(10));
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("double Ctrl-C should exit (async): {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "async REPL should exit cleanly on double Ctrl-C");
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_double_ctrlc_exit.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_double_ctrlc_exit.rs
@@ -24,7 +24,10 @@ fn double_ctrlc_exits_sync_repl() {
 
     // First Ctrl-C — clears prompt, shows "Press Ctrl-C again to exit".
     sess.send("\x03").expect("send first Ctrl-C");
-    std::thread::sleep(Duration::from_millis(100));
+    sess.expect("Press Ctrl-C again").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should see exit hint after first Ctrl-C: {e}\nPTY screen:\n{screen}");
+    });
 
     // Second Ctrl-C within 800ms — should exit.
     sess.send("\x03").expect("send second Ctrl-C");
@@ -52,7 +55,15 @@ fn double_ctrlc_exits_async_repl() {
 
     // First Ctrl-C — cancels (no-op since no turn), records timestamp.
     sess.send("\x03").expect("send first Ctrl-C");
-    std::thread::sleep(Duration::from_millis(100));
+    sess.expect("Press Ctrl-C again").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should see exit hint after first Ctrl-C: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Small delay so readline() is fully re-entered before the second
+    // SIGINT arrives — rustyline only catches SIGINT while readline() is
+    // active; between calls the default handler may be in effect.
+    std::thread::sleep(Duration::from_millis(200));
 
     // Second Ctrl-C within 800ms — should exit.
     sess.send("\x03").expect("send second Ctrl-C");


### PR DESCRIPTION
## Summary

- Extract `cancel.rs` as SSOT for double Ctrl-C constants, cross-turn timestamp, and helpers (`is_double_ctrlc()`, `record_ctrlc()`, `process_uptime_ms()`)
- DRY `handle_config_set` — extract `parse_on_off()` helper shared by both toggle arms
- Wire ESC cancel in async REPL via `ConditionalEventHandler` (`EscCancelHandler`) — avoids raw-mode stdin conflict with rustyline
- Wire Ctrl-C cancel + double Ctrl-C exit in async REPL through `cancel.rs` — unified SSOT, two entry points (sync monitor + async input thread)
- Dispatch slash commands in async REPL's `TurnDriver::run_turn` (was sending `/config set` etc. to the LLM)
- Change `QueueMode` default from `Off` to `Queue` (CC parity) — safe because ESC/Ctrl-C cancel now work in async mode
- Fix `process_uptime_ms()` returning 0 (sentinel conflict) + set `keyseq_timeout(50ms)` for standalone ESC detection in Emacs mode
- Stabilize PTY test infra: default `SUDOCODE_INTERRUPT_QUEUE_MODE=off` so sync-REPL tests are unaffected

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --package rusty-sudocode-cli`
- [x] All 17 PTY tests pass: `pty_cancel`, `pty_core_conversation`, `pty_resume`, `pty_repl_async_queue`, `pty_repl_async_interrupt`, `pty_config_set`, `pty_double_ctrlc_exit`, `pty_async_esc_cancel`
- [ ] CI green
- [ ] Manual: `scode` (no env var) → async REPL active, ESC cancels, double Ctrl-C exits