### PR TITLE
feat(cli): restore input echo in async REPL

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
@@ -52,22 +52,33 @@ pub fn print_before_prompt() -> io::Result<()> {
     stdout.flush()
 }
 
-/// After the user submits text: clear the bottom sep + footer, replace the
-/// prompt line with a styled echo, then print a trailing separator.
+/// After the user submits text: clear the pre-printed bottom sep + footer
+/// (sync REPL only), replace the prompt line with a styled echo, then
+/// print a trailing separator.
 /// Returns the terminal width (callers may need it for downstream formatting).
 pub fn replace_after_submit(input: &str) -> io::Result<usize> {
+    replace_after_submit_inner(input, true)
+}
+
+/// Same as [`replace_after_submit`] but skips the `\x1b[J` clear (async REPL
+/// has no pre-printed footer to erase).
+pub fn echo_submit(input: &str) -> io::Result<usize> {
+    replace_after_submit_inner(input, false)
+}
+
+fn replace_after_submit_inner(input: &str, clear_footer: bool) -> io::Result<usize> {
     let w = term_width();
     let sep = separator(w);
     let mut stdout = io::stdout();
 
-    // Clear pre-printed bottom sep + footer.
-    write!(stdout, "\x1b[J")?;
+    if clear_footer {
+        // Clear pre-printed bottom sep + footer (sync REPL chrome).
+        write!(stdout, "\x1b[J")?;
+    }
 
     // Replace prompt line with a gray-background echo of the user input.
     let trimmed = input.trim();
     let (echo_block, line_count) = format_input_echo(trimmed, w);
-    // Move the cursor up past every row rustyline rendered for the input
-    // and clear each one, then write the echo block in their place.
     for _ in 0..line_count {
         write!(stdout, "\x1b[1F\x1b[2K")?;
     }

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -218,14 +218,15 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                 esc_abort_hook,
             );
             loop {
-                // No input chrome in the async REPL — raw ANSI cursor
-                // manipulation (print_before_prompt / replace_after_submit)
-                // races with the runner thread's stdout, causing garbled
-                // output. The sync REPL can use chrome safely because it's
-                // single-threaded. A proper fix requires a TUI framework
-                // (ratatui) that owns the full terminal layout.
                 match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {
+                        // Echo the submitted text as ` › ...` (gray background)
+                        // before notifying the coordinator. This is safe: the
+                        // runner hasn't started yet (send is below), so no
+                        // stdout race. replace_after_submit uses ANSI cursor-up
+                        // to overwrite rustyline's raw prompt with the styled
+                        // echo + a trailing separator.
+                        let _ = input_chrome::echo_submit(&text);
                         if input_tx_clone.send(InputEvent::Submit(text)).is_err() {
                             break;
                         }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_double_ctrlc_exit.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_double_ctrlc_exit.rs
@@ -29,6 +29,9 @@ fn double_ctrlc_exits_sync_repl() {
         panic!("should see exit hint after first Ctrl-C: {e}\nPTY screen:\n{screen}");
     });
 
+    // Small delay so readline() is re-entered before the second SIGINT.
+    std::thread::sleep(Duration::from_millis(200));
+
     // Second Ctrl-C within 800ms — should exit.
     sess.send("\x03").expect("send second Ctrl-C");
 


### PR DESCRIPTION
Restore › echo for submitted text in async REPL. Race-free: called before coordinator send. Live-verified.