### PR TITLE
fix(spinner): remove double-draw and restore footer separator

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -194,8 +194,12 @@ impl CliOutput {
     }
 }
 
-/// Format the sticky footer bar text.
+/// Format the sticky footer bar text with a separator line above.
 fn format_footer_bar(permission_mode: &str) -> String {
+    let width = crossterm::terminal::size()
+        .map(|(cols, _)| cols as usize)
+        .unwrap_or(80);
+    let separator = format!("\x1b[2m{}\x1b[0m", "─".repeat(width));
     let icon = match permission_mode {
         "danger-full-access" => "⏵⏵",
         "workspace-write" => "⏵",
@@ -207,7 +211,9 @@ fn format_footer_bar(permission_mode: &str) -> String {
         "read-only" => "read only",
         other => other,
     };
-    format!("\x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m")
+    format!(
+        "{separator}\n  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m"
+    )
 }
 
 /// Shared spinner reference for streaming and tool execution layers.
@@ -418,7 +424,6 @@ impl SpinnerHandle {
                     let color_code = if is_stalled { "33" } else { "34" };
                     let colored = format!("\x1b[{color_code}m{line}\x1b[0m");
                     pb.set_message(colored);
-                    pb.tick();
                 }
 
                 std::thread::sleep(std::time::Duration::from_millis(80));


### PR DESCRIPTION
## Summary

Fixes two regressions from #379:

- **Spinner double-draw**: `set_message()` + `tick()` each trigger a MultiProgress redraw, causing every spinner frame to appear twice in scrollback. Removed redundant `tick()`.
- **Missing separator**: Deleted `input_chrome.rs` removed the visual separator line. Restored it as part of the footer bar text.

## Test plan

- [x] `cargo test --workspace` — all pass
- [ ] CI green
- [ ] Manual: spinner renders single frame, separator line visible below prompt