### PR TITLE
fix(test): add readiness signal to TestServer to prevent CI flakes

### DIFF
--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -12695,31 +12695,33 @@ printf 'pwsh:%s' "$1"
                 // Signal that the accept loop is about to start.
                 let _ = ready_tx.send(());
                 loop {
-                if rx.try_recv().is_ok() {
-                    break;
-                }
+                    if rx.try_recv().is_ok() {
+                        break;
+                    }
 
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let mut buffer = [0_u8; 4096];
-                        let size = match stream.read(&mut buffer) {
-                            Ok(n) => n,
-                            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-                            Err(e) => panic!("read request: {e}"),
-                        };
-                        let request = String::from_utf8_lossy(&buffer[..size]).into_owned();
-                        let request_line = request.lines().next().unwrap_or_default().to_string();
-                        let response = handler(&request_line);
-                        stream
-                            .write_all(response.to_bytes().as_slice())
-                            .expect("write response");
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            let mut buffer = [0_u8; 4096];
+                            let size = match stream.read(&mut buffer) {
+                                Ok(n) => n,
+                                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                                Err(e) => panic!("read request: {e}"),
+                            };
+                            let request = String::from_utf8_lossy(&buffer[..size]).into_owned();
+                            let request_line =
+                                request.lines().next().unwrap_or_default().to_string();
+                            let response = handler(&request_line);
+                            stream
+                                .write_all(response.to_bytes().as_slice())
+                                .expect("write response");
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(error) => panic!("server accept failed: {error}"),
                     }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
-                    }
-                    Err(error) => panic!("server accept failed: {error}"),
                 }
-            }});
+            });
 
             // Wait for the server thread to enter the accept loop before
             // returning. Without this, the client can connect before the

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -12689,8 +12689,12 @@ printf 'pwsh:%s' "$1"
                 .expect("set nonblocking listener");
             let addr = listener.local_addr().expect("local addr");
             let (tx, rx) = std::sync::mpsc::channel::<()>();
+            let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
 
-            let handle = thread::spawn(move || loop {
+            let handle = thread::spawn(move || {
+                // Signal that the accept loop is about to start.
+                let _ = ready_tx.send(());
+                loop {
                 if rx.try_recv().is_ok() {
                     break;
                 }
@@ -12715,7 +12719,12 @@ printf 'pwsh:%s' "$1"
                     }
                     Err(error) => panic!("server accept failed: {error}"),
                 }
-            });
+            }});
+
+            // Wait for the server thread to enter the accept loop before
+            // returning. Without this, the client can connect before the
+            // thread is scheduled, causing "connection refused" on macOS CI.
+            ready_rx.recv().expect("server readiness signal");
 
             Self {
                 addr,


### PR DESCRIPTION
## Summary

Fix macOS CI flakes in `web_fetch` and `web_search` tests.

**Root cause:** `TestServer::spawn()` returned immediately after `TcpListener::bind()` but before the server thread entered its accept loop. On macOS CI, the client connected before the thread was scheduled → `connection refused`.

**Fix:** `mpsc::channel` readiness signal. Server thread sends `ready_tx.send(())` before entering the accept loop, `spawn()` blocks on `ready_rx.recv()` until it arrives. No timeout, no sleep, deterministic.

## Test plan
- [x] All 6 web_fetch/web_search tests pass locally
- [ ] CI green (this was the only failing test on `87078fb`)