### PR TITLE
fix(runtime): ESC/Ctrl-C cancel works during API retries

### DIFF
--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -868,11 +868,34 @@ where
                 messages: self.session.messages.clone(),
                 trace_id: self.trace_id.clone(),
             };
-            let mut stream = match self.api_client.stream(request).await {
-                Ok(stream) => stream,
-                Err(error) => {
-                    self.record_turn_failed(iterations, &error);
-                    return Err(error);
+            // Race the API stream (which includes the retry loop) against
+            // the abort signal so ESC/Ctrl-C cancels even during retries.
+            let mut stream = {
+                let abort = &self.hook_abort_signal;
+                tokio::select! {
+                    biased;
+                    () = abort.cancelled() => {
+                        self.finalize_cancelled_turn(Vec::new());
+                        let turn_usage = sum_assistant_message_usage(&assistant_messages);
+                        let session_usage = self.usage_tracker.cumulative_usage();
+                        return Ok(TurnSummary {
+                            assistant_messages,
+                            tool_results,
+                            prompt_cache_events,
+                            iterations,
+                            turn_usage,
+                            session_usage,
+                            auto_compaction: None,
+                            cancelled: true,
+                        });
+                    }
+                    result = self.api_client.stream(request) => match result {
+                        Ok(stream) => stream,
+                        Err(error) => {
+                            self.record_turn_failed(iterations, &error);
+                            return Err(error);
+                        }
+                    }
                 }
             };
 


### PR DESCRIPTION
## Summary

ESC/Ctrl-C had no effect while the retry spinner was showing (`⟳ retry 1/8 in 1s — 503`). The retry loop's `tokio::time::sleep` wasn't racing against the abort signal.

Fix: wrap `api_client.stream(request)` with `tokio::select!` against the abort signal in `conversation.rs`, so cancellation fires even during retry backoff.

## Test plan

- [x] `SCODE_TEST_BACKEND=live cargo test --test pty_async_esc_cancel` — pass
- [x] `SCODE_TEST_BACKEND=live cargo test --test pty_cancel -- esc_cancels_turn_in_repl` — pass
- [ ] CI green
- [ ] Manual: trigger 503 retry → press ESC → immediately cancels