### PR TITLE
refactor(cli): /model without args shows report instead of picker

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -4087,31 +4087,16 @@ impl LiveCli {
 
     fn set_model(&mut self, model: Option<String>) -> Result<bool, Box<dyn std::error::Error>> {
         let Some(model) = model else {
-            let sudocode_config = load_sudocode_config_for_current_dir();
-            let config_keys: Vec<String> = sudocode_config.models.keys().cloned().collect();
-            let models = runtime::model_capabilities::merge_discovery_ids(&config_keys);
-            if self.is_async_mode() {
-                println!("\x1b[1mAvailable models:\x1b[0m");
-                for (i, m) in models.iter().enumerate() {
-                    let marker = if *m == self.config.model {
-                        " ← current"
-                    } else {
-                        ""
-                    };
-                    println!("  \x1b[2m{:>2}.\x1b[0m {m}{marker}", i + 1);
-                }
-                println!("\n\x1b[2mUsage: /model <name>\x1b[0m");
-                return Ok(false);
-            }
-            let selection = FuzzySelect::new()
-                .with_prompt("Select model")
-                .items(&models)
-                .default(0)
-                .interact_opt()?;
-            return match selection {
-                Some(idx) => self.set_model(Some(models[idx].clone())),
-                None => Ok(false),
-            };
+            // /model without args: show the model report (current + available).
+            println!(
+                "{}",
+                format_model_report(
+                    &self.config.model,
+                    self.runtime.session().messages.len(),
+                    self.runtime.usage().turns(),
+                )
+            );
+            return Ok(false);
         };
 
         let model = resolve_model_alias_with_config(&model);

--- a/rust/crates/rusty-sudocode-cli/tests/pty_config_discovery.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_config_discovery.rs
@@ -86,14 +86,10 @@ fn model_switch_in_repl() {
 // 2b. /model report shows capabilities SSOT models
 // ──────────────────────────────────────────────────────────────────────
 
-/// After entering the REPL, `/model sonnet` switches (or confirms)
-/// the model, then `/model sonnet` again triggers the model report
-/// (no-op switch — same model). The report should list not just the
-/// config aliases but also capabilities SSOT models (e.g. deepseek).
-///
-/// This validates the model-discovery SSOT merge:
-/// - Config aliases appear with display name + provider info.
-/// - Capabilities models not in config appear as wire IDs.
+/// `/model` without arguments shows the model report: current model,
+/// available models (config aliases + capabilities SSOT), and session
+/// info. The report should include capabilities-only models like
+/// deepseek that are not in the config aliases.
 #[test]
 fn model_report_shows_capabilities_models() {
     let env = TestEnv::new("model-report-caps");
@@ -101,17 +97,8 @@ fn model_report_shows_capabilities_models() {
 
     sess.expect("❯").expect("should see REPL prompt");
 
-    // First /model sonnet — ensures we are on sonnet (may switch or confirm).
-    sess.send("/model sonnet\r")
-        .expect("send /model sonnet (first)");
-    sess.expect("(?i)(sonnet|model)")
-        .expect("should see model confirmation");
-
-    sess.expect("❯").expect("prompt after first /model");
-
-    // Second /model sonnet — same model, triggers report with full list.
-    sess.send("/model sonnet\r")
-        .expect("send /model sonnet (second, triggers report)");
+    // /model without args shows the report (not a picker).
+    sess.send("/model\r").expect("send /model (no args)");
 
     // Should see the "Available models" section.
     sess.expect("Available models")


### PR DESCRIPTION
## Summary

`/model` (no args) now shows the model report (current model + available models + session info) instead of a FuzzySelect picker.

## Why

After sudocode#344, the capabilities SSOT exposes ~178 models. Scrolling through 178 items in a FuzzySelect picker is poor UX. The report gives a clear overview; users switch via `/model <name>` with tab completion.

## Test plan

- [x] PTY test `model_report_shows_capabilities_models` — simplified to test `/model` (no args) directly
- [x] Full `pty_config_discovery` suite — 9/9 pass (mock + live)