### PR TITLE
feat(cli): separator lines in async REPL via runner-side printing

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
@@ -29,6 +29,14 @@ fn separator(width: usize) -> String {
 
 const FOOTER: &str = "  \x1b[2m/help · /status · Tab for /commands\x1b[0m";
 
+/// Print a plain separator line to stdout. No cursor manipulation — safe
+/// to call from any thread. Used by the async REPL's runner/coordinator
+/// to visually separate output from the next prompt.
+pub fn print_separator() {
+    let w = term_width();
+    println!("{}", separator(w));
+}
+
 /// Print the input chrome block (top sep, prompt placeholder, bottom sep,
 /// footer) then move the cursor back to the prompt line so `read_line()`
 /// renders there.

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1817,11 +1817,13 @@ impl repl_async::TurnDriver for LiveCliDriver {
                     Ok(false) => {}
                     Err(e) => eprintln!("\x1b[31m{e}\x1b[0m"),
                 }
+                input_chrome::print_separator();
                 true
             }
             Ok(None) => false,
             Err(error) => {
                 eprintln!("\x1b[31m{error}\x1b[0m");
+                input_chrome::print_separator();
                 true
             }
         }
@@ -1832,6 +1834,7 @@ impl repl_async::TurnDriver for LiveCliDriver {
         if let Err(e) = cli.run_turn(prompt) {
             eprintln!("\x1b[31m{e}\x1b[0m");
         }
+        input_chrome::print_separator();
     }
 
     fn on_exit(&self) {

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -77,6 +77,7 @@ use std::thread;
 use std::time::Duration;
 
 use crate::input::{EscAbortHook, LineEditor, ReadOutcome};
+use crate::input_chrome;
 use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
 
 /// Shared queue mode that can be toggled at runtime via `/config set`.
@@ -192,6 +193,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     esc_abort_hook: Option<EscAbortHook>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("{startup_banner}");
+    input_chrome::print_separator();
 
     let coord = Arc::new(Mutex::new(TurnInputCoordinator::new()));
     let (input_tx, input_rx) = sync_channel::<InputEvent>(16);


### PR DESCRIPTION
Print separators AFTER output (runner/coordinator thread), not before input (input thread). No ANSI cursor manipulation, no race. Live-verified.