### PR TITLE
Fix COS install mirror command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,5 +266,6 @@ jobs:
             echo "Uploading $filename"
             coscmd upload "$file" "sudocode/release/latest/$filename"
           done
+          coscmd upload install.sh "sudocode/release/latest/install.sh"
           coscmd upload dist/SHA256SUMS.txt "sudocode/release/latest/SHA256SUMS.txt"
           echo "Done: https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/"

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Overrides:
 China mirror (checksums still verified against GitHub):
 
 ```bash
-SCODE_MIRROR=https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \
-  curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
+curl -fsSL https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/install.sh | \
+  SCODE_MIRROR=https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest sh
 ```
 
 ## Build from source

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@
 #                       Use this to point at a mirror (e.g. Tencent COS) for
 #                       faster downloads in China. The checksum file is always
 #                       fetched from GitHub Releases for security.
-#                       Example: https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest
+#                       Example: https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest
 #   NO_COLOR            Disable ANSI color output when set.
 #
 # Flags:
@@ -89,8 +89,8 @@ ${C_BOLD}EXAMPLES${C_RESET}
     sh install.sh --prefix /usr/local
     sh install.sh --no-sudo
     # China mirror (faster in mainland China):
-    SCODE_MIRROR=https://sudowork-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest \\
-      curl -fsSL https://raw.githubusercontent.com/sudoprivacy/sudocode/main/install.sh | sh
+    curl -fsSL https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/install.sh | \\
+      SCODE_MIRROR=https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest sh
 EOF
 }
 


### PR DESCRIPTION
## Summary
- update the China mirror command so install.sh is downloaded from the same COS release bucket as archives
- sync install.sh help text and SCODE_MIRROR example
- upload install.sh to COS during release publishing

## Verification
- Uploaded install.sh to cos://sudowork-release-1309794936/sudocode/release/latest/install.sh
- Verified the COS install path with:
  curl -fsSL https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/install.sh | SCODE_INSTALL_DIR=/private/tmp/scode-install-verify-bin SCODE_MIRROR=https://sudowork-release-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest sh
- Installer completed and reported: scode is working: scode 0.1.17