### PR TITLE
feat(cli): input chrome (separator + footer) in async REPL

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
@@ -1,0 +1,71 @@
+//! Input chrome — the separator/footer UI around the REPL prompt.
+//!
+//! Both the sync REPL (`run_repl_loop`) and the async REPL input thread
+//! render the same visual structure:
+//!
+//! ```text
+//! ──────────────────────── (top separator)
+//! ❯ <user input here>     (prompt — rendered by rustyline)
+//! ──────────────────────── (bottom separator)
+//!   /help · /status · Tab for /commands  (footer)
+//! ```
+//!
+//! After the user submits, the chrome is replaced with a styled echo of
+//! the input. This module owns the rendering so neither REPL duplicates it.
+
+use std::io::{self, Write};
+
+use crate::cli::format::format_input_echo;
+
+fn term_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(cols, _)| cols as usize)
+        .unwrap_or(80)
+}
+
+fn separator(width: usize) -> String {
+    format!("\x1b[2m{}\x1b[0m", "─".repeat(width))
+}
+
+const FOOTER: &str = "  \x1b[2m/help · /status · Tab for /commands\x1b[0m";
+
+/// Print the input chrome block (top sep, prompt placeholder, bottom sep,
+/// footer) then move the cursor back to the prompt line so `read_line()`
+/// renders there.
+pub fn print_before_prompt() -> io::Result<()> {
+    let w = term_width();
+    let sep = separator(w);
+    let mut stdout = io::stdout();
+    writeln!(stdout, "{sep}")?;
+    writeln!(stdout)?; // prompt placeholder
+    writeln!(stdout, "{sep}")?;
+    write!(stdout, "{FOOTER}")?;
+    write!(stdout, "\x1b[2F\x1b[2K")?; // cursor up 2, clear prompt placeholder
+    stdout.flush()
+}
+
+/// After the user submits text: clear the bottom sep + footer, replace the
+/// prompt line with a styled echo, then print a trailing separator.
+/// Returns the terminal width (callers may need it for downstream formatting).
+pub fn replace_after_submit(input: &str) -> io::Result<usize> {
+    let w = term_width();
+    let sep = separator(w);
+    let mut stdout = io::stdout();
+
+    // Clear pre-printed bottom sep + footer.
+    write!(stdout, "\x1b[J")?;
+
+    // Replace prompt line with a gray-background echo of the user input.
+    let trimmed = input.trim();
+    let (echo_block, line_count) = format_input_echo(trimmed, w);
+    // Move the cursor up past every row rustyline rendered for the input
+    // and clear each one, then write the echo block in their place.
+    for _ in 0..line_count {
+        write!(stdout, "\x1b[1F\x1b[2K")?;
+    }
+    write!(stdout, "{echo_block}")?;
+    writeln!(stdout)?;
+    writeln!(stdout, "{sep}")?;
+    stdout.flush()?;
+    Ok(w)
+}

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -16,6 +16,7 @@ mod cancel;
 mod cli;
 mod init;
 mod input;
+mod input_chrome;
 mod input_queue;
 mod render;
 mod repl_async;
