### PR TITLE
fix(cli): restore ↑ history + /resume picker in async REPL

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -1386,7 +1386,7 @@ pub fn validate_slash_command_input(
             SlashCommand::Cost
         }
         "resume" => SlashCommand::Resume {
-            session_path: Some(require_remainder(command, remainder, "<session-path>")?),
+            session_path: remainder.map(|s| s.to_string()),
         },
         "config" => {
             if args.first().map(|s| s.to_ascii_lowercase()) == Some("set".into()) {

--- a/rust/crates/rusty-sudocode-cli/src/input.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input.rs
@@ -460,6 +460,7 @@ impl LineEditor {
             match self.editor.readline(&self.prompt) {
                 Ok(line) => {
                     self.pending_exit_at = None;
+                    self.push_history(&line);
                     return Ok(ReadOutcome::Submit(line));
                 }
                 Err(ReadlineError::Interrupted) => {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1673,14 +1673,12 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
                     &trimmed,
                     Some(cli.runtime.plugin_load_outcome()),
                 ) {
-                    editor.push_history(input);
                     cli.record_prompt_history(&trimmed);
                     if let Err(e) = cli.run_turn(&prompt) {
                         eprintln!("\x1b[31m{e}\x1b[0m");
                     }
                     continue;
                 }
-                editor.push_history(input);
                 cli.record_prompt_history(&trimmed);
                 if let Err(e) = cli.run_turn(&trimmed) {
                     eprintln!("\x1b[31m{e}\x1b[0m");

--- a/rust/crates/rusty-sudocode-cli/tests/pty_config_discovery.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_config_discovery.rs
@@ -87,8 +87,6 @@ fn model_switch_in_repl() {
 // ──────────────────────────────────────────────────────────────────────
 
 /// In the REPL, `/model` without arguments opens the interactive picker.
-/// The model report behavior is used by ACP mode, where there is no local
-/// TTY picker to drive.
 #[test]
 fn model_without_args_opens_picker() {
     let env = TestEnv::new("model-picker");
@@ -96,7 +94,6 @@ fn model_without_args_opens_picker() {
 
     sess.expect("❯").expect("should see REPL prompt");
 
-    // /model without args opens the interactive picker in the REPL.
     sess.send("/model\r").expect("send /model (no args)");
 
     sess.expect("Select model")


### PR DESCRIPTION
Input thread push_history on submit. /resume without args shows Select picker. Live-verified.