### PR TITLE
cli: replace MultiProgress with TurnRenderer for unified spinner

### DIFF
--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -20,6 +20,7 @@ compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
 futures = "0.3"
 indicatif = "0.17"
+iocraft = "0.8"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 pulldown-cmark = "0.13"
 rustyline = "15"

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 [dependencies]
 api = { path = "../api" }
 arboard = { version = "3", features = ["image-data"] }
-smol = "2"
 async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
@@ -21,7 +20,6 @@ compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
 futures = "0.3"
 indicatif = "0.17"
-iocraft = "0.8"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 pulldown-cmark = "0.13"
 rustyline = "15"

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 api = { path = "../api" }
 arboard = { version = "3", features = ["image-data"] }
+smol = "2"
 async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -49,5 +49,5 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-tungstenite = "0.29"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["term", "poll", "fs"] }
+nix = { version = "0.29", features = ["term", "poll"] }
 

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -49,5 +49,5 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-tungstenite = "0.29"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["term", "poll"] }
+nix = { version = "0.29", features = ["term", "poll", "fs"] }
 

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -18,7 +18,6 @@ use tools::GlobalToolRegistry;
 
 use super::format::{format_tool_call_start, format_user_visible_api_error};
 use crate::render::{MarkdownStreamState, SpinnerRef, TerminalRenderer};
-use crate::repl_ui::TurnOutput;
 use std::sync::Arc;
 
 use crate::{
@@ -45,8 +44,6 @@ pub(crate) struct AnthropicRuntimeClient {
     /// Shared spinner reference for pausing, thinking indicator, and
     /// response-byte counting.
     pub(crate) spinner: Option<SpinnerRef>,
-    /// Channel-backed output for routing text through iocraft (REPL mode).
-    pub(crate) turn_output: Option<TurnOutput>,
 }
 
 impl AnthropicRuntimeClient {
@@ -83,16 +80,11 @@ impl AnthropicRuntimeClient {
             progress_reporter: config.progress_reporter.clone(),
             reasoning_effort: None,
             spinner: None,
-            turn_output: None,
         })
     }
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
         self.spinner = Some(ref_);
-    }
-
-    pub(crate) fn set_turn_output(&mut self, output: TurnOutput) {
-        self.turn_output = Some(output);
     }
 
     /// Pause the spinner and clear its line before writing content.
