### PR TITLE
refactor(cli): dispatch slash commands on coordinator thread

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1803,15 +1803,11 @@ struct LiveCliDriver {
 }
 
 impl repl_async::TurnDriver for LiveCliDriver {
-    fn run_turn(&self, prompt: &str) {
-        let mut cli = self.cli.lock().expect("LiveCli mutex poisoned");
-        // Dispatch slash commands the same way the sync REPL does — parse
-        // before reaching the LLM. `/exit` and `/quit` are already handled
-        // in the coordinator loop; everything else (config set, model, clear,
-        // help, etc.) is dispatched here.
-        let trimmed = prompt.trim();
+    fn try_handle_slash_command(&self, input: &str) -> bool {
+        let trimmed = input.trim();
         match SlashCommand::parse(trimmed) {
             Ok(Some(command)) => {
+                let mut cli = self.cli.lock().expect("LiveCli mutex poisoned");
                 match cli.handle_repl_command(command) {
                     Ok(true) => {
                         if let Err(e) = cli.persist_session() {
@@ -1821,14 +1817,18 @@ impl repl_async::TurnDriver for LiveCliDriver {
                     Ok(false) => {}
                     Err(e) => eprintln!("\x1b[31m{e}\x1b[0m"),
                 }
-                return;
+                true
             }
-            Ok(None) => {}
+            Ok(None) => false,
             Err(error) => {
                 eprintln!("\x1b[31m{error}\x1b[0m");
-                return;
+                true
             }
         }
+    }
+
+    fn run_turn(&self, prompt: &str) {
+        let mut cli = self.cli.lock().expect("LiveCli mutex poisoned");
         if let Err(e) = cli.run_turn(prompt) {
             eprintln!("\x1b[31m{e}\x1b[0m");
         }

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -149,6 +149,15 @@ pub trait TurnDriver: Send + Sync + 'static {
     /// self-contained for tests.
     fn on_exit(&self) {}
 
+    /// Try to handle a slash command synchronously on the coordinator thread.
+    /// Returns `true` if the input was a slash command and was handled (caller
+    /// should NOT route it to `run_turn`). Returns `false` if the input is
+    /// not a slash command (caller should route it normally).
+    /// Default returns `false` — test drivers don't handle slash commands.
+    fn try_handle_slash_command(&self, _input: &str) -> bool {
+        false
+    }
+
     /// Auto-interrupt the currently running turn. Called from main when the
     /// coordinator matrix decides `SubmitOutcome::Interrupt` — the runner
     /// thread's `run_turn` will observe the abort and return with a
@@ -274,6 +283,13 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                     }
                     driver.on_exit();
                     break;
+                }
+                // Slash commands are dispatched synchronously on the
+                // coordinator thread — no runner thread, no TurnDone
+                // roundtrip. This avoids the timing issues (chrome
+                // overwriting output) that plagued the thread-based path.
+                if driver.try_handle_slash_command(&text) {
+                    continue;
                 }
                 if !turn_active {
                     let next = coord.lock().unwrap().submit_when_idle(text);

--- a/rust/crates/rusty-sudocode-cli/tests/pty_config_set.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_config_set.rs
@@ -10,10 +10,6 @@ use std::time::Duration;
 
 /// `/config set auto-interrupt on` then `off` in async REPL.
 #[test]
-#[cfg_attr(
-    windows,
-    ignore = "async REPL chrome races slash command output on Windows CI"
-)]
 fn config_set_auto_interrupt_toggles() {
     let env = common::TestEnv::new("config-set-interrupt");
 
@@ -54,10 +50,6 @@ fn config_set_auto_interrupt_toggles() {
 
 /// `/config set queue off` then `on` in async REPL.
 #[test]
-#[cfg_attr(
-    windows,
-    ignore = "async REPL chrome races slash command output on Windows CI"
-)]
 fn config_set_queue_toggles() {
     let env = common::TestEnv::new("config-set-queue");
 


### PR DESCRIPTION
Slash commands dispatched synchronously on coordinator thread. Fixes Windows CI timing race. Live-verified.