### PR TITLE
fix(cli): permission-mode footer + clear on submit

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
@@ -27,13 +27,7 @@ fn separator(width: usize) -> String {
     format!("\x1b[2m{}\x1b[0m", "─".repeat(width))
 }
 
-const FOOTER: &str = "  \x1b[2m/help · /status · Tab for /commands\x1b[0m";
-
-/// Print a separator line + permission-mode footer below the prompt.
-/// No cursor manipulation — safe to call from any thread.
-pub fn print_separator_with_footer(permission_mode: &str) {
-    let w = term_width();
-    let sep = separator(w);
+fn format_footer(permission_mode: &str) -> String {
     let icon = match permission_mode {
         "danger-full-access" => "⏵⏵",
         "workspace-write" => "⏵",
@@ -45,48 +39,35 @@ pub fn print_separator_with_footer(permission_mode: &str) {
         "read-only" => "read only",
         other => other,
     };
-    println!("{sep}");
-    println!("  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m");
+    format!("  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m")
 }
 
 /// Print the input chrome block (top sep, prompt placeholder, bottom sep,
 /// footer) then move the cursor back to the prompt line so `read_line()`
 /// renders there.
-pub fn print_before_prompt() -> io::Result<()> {
+pub fn print_before_prompt(permission_mode: &str) -> io::Result<()> {
     let w = term_width();
     let sep = separator(w);
+    let footer = format_footer(permission_mode);
     let mut stdout = io::stdout();
     writeln!(stdout, "{sep}")?;
     writeln!(stdout)?; // prompt placeholder
     writeln!(stdout, "{sep}")?;
-    write!(stdout, "{FOOTER}")?;
+    write!(stdout, "{footer}")?;
     write!(stdout, "\x1b[2F\x1b[2K")?; // cursor up 2, clear prompt placeholder
     stdout.flush()
 }
 
-/// After the user submits text: clear the pre-printed bottom sep + footer
-/// (sync REPL only), replace the prompt line with a styled echo, then
-/// print a trailing separator.
-/// Returns the terminal width (callers may need it for downstream formatting).
+/// After the user submits text: clear the pre-printed bottom sep + footer,
+/// replace the prompt line with a styled echo, then print a trailing separator.
+/// Used by both sync and async REPLs (both now use `print_before_prompt`).
 pub fn replace_after_submit(input: &str) -> io::Result<usize> {
-    replace_after_submit_inner(input, true)
-}
-
-/// Same as [`replace_after_submit`] but skips the `\x1b[J` clear (async REPL
-/// has no pre-printed footer to erase).
-pub fn echo_submit(input: &str) -> io::Result<usize> {
-    replace_after_submit_inner(input, false)
-}
-
-fn replace_after_submit_inner(input: &str, clear_footer: bool) -> io::Result<usize> {
     let w = term_width();
     let sep = separator(w);
     let mut stdout = io::stdout();
 
-    if clear_footer {
-        // Clear pre-printed bottom sep + footer (sync REPL chrome).
-        write!(stdout, "\x1b[J")?;
-    }
+    // Clear pre-printed bottom sep + footer.
+    write!(stdout, "\x1b[J")?;
 
     // Replace prompt line with a gray-background echo of the user input.
     let trimmed = input.trim();

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1634,7 +1634,7 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
-        input_chrome::print_before_prompt()?;
+        input_chrome::print_before_prompt(cli.config.permission_mode.as_str())?;
         match editor.read_line()? {
             input::ReadOutcome::Submit(input) => {
                 input_chrome::replace_after_submit(&input)?;

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -214,6 +214,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     // because rustyline already owns stdin.
     let input_tx_clone = input_tx.clone();
     let dequeue_hook = make_up_arrow_hook(Arc::clone(&coord));
+    let perm_mode = permission_mode.to_string();
     thread::Builder::new()
         .name("repl-input".into())
         .spawn(move || {
@@ -223,22 +224,17 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                 Some(dequeue_hook),
                 esc_abort_hook,
             );
-            // Wait for the startup banner + separator to finish before
-            // showing the first ❯ prompt.
             if prompt_ready_rx.recv().is_err() {
-                return; // coordinator exited
+                return;
             }
             loop {
-                // Print chrome: ❯ prompt sits between two separators with
-                // a footer below. Safe: prompt_ready guarantees the runner
-                // is not writing to stdout.
-                let _ = input_chrome::print_before_prompt();
+                let _ = input_chrome::print_before_prompt(&perm_mode);
                 match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {
                         // Echo the submitted text as ` › ...` (gray background)
                         // before notifying the coordinator. Safe: the runner
                         // hasn't started yet (send is below), no stdout race.
-                        let _ = input_chrome::echo_submit(&text);
+                        let _ = input_chrome::replace_after_submit(&text);
                         if input_tx_clone.send(InputEvent::Submit(text)).is_err() {
                             break;
                         }


### PR DESCRIPTION
Footer shows permission mode (CC parity). Clear on submit. Live-verified.