@@ -62,7 +63,7 @@ use cli::export::{
 use cli::format::{
     describe_tool_progress, first_visible_line, format_auth_report, format_auth_switch_report,
     format_auto_compaction_notice, format_bughunter_report, format_commit_preflight_report,
-    format_commit_skipped_report, format_compact_report, format_cost_report, format_input_echo,
+    format_commit_skipped_report, format_compact_report, format_cost_report,
     format_internal_prompt_progress_line, format_issue_report, format_model_report,
     format_model_switch_report, format_permission_prompt_box, format_permissions_report,
     format_permissions_switch_report, format_pr_report, format_resume_report,
@@ -1633,38 +1634,11 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
-        let term_width = crossterm::terminal::size()
-            .map(|(cols, _)| cols as usize)
-            .unwrap_or(80);
-        let separator = format!("\x1b[2m{}\x1b[0m", "─".repeat(term_width));
-        let footer = "  \x1b[2m/help · /status · Tab for /commands\x1b[0m";
-        // Print the entire input chrome block: top sep, prompt placeholder,
-        // bottom sep, footer.  Then move the cursor back to the prompt line
-        // so read_line() renders there — the user sees all four elements at once.
-        println!("{separator}");
-        println!();
-        println!("{separator}");
-        print!("{footer}");
-        print!("\x1b[2F\x1b[2K"); // cursor up 2 lines, clear prompt placeholder
-        std::io::Write::flush(&mut std::io::stdout())?;
+        input_chrome::print_before_prompt()?;
         match editor.read_line()? {
             input::ReadOutcome::Submit(input) => {
-                // Clear pre-printed bottom sep + footer
-                print!("\x1b[J");
-                // Replace prompt line with a gray-background echo of the user
-                // input.  Multi-line input renders one styled row per line so
-                // the echo matches what the user actually typed (#182 item 3).
+                input_chrome::replace_after_submit(&input)?;
                 let trimmed = input.trim().to_string();
-                let (echo_block, line_count) = format_input_echo(&trimmed, term_width);
-                // Move the cursor up past every row rustyline rendered for the
-                // input and clear each one, then write the echo block in their
-                // place.
-                for _ in 0..line_count {
-                    print!("\x1b[1F\x1b[2K");
-                }
-                print!("{echo_block}");
-                println!();
-                println!("{separator}");
                 if matches!(trimmed.as_str(), "/exit" | "/quit") {
                     cli.persist_session()?;
                     break;

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -77,6 +77,7 @@ use std::thread;
 use std::time::Duration;
 
 use crate::input::{EscAbortHook, LineEditor, ReadOutcome};
+use crate::input_chrome;
 use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
 
 /// Shared queue mode that can be toggled at runtime via `/config set`.
@@ -207,8 +208,10 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                 esc_abort_hook,
             );
             loop {
+                let _ = input_chrome::print_before_prompt();
                 match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {
+                        let _ = input_chrome::replace_after_submit(&text);
                         if input_tx_clone.send(InputEvent::Submit(text)).is_err() {
                             break;
                         }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_input_chrome.rs
@@ -1,0 +1,57 @@
+//! PTY test: input chrome (separator + footer) renders in async REPL.
+//!
+//! Verifies that the input chrome (top separator, prompt, bottom separator,
+//! footer) renders correctly in both sync and async REPL modes, and that
+//! the echo block replaces the prompt after submit.
+
+mod common;
+
+use std::time::Duration;
+
+/// Async REPL: separator lines and footer render around the prompt.
+#[test]
+fn async_repl_renders_input_chrome() {
+    let env = common::TestEnv::new("input-chrome-async");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    // The separator line (─) should appear before the prompt.
+    sess.expect("─").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should see separator in async REPL: {e}\nPTY screen:\n{screen}");
+    });
+
+    // The footer hint should appear.
+    sess.expect("Tab for /commands").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should see footer hint in async REPL: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Submit a prompt and verify the echo block appears (› prefix).
+    let prompt = env.prompt("What is 2+2? Answer briefly.", "single_turn_text");
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+
+    sess.expect("›").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should see echo block (›) after submit: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Clean exit.
+    sess.expect("4").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should see LLM answer: {e}\nPTY screen:\n{screen}");
+    });
+
+    std::thread::sleep(Duration::from_millis(500));
+    sess.send("/exit\r").expect("send exit");
+    sess.set_default_timeout(Duration::from_secs(15));
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}


### PR DESCRIPTION
## Summary

- Extract `input_chrome.rs` module — SSOT for the separator/footer chrome around the REPL prompt
- Wire into async REPL input thread (queue mode, now default) — previously only the sync REPL rendered chrome
- Refactor sync REPL (`run_repl_loop`) to use the same module (DRY)
- Add `pty_input_chrome` test verifying separator + footer + echo in async mode

## Test plan

- [x] `SCODE_TEST_BACKEND=live cargo test --test pty_input_chrome` — pass
- [x] `SCODE_TEST_BACKEND=live cargo test --test pty_async_esc_cancel --test pty_double_ctrlc_exit --test pty_config_set --test pty_cancel` — all 7 pass
- [x] `SCODE_TEST_BACKEND=live cargo test --test pty_core_conversation -- single_turn` — pass
- [ ] CI green