@@ -196,7 +188,6 @@ struct CliStreamState {
     emit_output: bool,
     progress_reporter: Option<InternalPromptProgressReporter>,
     spinner: Option<SpinnerRef>,
-    turn_output: Option<TurnOutput>,
     pending_tool: Option<(String, String, String, Option<String>)>,
     block_has_thinking_summary: bool,
     markdown_stream: MarkdownStreamState,
@@ -215,22 +206,13 @@ struct CliStreamState {
 }
 
 impl CliStreamState {
-    /// Pause the spinner before raw I/O. Skipped when TurnOutput is
-    /// active (iocraft handles cursor coordination).
     fn pause_output(&self) {
-        if self.turn_output.is_some() {
-            return;
-        }
         if let Some(s) = &self.spinner {
             s.pause();
         }
     }
 
-    /// Resume after raw I/O.
     fn resume_output(&self) {
-        if self.turn_output.is_some() {
-            return;
-        }
         if let Some(s) = &self.spinner {
             s.resume();
         }
@@ -250,13 +232,8 @@ impl CliStreamState {
     fn process_provider_event(&mut self, event: ApiStreamEvent) -> Result<(), RuntimeError> {
         let mut stdout = io::stdout();
         let mut sink = io::sink();
-        let mut turn_out_clone = self.turn_output.clone();
         let out: &mut dyn Write = if self.emit_output {
-            if let Some(ref mut turn_out) = turn_out_clone {
-                turn_out
-            } else {
-                &mut stdout
-            }
+            &mut stdout
         } else {
             &mut sink
         };
@@ -439,7 +416,6 @@ impl AnthropicRuntimeClient {
             emit_output: self.emit_output,
             progress_reporter: self.progress_reporter.clone(),
             spinner: self.spinner.clone(),
-            turn_output: self.turn_output.clone(),
             pending_tool: None,
             block_has_thinking_summary: false,
             markdown_stream: MarkdownStreamState::default(),

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -18,6 +18,7 @@ use tools::GlobalToolRegistry;
 
 use super::format::{format_tool_call_start, format_user_visible_api_error};
 use crate::render::{MarkdownStreamState, SpinnerRef, TerminalRenderer};
+use crate::repl_ui::TurnOutput;
 use std::sync::Arc;
 
 use crate::{
@@ -44,6 +45,8 @@ pub(crate) struct AnthropicRuntimeClient {
     /// Shared spinner reference for pausing, thinking indicator, and
     /// response-byte counting.
     pub(crate) spinner: Option<SpinnerRef>,
+    /// Channel-backed output for routing text through iocraft (REPL mode).
+    pub(crate) turn_output: Option<TurnOutput>,
 }
 
 impl AnthropicRuntimeClient {
@@ -80,11 +83,16 @@ impl AnthropicRuntimeClient {
             progress_reporter: config.progress_reporter.clone(),
             reasoning_effort: None,
             spinner: None,
+            turn_output: None,
         })
     }
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
         self.spinner = Some(ref_);
+    }
+
+    pub(crate) fn set_turn_output(&mut self, output: TurnOutput) {
+        self.turn_output = Some(output);
     }
 
     /// Pause the spinner and clear its line before writing content.
@@ -188,6 +196,7 @@ struct CliStreamState {
     emit_output: bool,
     progress_reporter: Option<InternalPromptProgressReporter>,
     spinner: Option<SpinnerRef>,
+    turn_output: Option<TurnOutput>,
     pending_tool: Option<(String, String, String, Option<String>)>,
     block_has_thinking_summary: bool,
     markdown_stream: MarkdownStreamState,
@@ -206,8 +215,12 @@ struct CliStreamState {
 }
 
 impl CliStreamState {
-    /// Pause the spinner before raw I/O.
+    /// Pause the spinner before raw I/O. Skipped when TurnOutput is
+    /// active (iocraft handles cursor coordination).
     fn pause_output(&self) {
+        if self.turn_output.is_some() {
+            return;
+        }
         if let Some(s) = &self.spinner {
             s.pause();
         }
@@ -215,6 +228,9 @@ impl CliStreamState {
 
     /// Resume after raw I/O.
     fn resume_output(&self) {
+        if self.turn_output.is_some() {
+            return;
+        }
         if let Some(s) = &self.spinner {
             s.resume();
         }
@@ -234,8 +250,13 @@ impl CliStreamState {
     fn process_provider_event(&mut self, event: ApiStreamEvent) -> Result<(), RuntimeError> {
         let mut stdout = io::stdout();
         let mut sink = io::sink();
+        let mut turn_out_clone = self.turn_output.clone();
         let out: &mut dyn Write = if self.emit_output {
-            &mut stdout
+            if let Some(ref mut turn_out) = turn_out_clone {
+                turn_out
+            } else {
+                &mut stdout
+            }
         } else {
             &mut sink
         };
@@ -418,6 +439,7 @@ impl AnthropicRuntimeClient {
             emit_output: self.emit_output,
             progress_reporter: self.progress_reporter.clone(),
             spinner: self.spinner.clone(),
+            turn_output: self.turn_output.clone(),
             pending_tool: None,
             block_has_thinking_summary: false,
             markdown_stream: MarkdownStreamState::default(),

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -17,7 +17,7 @@ use telemetry::{SessionTracer, SudoclawLogSink};
 use tools::GlobalToolRegistry;
 
 use super::format::{format_tool_call_start, format_user_visible_api_error};
-use crate::render::{CliOutput, MarkdownStreamState, SpinnerRef, TerminalRenderer};
+use crate::render::{MarkdownStreamState, SpinnerRef, TerminalRenderer};
 use std::sync::Arc;
 
 use crate::{
@@ -44,8 +44,6 @@ pub(crate) struct AnthropicRuntimeClient {
     /// Shared spinner reference for pausing, thinking indicator, and
     /// response-byte counting.
     pub(crate) spinner: Option<SpinnerRef>,
-    /// MultiProgress output manager for REPL mode.
-    pub(crate) cli_output: Option<CliOutput>,
 }
 
 impl AnthropicRuntimeClient {
@@ -82,16 +80,11 @@ impl AnthropicRuntimeClient {
             progress_reporter: config.progress_reporter.clone(),
             reasoning_effort: None,
             spinner: None,
-            cli_output: None,
         })
     }
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
         self.spinner = Some(ref_);
-    }
-
-    pub(crate) fn set_cli_output(&mut self, output: CliOutput) {
-        self.cli_output = Some(output);
     }
 
     /// Pause the spinner and clear its line before writing content.
@@ -195,7 +188,6 @@ struct CliStreamState {
     emit_output: bool,
     progress_reporter: Option<InternalPromptProgressReporter>,
     spinner: Option<SpinnerRef>,
-    cli_output: Option<CliOutput>,
     pending_tool: Option<(String, String, String, Option<String>)>,
     block_has_thinking_summary: bool,
     markdown_stream: MarkdownStreamState,
@@ -214,7 +206,7 @@ struct CliStreamState {
 }
 
 impl CliStreamState {
-    /// Suspend MultiProgress (or fall back to spinner pause) before raw I/O.
+    /// Pause the spinner before raw I/O.
     fn pause_output(&self) {
         if let Some(s) = &self.spinner {
             s.pause();
@@ -426,7 +418,6 @@ impl AnthropicRuntimeClient {
             emit_output: self.emit_output,
             progress_reporter: self.progress_reporter.clone(),
             spinner: self.spinner.clone(),
-            cli_output: self.cli_output.clone(),
             pending_tool: None,
             block_has_thinking_summary: false,
             markdown_stream: MarkdownStreamState::default(),

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use tools::GlobalToolRegistry;
 
 use super::format::format_tool_result;
-use crate::render::{CliOutput, SpinnerRef, TerminalRenderer};
+use crate::render::{SpinnerRef, TerminalRenderer};
 use crate::{AllowedToolSet, RuntimeMcpState};
 
 #[derive(Debug, Deserialize)]
@@ -56,7 +56,6 @@ pub(crate) struct CliToolExecutor {
     tool_registry: GlobalToolRegistry,
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     spinner: Option<SpinnerRef>,
-    cli_output: Option<CliOutput>,
     question_prompter: Option<Box<dyn QuestionPrompter>>,
     abort_signal: Option<runtime::HookAbortSignal>,
 }
@@ -75,7 +74,6 @@ impl CliToolExecutor {
             tool_registry,
             mcp_state,
             spinner: None,
-            cli_output: None,
             question_prompter: None,
             abort_signal: None,
         }
@@ -83,10 +81,6 @@ impl CliToolExecutor {
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
         self.spinner = Some(ref_);
-    }
-
-    pub(crate) fn set_cli_output(&mut self, output: CliOutput) {
-        self.cli_output = Some(output);
     }
 
     pub(crate) fn set_question_prompter(&mut self, prompter: Box<dyn QuestionPrompter>) {
@@ -111,7 +105,6 @@ impl CliToolExecutor {
     /// to the terminal. Returns `None` when no spinner ref is configured.
     fn make_mcp_progress_callback(&self) -> Option<runtime::McpProgressCallback> {
         let spinner = self.spinner.clone()?;
-        let cli_output = self.cli_output.clone();
         Some(Box::new(
             move |progress: runtime::McpProgressNotification| {
                 let mut status = String::new();
@@ -129,16 +122,10 @@ impl CliToolExecutor {
                         progress.progress
                     )
                 };
-                if let Some(ref output) = cli_output {
-                    spinner.pause();
-                    output.println(&line);
-                    spinner.resume();
-                } else {
-                    spinner.suspend(|| {
-                        let _ = writeln!(io::stdout(), "{line}");
-                        let _ = io::stdout().flush();
-                    });
-                }
+                spinner.suspend(|| {
+                    let _ = writeln!(io::stdout(), "{line}");
+                    let _ = io::stdout().flush();
+                });
             },
         ))
     }
@@ -147,13 +134,11 @@ impl CliToolExecutor {
     /// terminal. Returns `None` when no spinner ref is configured.
     fn make_bash_progress_callback(&self) -> Option<runtime::BashProgressCallback> {
         let spinner = self.spinner.clone()?;
-        let cli_output = self.cli_output.clone();
         Some(Box::new(move |progress: runtime::BashProgress<'_>| {
             let trimmed = progress.output.trim_end();
             if trimmed.is_empty() {
                 return;
             }
-            // Show last line of new output + cumulative stats on one line.
             let last_line = trimmed.lines().next_back().unwrap_or("");
             let bytes_display = if progress.total_bytes >= 1024 {
                 format!("{:.1} KB", progress.total_bytes as f64 / 1024.0)
@@ -164,16 +149,10 @@ impl CliToolExecutor {
                 "  \x1b[2m⟳ {last_line}  ({} lines, {bytes_display})\x1b[0m",
                 progress.total_lines,
             );
-            if let Some(ref output) = cli_output {
-                spinner.pause();
-                output.println(&line);
-                spinner.resume();
-            } else {
-                spinner.suspend(|| {
-                    let _ = writeln!(io::stdout(), "{line}");
-                    let _ = io::stdout().flush();
-                });
-            }
+            spinner.suspend(|| {
+                let _ = writeln!(io::stdout(), "{line}");
+                let _ = io::stdout().flush();
+            });
         }))
     }
 
@@ -348,13 +327,9 @@ impl ToolExecutor for CliToolExecutor {
                         .as_ref()
                         .is_some_and(runtime::HookAbortSignal::is_aborted);
                     let formatted = format_tool_result(tool_name, &output, interrupted);
-                    if let Some(ref cli_output) = self.cli_output {
-                        cli_output.println(&formatted);
-                    } else {
-                        writeln!(io::stdout(), "{formatted}")
-                            .and_then(|()| io::stdout().flush())
-                            .map_err(|error| ToolError::new(error.to_string()))?;
-                    }
+                    writeln!(io::stdout(), "{formatted}")
+                        .and_then(|()| io::stdout().flush())
+                        .map_err(|error| ToolError::new(error.to_string()))?;
                     self.resume_spinner();
                 }
                 Ok(output)
@@ -363,13 +338,9 @@ impl ToolExecutor for CliToolExecutor {
                 if self.emit_output {
                     self.pause_spinner();
                     let formatted = format_tool_result(tool_name, &error.to_string(), true);
-                    if let Some(ref cli_output) = self.cli_output {
-                        cli_output.println(&formatted);
-                    } else {
-                        writeln!(io::stdout(), "{formatted}")
-                            .and_then(|()| io::stdout().flush())
-                            .map_err(|error| ToolError::new(error.to_string()))?;
-                    }
+                    writeln!(io::stdout(), "{formatted}")
+                        .and_then(|()| io::stdout().flush())
+                        .map_err(|error| ToolError::new(error.to_string()))?;
                     self.resume_spinner();
                 }
                 Err(error)

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -10,7 +10,6 @@ use tools::GlobalToolRegistry;
 
 use super::format::format_tool_result;
 use crate::render::{SpinnerRef, TerminalRenderer};
-use crate::repl_ui::TurnOutput;
 use crate::{AllowedToolSet, RuntimeMcpState};
 
 #[derive(Debug, Deserialize)]
@@ -57,7 +56,6 @@ pub(crate) struct CliToolExecutor {
     tool_registry: GlobalToolRegistry,
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     spinner: Option<SpinnerRef>,
-    turn_output: Option<TurnOutput>,
     question_prompter: Option<Box<dyn QuestionPrompter>>,
     abort_signal: Option<runtime::HookAbortSignal>,
 }
@@ -76,7 +74,6 @@ impl CliToolExecutor {
             tool_registry,
             mcp_state,
             spinner: None,
-            turn_output: None,
             question_prompter: None,
             abort_signal: None,
         }
@@ -84,10 +81,6 @@ impl CliToolExecutor {
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
         self.spinner = Some(ref_);
-    }
-
-    pub(crate) fn set_turn_output(&mut self, output: TurnOutput) {
-        self.turn_output = Some(output);
     }
 
     pub(crate) fn set_question_prompter(&mut self, prompter: Box<dyn QuestionPrompter>) {
@@ -112,7 +105,6 @@ impl CliToolExecutor {
     /// to the terminal. Returns `None` when no spinner ref is configured.
     fn make_mcp_progress_callback(&self) -> Option<runtime::McpProgressCallback> {
         let spinner = self.spinner.clone()?;
-        let turn_output = self.turn_output.clone();
         Some(Box::new(
             move |progress: runtime::McpProgressNotification| {
                 let mut status = String::new();
@@ -130,21 +122,16 @@ impl CliToolExecutor {
                         progress.progress
                     )
                 };
-                if let Some(ref out) = turn_output {
-                    out.println(&line);
-                } else {
-                    spinner.suspend(|| {
-                        let _ = writeln!(io::stdout(), "{line}");
-                        let _ = io::stdout().flush();
-                    });
-                }
+                spinner.suspend(|| {
+                    let _ = writeln!(io::stdout(), "{line}");
+                    let _ = io::stdout().flush();
+                });
             },
         ))
     }
 
     fn make_bash_progress_callback(&self) -> Option<runtime::BashProgressCallback> {
         let spinner = self.spinner.clone()?;
-        let turn_output = self.turn_output.clone();
         Some(Box::new(move |progress: runtime::BashProgress<'_>| {
             let trimmed = progress.output.trim_end();
             if trimmed.is_empty() {
@@ -160,14 +147,10 @@ impl CliToolExecutor {
                 "  \x1b[2m⟳ {last_line}  ({} lines, {bytes_display})\x1b[0m",
                 progress.total_lines,
             );
-            if let Some(ref out) = turn_output {
-                out.println(&line);
-            } else {
-                spinner.suspend(|| {
-                    let _ = writeln!(io::stdout(), "{line}");
-                    let _ = io::stdout().flush();
-                });
-            }
+            spinner.suspend(|| {
+                let _ = writeln!(io::stdout(), "{line}");
+                let _ = io::stdout().flush();
+            });
         }))
     }
 
@@ -342,13 +325,9 @@ impl ToolExecutor for CliToolExecutor {
                         .as_ref()
                         .is_some_and(runtime::HookAbortSignal::is_aborted);
                     let formatted = format_tool_result(tool_name, &output, interrupted);
-                    if let Some(ref turn_out) = self.turn_output {
-                        turn_out.println(&formatted);
-                    } else {
-                        writeln!(io::stdout(), "{formatted}")
-                            .and_then(|()| io::stdout().flush())
-                            .map_err(|error| ToolError::new(error.to_string()))?;
-                    }
+                    writeln!(io::stdout(), "{formatted}")
+                        .and_then(|()| io::stdout().flush())
+                        .map_err(|error| ToolError::new(error.to_string()))?;
                     self.resume_spinner();
                 }
                 Ok(output)
@@ -357,13 +336,9 @@ impl ToolExecutor for CliToolExecutor {
                 if self.emit_output {
                     self.pause_spinner();
                     let formatted = format_tool_result(tool_name, &error.to_string(), true);
-                    if let Some(ref turn_out) = self.turn_output {
-                        turn_out.println(&formatted);
-                    } else {
-                        writeln!(io::stdout(), "{formatted}")
-                            .and_then(|()| io::stdout().flush())
-                            .map_err(|error| ToolError::new(error.to_string()))?;
-                    }
+                    writeln!(io::stdout(), "{formatted}")
+                        .and_then(|()| io::stdout().flush())
+                        .map_err(|error| ToolError::new(error.to_string()))?;
                     self.resume_spinner();
                 }
                 Err(error)

--- a/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/tool_executor.rs
@@ -10,6 +10,7 @@ use tools::GlobalToolRegistry;
 
 use super::format::format_tool_result;
 use crate::render::{SpinnerRef, TerminalRenderer};
+use crate::repl_ui::TurnOutput;
 use crate::{AllowedToolSet, RuntimeMcpState};
 
 #[derive(Debug, Deserialize)]
@@ -56,6 +57,7 @@ pub(crate) struct CliToolExecutor {
     tool_registry: GlobalToolRegistry,
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     spinner: Option<SpinnerRef>,
+    turn_output: Option<TurnOutput>,
     question_prompter: Option<Box<dyn QuestionPrompter>>,
     abort_signal: Option<runtime::HookAbortSignal>,
 }
@@ -74,6 +76,7 @@ impl CliToolExecutor {
             tool_registry,
             mcp_state,
             spinner: None,
+            turn_output: None,
             question_prompter: None,
             abort_signal: None,
         }
@@ -81,6 +84,10 @@ impl CliToolExecutor {
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
         self.spinner = Some(ref_);
+    }
+
+    pub(crate) fn set_turn_output(&mut self, output: TurnOutput) {
+        self.turn_output = Some(output);
     }
 
     pub(crate) fn set_question_prompter(&mut self, prompter: Box<dyn QuestionPrompter>) {
@@ -105,6 +112,7 @@ impl CliToolExecutor {
     /// to the terminal. Returns `None` when no spinner ref is configured.
     fn make_mcp_progress_callback(&self) -> Option<runtime::McpProgressCallback> {
         let spinner = self.spinner.clone()?;
+        let turn_output = self.turn_output.clone();
         Some(Box::new(
             move |progress: runtime::McpProgressNotification| {
                 let mut status = String::new();
@@ -122,18 +130,21 @@ impl CliToolExecutor {
                         progress.progress
                     )
                 };
-                spinner.suspend(|| {
-                    let _ = writeln!(io::stdout(), "{line}");
-                    let _ = io::stdout().flush();
-                });
+                if let Some(ref out) = turn_output {
+                    out.println(&line);
+                } else {
+                    spinner.suspend(|| {
+                        let _ = writeln!(io::stdout(), "{line}");
+                        let _ = io::stdout().flush();
+                    });
+                }
             },
         ))
     }
 
-    /// Build a progress callback that prints streaming bash output to the
-    /// terminal. Returns `None` when no spinner ref is configured.
     fn make_bash_progress_callback(&self) -> Option<runtime::BashProgressCallback> {
         let spinner = self.spinner.clone()?;
+        let turn_output = self.turn_output.clone();
         Some(Box::new(move |progress: runtime::BashProgress<'_>| {
             let trimmed = progress.output.trim_end();
             if trimmed.is_empty() {
@@ -149,10 +160,14 @@ impl CliToolExecutor {
                 "  \x1b[2m⟳ {last_line}  ({} lines, {bytes_display})\x1b[0m",
                 progress.total_lines,
             );
-            spinner.suspend(|| {
-                let _ = writeln!(io::stdout(), "{line}");
-                let _ = io::stdout().flush();
-            });
+            if let Some(ref out) = turn_output {
+                out.println(&line);
+            } else {
+                spinner.suspend(|| {
+                    let _ = writeln!(io::stdout(), "{line}");
+                    let _ = io::stdout().flush();
+                });
+            }
         }))
     }
 
@@ -327,9 +342,13 @@ impl ToolExecutor for CliToolExecutor {
                         .as_ref()
                         .is_some_and(runtime::HookAbortSignal::is_aborted);
                     let formatted = format_tool_result(tool_name, &output, interrupted);
-                    writeln!(io::stdout(), "{formatted}")
-                        .and_then(|()| io::stdout().flush())
-                        .map_err(|error| ToolError::new(error.to_string()))?;
+                    if let Some(ref turn_out) = self.turn_output {
+                        turn_out.println(&formatted);
+                    } else {
+                        writeln!(io::stdout(), "{formatted}")
+                            .and_then(|()| io::stdout().flush())
+                            .map_err(|error| ToolError::new(error.to_string()))?;
+                    }
                     self.resume_spinner();
                 }
                 Ok(output)
@@ -338,9 +357,13 @@ impl ToolExecutor for CliToolExecutor {
                 if self.emit_output {
                     self.pause_spinner();
                     let formatted = format_tool_result(tool_name, &error.to_string(), true);
-                    writeln!(io::stdout(), "{formatted}")
-                        .and_then(|()| io::stdout().flush())
-                        .map_err(|error| ToolError::new(error.to_string()))?;
+                    if let Some(ref turn_out) = self.turn_output {
+                        turn_out.println(&formatted);
+                    } else {
+                        writeln!(io::stdout(), "{formatted}")
+                            .and_then(|()| io::stdout().flush())
+                            .map_err(|error| ToolError::new(error.to_string()))?;
+                    }
                     self.resume_spinner();
                 }
                 Err(error)

--- a/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/src/input_chrome.rs
@@ -1,0 +1,63 @@
+//! Input chrome — the separator/footer UI around the REPL prompt.
+//!
+//! Renders a sandwich layout:
+//!
+//! ```text
+//! ──────────────────────── (top separator)
+//! ❯ <user input here>     (prompt — rendered by rustyline)
+//! ──────────────────────── (bottom separator)
+//!   ⏵⏵ full access mode · /help for commands · /permissions to change
+//! ```
+//!
+//! `print_before_prompt` prints all four lines then cursors back to the
+//! prompt line. This cursor-up is safe because the lines were just printed
+//! (positions are deterministic, no scrolling has occurred).
+//!
+//! After the user submits, the caller clears the bottom sep + footer with
+//! `\x1b[J` and prints the echo downward via `println!`. The old
+//! `replace_after_submit` (which cursored UP after readline returned) was
+//! the root cause of scrollback jumping and has been permanently removed.
+
+use std::io::{self, Write};
+
+fn term_width() -> usize {
+    crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize)
+}
+
+fn separator(width: usize) -> String {
+    format!("\x1b[2m{}\x1b[0m", "─".repeat(width))
+}
+
+fn format_footer(permission_mode: &str) -> String {
+    let icon = match permission_mode {
+        "danger-full-access" => "⏵⏵",
+        "workspace-write" => "⏵",
+        _ => "▷",
+    };
+    let label = match permission_mode {
+        "danger-full-access" => "full access",
+        "workspace-write" => "workspace write",
+        "read-only" => "read only",
+        other => other,
+    };
+    format!("  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m")
+}
+
+/// Print the sandwich chrome (top sep, prompt placeholder, bottom sep,
+/// footer) then cursor back to the prompt line so `read_line()` renders
+/// there.
+///
+/// The `\x1b[2F` is safe: we just printed these lines so positions are
+/// deterministic.
+pub fn print_before_prompt(permission_mode: &str) {
+    let w = term_width();
+    let sep = separator(w);
+    let footer = format_footer(permission_mode);
+    let mut stdout = io::stdout();
+    let _ = writeln!(stdout, "{sep}");
+    let _ = writeln!(stdout); // prompt placeholder
+    let _ = writeln!(stdout, "{sep}");
+    let _ = write!(stdout, "{footer}");
+    let _ = write!(stdout, "\x1b[2F\x1b[2K"); // cursor up 2, clear prompt placeholder
+    let _ = stdout.flush();
+}

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3624,14 +3624,18 @@ impl LiveCli {
         let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
         let token_budget = crate::render::parse_token_budget(input);
-        // Use iocraft TurnRenderer when explicitly enabled and in REPL mode.
-        // Default path uses the standalone indicatif spinner.
-        let use_iocraft =
+        // Use TurnRenderer for unified chrome during REPL turns when
+        // SUDOCODE_IOCRAFT=1. Falls back to standalone indicatif spinner
+        // otherwise. Live-mode PTY tests revealed that the render thread's
+        // stdout writes can block when the PTY buffer fills (long-running
+        // LLM responses), preventing clean process exit. The env gate
+        // remains until non-blocking stdout is implemented.
+        let use_turn_renderer =
             io::stdout().is_terminal() && env::var("SUDOCODE_IOCRAFT").is_ok_and(|v| v == "1");
         let mut turn_renderer: Option<repl_ui::TurnRenderer> = None;
         let mut spinner: Option<SpinnerHandle> = None;
 
-        if use_iocraft {
+        if use_turn_renderer {
             let renderer = repl_ui::TurnRenderer::new(
                 "🦀 Thinking...",
                 Some(self.config.model.as_str()),

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3623,21 +3623,49 @@ impl LiveCli {
     fn run_turn(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
         let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
-        // Coordinator-mode `<task-notification>` push is now
-        // handled inside `ConversationRuntime::run_turn_with_blocks`
-        // so ACP / MCP / print-mode paths inherit it — see the drain
-        // call in `runtime/src/conversation.rs`.  The CLI no longer
-        // duplicates it here.
         let token_budget = crate::render::parse_token_budget(input);
-        let mut spinner = SpinnerHandle::new(
-            "🦀 Thinking...",
-            Some(self.config.model.as_str()),
-            TerminalRenderer::new().color_theme(),
-            token_budget,
-        );
-        let spinner_ref = spinner.spinner_ref();
-        runtime.api_client_mut().set_spinner(spinner_ref.clone());
-        runtime.tool_executor_mut().set_spinner(spinner_ref);
+        // Use iocraft TurnRenderer when explicitly enabled and in REPL mode.
+        // Default path uses the standalone indicatif spinner.
+        let use_iocraft =
+            io::stdout().is_terminal() && env::var("SUDOCODE_IOCRAFT").is_ok_and(|v| v == "1");
+        let mut turn_renderer: Option<repl_ui::TurnRenderer> = None;
+        let mut spinner: Option<SpinnerHandle> = None;
+
+        if use_iocraft {
+            let renderer = repl_ui::TurnRenderer::new(
+                "🦀 Thinking...",
+                Some(self.config.model.as_str()),
+                token_budget,
+                self.config.permission_mode.as_str(),
+            );
+            let spinner_state = renderer.spinner().clone();
+            // Wire the spinner state into the existing SpinnerRef API
+            // so streaming/tool layers can update bytes + thinking.
+            let spinner_ref = render::SpinnerRef::from_state(
+                &spinner_state.response_bytes,
+                &spinner_state.is_thinking,
+                &spinner_state.is_paused,
+            );
+            runtime.api_client_mut().set_spinner(spinner_ref.clone());
+            runtime.tool_executor_mut().set_spinner(spinner_ref);
+            if let Some(output) = renderer.output() {
+                runtime.api_client_mut().set_turn_output(output.clone());
+                runtime.tool_executor_mut().set_turn_output(output);
+            }
+            turn_renderer = Some(renderer);
+        } else {
+            let s = SpinnerHandle::new(
+                "🦀 Thinking...",
+                Some(self.config.model.as_str()),
+                TerminalRenderer::new().color_theme(),
+                token_budget,
+            );
+            let spinner_ref = s.spinner_ref();
+            runtime.api_client_mut().set_spinner(spinner_ref.clone());
+            runtime.tool_executor_mut().set_spinner(spinner_ref);
+            spinner = Some(s);
+        }
+
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
         let result = self.tokio_runtime.block_on(runtime.run_turn(
             input,
@@ -3649,9 +3677,17 @@ impl LiveCli {
             Ok(summary) => {
                 self.replace_runtime(runtime)?;
                 if summary.cancelled {
-                    spinner.fail("⏹ Cancelled");
+                    if let Some(mut r) = turn_renderer {
+                        r.fail("⏹ Cancelled");
+                    } else if let Some(ref mut s) = spinner {
+                        s.fail("⏹ Cancelled");
+                    }
                 } else {
-                    spinner.clear();
+                    if let Some(mut r) = turn_renderer {
+                        r.clear();
+                    } else if let Some(ref mut s) = spinner {
+                        s.clear();
+                    }
                     if let Some(event) = summary.auto_compaction {
                         self.out_println(format_auto_compaction_notice(
                             event.removed_message_count,
@@ -3685,7 +3721,11 @@ impl LiveCli {
             Err(error) => {
                 runtime.shutdown_mcp()?;
                 runtime.shutdown_plugins()?;
-                spinner.fail("❌ Request failed");
+                if let Some(mut r) = turn_renderer {
+                    r.fail("❌ Request failed");
+                } else if let Some(ref mut s) = spinner {
+                    s.fail("❌ Request failed");
+                }
                 Err(Box::new(error))
             }
         }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3624,14 +3624,14 @@ impl LiveCli {
         let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
         let token_budget = crate::render::parse_token_budget(input);
-        // Use TurnRenderer for unified chrome during REPL turns when
-        // SUDOCODE_IOCRAFT=1. Falls back to standalone indicatif spinner
-        // otherwise. Live-mode PTY tests revealed that the render thread's
-        // stdout writes can block when the PTY buffer fills (long-running
-        // LLM responses), preventing clean process exit. The env gate
-        // remains until non-blocking stdout is implemented.
-        let use_turn_renderer =
-            io::stdout().is_terminal() && env::var("SUDOCODE_IOCRAFT").is_ok_and(|v| v == "1");
+        // Use TurnRenderer for unified output routing during REPL turns.
+        // Non-interactive (piped) mode uses the standalone indicatif spinner.
+        // TurnRenderer routes all output through a channel to the render
+        // thread, keeping spinner updates coordinated. Opt-in for now
+        // (SUDOCODE_TURN_RENDERER=1) until all PTY tests are adapted.
+        let use_turn_renderer = io::stdout().is_terminal()
+            && env::var("SUDOCODE_TURN_RENDERER")
+                .is_ok_and(|v| !matches!(v.as_str(), "0" | "off" | "false"));
         let mut turn_renderer: Option<repl_ui::TurnRenderer> = None;
         let mut spinner: Option<SpinnerHandle> = None;
 
@@ -3640,7 +3640,6 @@ impl LiveCli {
                 "🦀 Thinking...",
                 Some(self.config.model.as_str()),
                 token_budget,
-                self.config.permission_mode.as_str(),
             );
             let spinner_state = renderer.spinner().clone();
             // Wire the spinner state into the existing SpinnerRef API

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3626,12 +3626,7 @@ impl LiveCli {
         let token_budget = crate::render::parse_token_budget(input);
         // Use TurnRenderer for unified output routing during REPL turns.
         // Non-interactive (piped) mode uses the standalone indicatif spinner.
-        // TurnRenderer routes all output through a channel to the render
-        // thread, keeping spinner updates coordinated. Opt-in for now
-        // (SUDOCODE_TURN_RENDERER=1) until all PTY tests are adapted.
-        let use_turn_renderer = io::stdout().is_terminal()
-            && env::var("SUDOCODE_TURN_RENDERER")
-                .is_ok_and(|v| !matches!(v.as_str(), "0" | "off" | "false"));
+        let use_turn_renderer = io::stdout().is_terminal();
         let mut turn_renderer: Option<repl_ui::TurnRenderer> = None;
         let mut spinner: Option<SpinnerHandle> = None;
 
@@ -3651,10 +3646,6 @@ impl LiveCli {
             );
             runtime.api_client_mut().set_spinner(spinner_ref.clone());
             runtime.tool_executor_mut().set_spinner(spinner_ref);
-            if let Some(output) = renderer.output() {
-                runtime.api_client_mut().set_turn_output(output.clone());
-                runtime.tool_executor_mut().set_turn_output(output);
-            }
             turn_renderer = Some(renderer);
         } else {
             let s = SpinnerHandle::new(

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -16,6 +16,7 @@ mod cancel;
 mod cli;
 mod init;
 mod input;
+mod input_chrome;
 mod input_queue;
 mod render;
 mod repl_async;
@@ -108,7 +109,7 @@ use init::initialize_repo;
 use plugins::{
     render_plugin_capabilities_section, PluginLoadOutcome, PluginManager, PluginRegistry,
 };
-use render::{CliOutput, MarkdownStreamState, SpinnerHandle, TerminalRenderer};
+use render::{MarkdownStreamState, SpinnerHandle, TerminalRenderer};
 use runtime::{
     check_base_commit, compact_session, estimate_block_tokens, estimate_session_tokens,
     format_stale_base_warning, format_usd, load_oauth_credentials, load_system_prompt,
@@ -1594,9 +1595,7 @@ fn run_repl(
 fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
     let mut editor =
         input::LineEditor::new("❯ ", cli.repl_completion_candidates().unwrap_or_default());
-    let output = CliOutput::new(cli.config.permission_mode.as_str());
-    cli.output = Some(output.clone());
-    output.println(cli.startup_banner());
+    println!("{}", cli.startup_banner());
 
     // Render existing messages and seed editor history from user prompts.
     // Same code path for new sessions (messages empty → no-op) and resumed
@@ -1609,7 +1608,7 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
         let renderer = render::TerminalRenderer::new();
         let rendered = render_messages(messages, term_width, &renderer);
         if !rendered.is_empty() {
-            output.println(rendered);
+            println!("{rendered}");
         }
         // Seed rustyline history so ↑ recalls previous prompts.
         for msg in messages {
@@ -1635,21 +1634,16 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
-        let read_result = output.suspend(|| editor.read_line());
-        match read_result? {
+        input_chrome::print_before_prompt(cli.config.permission_mode.as_str());
+        match editor.read_line()? {
             input::ReadOutcome::Submit(input) => {
-                // Echo the submitted input above the sticky bars.
-                let trimmed_text = input.trim();
-                if !trimmed_text.is_empty() {
-                    let w = crossterm::terminal::size()
-                        .map(|(cols, _)| cols as usize)
-                        .unwrap_or(80);
-                    let (echo, _) = cli::format::format_input_echo(trimmed_text, w);
-                    output.println(echo);
-                }
+                // Clear the pre-printed bottom sep + footer. After
+                // readline, cursor is at the start of the bottom sep
+                // line. \x1b[J clears from cursor to end of screen.
+                print!("\x1b[J");
+                let _ = io::stdout().flush();
                 let trimmed = input.trim().to_string();
                 if matches!(trimmed.as_str(), "/exit" | "/quit") {
-                    output.finish();
                     cli.persist_session()?;
                     break;
                 }
@@ -1695,7 +1689,6 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             input::ReadOutcome::Exit => {
-                output.finish();
                 cli.persist_session()?;
                 break;
             }
@@ -1756,9 +1749,7 @@ fn run_repl_async_dispatch(
         Arc::new(move || sig.abort())
     };
 
-    // Create CliOutput for the async REPL and store on cli.
-    let output = CliOutput::new(cli.config.permission_mode.as_str());
-    cli.output = Some(output.clone());
+    let permission_label = cli.config.permission_mode.as_str().to_string();
 
     let cli_shared = std::sync::Arc::new(std::sync::Mutex::new(cli));
     let driver: std::sync::Arc<LiveCliDriver> = std::sync::Arc::new(LiveCliDriver {
@@ -1770,10 +1761,10 @@ fn run_repl_async_dispatch(
     repl_async::run_coordinator_loop(
         driver,
         shared_mode,
-        output,
         banner,
         completions,
         Some(esc_abort_hook),
+        &permission_label,
     )?;
 
     // All threads spawned by the coordinator loop have already been joined
@@ -1896,9 +1887,6 @@ struct LiveCli {
     /// Shared atomic queue mode for the async REPL. `/config set auto-interrupt`
     /// writes to this; the coordinator reads it each `submit_during_turn`.
     shared_queue_mode: Option<repl_async::SharedQueueMode>,
-    /// MultiProgress-based output manager. `Some` in REPL mode; `None` for
-    /// one-shot subcommands. All REPL stdout goes through this.
-    output: Option<CliOutput>,
 }
 
 pub(crate) struct RuntimePluginState {
@@ -3328,24 +3316,12 @@ impl LiveCli {
         self.persistent_abort_signal.is_some()
     }
 
-    /// Print a line through `CliOutput` (MultiProgress-safe) when available,
-    /// falling back to raw `println!` for one-shot / non-REPL paths.
     fn out_println(&self, msg: impl AsRef<str>) {
-        if let Some(ref output) = self.output {
-            output.println(msg);
-        } else {
-            println!("{}", msg.as_ref());
-        }
+        println!("{}", msg.as_ref());
     }
 
-    /// Suspend MultiProgress bars, run `f`, then redraw. Falls back to
-    /// just calling `f` directly when no CliOutput is set.
     fn out_suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
-        if let Some(ref output) = self.output {
-            output.suspend(f)
-        } else {
-            f()
-        }
+        f()
     }
 
     fn new(
@@ -3432,7 +3408,6 @@ impl LiveCli {
             esc_monitor_enabled: true,
             persistent_abort_signal: None,
             shared_queue_mode: None,
-            output: None,
         };
         cli.persist_session()?;
 
@@ -3658,14 +3633,9 @@ impl LiveCli {
             Some(self.config.model.as_str()),
             TerminalRenderer::new().color_theme(),
             token_budget,
-            self.output.as_ref(),
         );
         let spinner_ref = spinner.spinner_ref();
         runtime.api_client_mut().set_spinner(spinner_ref.clone());
-        if let Some(ref output) = self.output {
-            runtime.api_client_mut().set_cli_output(output.clone());
-            runtime.tool_executor_mut().set_cli_output(output.clone());
-        }
         runtime.tool_executor_mut().set_spinner(spinner_ref);
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
         let result = self.tokio_runtime.block_on(runtime.run_turn(
@@ -4231,10 +4201,6 @@ impl LiveCli {
         self.config.permission_mode = permission_mode_from_label(normalized);
         let runtime = self.build_replacement_runtime(session, session_id, self.config.clone())?;
         self.replace_runtime(runtime)?;
-        // Update the footer bar to reflect the new permission mode.
-        if let Some(ref output) = self.output {
-            output.set_footer(normalized);
-        }
         self.out_println(format_permissions_switch_report(&previous, normalized));
         Ok(true)
     }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -20,6 +20,7 @@ mod input_chrome;
 mod input_queue;
 mod render;
 mod repl_async;
+mod repl_ui;
 mod vlm_describe;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -147,6 +147,22 @@ pub struct SpinnerRef {
 }
 
 impl SpinnerRef {
+    /// Create a `SpinnerRef` from shared atomics (used by iocraft
+    /// `TurnRenderer` which manages its own spinner rendering).
+    /// The `ProgressBar` is a hidden dummy — only the atomics matter.
+    pub fn from_state(
+        response_bytes: &Arc<AtomicU32>,
+        is_thinking: &Arc<AtomicBool>,
+        is_paused: &Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            pb: ProgressBar::hidden(),
+            response_bytes: Arc::clone(response_bytes),
+            is_thinking: Arc::clone(is_thinking),
+            is_paused: Arc::clone(is_paused),
+        }
+    }
+
     /// Pause the spinner, run the closure, resume the spinner.
     pub fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
         self.pause();

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crossterm::style::{Color, Stylize};
-use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{Style as SyntectStyle, Theme, ThemeSet};
@@ -136,80 +136,6 @@ impl Default for ColorTheme {
     }
 }
 
-/// Unified terminal output manager backed by `indicatif::MultiProgress`.
-///
-/// All text output in the REPL goes through `CliOutput::println()` (inserted
-/// above sticky bars). The footer bar shows the current permission mode and
-/// help hints. Spinners register themselves via `mp.add()` so all bars are
-/// managed consistently — no raw cursor manipulation needed.
-///
-/// Clone is cheap — both `MultiProgress` and `ProgressBar` are `Arc`-wrapped.
-#[derive(Clone)]
-pub struct CliOutput {
-    mp: MultiProgress,
-    footer: ProgressBar,
-}
-
-impl CliOutput {
-    /// Create a new `CliOutput` with a sticky footer bar showing the
-    /// permission mode.
-    #[must_use]
-    pub fn new(permission_mode: &str) -> Self {
-        let mp = MultiProgress::new();
-        let footer = mp.add(ProgressBar::new_spinner());
-        footer.set_style(ProgressStyle::with_template("{msg}").unwrap());
-        let footer_text = format_footer_bar(permission_mode);
-        footer.set_message(footer_text);
-        // Prevent the footer from being auto-finished; it stays visible.
-        footer.enable_steady_tick(std::time::Duration::from_secs(3600));
-        Self { mp, footer }
-    }
-
-    /// Print a line above the sticky bars. Thread-safe.
-    pub fn println(&self, msg: impl AsRef<str>) {
-        let _ = self.mp.println(msg);
-    }
-
-    /// Temporarily clear all bars, run `f`, then redraw. Use for raw I/O
-    /// that must own the terminal (rustyline, dialoguer, streaming writes).
-    pub fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
-        self.mp.suspend(f)
-    }
-
-    /// Update the footer bar text (e.g. after `/permissions` changes the mode).
-    pub fn set_footer(&self, permission_mode: &str) {
-        self.footer.set_message(format_footer_bar(permission_mode));
-    }
-
-    /// Access the underlying `MultiProgress` so spinners can register via
-    /// `mp.add(pb)`.
-    #[must_use]
-    pub fn multi(&self) -> &MultiProgress {
-        &self.mp
-    }
-
-    /// Finish and clear the footer bar. Called on exit.
-    pub fn finish(&self) {
-        self.footer.finish_and_clear();
-    }
-}
-
-/// Format the sticky footer bar text.
-fn format_footer_bar(permission_mode: &str) -> String {
-    let icon = match permission_mode {
-        "danger-full-access" => "⏵⏵",
-        "workspace-write" => "⏵",
-        _ => "▷",
-    };
-    let label = match permission_mode {
-        "danger-full-access" => "full access",
-        "workspace-write" => "workspace write",
-        "read-only" => "read only",
-        other => other,
-    };
-    format!("\x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m")
-}
-
 /// Shared spinner reference for streaming and tool execution layers.
 /// Clone is cheap — `ProgressBar` is internally `Arc`-wrapped.
 #[derive(Clone)]
@@ -229,12 +155,13 @@ impl SpinnerRef {
         result
     }
 
-    /// Pause the spinner. The updater thread stops ticking while paused.
-    /// When registered with MultiProgress, bar clearing is handled
-    /// automatically; the manual `\r\x1b[2K` is no longer needed.
+    /// Pause the spinner and clear its line. The updater thread stops
+    /// ticking while paused.
     pub fn pause(&self) {
         self.is_paused.store(true, Ordering::SeqCst);
         std::thread::sleep(std::time::Duration::from_millis(10));
+        let _ = write!(io::stdout(), "\r\x1b[2K");
+        let _ = io::stdout().flush();
     }
 
     /// Resume the spinner after a pause.
@@ -265,7 +192,6 @@ pub struct SpinnerHandle {
     start_time: Instant,
     stop: Arc<AtomicBool>,
     updater: Option<std::thread::JoinHandle<()>>,
-    output: Option<CliOutput>,
 }
 
 impl SpinnerHandle {
@@ -281,17 +207,9 @@ impl SpinnerHandle {
         model: Option<&str>,
         theme: &ColorTheme,
         token_budget: Option<u32>,
-        output: Option<&CliOutput>,
     ) -> Self {
-        let pb = if let Some(output) = output {
-            let bar = ProgressBar::new_spinner();
-            bar.set_style(ProgressStyle::with_template("{msg}").unwrap());
-            output.mp.insert_before(&output.footer, bar)
-        } else {
-            let bar = ProgressBar::with_draw_target(None, ProgressDrawTarget::stdout());
-            bar.set_style(ProgressStyle::with_template("{msg}").unwrap());
-            bar
-        };
+        let pb = ProgressBar::with_draw_target(None, ProgressDrawTarget::stdout());
+        pb.set_style(ProgressStyle::with_template("{msg}").unwrap());
 
         let response_bytes = Arc::new(AtomicU32::new(0));
         let is_thinking = Arc::new(AtomicBool::new(false));
@@ -303,7 +221,6 @@ impl SpinnerHandle {
             response_bytes,
             is_thinking,
             is_paused,
-            output: output.cloned(),
             token_budget,
             label: label.to_string(),
             model: model.map(ToString::to_string),
@@ -442,23 +359,13 @@ impl SpinnerHandle {
     pub fn finish(&mut self, label: &str) {
         self.stop_updater();
         self.pb.finish_and_clear();
-        let msg = format!("\x1b[32m✔ {label}\x1b[0m");
-        if let Some(ref output) = self.output {
-            output.println(&msg);
-        } else {
-            println!("{msg}");
-        }
+        println!("\x1b[32m✔ {label}\x1b[0m");
     }
 
     pub fn fail(&mut self, label: &str) {
         self.stop_updater();
         self.pb.finish_and_clear();
-        let msg = format!("\x1b[31m✘ {label}\x1b[0m");
-        if let Some(ref output) = self.output {
-            output.println(&msg);
-        } else {
-            println!("{msg}");
-        }
+        println!("\x1b[31m✘ {label}\x1b[0m");
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -144,6 +144,9 @@ pub struct SpinnerRef {
     response_bytes: Arc<AtomicU32>,
     is_thinking: Arc<AtomicBool>,
     is_paused: Arc<AtomicBool>,
+    /// When true, a TurnRenderer manages the spinner display — pause/resume
+    /// only set the atomic flag without writing to stdout.
+    managed: bool,
 }
 
 impl SpinnerRef {
@@ -160,6 +163,7 @@ impl SpinnerRef {
             response_bytes: Arc::clone(response_bytes),
             is_thinking: Arc::clone(is_thinking),
             is_paused: Arc::clone(is_paused),
+            managed: true,
         }
     }
 
@@ -172,9 +176,15 @@ impl SpinnerRef {
     }
 
     /// Pause the spinner and clear its line. The updater thread stops
-    /// ticking while paused.
+    /// ticking while paused. When managed by a TurnRenderer, only the
+    /// atomic flag is set — the render thread handles clearing.
     pub fn pause(&self) {
         self.is_paused.store(true, Ordering::SeqCst);
+        if self.managed {
+            // TurnRenderer sees is_paused and clears the spinner line
+            // on its next tick (≤80ms). No direct stdout write needed.
+            return;
+        }
         std::thread::sleep(std::time::Duration::from_millis(10));
         let _ = write!(io::stdout(), "\r\x1b[2K");
         let _ = io::stdout().flush();
@@ -257,6 +267,7 @@ impl SpinnerHandle {
             response_bytes: Arc::clone(&self.response_bytes),
             is_thinking: Arc::clone(&self.is_thinking),
             is_paused: Arc::clone(&self.is_paused),
+            managed: false,
         }
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_async.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_async.rs
@@ -70,6 +70,7 @@
 //! The [`sudocode plan doc`](https://github.com/sudoprivacy/sudocode/blob/main/notes/plans/conversation-interrupt-queue-sudocode.md)
 //! §落地节奏 covers the full sequence; this file is Phase-2 commit 1.
 
+use std::io::Write;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc::{sync_channel, RecvTimeoutError, SyncSender};
 use std::sync::{Arc, Mutex};
@@ -77,8 +78,8 @@ use std::thread;
 use std::time::Duration;
 
 use crate::input::{EscAbortHook, LineEditor, ReadOutcome};
+use crate::input_chrome;
 use crate::input_queue::{QueueMode, SubmitOutcome, TurnInputCoordinator};
-use crate::render::CliOutput;
 
 /// Shared queue mode that can be toggled at runtime via `/config set`.
 pub type SharedQueueMode = Arc<AtomicU8>;
@@ -188,10 +189,10 @@ fn is_exit_command(text: &str) -> bool {
 pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     driver: Arc<D>,
     mode: SharedQueueMode,
-    output: CliOutput,
     startup_banner: String,
     initial_completions: Vec<(String, String)>,
     esc_abort_hook: Option<EscAbortHook>,
+    permission_mode: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let coord = Arc::new(Mutex::new(TurnInputCoordinator::new()));
     let (input_tx, input_rx) = sync_channel::<InputEvent>(16);
@@ -201,7 +202,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     // the input thread doesn't wait (user can type during streaming).
     let (prompt_ready_tx, prompt_ready_rx) = sync_channel::<()>(1);
 
-    output.println(startup_banner);
+    println!("{startup_banner}");
     // Signal the input thread: startup output is done, show ❯.
     let _ = prompt_ready_tx.send(());
 
@@ -214,7 +215,7 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
     // because rustyline already owns stdin.
     let input_tx_clone = input_tx.clone();
     let dequeue_hook = make_up_arrow_hook(Arc::clone(&coord));
-    let input_output = output.clone();
+    let perm_mode = permission_mode.to_string();
     thread::Builder::new()
         .name("repl-input".into())
         .spawn(move || {
@@ -228,18 +229,14 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                 return;
             }
             loop {
-                let read_result = input_output.suspend(|| editor.read_line());
-                match read_result {
+                input_chrome::print_before_prompt(&perm_mode);
+                match editor.read_line() {
                     Ok(ReadOutcome::Submit(text)) => {
-                        // Echo the submitted input above the sticky bars.
-                        let trimmed = text.trim();
-                        if !trimmed.is_empty() {
-                            let w = crossterm::terminal::size()
-                                .map(|(cols, _)| cols as usize)
-                                .unwrap_or(80);
-                            let (echo, _) = crate::cli::format::format_input_echo(trimmed, w);
-                            input_output.println(echo);
-                        }
+                        // Clear the pre-printed bottom sep + footer.
+                        // After readline, cursor is at the start of the
+                        // bottom sep line. \x1b[J clears to end of screen.
+                        print!("\x1b[J");
+                        let _ = std::io::stdout().flush();
                         if input_tx_clone.send(InputEvent::Submit(text)).is_err() {
                             break;
                         }
@@ -290,7 +287,6 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                     // flushed cleanly.
                     let _ = h.join();
                 }
-                output.finish();
                 driver.on_exit();
                 break;
             }
@@ -306,7 +302,6 @@ pub fn run_coordinator_loop<D: TurnDriver + 'static>(
                     if let Some(h) = runner_handle.take() {
                         let _ = h.join();
                     }
-                    output.finish();
                     driver.on_exit();
                     break;
                 }

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -161,102 +161,15 @@ fn format_compact_tokens(tokens: u32) -> String {
     }
 }
 
-// ── Chrome rendering ───────────────────────────────────────────────────
-
-/// Number of chrome lines: spinner, top sep, prompt placeholder, bottom
-/// sep, footer.
-const CHROME_LINES: usize = 5;
-
-fn term_width() -> usize {
-    crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize)
-}
-
-fn format_separator() -> String {
-    let w = term_width();
-    format!("\x1b[2m{}\x1b[0m", "─".repeat(w))
-}
-
-fn format_footer(permission_mode: &str) -> String {
-    let icon = match permission_mode {
-        "danger-full-access" => "⏵⏵",
-        "workspace-write" => "⏵",
-        _ => "▷",
-    };
-    let label = match permission_mode {
-        "danger-full-access" => "full access",
-        "workspace-write" => "workspace write",
-        "read-only" => "read only",
-        other => other,
-    };
-    format!("  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m")
-}
-
-/// Draw the initial chrome block (5 lines) at the current cursor position.
-fn draw_chrome_initial(spinner_text: &str, permission_mode: &str) {
-    let sep = format_separator();
-    let footer = format_footer(permission_mode);
-    let mut stdout = io::stdout();
-    let _ = writeln!(stdout, "{spinner_text}");
-    let _ = writeln!(stdout, "{sep}");
-    let _ = writeln!(stdout); // prompt placeholder
-    let _ = writeln!(stdout, "{sep}");
-    let _ = write!(stdout, "{footer}");
-    let _ = stdout.flush();
-}
-
-/// Redraw the chrome in place. The cursor must be at the start of the
-/// spinner line (first of CHROME_LINES). Clears each line before writing.
-fn redraw_chrome(spinner_text: &str, permission_mode: &str) {
-    let sep = format_separator();
-    let footer = format_footer(permission_mode);
-    let mut stdout = io::stdout();
-    // Line 1: spinner
-    let _ = write!(stdout, "\x1b[2K{spinner_text}\n");
-    // Line 2: top sep
-    let _ = write!(stdout, "\x1b[2K{sep}\n");
-    // Line 3: prompt placeholder (empty)
-    let _ = write!(stdout, "\x1b[2K\n");
-    // Line 4: bottom sep
-    let _ = write!(stdout, "\x1b[2K{sep}\n");
-    // Line 5: footer (no trailing newline — cursor stays at end)
-    let _ = write!(stdout, "\x1b[2K{footer}");
-    // Move cursor back up to start of spinner line for next redraw.
-    let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
-    let _ = stdout.flush();
-}
-
-/// Clear the chrome region. Cursor must be at the spinner line start.
-fn clear_chrome() {
-    let mut stdout = io::stdout();
-    for _ in 0..CHROME_LINES {
-        let _ = write!(stdout, "\x1b[2K\n");
-    }
-    // Move back up to where spinner was.
-    let _ = write!(stdout, "\x1b[{}F", CHROME_LINES);
-    let _ = stdout.flush();
-}
-
 // ── Render thread ──────────────────────────────────────────────────────
 
-/// The render loop running on the `repl-render` thread.
-/// Polls the output channel and redraws the chrome at 80ms intervals.
-fn render_loop(
-    output_rx: Receiver<OutputMsg>,
-    spinner: SpinnerState,
-    permission_mode: &str,
-    stop: Arc<AtomicBool>,
-) {
-    let mut stdout = io::stdout();
+/// The render loop: drains the output channel and prints to stdout.
+/// The spinner is a single-line overwrite (`\r\x1b[2K` + text) — same
+/// approach as indicatif's `ProgressBar`, keeping stdout writes minimal
+/// to avoid filling the PTY buffer during long streaming responses.
+fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<AtomicBool>) {
     let mut frame_index: usize = 0;
-    let mut chrome_visible = false;
-
-    // Draw initial chrome.
-    let initial_spinner = spinner.render_frame(frame_index);
-    draw_chrome_initial(&initial_spinner, permission_mode);
-    let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
-    let _ = stdout.flush();
-    chrome_visible = true;
-    frame_index += 1;
+    let mut spinner_visible = false;
 
     loop {
         if stop.load(Ordering::SeqCst) {
@@ -268,60 +181,63 @@ fn render_loop(
         loop {
             match output_rx.try_recv() {
                 Ok(msg) => {
-                    if !had_output && chrome_visible {
-                        clear_chrome();
-                        chrome_visible = false;
-                        had_output = true;
+                    if !had_output && spinner_visible {
+                        // Clear the spinner line before printing output.
+                        let _ = write!(io::stdout(), "\r\x1b[2K");
+                        spinner_visible = false;
                     }
                     match msg {
                         OutputMsg::Print(text) => {
-                            let _ = write!(stdout, "{text}");
+                            let _ = write!(io::stdout(), "{text}");
                         }
                         OutputMsg::Println(text) => {
-                            let _ = writeln!(stdout, "{text}");
+                            let _ = writeln!(io::stdout(), "{text}");
                         }
                     }
                     had_output = true;
                 }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
-                    if had_output {
-                        let _ = stdout.flush();
+                    if spinner_visible {
+                        let _ = write!(io::stdout(), "\r\x1b[2K");
                     }
-                    if chrome_visible {
-                        clear_chrome();
-                    }
+                    let _ = io::stdout().flush();
                     return;
                 }
             }
         }
 
-        // Check stop again after draining — avoids one extra 80ms sleep.
         if stop.load(Ordering::SeqCst) {
-            if had_output {
-                let _ = stdout.flush();
-            }
             break;
         }
 
         if had_output {
-            let _ = stdout.flush();
-            let spinner_text = spinner.render_frame(frame_index);
-            draw_chrome_initial(&spinner_text, permission_mode);
-            let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
-            let _ = stdout.flush();
-            chrome_visible = true;
-        } else {
-            let spinner_text = spinner.render_frame(frame_index);
-            redraw_chrome(&spinner_text, permission_mode);
+            let _ = io::stdout().flush();
+        }
+
+        // Update spinner — single line overwrite. When paused
+        // (e.g. during permission prompts or tool output), clear the
+        // spinner line and don't redraw so external code can write to
+        // stdout without interference.
+        let spinner_text = spinner.render_frame(frame_index);
+        if !spinner_text.is_empty() {
+            let _ = write!(io::stdout(), "\r\x1b[2K{spinner_text}");
+            let _ = io::stdout().flush();
+            spinner_visible = true;
+        } else if spinner_visible {
+            // Spinner just became paused — clear its line.
+            let _ = write!(io::stdout(), "\r\x1b[2K");
+            let _ = io::stdout().flush();
+            spinner_visible = false;
         }
 
         frame_index = frame_index.wrapping_add(1);
         std::thread::sleep(Duration::from_millis(80));
     }
 
-    if chrome_visible {
-        clear_chrome();
+    if spinner_visible {
+        let _ = write!(io::stdout(), "\r\x1b[2K");
+        let _ = io::stdout().flush();
     }
 }
 
@@ -339,24 +255,18 @@ pub struct TurnRenderer {
 impl TurnRenderer {
     /// Start a new render thread for a turn.
     #[must_use]
-    pub fn new(
-        label: &str,
-        model: Option<&str>,
-        token_budget: Option<u32>,
-        permission_mode: &str,
-    ) -> Self {
+    pub fn new(label: &str, model: Option<&str>, token_budget: Option<u32>) -> Self {
         let (output_tx, output_rx) = mpsc::sync_channel::<OutputMsg>(256);
         let stop = Arc::new(AtomicBool::new(false));
 
         let spinner = SpinnerState::new(label, model, token_budget);
         let spinner_clone = spinner.clone();
-        let perm = permission_mode.to_string();
         let stop_clone = Arc::clone(&stop);
 
         let join_handle = std::thread::Builder::new()
             .name("repl-render".into())
             .spawn(move || {
-                render_loop(output_rx, spinner_clone, &perm, stop_clone);
+                render_loop(output_rx, spinner_clone, stop_clone);
             })
             .expect("spawn repl-render thread");
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -161,53 +161,12 @@ fn format_compact_tokens(tokens: u32) -> String {
     }
 }
 
-// ── Non-blocking stdout ────────────────────────────────────────────────
-
-/// Set stdout to non-blocking mode on Unix. Returns `true` on success.
-/// When non-blocking, `write()` returns `WouldBlock` instead of blocking
-/// when the PTY buffer is full — the render thread drops the data and
-/// retries on the next tick rather than stalling.
-#[cfg(unix)]
-fn set_stdout_nonblocking(nonblock: bool) -> bool {
-    use nix::fcntl::{fcntl, FcntlArg, OFlag};
-    use std::os::unix::io::AsRawFd;
-    let fd = io::stdout().as_raw_fd();
-    let Ok(flags) = fcntl(fd, FcntlArg::F_GETFL) else {
-        return false;
-    };
-    let Some(mut oflags) = OFlag::from_bits(flags) else {
-        return false;
-    };
-    oflags.set(OFlag::O_NONBLOCK, nonblock);
-    fcntl(fd, FcntlArg::F_SETFL(oflags)).is_ok()
-}
-
-#[cfg(not(unix))]
-fn set_stdout_nonblocking(_nonblock: bool) -> bool {
-    false
-}
-
-/// Write spinner/cosmetic data to stdout, silently dropping if the fd
-/// is non-blocking and the buffer is full (`WouldBlock`). Used only for
-/// spinner frame updates — user-visible text uses `write_blocking`.
-fn write_nonblocking(data: &[u8]) {
-    let mut stdout = io::stdout().lock();
-    match stdout.write_all(data) {
-        Ok(()) => {}
-        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
-        Err(_) => {}
-    }
-    let _ = stdout.flush();
-}
-
-/// Write user-visible text to stdout. Temporarily switches back to
-/// blocking mode so no content is lost.
-fn write_blocking(data: &[u8]) {
-    set_stdout_nonblocking(false);
+/// Write to stdout from the render thread. Errors are silently ignored
+/// (the spinner is cosmetic — losing a frame is harmless).
+fn write_render(data: &[u8]) {
     let mut stdout = io::stdout().lock();
     let _ = stdout.write_all(data);
     let _ = stdout.flush();
-    set_stdout_nonblocking(true);
 }
 
 // ── Render thread ──────────────────────────────────────────────────────
@@ -216,12 +175,7 @@ fn write_blocking(data: &[u8]) {
 /// The spinner is a single-line overwrite (`\r\x1b[2K` + text) — same
 /// approach as indicatif's `ProgressBar`, keeping stdout writes minimal
 /// to avoid filling the PTY buffer during long streaming responses.
-///
-/// stdout is set to non-blocking mode on entry and restored on exit so
-/// writes never block the thread (preventing process hang on PTY buffer
-/// pressure).
 fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<AtomicBool>) {
-    let was_nonblocking = set_stdout_nonblocking(true);
     let mut frame_index: usize = 0;
     let mut spinner_visible = false;
 
@@ -236,17 +190,17 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
             match output_rx.try_recv() {
                 Ok(msg) => {
                     if !had_output && spinner_visible {
-                        write_nonblocking(b"\r\x1b[2K");
+                        write_render(b"\r\x1b[2K");
                         spinner_visible = false;
                     }
                     match msg {
                         OutputMsg::Print(text) => {
-                            write_blocking(text.as_bytes());
+                            write_render(text.as_bytes());
                         }
                         OutputMsg::Println(text) => {
                             let mut buf = text.into_bytes();
                             buf.push(b'\n');
-                            write_blocking(&buf);
+                            write_render(&buf);
                         }
                     }
                     had_output = true;
@@ -254,10 +208,7 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
                     if spinner_visible {
-                        write_nonblocking(b"\r\x1b[2K");
-                    }
-                    if was_nonblocking {
-                        set_stdout_nonblocking(false);
+                        write_render(b"\r\x1b[2K");
                     }
                     return;
                 }
@@ -274,10 +225,10 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
         // stdout without interference.
         let spinner_text = spinner.render_frame(frame_index);
         if !spinner_text.is_empty() {
-            write_nonblocking(format!("\r\x1b[2K{spinner_text}").as_bytes());
+            write_render(format!("\r\x1b[2K{spinner_text}").as_bytes());
             spinner_visible = true;
         } else if spinner_visible {
-            write_nonblocking(b"\r\x1b[2K");
+            write_render(b"\r\x1b[2K");
             spinner_visible = false;
         }
 
@@ -286,10 +237,7 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
     }
 
     if spinner_visible {
-        write_nonblocking(b"\r\x1b[2K");
-    }
-    if was_nonblocking {
-        set_stdout_nonblocking(false);
+        write_render(b"\r\x1b[2K");
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -1,38 +1,38 @@
 //! iocraft-based terminal UI for the REPL.
 //!
-//! During a turn, `TurnRenderer` starts an iocraft render loop on a
-//! dedicated thread. The render loop manages:
-//! - **SpinnerLine**: animated spinner with model/timing/token info
-//! - **Chrome**: separator lines + permission mode footer
+//! During a turn, `TurnRenderer` manages a dedicated render thread that:
+//! - Drains `TurnOutput` messages (text from the runner thread) and prints
+//!   them above a fixed-position bottom chrome region.
+//! - Redraws the bottom chrome (spinner + separators + permission footer)
+//!   at 80ms intervals using cursor manipulation.
 //!
-//! All terminal output during a turn flows through `TurnOutput` (a
-//! channel-backed `Write` impl) → iocraft `UseOutput::println()`, which
-//! inserts text above the fixed chrome region. This eliminates the
-//! cursor-management conflicts between raw ANSI writes and managed UI.
+//! The chrome is positioned using cursor-save/restore and line-clear
+//! sequences. Scrollback text is written ABOVE the chrome: the render
+//! thread moves the cursor up, inserts lines, then restores the chrome.
+//!
+//! This approach avoids iocraft's `render_loop()` (which enters raw mode
+//! and blocks on stdin events). Instead, it uses iocraft's `element!().print()`
+//! for one-shot rendering of the chrome layout at construction time, and
+//! manages cursor state manually on the timer loop.
 
 use std::fmt::Write as FmtWrite;
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::mpsc::{self, SyncSender, TryRecvError};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use iocraft::prelude::*;
-
 // ── TurnOutput ─────────────────────────────────────────────────────────
 
-/// Messages from the runner thread to the iocraft render loop.
+/// Messages from the runner thread to the render thread.
 enum OutputMsg {
-    /// Write text without trailing newline.
     Print(String),
-    /// Write text with trailing newline.
     Println(String),
 }
 
-/// Channel-backed output handle for routing terminal output through
-/// iocraft's `UseOutput` during a turn. Clone is cheap (SyncSender is
-/// Arc-wrapped internally). Implements `Write` so it can be used as a
-/// drop-in replacement for `io::stdout()`.
+/// Channel-backed output handle for routing terminal output through the
+/// render thread during a turn. Clone is cheap. Implements `Write` so it
+/// can be used as a drop-in replacement for `io::stdout()`.
 #[derive(Clone)]
 pub struct TurnOutput {
     tx: SyncSender<OutputMsg>,
@@ -62,9 +62,9 @@ impl Write for TurnOutput {
 
 // ── SpinnerState ───────────────────────────────────────────────────────
 
-/// Shared state for the spinner, read by the iocraft component and
-/// written by the runner thread. All fields are atomic for lock-free
-/// cross-thread access.
+/// Shared state for the spinner, read by the render thread and written
+/// by the runner thread. All fields are atomic for lock-free cross-thread
+/// access.
 #[derive(Clone)]
 pub struct SpinnerState {
     pub response_bytes: Arc<AtomicU32>,
@@ -90,10 +90,9 @@ impl SpinnerState {
         }
     }
 
-    /// Render the current spinner frame as a styled string.
+    /// Render the current spinner frame as a colored ANSI string.
     fn render_frame(&self, frame_index: usize) -> String {
-        let paused = self.is_paused.load(Ordering::SeqCst);
-        if paused {
+        if self.is_paused.load(Ordering::SeqCst) {
             return String::new();
         }
 
@@ -145,7 +144,10 @@ impl SpinnerState {
             }
         }
 
-        line
+        // Stall detection: yellow when no new bytes for 3+ seconds.
+        let is_stalled = bytes > 0 && !thinking && elapsed > 3.0;
+        let color_code = if is_stalled { "33" } else { "34" };
+        format!("\x1b[{color_code}m{line}\x1b[0m")
     }
 }
 
@@ -159,126 +161,170 @@ fn format_compact_tokens(tokens: u32) -> String {
     }
 }
 
-// ── Render context ─────────────────────────────────────────────────────
+// ── Chrome rendering ───────────────────────────────────────────────────
 
-/// Context provided to the iocraft component tree via `ContextProvider`.
-struct RenderContext {
-    output_rx: Arc<std::sync::Mutex<mpsc::Receiver<OutputMsg>>>,
-    spinner: SpinnerState,
-    permission_mode: String,
+/// Number of chrome lines: spinner, top sep, prompt placeholder, bottom
+/// sep, footer.
+const CHROME_LINES: usize = 5;
+
+fn term_width() -> usize {
+    crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize)
 }
 
-// ── iocraft components ─────────────────────────────────────────────────
+fn format_separator() -> String {
+    let w = term_width();
+    format!("\x1b[2m{}\x1b[0m", "─".repeat(w))
+}
 
-#[component]
-fn TurnChrome(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
-    let ctx = hooks.use_context::<RenderContext>();
-    let spinner = ctx.spinner.clone();
-    let permission_mode = ctx.permission_mode.clone();
-    let output_rx_mutex = &ctx.output_rx;
-
-    let (stdout, _stderr) = hooks.use_output();
-    let mut system = hooks.use_context_mut::<SystemContext>();
-    let mut frame_index = hooks.use_state(|| 0usize);
-    let mut spinner_text = hooks.use_state(String::new);
-    let mut should_exit = hooks.use_state(|| false);
-
-    // Drain the output channel and print above the chrome.
-    // Also update spinner frame.
-    {
-        let spinner_clone = spinner.clone();
-        let output_rx = Arc::clone(output_rx_mutex);
-        hooks.use_future(async move {
-            loop {
-                // Drain all pending output messages.
-                if let Ok(rx) = output_rx.lock() {
-                    loop {
-                        match rx.try_recv() {
-                            Ok(OutputMsg::Print(text)) => stdout.print(&text),
-                            Ok(OutputMsg::Println(text)) => stdout.println(&text),
-                            Err(TryRecvError::Empty) => break,
-                            Err(TryRecvError::Disconnected) => {
-                                should_exit.set(true);
-                                return;
-                            }
-                        }
-                    }
-                }
-
-                // Update spinner.
-                let idx = frame_index.get();
-                let text = spinner_clone.render_frame(idx);
-                spinner_text.set(text);
-                frame_index.set(idx.wrapping_add(1));
-
-                // 80ms tick — matches the original spinner update interval.
-                smol::Timer::after(Duration::from_millis(80)).await;
-            }
-        });
-    }
-
-    if *should_exit.read() {
-        system.exit();
-    }
-
-    let w = crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize);
-    let sep = format!("\x1b[2m{}\x1b[0m", "─".repeat(w));
-
-    let icon = match permission_mode.as_str() {
+fn format_footer(permission_mode: &str) -> String {
+    let icon = match permission_mode {
         "danger-full-access" => "⏵⏵",
         "workspace-write" => "⏵",
         _ => "▷",
     };
-    let label = match permission_mode.as_str() {
+    let label = match permission_mode {
         "danger-full-access" => "full access",
         "workspace-write" => "workspace write",
         "read-only" => "read only",
         other => other,
     };
-    let footer = format!(
-        "  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m"
-    );
+    format!("  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m")
+}
 
-    let spinner_content = spinner_text.read().clone();
-    let spinner_color = if spinner_content.is_empty() {
-        ""
-    } else {
-        "\x1b[34m"
-    };
-    let colored_spinner = if spinner_content.is_empty() {
-        String::new()
-    } else {
-        format!("{spinner_color}{spinner_content}\x1b[0m")
-    };
+/// Draw the initial chrome block (5 lines) at the current cursor position.
+fn draw_chrome_initial(spinner_text: &str, permission_mode: &str) {
+    let sep = format_separator();
+    let footer = format_footer(permission_mode);
+    let mut stdout = io::stdout();
+    let _ = writeln!(stdout, "{spinner_text}");
+    let _ = writeln!(stdout, "{sep}");
+    let _ = writeln!(stdout); // prompt placeholder
+    let _ = writeln!(stdout, "{sep}");
+    let _ = write!(stdout, "{footer}");
+    let _ = stdout.flush();
+}
 
-    element! {
-        View(flex_direction: FlexDirection::Column) {
-            #(if !colored_spinner.is_empty() {
-                Some(element! { Text(content: colored_spinner) })
-            } else {
-                None
-            })
-            Text(content: sep.clone())
-            Text(content: "")
-            Text(content: sep)
-            Text(content: footer)
-        }
+/// Redraw the chrome in place. The cursor must be at the start of the
+/// spinner line (first of CHROME_LINES). Clears each line before writing.
+fn redraw_chrome(spinner_text: &str, permission_mode: &str) {
+    let sep = format_separator();
+    let footer = format_footer(permission_mode);
+    let mut stdout = io::stdout();
+    // Line 1: spinner
+    let _ = write!(stdout, "\x1b[2K{spinner_text}\n");
+    // Line 2: top sep
+    let _ = write!(stdout, "\x1b[2K{sep}\n");
+    // Line 3: prompt placeholder (empty)
+    let _ = write!(stdout, "\x1b[2K\n");
+    // Line 4: bottom sep
+    let _ = write!(stdout, "\x1b[2K{sep}\n");
+    // Line 5: footer (no trailing newline — cursor stays at end)
+    let _ = write!(stdout, "\x1b[2K{footer}");
+    // Move cursor back up to start of spinner line for next redraw.
+    let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
+    let _ = stdout.flush();
+}
+
+/// Clear the chrome region. Cursor must be at the spinner line start.
+fn clear_chrome() {
+    let mut stdout = io::stdout();
+    for _ in 0..CHROME_LINES {
+        let _ = write!(stdout, "\x1b[2K\n");
     }
+    // Move back up to where spinner was.
+    let _ = write!(stdout, "\x1b[{}F", CHROME_LINES);
+    let _ = stdout.flush();
+}
+
+// ── Render thread ──────────────────────────────────────────────────────
+
+/// The render loop running on the `repl-render` thread.
+/// Polls the output channel and redraws the chrome at 80ms intervals.
+fn render_loop(
+    output_rx: Receiver<OutputMsg>,
+    spinner: SpinnerState,
+    permission_mode: &str,
+    stop: Arc<AtomicBool>,
+) {
+    let mut stdout = io::stdout();
+    let mut frame_index: usize = 0;
+
+    // Draw initial chrome.
+    let initial_spinner = spinner.render_frame(frame_index);
+    draw_chrome_initial(&initial_spinner, permission_mode);
+    // Position cursor at the start of the spinner line.
+    let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
+    let _ = stdout.flush();
+    frame_index += 1;
+
+    loop {
+        if stop.load(Ordering::SeqCst) {
+            break;
+        }
+
+        // Drain pending output messages.
+        let mut had_output = false;
+        loop {
+            match output_rx.try_recv() {
+                Ok(msg) => {
+                    if !had_output {
+                        // Clear chrome before printing output above it.
+                        clear_chrome();
+                        had_output = true;
+                    }
+                    match msg {
+                        OutputMsg::Print(text) => {
+                            let _ = write!(stdout, "{text}");
+                        }
+                        OutputMsg::Println(text) => {
+                            let _ = writeln!(stdout, "{text}");
+                        }
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    if had_output {
+                        let _ = stdout.flush();
+                    }
+                    return; // Channel closed — turn is ending.
+                }
+            }
+        }
+
+        if had_output {
+            let _ = stdout.flush();
+            // Redraw chrome below the new output.
+            let spinner_text = spinner.render_frame(frame_index);
+            draw_chrome_initial(&spinner_text, permission_mode);
+            let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
+            let _ = stdout.flush();
+        } else {
+            // No output — just update the spinner in place.
+            let spinner_text = spinner.render_frame(frame_index);
+            redraw_chrome(&spinner_text, permission_mode);
+        }
+
+        frame_index = frame_index.wrapping_add(1);
+        std::thread::sleep(Duration::from_millis(80));
+    }
+
+    // Clear chrome on exit.
+    clear_chrome();
 }
 
 // ── TurnRenderer ───────────────────────────────────────────────────────
 
-/// Manages an iocraft render loop on a dedicated thread during a turn.
-/// Created at the start of `run_turn()`, stopped at the end.
+/// Manages a render thread during a turn. Created at the start of
+/// `run_turn()`, stopped at the end.
 pub struct TurnRenderer {
     output: Option<TurnOutput>,
     spinner: SpinnerState,
-    stop_tx: Option<SyncSender<()>>,
+    stop: Arc<AtomicBool>,
     join_handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl TurnRenderer {
-    /// Start a new render loop for a turn.
+    /// Start a new render thread for a turn.
     #[must_use]
     pub fn new(
         label: &str,
@@ -287,47 +333,29 @@ impl TurnRenderer {
         permission_mode: &str,
     ) -> Self {
         let (output_tx, output_rx) = mpsc::sync_channel::<OutputMsg>(256);
-        let (stop_tx, stop_rx) = mpsc::sync_channel::<()>(1);
+        let stop = Arc::new(AtomicBool::new(false));
 
         let spinner = SpinnerState::new(label, model, token_budget);
         let spinner_clone = spinner.clone();
         let perm = permission_mode.to_string();
+        let stop_clone = Arc::clone(&stop);
 
         let join_handle = std::thread::Builder::new()
             .name("repl-render".into())
             .spawn(move || {
-                let ctx = RenderContext {
-                    output_rx: Arc::new(std::sync::Mutex::new(output_rx)),
-                    spinner: spinner_clone,
-                    permission_mode: perm,
-                };
-
-                // Drive the render loop with smol's executor which
-                // includes the async-io reactor for Timer support.
-                smol::block_on(async {
-                    let _ = element! {
-                        ContextProvider(value: Context::owned(ctx)) {
-                            TurnChrome
-                        }
-                    }
-                    .render_loop()
-                    .await;
-                });
-
-                // Consume the stop signal if it arrived (non-blocking).
-                let _ = stop_rx.try_recv();
+                render_loop(output_rx, spinner_clone, &perm, stop_clone);
             })
             .expect("spawn repl-render thread");
 
         Self {
             output: Some(TurnOutput { tx: output_tx }),
             spinner,
-            stop_tx: Some(stop_tx),
+            stop,
             join_handle: Some(join_handle),
         }
     }
 
-    /// Get a cloneable output handle for sending text to the render loop.
+    /// Get a cloneable output handle for sending text to the render thread.
     pub fn output(&self) -> Option<TurnOutput> {
         self.output.clone()
     }
@@ -339,23 +367,21 @@ impl TurnRenderer {
     }
 
     fn stop_render(&mut self) {
-        // Drop the output sender so the render loop sees Disconnected.
+        self.stop.store(true, Ordering::SeqCst);
+        // Drop the output sender so the render thread sees Disconnected.
         self.output.take();
-        if let Some(tx) = self.stop_tx.take() {
-            let _ = tx.send(());
-        }
         if let Some(h) = self.join_handle.take() {
             let _ = h.join();
         }
     }
 
-    /// Signal the render loop to stop and print a success message.
+    /// Signal the render thread to stop and print a success message.
     pub fn finish(&mut self, label: &str) {
         self.stop_render();
         println!("\x1b[32m✔ {label}\x1b[0m");
     }
 
-    /// Signal the render loop to stop and print a failure message.
+    /// Signal the render thread to stop and print a failure message.
     pub fn fail(&mut self, label: &str) {
         self.stop_render();
         println!("\x1b[31m✘ {label}\x1b[0m");

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -248,13 +248,14 @@ fn render_loop(
 ) {
     let mut stdout = io::stdout();
     let mut frame_index: usize = 0;
+    let mut chrome_visible = false;
 
     // Draw initial chrome.
     let initial_spinner = spinner.render_frame(frame_index);
     draw_chrome_initial(&initial_spinner, permission_mode);
-    // Position cursor at the start of the spinner line.
     let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
     let _ = stdout.flush();
+    chrome_visible = true;
     frame_index += 1;
 
     loop {
@@ -267,9 +268,9 @@ fn render_loop(
         loop {
             match output_rx.try_recv() {
                 Ok(msg) => {
-                    if !had_output {
-                        // Clear chrome before printing output above it.
+                    if !had_output && chrome_visible {
                         clear_chrome();
+                        chrome_visible = false;
                         had_output = true;
                     }
                     match msg {
@@ -280,26 +281,37 @@ fn render_loop(
                             let _ = writeln!(stdout, "{text}");
                         }
                     }
+                    had_output = true;
                 }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
                     if had_output {
                         let _ = stdout.flush();
                     }
-                    return; // Channel closed — turn is ending.
+                    if chrome_visible {
+                        clear_chrome();
+                    }
+                    return;
                 }
             }
         }
 
+        // Check stop again after draining — avoids one extra 80ms sleep.
+        if stop.load(Ordering::SeqCst) {
+            if had_output {
+                let _ = stdout.flush();
+            }
+            break;
+        }
+
         if had_output {
             let _ = stdout.flush();
-            // Redraw chrome below the new output.
             let spinner_text = spinner.render_frame(frame_index);
             draw_chrome_initial(&spinner_text, permission_mode);
             let _ = write!(stdout, "\x1b[{}F", CHROME_LINES - 1);
             let _ = stdout.flush();
+            chrome_visible = true;
         } else {
-            // No output — just update the spinner in place.
             let spinner_text = spinner.render_frame(frame_index);
             redraw_chrome(&spinner_text, permission_mode);
         }
@@ -308,8 +320,9 @@ fn render_loop(
         std::thread::sleep(Duration::from_millis(80));
     }
 
-    // Clear chrome on exit.
-    clear_chrome();
+    if chrome_visible {
+        clear_chrome();
+    }
 }
 
 // ── TurnRenderer ───────────────────────────────────────────────────────
@@ -371,7 +384,21 @@ impl TurnRenderer {
         // Drop the output sender so the render thread sees Disconnected.
         self.output.take();
         if let Some(h) = self.join_handle.take() {
-            let _ = h.join();
+            // The render thread checks `stop` each 80ms tick and should
+            // exit promptly. Use a timeout to avoid blocking forever if
+            // the thread is stuck on a stdout write (PTY buffer full).
+            let deadline = std::time::Instant::now() + Duration::from_millis(500);
+            while !h.is_finished() {
+                if std::time::Instant::now() >= deadline {
+                    // Render thread stuck — abandon it (it will be cleaned
+                    // up when the process exits).
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if h.is_finished() {
+                let _ = h.join();
+            }
         }
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -161,13 +161,67 @@ fn format_compact_tokens(tokens: u32) -> String {
     }
 }
 
+// ── Non-blocking stdout ────────────────────────────────────────────────
+
+/// Set stdout to non-blocking mode on Unix. Returns `true` on success.
+/// When non-blocking, `write()` returns `WouldBlock` instead of blocking
+/// when the PTY buffer is full — the render thread drops the data and
+/// retries on the next tick rather than stalling.
+#[cfg(unix)]
+fn set_stdout_nonblocking(nonblock: bool) -> bool {
+    use nix::fcntl::{fcntl, FcntlArg, OFlag};
+    use std::os::unix::io::AsRawFd;
+    let fd = io::stdout().as_raw_fd();
+    let Ok(flags) = fcntl(fd, FcntlArg::F_GETFL) else {
+        return false;
+    };
+    let Some(mut oflags) = OFlag::from_bits(flags) else {
+        return false;
+    };
+    oflags.set(OFlag::O_NONBLOCK, nonblock);
+    fcntl(fd, FcntlArg::F_SETFL(oflags)).is_ok()
+}
+
+#[cfg(not(unix))]
+fn set_stdout_nonblocking(_nonblock: bool) -> bool {
+    false
+}
+
+/// Write spinner/cosmetic data to stdout, silently dropping if the fd
+/// is non-blocking and the buffer is full (`WouldBlock`). Used only for
+/// spinner frame updates — user-visible text uses `write_blocking`.
+fn write_nonblocking(data: &[u8]) {
+    let mut stdout = io::stdout().lock();
+    match stdout.write_all(data) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+        Err(_) => {}
+    }
+    let _ = stdout.flush();
+}
+
+/// Write user-visible text to stdout. Temporarily switches back to
+/// blocking mode so no content is lost.
+fn write_blocking(data: &[u8]) {
+    set_stdout_nonblocking(false);
+    let mut stdout = io::stdout().lock();
+    let _ = stdout.write_all(data);
+    let _ = stdout.flush();
+    set_stdout_nonblocking(true);
+}
+
 // ── Render thread ──────────────────────────────────────────────────────
 
 /// The render loop: drains the output channel and prints to stdout.
 /// The spinner is a single-line overwrite (`\r\x1b[2K` + text) — same
 /// approach as indicatif's `ProgressBar`, keeping stdout writes minimal
 /// to avoid filling the PTY buffer during long streaming responses.
+///
+/// stdout is set to non-blocking mode on entry and restored on exit so
+/// writes never block the thread (preventing process hang on PTY buffer
+/// pressure).
 fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<AtomicBool>) {
+    let was_nonblocking = set_stdout_nonblocking(true);
     let mut frame_index: usize = 0;
     let mut spinner_visible = false;
 
@@ -182,16 +236,17 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
             match output_rx.try_recv() {
                 Ok(msg) => {
                     if !had_output && spinner_visible {
-                        // Clear the spinner line before printing output.
-                        let _ = write!(io::stdout(), "\r\x1b[2K");
+                        write_nonblocking(b"\r\x1b[2K");
                         spinner_visible = false;
                     }
                     match msg {
                         OutputMsg::Print(text) => {
-                            let _ = write!(io::stdout(), "{text}");
+                            write_blocking(text.as_bytes());
                         }
                         OutputMsg::Println(text) => {
-                            let _ = writeln!(io::stdout(), "{text}");
+                            let mut buf = text.into_bytes();
+                            buf.push(b'\n');
+                            write_blocking(&buf);
                         }
                     }
                     had_output = true;
@@ -199,9 +254,11 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
                     if spinner_visible {
-                        let _ = write!(io::stdout(), "\r\x1b[2K");
+                        write_nonblocking(b"\r\x1b[2K");
                     }
-                    let _ = io::stdout().flush();
+                    if was_nonblocking {
+                        set_stdout_nonblocking(false);
+                    }
                     return;
                 }
             }
@@ -211,23 +268,16 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
             break;
         }
 
-        if had_output {
-            let _ = io::stdout().flush();
-        }
-
         // Update spinner — single line overwrite. When paused
         // (e.g. during permission prompts or tool output), clear the
         // spinner line and don't redraw so external code can write to
         // stdout without interference.
         let spinner_text = spinner.render_frame(frame_index);
         if !spinner_text.is_empty() {
-            let _ = write!(io::stdout(), "\r\x1b[2K{spinner_text}");
-            let _ = io::stdout().flush();
+            write_nonblocking(format!("\r\x1b[2K{spinner_text}").as_bytes());
             spinner_visible = true;
         } else if spinner_visible {
-            // Spinner just became paused — clear its line.
-            let _ = write!(io::stdout(), "\r\x1b[2K");
-            let _ = io::stdout().flush();
+            write_nonblocking(b"\r\x1b[2K");
             spinner_visible = false;
         }
 
@@ -236,8 +286,10 @@ fn render_loop(output_rx: Receiver<OutputMsg>, spinner: SpinnerState, stop: Arc<
     }
 
     if spinner_visible {
-        let _ = write!(io::stdout(), "\r\x1b[2K");
-        let _ = io::stdout().flush();
+        write_nonblocking(b"\r\x1b[2K");
+    }
+    if was_nonblocking {
+        set_stdout_nonblocking(false);
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -212,7 +212,7 @@ fn TurnChrome(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 frame_index.set(idx.wrapping_add(1));
 
                 // 80ms tick — matches the original spinner update interval.
-                tokio::time::sleep(Duration::from_millis(80)).await;
+                smol::Timer::after(Duration::from_millis(80)).await;
             }
         });
     }
@@ -302,14 +302,9 @@ impl TurnRenderer {
                     permission_mode: perm,
                 };
 
-                // Build a minimal tokio runtime for the timer inside
-                // the component's use_future.
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_time()
-                    .build()
-                    .expect("tokio current-thread runtime for render loop");
-
-                rt.block_on(async {
+                // Drive the render loop with smol's executor which
+                // includes the async-io reactor for Timer support.
+                smol::block_on(async {
                     let _ = element! {
                         ContextProvider(value: Context::owned(ctx)) {
                             TurnChrome

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -1,0 +1,379 @@
+//! iocraft-based terminal UI for the REPL.
+//!
+//! During a turn, `TurnRenderer` starts an iocraft render loop on a
+//! dedicated thread. The render loop manages:
+//! - **SpinnerLine**: animated spinner with model/timing/token info
+//! - **Chrome**: separator lines + permission mode footer
+//!
+//! All terminal output during a turn flows through `TurnOutput` (a
+//! channel-backed `Write` impl) → iocraft `UseOutput::println()`, which
+//! inserts text above the fixed chrome region. This eliminates the
+//! cursor-management conflicts between raw ANSI writes and managed UI.
+
+use std::fmt::Write as FmtWrite;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::mpsc::{self, SyncSender, TryRecvError};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use iocraft::prelude::*;
+
+// ── TurnOutput ─────────────────────────────────────────────────────────
+
+/// Messages from the runner thread to the iocraft render loop.
+enum OutputMsg {
+    /// Write text without trailing newline.
+    Print(String),
+    /// Write text with trailing newline.
+    Println(String),
+}
+
+/// Channel-backed output handle for routing terminal output through
+/// iocraft's `UseOutput` during a turn. Clone is cheap (SyncSender is
+/// Arc-wrapped internally). Implements `Write` so it can be used as a
+/// drop-in replacement for `io::stdout()`.
+#[derive(Clone)]
+pub struct TurnOutput {
+    tx: SyncSender<OutputMsg>,
+}
+
+impl TurnOutput {
+    pub fn print(&self, text: &str) {
+        let _ = self.tx.send(OutputMsg::Print(text.to_string()));
+    }
+
+    pub fn println(&self, text: &str) {
+        let _ = self.tx.send(OutputMsg::Println(text.to_string()));
+    }
+}
+
+impl Write for TurnOutput {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let text = String::from_utf8_lossy(buf).to_string();
+        let _ = self.tx.send(OutputMsg::Print(text));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+// ── SpinnerState ───────────────────────────────────────────────────────
+
+/// Shared state for the spinner, read by the iocraft component and
+/// written by the runner thread. All fields are atomic for lock-free
+/// cross-thread access.
+#[derive(Clone)]
+pub struct SpinnerState {
+    pub response_bytes: Arc<AtomicU32>,
+    pub is_thinking: Arc<AtomicBool>,
+    pub is_paused: Arc<AtomicBool>,
+    start_time: Instant,
+    label: String,
+    model: Option<String>,
+    token_budget: Option<u32>,
+}
+
+impl SpinnerState {
+    #[must_use]
+    pub fn new(label: &str, model: Option<&str>, token_budget: Option<u32>) -> Self {
+        Self {
+            response_bytes: Arc::new(AtomicU32::new(0)),
+            is_thinking: Arc::new(AtomicBool::new(false)),
+            is_paused: Arc::new(AtomicBool::new(false)),
+            start_time: Instant::now(),
+            label: label.to_string(),
+            model: model.map(ToString::to_string),
+            token_budget,
+        }
+    }
+
+    /// Render the current spinner frame as a styled string.
+    fn render_frame(&self, frame_index: usize) -> String {
+        let paused = self.is_paused.load(Ordering::SeqCst);
+        if paused {
+            return String::new();
+        }
+
+        let thinking = self.is_thinking.load(Ordering::SeqCst);
+        let frames: &[&str] = if thinking {
+            &["◐", "◓", "◑", "◒"]
+        } else {
+            &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+        };
+        let current_label = if thinking {
+            "🧠 Reasoning..."
+        } else {
+            &self.label
+        };
+
+        let frame = frames[frame_index % frames.len()];
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+
+        let mut line = format!("{frame} {current_label}");
+        if let Some(ref m) = self.model {
+            let _ = write!(line, " [{m}]");
+        }
+        let _ = write!(line, " ({elapsed:.1}s)");
+
+        let bytes = self.response_bytes.load(Ordering::Relaxed);
+        if bytes > 0 && elapsed >= 1.0 {
+            let approx_tokens = bytes / 4;
+            if let Some(budget) = self.token_budget {
+                let pct = (f64::from(approx_tokens) / f64::from(budget) * 100.0).min(100.0);
+                let fmt_t = format_compact_tokens(approx_tokens);
+                let fmt_b = format_compact_tokens(budget);
+                let _ = write!(line, " ↓ {fmt_t} / {fmt_b} ({pct:.0}%)");
+                if approx_tokens >= 2000 && elapsed > 5.0 {
+                    let rate = f64::from(approx_tokens) / elapsed;
+                    let remaining = f64::from(budget.saturating_sub(approx_tokens));
+                    let eta_secs = remaining / rate;
+                    let _ = if eta_secs >= 60.0 {
+                        write!(line, " ~{:.0}m", eta_secs / 60.0)
+                    } else {
+                        write!(line, " ~{eta_secs:.0}s")
+                    };
+                }
+            } else {
+                let _ = if approx_tokens >= 1000 {
+                    write!(line, " ↓ {:.1}k tokens", f64::from(approx_tokens) / 1000.0)
+                } else {
+                    write!(line, " ↓ {approx_tokens} tokens")
+                };
+            }
+        }
+
+        line
+    }
+}
+
+fn format_compact_tokens(tokens: u32) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}M", f64::from(tokens) / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", f64::from(tokens) / 1_000.0)
+    } else {
+        tokens.to_string()
+    }
+}
+
+// ── Render context ─────────────────────────────────────────────────────
+
+/// Context provided to the iocraft component tree via `ContextProvider`.
+struct RenderContext {
+    output_rx: Arc<std::sync::Mutex<mpsc::Receiver<OutputMsg>>>,
+    spinner: SpinnerState,
+    permission_mode: String,
+}
+
+// ── iocraft components ─────────────────────────────────────────────────
+
+#[component]
+fn TurnChrome(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
+    let ctx = hooks.use_context::<RenderContext>();
+    let spinner = ctx.spinner.clone();
+    let permission_mode = ctx.permission_mode.clone();
+    let output_rx_mutex = &ctx.output_rx;
+
+    let (stdout, _stderr) = hooks.use_output();
+    let mut system = hooks.use_context_mut::<SystemContext>();
+    let mut frame_index = hooks.use_state(|| 0usize);
+    let mut spinner_text = hooks.use_state(String::new);
+    let mut should_exit = hooks.use_state(|| false);
+
+    // Drain the output channel and print above the chrome.
+    // Also update spinner frame.
+    {
+        let spinner_clone = spinner.clone();
+        let output_rx = Arc::clone(output_rx_mutex);
+        hooks.use_future(async move {
+            loop {
+                // Drain all pending output messages.
+                if let Ok(rx) = output_rx.lock() {
+                    loop {
+                        match rx.try_recv() {
+                            Ok(OutputMsg::Print(text)) => stdout.print(&text),
+                            Ok(OutputMsg::Println(text)) => stdout.println(&text),
+                            Err(TryRecvError::Empty) => break,
+                            Err(TryRecvError::Disconnected) => {
+                                should_exit.set(true);
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                // Update spinner.
+                let idx = frame_index.get();
+                let text = spinner_clone.render_frame(idx);
+                spinner_text.set(text);
+                frame_index.set(idx.wrapping_add(1));
+
+                // 80ms tick — matches the original spinner update interval.
+                tokio::time::sleep(Duration::from_millis(80)).await;
+            }
+        });
+    }
+
+    if *should_exit.read() {
+        system.exit();
+    }
+
+    let w = crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize);
+    let sep = format!("\x1b[2m{}\x1b[0m", "─".repeat(w));
+
+    let icon = match permission_mode.as_str() {
+        "danger-full-access" => "⏵⏵",
+        "workspace-write" => "⏵",
+        _ => "▷",
+    };
+    let label = match permission_mode.as_str() {
+        "danger-full-access" => "full access",
+        "workspace-write" => "workspace write",
+        "read-only" => "read only",
+        other => other,
+    };
+    let footer = format!(
+        "  \x1b[2m{icon} {label} mode · /help for commands · /permissions to change\x1b[0m"
+    );
+
+    let spinner_content = spinner_text.read().clone();
+    let spinner_color = if spinner_content.is_empty() {
+        ""
+    } else {
+        "\x1b[34m"
+    };
+    let colored_spinner = if spinner_content.is_empty() {
+        String::new()
+    } else {
+        format!("{spinner_color}{spinner_content}\x1b[0m")
+    };
+
+    element! {
+        View(flex_direction: FlexDirection::Column) {
+            #(if !colored_spinner.is_empty() {
+                Some(element! { Text(content: colored_spinner) })
+            } else {
+                None
+            })
+            Text(content: sep.clone())
+            Text(content: "")
+            Text(content: sep)
+            Text(content: footer)
+        }
+    }
+}
+
+// ── TurnRenderer ───────────────────────────────────────────────────────
+
+/// Manages an iocraft render loop on a dedicated thread during a turn.
+/// Created at the start of `run_turn()`, stopped at the end.
+pub struct TurnRenderer {
+    output: Option<TurnOutput>,
+    spinner: SpinnerState,
+    stop_tx: Option<SyncSender<()>>,
+    join_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl TurnRenderer {
+    /// Start a new render loop for a turn.
+    #[must_use]
+    pub fn new(
+        label: &str,
+        model: Option<&str>,
+        token_budget: Option<u32>,
+        permission_mode: &str,
+    ) -> Self {
+        let (output_tx, output_rx) = mpsc::sync_channel::<OutputMsg>(256);
+        let (stop_tx, stop_rx) = mpsc::sync_channel::<()>(1);
+
+        let spinner = SpinnerState::new(label, model, token_budget);
+        let spinner_clone = spinner.clone();
+        let perm = permission_mode.to_string();
+
+        let join_handle = std::thread::Builder::new()
+            .name("repl-render".into())
+            .spawn(move || {
+                let ctx = RenderContext {
+                    output_rx: Arc::new(std::sync::Mutex::new(output_rx)),
+                    spinner: spinner_clone,
+                    permission_mode: perm,
+                };
+
+                // Build a minimal tokio runtime for the timer inside
+                // the component's use_future.
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_time()
+                    .build()
+                    .expect("tokio current-thread runtime for render loop");
+
+                rt.block_on(async {
+                    let _ = element! {
+                        ContextProvider(value: Context::owned(ctx)) {
+                            TurnChrome
+                        }
+                    }
+                    .render_loop()
+                    .await;
+                });
+
+                // Consume the stop signal if it arrived (non-blocking).
+                let _ = stop_rx.try_recv();
+            })
+            .expect("spawn repl-render thread");
+
+        Self {
+            output: Some(TurnOutput { tx: output_tx }),
+            spinner,
+            stop_tx: Some(stop_tx),
+            join_handle: Some(join_handle),
+        }
+    }
+
+    /// Get a cloneable output handle for sending text to the render loop.
+    pub fn output(&self) -> Option<TurnOutput> {
+        self.output.clone()
+    }
+
+    /// Get the shared spinner state for the runner to update.
+    #[must_use]
+    pub fn spinner(&self) -> &SpinnerState {
+        &self.spinner
+    }
+
+    fn stop_render(&mut self) {
+        // Drop the output sender so the render loop sees Disconnected.
+        self.output.take();
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.join_handle.take() {
+            let _ = h.join();
+        }
+    }
+
+    /// Signal the render loop to stop and print a success message.
+    pub fn finish(&mut self, label: &str) {
+        self.stop_render();
+        println!("\x1b[32m✔ {label}\x1b[0m");
+    }
+
+    /// Signal the render loop to stop and print a failure message.
+    pub fn fail(&mut self, label: &str) {
+        self.stop_render();
+        println!("\x1b[31m✘ {label}\x1b[0m");
+    }
+
+    /// Stop without printing a final message.
+    pub fn clear(&mut self) {
+        self.stop_render();
+    }
+}
+
+impl Drop for TurnRenderer {
+    fn drop(&mut self) {
+        self.stop_render();
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
@@ -1,0 +1,142 @@
+//! PTY tests for the iocraft-based TurnRenderer chrome.
+//!
+//! These tests verify that the turn-scoped chrome (spinner + separators +
+//! footer) renders correctly and cleans up when the turn ends. They run
+//! with `SUDOCODE_IOCRAFT=1` to activate the iocraft render path.
+//!
+//! ```bash
+//! cargo test --test pty_iocraft_chrome                          # mock (CI)
+//! SCODE_TEST_BACKEND=live cargo test --test pty_iocraft_chrome  # real API
+//! ```
+
+mod common;
+
+use common::TestEnv;
+
+/// The iocraft spinner renders during a single-turn prompt and the
+/// response text appears above the chrome region.
+#[test]
+fn iocraft_single_turn_shows_response() {
+    let env = TestEnv::new("iocraft-single-turn");
+    let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only", &prompt],
+        &[("SUDOCODE_IOCRAFT", "1")],
+    );
+
+    // The response should contain "4".
+    sess.expect("4").expect("response should contain 4");
+
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// After a turn completes, the chrome (separator + footer) is cleared
+/// and the status line is printed. No orphaned chrome lines should
+/// remain in the output.
+#[test]
+fn iocraft_chrome_cleared_after_turn() {
+    let env = TestEnv::new("iocraft-chrome-clear");
+    let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only", &prompt],
+        &[("SUDOCODE_IOCRAFT", "1")],
+    );
+
+    // Wait for the response to complete.
+    sess.expect("4").expect("response");
+
+    // The process should exit cleanly — no hanging render thread.
+    let exit = sess.expect_eof().expect("clean exit");
+    assert_eq!(exit, 0);
+}
+
+/// In REPL mode with iocraft, the chrome appears during the turn and
+/// the prompt re-appears after the turn completes.
+#[test]
+fn iocraft_repl_turn_completes_and_reprompts() {
+    let env = TestEnv::new("iocraft-repl-reprompt");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_IOCRAFT", "1")],
+    );
+
+    // Wait for initial prompt.
+    sess.expect("❯").expect("initial prompt");
+
+    // Submit a prompt.
+    let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+
+    // Response should appear.
+    sess.expect("4").expect("response");
+
+    // After the turn, a new prompt should appear.
+    sess.expect("❯").expect("prompt after turn");
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("clean exit");
+    assert_eq!(exit, 0);
+}
+
+/// The spinner line contains the model name during a turn.
+#[test]
+fn iocraft_spinner_shows_model_name() {
+    let env = TestEnv::new("iocraft-spinner-model");
+    let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only", &prompt],
+        &[("SUDOCODE_IOCRAFT", "1")],
+    );
+
+    // The spinner should show a model identifier in brackets.
+    // In mock mode the model is "sonnet", in live it's the real model.
+    if env.is_mock() {
+        sess.expect("sonnet")
+            .expect("spinner should show model name");
+    }
+
+    // Response should complete.
+    sess.expect("4").expect("response");
+
+    let exit = sess.expect_eof().expect("clean exit");
+    assert_eq!(exit, 0);
+}
+
+/// The footer shows the current permission mode during a turn.
+#[test]
+fn iocraft_footer_shows_permission_mode() {
+    let env = TestEnv::new("iocraft-footer-perm");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_IOCRAFT", "1")],
+    );
+
+    // The footer should show "read only" mode text.
+    sess.expect("read only")
+        .expect("footer should show permission mode");
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("clean exit");
+    assert_eq!(exit, 0);
+}
+
+/// Tool output appears during a turn with bash tool calls. The process
+/// exits cleanly (no hanging render thread).
+#[test]
+fn iocraft_tool_output_during_turn() {
+    let env = TestEnv::new("iocraft-tool-output");
+    let prompt = env.prompt("Run echo hello in bash", "bash_stdout_roundtrip");
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "danger-full-access", &prompt],
+        &[("SUDOCODE_IOCRAFT", "1")],
+    );
+
+    // In mock mode the bash tool call produces "bash completed: <output>".
+    // In live mode the actual echo output appears. Either way, the process
+    // should exit cleanly.
+    let exit = sess
+        .expect_eof()
+        .expect("process should exit after single turn");
+    assert_eq!(exit, 0);
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
@@ -1,8 +1,7 @@
-//! PTY tests for the iocraft-based TurnRenderer chrome.
+//! PTY tests for the TurnRenderer chrome.
 //!
 //! These tests verify that the turn-scoped chrome (spinner + separators +
-//! footer) renders correctly and cleans up when the turn ends. They run
-//! with `SUDOCODE_IOCRAFT=1` to activate the iocraft render path.
+//! footer) renders correctly and cleans up when the turn ends.
 //!
 //! ```bash
 //! cargo test --test pty_iocraft_chrome                          # mock (CI)

--- a/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
@@ -1,7 +1,8 @@
 //! PTY tests for the TurnRenderer chrome.
 //!
 //! These tests verify that the turn-scoped chrome (spinner + output
-//! routing) works correctly with `SUDOCODE_TURN_RENDERER=1`.
+//! routing) works correctly. TurnRenderer is active by default when
+//! stdout is a terminal (which it is in PTY tests).
 //!
 //! ```bash
 //! cargo test --test pty_iocraft_chrome                          # mock (CI)
@@ -12,14 +13,12 @@ mod common;
 
 use common::TestEnv;
 
-const TR_ENV: (&str, &str) = ("SUDOCODE_TURN_RENDERER", "1");
-
-/// Single-turn prompt with TurnRenderer — response text appears.
+/// Single-turn prompt — response text appears and process exits.
 #[test]
 fn turn_renderer_single_turn_shows_response() {
     let env = TestEnv::new("tr-single-turn");
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
-    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only", &prompt], &[TR_ENV]);
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
 
     sess.expect("4").expect("response should contain 4");
     let exit = sess.expect_eof().expect("scode should exit");
@@ -31,7 +30,7 @@ fn turn_renderer_single_turn_shows_response() {
 fn turn_renderer_clean_exit() {
     let env = TestEnv::new("tr-clean-exit");
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
-    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only", &prompt], &[TR_ENV]);
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
 
     sess.expect("4").expect("response");
     let exit = sess.expect_eof().expect("clean exit");
@@ -42,7 +41,7 @@ fn turn_renderer_clean_exit() {
 #[test]
 fn turn_renderer_repl_reprompt() {
     let env = TestEnv::new("tr-repl-reprompt");
-    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[TR_ENV]);
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
 
     sess.expect("❯").expect("initial prompt");
 
@@ -62,7 +61,7 @@ fn turn_renderer_repl_reprompt() {
 fn turn_renderer_spinner_shows_model() {
     let env = TestEnv::new("tr-spinner-model");
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
-    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only", &prompt], &[TR_ENV]);
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
 
     if env.is_mock() {
         sess.expect("sonnet")
@@ -78,10 +77,7 @@ fn turn_renderer_spinner_shows_model() {
 fn turn_renderer_tool_output() {
     let env = TestEnv::new("tr-tool-output");
     let prompt = env.prompt("Run echo hello in bash", "bash_stdout_roundtrip");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "danger-full-access", &prompt],
-        &[TR_ENV],
-    );
+    let mut sess = env.spawn(&["--permission-mode", "danger-full-access", &prompt]);
 
     let exit = sess
         .expect_eof()

--- a/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_iocraft_chrome.rs
@@ -1,7 +1,7 @@
 //! PTY tests for the TurnRenderer chrome.
 //!
-//! These tests verify that the turn-scoped chrome (spinner + separators +
-//! footer) renders correctly and cleans up when the turn ends.
+//! These tests verify that the turn-scoped chrome (spinner + output
+//! routing) works correctly with `SUDOCODE_TURN_RENDERER=1`.
 //!
 //! ```bash
 //! cargo test --test pty_iocraft_chrome                          # mock (CI)
@@ -12,65 +12,44 @@ mod common;
 
 use common::TestEnv;
 
-/// The iocraft spinner renders during a single-turn prompt and the
-/// response text appears above the chrome region.
+const TR_ENV: (&str, &str) = ("SUDOCODE_TURN_RENDERER", "1");
+
+/// Single-turn prompt with TurnRenderer — response text appears.
 #[test]
-fn iocraft_single_turn_shows_response() {
-    let env = TestEnv::new("iocraft-single-turn");
+fn turn_renderer_single_turn_shows_response() {
+    let env = TestEnv::new("tr-single-turn");
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only", &prompt],
-        &[("SUDOCODE_IOCRAFT", "1")],
-    );
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only", &prompt], &[TR_ENV]);
 
-    // The response should contain "4".
     sess.expect("4").expect("response should contain 4");
-
     let exit = sess.expect_eof().expect("scode should exit");
     assert_eq!(exit, 0);
 }
 
-/// After a turn completes, the chrome (separator + footer) is cleared
-/// and the status line is printed. No orphaned chrome lines should
-/// remain in the output.
+/// Process exits cleanly — no hanging render thread.
 #[test]
-fn iocraft_chrome_cleared_after_turn() {
-    let env = TestEnv::new("iocraft-chrome-clear");
+fn turn_renderer_clean_exit() {
+    let env = TestEnv::new("tr-clean-exit");
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only", &prompt],
-        &[("SUDOCODE_IOCRAFT", "1")],
-    );
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only", &prompt], &[TR_ENV]);
 
-    // Wait for the response to complete.
     sess.expect("4").expect("response");
-
-    // The process should exit cleanly — no hanging render thread.
     let exit = sess.expect_eof().expect("clean exit");
     assert_eq!(exit, 0);
 }
 
-/// In REPL mode with iocraft, the chrome appears during the turn and
-/// the prompt re-appears after the turn completes.
+/// REPL mode: turn completes and prompt re-appears.
 #[test]
-fn iocraft_repl_turn_completes_and_reprompts() {
-    let env = TestEnv::new("iocraft-repl-reprompt");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only"],
-        &[("SUDOCODE_IOCRAFT", "1")],
-    );
+fn turn_renderer_repl_reprompt() {
+    let env = TestEnv::new("tr-repl-reprompt");
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only"], &[TR_ENV]);
 
-    // Wait for initial prompt.
     sess.expect("❯").expect("initial prompt");
 
-    // Submit a prompt.
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
     sess.send(&format!("{prompt}\r")).expect("send prompt");
 
-    // Response should appear.
     sess.expect("4").expect("response");
-
-    // After the turn, a new prompt should appear.
     sess.expect("❯").expect("prompt after turn");
 
     sess.send("/exit\r").expect("send /exit");
@@ -78,62 +57,32 @@ fn iocraft_repl_turn_completes_and_reprompts() {
     assert_eq!(exit, 0);
 }
 
-/// The spinner line contains the model name during a turn.
+/// Spinner shows model name during a turn.
 #[test]
-fn iocraft_spinner_shows_model_name() {
-    let env = TestEnv::new("iocraft-spinner-model");
+fn turn_renderer_spinner_shows_model() {
+    let env = TestEnv::new("tr-spinner-model");
     let prompt = env.prompt("What is 2+2? Answer only the number.", "single_turn_text");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only", &prompt],
-        &[("SUDOCODE_IOCRAFT", "1")],
-    );
+    let mut sess = env.spawn_with_env(&["--permission-mode", "read-only", &prompt], &[TR_ENV]);
 
-    // The spinner should show a model identifier in brackets.
-    // In mock mode the model is "sonnet", in live it's the real model.
     if env.is_mock() {
         sess.expect("sonnet")
             .expect("spinner should show model name");
     }
-
-    // Response should complete.
     sess.expect("4").expect("response");
-
     let exit = sess.expect_eof().expect("clean exit");
     assert_eq!(exit, 0);
 }
 
-/// The footer shows the current permission mode during a turn.
+/// Tool output with TurnRenderer — process exits cleanly.
 #[test]
-fn iocraft_footer_shows_permission_mode() {
-    let env = TestEnv::new("iocraft-footer-perm");
-    let mut sess = env.spawn_with_env(
-        &["--permission-mode", "read-only"],
-        &[("SUDOCODE_IOCRAFT", "1")],
-    );
-
-    // The footer should show "read only" mode text.
-    sess.expect("read only")
-        .expect("footer should show permission mode");
-
-    sess.send("/exit\r").expect("send /exit");
-    let exit = sess.expect_eof().expect("clean exit");
-    assert_eq!(exit, 0);
-}
-
-/// Tool output appears during a turn with bash tool calls. The process
-/// exits cleanly (no hanging render thread).
-#[test]
-fn iocraft_tool_output_during_turn() {
-    let env = TestEnv::new("iocraft-tool-output");
+fn turn_renderer_tool_output() {
+    let env = TestEnv::new("tr-tool-output");
     let prompt = env.prompt("Run echo hello in bash", "bash_stdout_roundtrip");
     let mut sess = env.spawn_with_env(
         &["--permission-mode", "danger-full-access", &prompt],
-        &[("SUDOCODE_IOCRAFT", "1")],
+        &[TR_ENV],
     );
 
-    // In mock mode the bash tool call produces "bash completed: <output>".
-    // In live mode the actual echo output appears. Either way, the process
-    // should exit cleanly.
     let exit = sess
         .expect_eof()
         .expect("process should exit after single turn");

--- a/rust/crates/rusty-sudocode-cli/tests/visual_regression.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/visual_regression.rs
@@ -1,0 +1,165 @@
+//! Visual regression tests for terminal output correctness.
+//!
+//! These tests verify that the REPL chrome (separator line, footer) renders
+//! correctly and that no *post-readline* cursor-up sequences pollute output.
+//!
+//! The sandwich chrome (`print_before_prompt`) uses `ESC[2F` to position the
+//! cursor on the prompt line — this is safe because positions are deterministic
+//! (lines were just printed). The dangerous case was `replace_after_submit`
+//! which cursored up AFTER readline returned (unpredictable → scrollback
+//! jumping). That function has been permanently removed; these tests guard
+//! against its reintroduction.
+//!
+//! ```bash
+//! cargo test --test visual_regression                          # mock (CI)
+//! SCODE_TEST_BACKEND=live cargo test --test visual_regression  # real API
+//! ```
+
+mod common;
+
+use common::TestEnv;
+
+/// After the startup banner, a `─` separator character appears in the REPL
+/// output before the prompt.
+#[test]
+fn separator_line_appears_after_startup() {
+    let env = TestEnv::new("visual-separator");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+
+    sess.expect("─")
+        .expect("separator line should appear after startup banner");
+
+    sess.expect("❯").expect("REPL prompt should appear");
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// REPL mode: the footer hint line with permission mode info should be
+/// visible in the output stream.
+#[test]
+fn footer_hint_appears_in_repl() {
+    let env = TestEnv::new("visual-footer");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+
+    sess.expect("read only")
+        .expect("footer should show permission mode");
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// After submitting input, the user's text must NOT appear twice (once in
+/// the prompt `❯ text` and again as an echo `› text`). The old
+/// `replace_after_submit` cursor-up was used to overwrite the prompt with
+/// a styled echo; without it, printing an echo causes duplication.
+/// The correct behavior is: prompt stays as-is, no echo printed.
+#[test]
+fn no_duplicate_echo_after_submit() {
+    let env = TestEnv::new("visual-no-dup-echo");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+
+    sess.expect("❯").expect("REPL prompt should appear");
+
+    // Send /help — deterministic output, no LLM call needed.
+    sess.send("/help\r").expect("send /help");
+
+    // Wait for the separator that precedes the next prompt — this
+    // confirms print_before_prompt ran and the full output is captured.
+    let output = sess.expect("─").expect("next separator should appear");
+
+    // The submitted text must NOT appear as a `›`-prefixed echo line.
+    // If it does, the echo duplication bug has regressed.
+    assert!(
+        !output.contains("› /help"),
+        "found echo line '› /help' — input was duplicated: {output:?}"
+    );
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// After submitting, the bottom separator and footer from the sandwich
+/// chrome must be cleared. If `\x1b[J]` fails to clear them, the bottom
+/// sep `─` would appear between the prompt and the command output.
+/// We verify by sending `/version` (short output) and checking that the
+/// output between the prompt echo and the version text has no stray `─`.
+#[test]
+fn bottom_chrome_cleared_after_submit() {
+    let env = TestEnv::new("visual-bottom-clear");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+
+    sess.expect("❯").expect("REPL prompt should appear");
+
+    // Send /version — produces "Sudo Code\n  Version ..." with no `─`.
+    sess.send("/version\r").expect("send /version");
+
+    // Expect the version output.
+    let output = sess
+        .expect("Version")
+        .expect("version output should appear");
+
+    // Between prompt submission and version output, there must be no
+    // stray bottom separator `─`. The only `─` should be from the TOP
+    // separator printed by print_before_prompt BEFORE readline.
+    // If `\x1b[J]` failed to clear the bottom sep, `─` would appear
+    // between the prompt echo and "Version".
+    let after_submit = output.split("/version").last().unwrap_or(&output);
+    assert!(
+        !after_submit.contains('─'),
+        "bottom separator leaked after submit: {after_submit:?}"
+    );
+
+    // Wait for next prompt before exiting.
+    sess.expect("❯").expect("next prompt");
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// Single-turn mode: output must not contain the dangerous `ESC[1F`
+/// cursor-up that was used by the old `replace_after_submit` (the root
+/// cause of scrollback jumping). `ESC[2F` in `print_before_prompt` is
+/// safe and expected.
+#[test]
+fn no_post_readline_cursor_up_in_single_turn() {
+    let env = TestEnv::new("visual-no-cursor-up");
+    let prompt = env.prompt("What is 2+2? Answer briefly.", "single_turn_text");
+
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
+
+    let matched = sess.expect("4").expect("response should contain '4'");
+    // ESC[1F was used by replace_after_submit to go back up per-line.
+    assert!(
+        !matched.contains("\x1b[1F"),
+        "output contains ESC[1F (replace_after_submit cursor-up): {matched:?}"
+    );
+
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// REPL mode: after submitting input, no `ESC[1F` (the dangerous
+/// per-line cursor-up from `replace_after_submit`) should appear. The
+/// `ESC[2F` from `print_before_prompt` is safe and expected.
+#[test]
+fn no_post_readline_cursor_up_in_repl() {
+    let env = TestEnv::new("visual-no-cursor-up-repl");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+
+    sess.expect("❯").expect("REPL prompt should appear");
+
+    sess.send("/help\r").expect("send /help");
+    let help_output = sess.expect("❯").expect("next prompt after /help");
+    assert!(
+        !help_output.contains("\x1b[1F"),
+        "post-submit output contains ESC[1F: {help_output:?}"
+    );
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}


### PR DESCRIPTION
## Summary

- Remove `CliOutput` (MultiProgress-based output manager) — the root cause of scrollback jumping when indicatif bars and raw ANSI writes interleave
- Add `input_chrome.rs` — cursor-safe sandwich layout for prompt chrome between turns  
- Add `TurnRenderer` + `SpinnerState` — dedicated render thread managing a single-line spinner with non-blocking stdout (`O_NONBLOCK` via nix fcntl)
- `SpinnerRef::from_state()` bridges TurnRenderer's atomics to the existing SpinnerRef API
- `SpinnerRef::managed` flag prevents stdout conflicts when TurnRenderer is active
- TurnRenderer is default for interactive REPL turns; non-interactive (piped) mode falls back to standalone indicatif SpinnerHandle

## What changed

| File | Change |
|------|--------|
| `render.rs` | Remove `CliOutput`, `format_footer_bar`; add `SpinnerRef::from_state()` + `managed` flag; restore manual `\r\x1b[2K` in `pause()` |
| `input_chrome.rs` | **New** — cursor-positioned sandwich chrome (separators + footer) between turns |
| `repl_ui.rs` | **New** — `TurnRenderer`, `TurnOutput`, `SpinnerState`, non-blocking render thread |
| `api_client.rs` | Remove `cli_output` field and routing; direct stdout for streaming |
| `tool_executor.rs` | Remove `cli_output` field and routing; direct stdout for tool results |
| `main.rs` | Wire `TurnRenderer` in `run_turn()` when `is_terminal()`; `out_println` → `println!` |
| `repl_async.rs` | Use `input_chrome::print_before_prompt()` instead of `CliOutput` |

## Testing

```bash
cargo fmt --all --check     # clean
cargo test -p rusty-sudocode-cli   # 230+ tests, 0 failures
SCODE_TEST_BACKEND=live cargo test -p rusty-sudocode-cli --test pty_iocraft_chrome  # live API
```

- **5 new TurnRenderer PTY tests** (`pty_iocraft_chrome.rs`): single-turn response, clean exit, REPL reprompt, spinner model name, tool output
- **6 new visual regression PTY tests** (`visual_regression.rs`): separator, footer, no echo duplication, chrome clear, no cursor-up
- All 230+ existing mock PTY tests pass — zero regressions
- Live single-turn hang is pre-existing on `main` (HookAbortMonitor raw-mode thread), not introduced here

## Known limitations

- Live PTY tests for single-turn mode hang on both main and this branch (HookAbortMonitor raw-mode thread holds stdin open in PTY). Tracked separately.
- `indicatif` and `dialoguer` dependencies retained — removing them is independent follow-up work.