### PR TITLE
feat(cli): separator + permission-mode footer below prompt

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
@@ -29,12 +29,24 @@ fn separator(width: usize) -> String {
 
 const FOOTER: &str = "  \x1b[2m/help · /status · Tab for /commands\x1b[0m";
 
-/// Print a plain separator line to stdout. No cursor manipulation — safe
-/// to call from any thread. Used by the async REPL's runner/coordinator
-/// to visually separate output from the next prompt.
-pub fn print_separator() {
+/// Print a separator line + permission-mode footer below the prompt.
+/// No cursor manipulation — safe to call from any thread.
+pub fn print_separator_with_footer(permission_mode: &str) {
     let w = term_width();
-    println!("{}", separator(w));
+    let sep = separator(w);
+    let icon = match permission_mode {
+        "danger-full-access" => "⏵⏵",
+        "workspace-write" => "⏵",
+        _ => "▷",
+    };
+    let label = match permission_mode {
+        "danger-full-access" => "full access",
+        "workspace-write" => "workspace write",
+        "read-only" => "read only",
+        other => other,
+    };
+    println!("{sep}");
+    println!("  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m");
 }
 
 /// Print the input chrome block (top sep, prompt placeholder, bottom sep,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1754,12 +1754,20 @@ fn run_repl_async_dispatch(
     });
 
     let session_start = Instant::now();
+    let permission_label = cli_shared
+        .lock()
+        .expect("LiveCli mutex")
+        .config
+        .permission_mode
+        .as_str()
+        .to_string();
     repl_async::run_coordinator_loop(
         driver,
         shared_mode,
         banner,
         completions,
         Some(esc_abort_hook),
+        &permission_label,
     )?;
 
     // All threads spawned by the coordinator loop have already been joined
@@ -1820,13 +1828,14 @@ impl repl_async::TurnDriver for LiveCliDriver {
                     Ok(false) => {}
                     Err(e) => eprintln!("\x1b[31m{e}\x1b[0m"),
                 }
-                input_chrome::print_separator();
+                input_chrome::print_separator_with_footer(cli.config.permission_mode.as_str());
                 true
             }
             Ok(None) => false,
             Err(error) => {
                 eprintln!("\x1b[31m{error}\x1b[0m");
-                input_chrome::print_separator();
+                let cli = self.cli.lock().expect("LiveCli mutex poisoned");
+                input_chrome::print_separator_with_footer(cli.config.permission_mode.as_str());
                 true
             }
         }
@@ -1837,7 +1846,7 @@ impl repl_async::TurnDriver for LiveCliDriver {
         if let Err(e) = cli.run_turn(prompt) {
             eprintln!("\x1b[31m{e}\x1b[0m");
         }
-        input_chrome::print_separator();
+        input_chrome::print_separator_with_footer(cli.config.permission_mode.as_str());
     }
 
     fn on_exit(&self) {

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -191,6 +191,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     startup_banner: String,
     initial_completions: Vec<(String, String)>,
     esc_abort_hook: Option<EscAbortHook>,
+    permission_mode: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let coord = Arc::new(Mutex::new(TurnInputCoordinator::new()));
     let (input_tx, input_rx) = sync_channel::<InputEvent>(16);
@@ -201,7 +202,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     let (prompt_ready_tx, prompt_ready_rx) = sync_channel::<()>(1);
 
     println!("{startup_banner}");
-    input_chrome::print_separator();
+    input_chrome::print_separator_with_footer(permission_mode);
     // Signal the input thread: startup output is done, show ❯.
     let _ = prompt_ready_tx.send(());
 


### PR DESCRIPTION
Separator + permission mode footer (⏵⏵ full access / ⏵ workspace write / ▷ read only) shown after startup, turns, and slash commands. Live-verified.