### PR TITLE
fix(cli): separator + footer below ❯ prompt (CC layout parity)

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1828,14 +1828,11 @@ impl repl_async::TurnDriver for LiveCliDriver {
                     Ok(false) => {}
                     Err(e) => eprintln!("\x1b[31m{e}\x1b[0m"),
                 }
-                input_chrome::print_separator_with_footer(cli.config.permission_mode.as_str());
                 true
             }
             Ok(None) => false,
             Err(error) => {
                 eprintln!("\x1b[31m{error}\x1b[0m");
-                let cli = self.cli.lock().expect("LiveCli mutex poisoned");
-                input_chrome::print_separator_with_footer(cli.config.permission_mode.as_str());
                 true
             }
         }
@@ -1846,7 +1843,6 @@ impl repl_async::TurnDriver for LiveCliDriver {
         if let Err(e) = cli.run_turn(prompt) {
             eprintln!("\x1b[31m{e}\x1b[0m");
         }
-        input_chrome::print_separator_with_footer(cli.config.permission_mode.as_str());
     }
 
     fn on_exit(&self) {

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -202,7 +202,6 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     let (prompt_ready_tx, prompt_ready_rx) = sync_channel::<()>(1);
 
     println!("{startup_banner}");
-    input_chrome::print_separator_with_footer(permission_mode);
     // Signal the input thread: startup output is done, show ❯.
     let _ = prompt_ready_tx.send(());
 
@@ -230,6 +229,10 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                 return; // coordinator exited
             }
             loop {
+                // Print chrome: ❯ prompt sits between two separators with
+                // a footer below. Safe: prompt_ready guarantees the runner
+                // is not writing to stdout.
+                let _ = input_chrome::print_before_prompt();
                 match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {
                         // Echo the submitted text as ` › ...` (gray background)


### PR DESCRIPTION
CC layout: ❯ on top, ─── + footer below. print_before_prompt in input thread (safe: prompt_ready guarantees no race). Live-verified.