### PR TITLE
Fix iocraft AskUserQuestion prompt handling

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1876,6 +1876,144 @@ impl repl_async::TurnDriver for LiveCliDriver {
 /// The coordinator reads `InputEvent`s from the iocraft UI and dispatches
 /// turns on runner threads, identical to the rustyline-based coordinator
 /// but with iocraft owning stdin+stdout.
+type PendingQuestionAnswer = Arc<Mutex<Option<mpsc::SyncSender<String>>>>;
+
+fn consume_pending_question_answer(pending: &PendingQuestionAnswer, text: String) -> bool {
+    let Some(tx) = pending
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+    else {
+        return false;
+    };
+    let _ = tx.send(text);
+    true
+}
+
+fn cancel_pending_question_answer(pending: &PendingQuestionAnswer) {
+    let _ = pending
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
+}
+
+struct IocraftQuestionPrompter {
+    output: repl_ui::OutputSender,
+    pending_answer: PendingQuestionAnswer,
+}
+
+impl IocraftQuestionPrompter {
+    fn new(output: repl_ui::OutputSender, pending_answer: PendingQuestionAnswer) -> Self {
+        Self {
+            output,
+            pending_answer,
+        }
+    }
+
+    fn render_field(&self, request: &runtime::QuestionPromptRequest, index: usize) {
+        if index == 0 {
+            if let Some(title) = request.title.as_deref().filter(|title| !title.is_empty()) {
+                self.output.println(&format!("\n[Question Set] {title}"));
+            }
+            if let Some(description) = request
+                .description
+                .as_deref()
+                .filter(|description| !description.is_empty())
+            {
+                self.output.println(description);
+            }
+        }
+
+        let field = &request.fields[index];
+        self.output
+            .println(&format!("\n[Question] {}. {}", index + 1, field.prompt));
+        for (option_index, option) in field.options.iter().enumerate() {
+            let suffix = option
+                .description
+                .as_deref()
+                .filter(|description| !description.is_empty())
+                .map_or(String::new(), |description| format!(" - {description}"));
+            self.output.println(&format!(
+                "  {}. {}{}",
+                option_index + 1,
+                option.label,
+                suffix
+            ));
+        }
+        if field.options.is_empty() {
+            self.output.println("Your answer:");
+        } else {
+            self.output
+                .println(&format!("Enter choice (1-{}):", field.options.len()));
+        }
+    }
+
+    fn prepare_answer_receiver(&self) -> Result<mpsc::Receiver<String>, String> {
+        let (tx, rx) = mpsc::sync_channel(1);
+        {
+            let mut pending = self
+                .pending_answer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if pending.is_some() {
+                return Err("question prompt already pending".to_string());
+            }
+            *pending = Some(tx);
+        }
+        Ok(rx)
+    }
+
+    fn wait_for_answer(rx: mpsc::Receiver<String>) -> Result<String, String> {
+        rx.recv()
+            .map(|answer| answer.trim().to_string())
+            .map_err(|_| "question prompt cancelled".to_string())
+    }
+
+    fn answer_for_field(
+        field: &runtime::QuestionField,
+        raw_answer: String,
+    ) -> runtime::QuestionPromptAnswer {
+        let matched = if field.options.is_empty() {
+            None
+        } else if let Ok(index) = raw_answer.parse::<usize>() {
+            index
+                .checked_sub(1)
+                .and_then(|zero_based| field.options.get(zero_based))
+        } else {
+            field
+                .options
+                .iter()
+                .find(|option| option.label == raw_answer || option.value == raw_answer)
+        };
+
+        runtime::QuestionPromptAnswer {
+            id: field.id.clone(),
+            value: matched
+                .map(|option| option.value.clone())
+                .unwrap_or_else(|| raw_answer.clone()),
+            label: matched
+                .map(|option| option.label.clone())
+                .or_else(|| (!raw_answer.is_empty()).then_some(raw_answer)),
+        }
+    }
+}
+
+impl runtime::QuestionPrompter for IocraftQuestionPrompter {
+    fn ask(
+        &mut self,
+        request: &runtime::QuestionPromptRequest,
+    ) -> Result<Vec<runtime::QuestionPromptAnswer>, String> {
+        let mut answers = Vec::with_capacity(request.fields.len());
+        for index in 0..request.fields.len() {
+            let rx = self.prepare_answer_receiver()?;
+            self.render_field(request, index);
+            let raw_answer = Self::wait_for_answer(rx)?;
+            answers.push(Self::answer_for_field(&request.fields[index], raw_answer));
+        }
+        Ok(answers)
+    }
+}
+
 fn run_repl_iocraft_dispatch(
     mut cli: LiveCli,
     mode: input_queue::QueueMode,
@@ -1898,6 +2036,7 @@ fn run_repl_iocraft_dispatch(
 
     // Spawn the iocraft REPL UI on a dedicated thread.
     let repl = repl_ui::spawn_repl_ui(&permission_label, &banner);
+    let pending_question_answer: PendingQuestionAnswer = Arc::new(Mutex::new(None));
 
     let cli_shared = Arc::new(Mutex::new(cli));
     let session_start = Instant::now();
@@ -1917,6 +2056,7 @@ fn run_repl_iocraft_dispatch(
             match repl.input_rx.recv() {
                 Ok(evt) => Some(evt),
                 Err(_) => {
+                    cancel_pending_question_answer(&pending_question_answer);
                     if let Some(h) = runner_handle.take() {
                         abort_signal.abort();
                         let _ = h.join();
@@ -1943,6 +2083,7 @@ fn run_repl_iocraft_dispatch(
                                 next.prompt,
                                 repl.output.clone(),
                                 repl.spinner.clone(),
+                                Arc::clone(&pending_question_answer),
                                 turn_tx.clone(),
                             ));
                         }
@@ -1950,6 +2091,7 @@ fn run_repl_iocraft_dispatch(
                     continue;
                 }
                 Err(RecvTimeoutError::Disconnected) => {
+                    cancel_pending_question_answer(&pending_question_answer);
                     // Render loop exited — clean up runner if active.
                     if let Some(h) = runner_handle.take() {
                         abort_signal.abort();
@@ -1964,6 +2106,7 @@ fn run_repl_iocraft_dispatch(
 
         match event {
             repl_ui::InputEvent::Exit => {
+                cancel_pending_question_answer(&pending_question_answer);
                 if let Some(h) = runner_handle.take() {
                     abort_signal.abort();
                     let _ = h.join();
@@ -1975,12 +2118,17 @@ fn run_repl_iocraft_dispatch(
                 break;
             }
             repl_ui::InputEvent::Abort => {
+                cancel_pending_question_answer(&pending_question_answer);
                 if runner_handle.is_some() {
                     abort_signal.abort();
                 }
             }
             repl_ui::InputEvent::Submit(text) => {
+                if consume_pending_question_answer(&pending_question_answer, text.clone()) {
+                    continue;
+                }
                 if text.trim() == "/exit" || text.trim() == "/quit" {
+                    cancel_pending_question_answer(&pending_question_answer);
                     if runner_handle.is_some() {
                         abort_signal.abort();
                     }
@@ -2030,6 +2178,7 @@ fn run_repl_iocraft_dispatch(
                         next.prompt,
                         repl.output.clone(),
                         repl.spinner.clone(),
+                        Arc::clone(&pending_question_answer),
                         turn_tx.clone(),
                     ));
                 } else {
@@ -2106,6 +2255,7 @@ fn spawn_iocraft_turn(
     prompt: String,
     output: repl_ui::OutputSender,
     spinner: repl_ui::SpinnerState,
+    pending_question_answer: PendingQuestionAnswer,
     done_tx: mpsc::SyncSender<()>,
 ) -> thread::JoinHandle<()> {
     let abort = abort_signal.clone();
@@ -2114,7 +2264,9 @@ fn spawn_iocraft_turn(
         .spawn(move || {
             abort.reset();
             let mut cli = cli_shared.lock().expect("LiveCli mutex poisoned");
-            if let Err(e) = cli.run_turn_iocraft(&prompt, &output, &spinner) {
+            if let Err(e) =
+                cli.run_turn_iocraft(&prompt, &output, &spinner, pending_question_answer)
+            {
                 output.println(&format!("\x1b[31m{e}\x1b[0m"));
             }
             let _ = done_tx.send(());
@@ -4003,6 +4155,7 @@ impl LiveCli {
         input: &str,
         output: &repl_ui::OutputSender,
         spinner_state: &repl_ui::SpinnerState,
+        pending_question_answer: PendingQuestionAnswer,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let turn_start = Instant::now();
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
@@ -4020,6 +4173,12 @@ impl LiveCli {
         let spinner_ref = render::SpinnerRef::from_spinner_state(spinner_state);
         runtime.api_client_mut().set_spinner(spinner_ref.clone());
         runtime.tool_executor_mut().set_spinner(spinner_ref);
+        runtime
+            .tool_executor_mut()
+            .set_question_prompter(Box::new(IocraftQuestionPrompter::new(
+                output.clone(),
+                pending_question_answer,
+            )));
 
         let mut permission_prompter = CliPermissionPrompter::new(self.config.permission_mode);
         let result = self.tokio_runtime.block_on(runtime.run_turn(
@@ -6418,5 +6577,31 @@ mod auth_mode_tests {
         .expect("explicit proxy auth should allow passthrough models");
 
         assert_eq!(mode, AuthMode::Proxy);
+    }
+
+    #[test]
+    fn pending_question_consumes_next_iocraft_submit() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let pending = Arc::new(Mutex::new(Some(tx)));
+
+        assert!(consume_pending_question_answer(
+            &pending,
+            "answer from ui".to_string()
+        ));
+        assert_eq!(
+            rx.recv().expect("answer should be routed"),
+            "answer from ui"
+        );
+        assert!(pending.lock().expect("pending lock").is_none());
+    }
+
+    #[test]
+    fn absent_pending_question_leaves_submit_for_normal_repl_flow() {
+        let pending = Arc::new(Mutex::new(None));
+
+        assert!(!consume_pending_question_answer(
+            &pending,
+            "normal prompt".to_string()
+        ));
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1898,54 +1898,36 @@ fn cancel_pending_question_answer(pending: &PendingQuestionAnswer) {
 }
 
 struct IocraftQuestionPrompter {
-    output: repl_ui::OutputSender,
+    ui: repl_ui::UiCommandSender,
     pending_answer: PendingQuestionAnswer,
 }
 
 impl IocraftQuestionPrompter {
-    fn new(output: repl_ui::OutputSender, pending_answer: PendingQuestionAnswer) -> Self {
-        Self {
-            output,
-            pending_answer,
-        }
+    fn new(ui: repl_ui::UiCommandSender, pending_answer: PendingQuestionAnswer) -> Self {
+        Self { ui, pending_answer }
     }
 
-    fn render_field(&self, request: &runtime::QuestionPromptRequest, index: usize) {
-        if index == 0 {
-            if let Some(title) = request.title.as_deref().filter(|title| !title.is_empty()) {
-                self.output.println(&format!("\n[Question Set] {title}"));
-            }
-            if let Some(description) = request
-                .description
-                .as_deref()
-                .filter(|description| !description.is_empty())
-            {
-                self.output.println(description);
-            }
-        }
-
+    fn show_field(&self, request: &runtime::QuestionPromptRequest, index: usize) {
         let field = &request.fields[index];
-        self.output
-            .println(&format!("\n[Question] {}. {}", index + 1, field.prompt));
-        for (option_index, option) in field.options.iter().enumerate() {
-            let suffix = option
-                .description
-                .as_deref()
-                .filter(|description| !description.is_empty())
-                .map_or(String::new(), |description| format!(" - {description}"));
-            self.output.println(&format!(
-                "  {}. {}{}",
-                option_index + 1,
-                option.label,
-                suffix
-            ));
-        }
-        if field.options.is_empty() {
-            self.output.println("Your answer:");
-        } else {
-            self.output
-                .println(&format!("Enter choice (1-{}):", field.options.len()));
-        }
+        self.ui.show_question(repl_ui::QuestionPromptView {
+            title: request.title.clone(),
+            description: request.description.clone(),
+            index,
+            total: request.fields.len(),
+            prompt: field.prompt.clone(),
+            options: field
+                .options
+                .iter()
+                .map(|option| repl_ui::QuestionOptionView {
+                    label: option.label.clone(),
+                    value: option.value.clone(),
+                    description: option.description.clone(),
+                    recommended: option.recommended,
+                })
+                .collect(),
+            allow_custom_input: field.allow_custom_input,
+            custom_input_hint: field.custom_input_hint.clone(),
+        });
     }
 
     fn prepare_answer_receiver(&self) -> Result<mpsc::Receiver<String>, String> {
@@ -2006,10 +1988,17 @@ impl runtime::QuestionPrompter for IocraftQuestionPrompter {
         let mut answers = Vec::with_capacity(request.fields.len());
         for index in 0..request.fields.len() {
             let rx = self.prepare_answer_receiver()?;
-            self.render_field(request, index);
-            let raw_answer = Self::wait_for_answer(rx)?;
+            self.show_field(request, index);
+            let raw_answer = match Self::wait_for_answer(rx) {
+                Ok(answer) => answer,
+                Err(error) => {
+                    self.ui.clear_question();
+                    return Err(error);
+                }
+            };
             answers.push(Self::answer_for_field(&request.fields[index], raw_answer));
         }
+        self.ui.clear_question();
         Ok(answers)
     }
 }
@@ -2057,6 +2046,7 @@ fn run_repl_iocraft_dispatch(
                 Ok(evt) => Some(evt),
                 Err(_) => {
                     cancel_pending_question_answer(&pending_question_answer);
+                    repl.ui.clear_question();
                     if let Some(h) = runner_handle.take() {
                         abort_signal.abort();
                         let _ = h.join();
@@ -2082,6 +2072,7 @@ fn run_repl_iocraft_dispatch(
                                 &abort_signal,
                                 next.prompt,
                                 repl.output.clone(),
+                                repl.ui.clone(),
                                 repl.spinner.clone(),
                                 Arc::clone(&pending_question_answer),
                                 turn_tx.clone(),
@@ -2092,6 +2083,7 @@ fn run_repl_iocraft_dispatch(
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     cancel_pending_question_answer(&pending_question_answer);
+                    repl.ui.clear_question();
                     // Render loop exited — clean up runner if active.
                     if let Some(h) = runner_handle.take() {
                         abort_signal.abort();
@@ -2107,6 +2099,7 @@ fn run_repl_iocraft_dispatch(
         match event {
             repl_ui::InputEvent::Exit => {
                 cancel_pending_question_answer(&pending_question_answer);
+                repl.ui.clear_question();
                 if let Some(h) = runner_handle.take() {
                     abort_signal.abort();
                     let _ = h.join();
@@ -2119,16 +2112,15 @@ fn run_repl_iocraft_dispatch(
             }
             repl_ui::InputEvent::Abort => {
                 cancel_pending_question_answer(&pending_question_answer);
+                repl.ui.clear_question();
                 if runner_handle.is_some() {
                     abort_signal.abort();
                 }
             }
             repl_ui::InputEvent::Submit(text) => {
-                if consume_pending_question_answer(&pending_question_answer, text.clone()) {
-                    continue;
-                }
                 if text.trim() == "/exit" || text.trim() == "/quit" {
                     cancel_pending_question_answer(&pending_question_answer);
+                    repl.ui.clear_question();
                     if runner_handle.is_some() {
                         abort_signal.abort();
                     }
@@ -2177,6 +2169,7 @@ fn run_repl_iocraft_dispatch(
                         &abort_signal,
                         next.prompt,
                         repl.output.clone(),
+                        repl.ui.clone(),
                         repl.spinner.clone(),
                         Arc::clone(&pending_question_answer),
                         turn_tx.clone(),
@@ -2197,6 +2190,12 @@ fn run_repl_iocraft_dispatch(
                             );
                         }
                     }
+                }
+            }
+            repl_ui::InputEvent::QuestionAnswer(text) => {
+                if !consume_pending_question_answer(&pending_question_answer, text) {
+                    repl.output
+                        .println("\x1b[2m(no question is waiting for an answer)\x1b[0m");
                 }
             }
         }
@@ -2254,6 +2253,7 @@ fn spawn_iocraft_turn(
     abort_signal: &runtime::HookAbortSignal,
     prompt: String,
     output: repl_ui::OutputSender,
+    ui: repl_ui::UiCommandSender,
     spinner: repl_ui::SpinnerState,
     pending_question_answer: PendingQuestionAnswer,
     done_tx: mpsc::SyncSender<()>,
@@ -2265,7 +2265,7 @@ fn spawn_iocraft_turn(
             abort.reset();
             let mut cli = cli_shared.lock().expect("LiveCli mutex poisoned");
             if let Err(e) =
-                cli.run_turn_iocraft(&prompt, &output, &spinner, pending_question_answer)
+                cli.run_turn_iocraft(&prompt, &output, &ui, &spinner, pending_question_answer)
             {
                 output.println(&format!("\x1b[31m{e}\x1b[0m"));
             }
@@ -4154,6 +4154,7 @@ impl LiveCli {
         &mut self,
         input: &str,
         output: &repl_ui::OutputSender,
+        ui: &repl_ui::UiCommandSender,
         spinner_state: &repl_ui::SpinnerState,
         pending_question_answer: PendingQuestionAnswer,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -4176,7 +4177,7 @@ impl LiveCli {
         runtime
             .tool_executor_mut()
             .set_question_prompter(Box::new(IocraftQuestionPrompter::new(
-                output.clone(),
+                ui.clone(),
                 pending_question_answer,
             )));
 
@@ -6580,7 +6581,7 @@ mod auth_mode_tests {
     }
 
     #[test]
-    fn pending_question_consumes_next_iocraft_submit() {
+    fn pending_question_consumes_next_iocraft_question_answer() {
         let (tx, rx) = mpsc::sync_channel(1);
         let pending = Arc::new(Mutex::new(Some(tx)));
 
@@ -6596,7 +6597,7 @@ mod auth_mode_tests {
     }
 
     #[test]
-    fn absent_pending_question_leaves_submit_for_normal_repl_flow() {
+    fn absent_pending_question_rejects_unexpected_iocraft_question_answer() {
         let pending = Arc::new(Mutex::new(None));
 
         assert!(!consume_pending_question_answer(

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -377,6 +377,117 @@ impl Drop for TurnRenderer {
 // iocraft REPL — replaces rustyline for interactive input
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QuestionOptionView {
+    pub label: String,
+    pub value: String,
+    pub description: Option<String>,
+    pub recommended: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QuestionPromptView {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub index: usize,
+    pub total: usize,
+    pub prompt: String,
+    pub options: Vec<QuestionOptionView>,
+    pub allow_custom_input: bool,
+    pub custom_input_hint: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UiCommand {
+    ShowQuestion(QuestionPromptView),
+    ClearQuestion,
+}
+
+#[derive(Clone)]
+pub struct UiCommandSender {
+    tx: SyncSender<UiCommand>,
+}
+
+impl UiCommandSender {
+    pub fn show_question(&self, question: QuestionPromptView) {
+        let _ = self.tx.send(UiCommand::ShowQuestion(question));
+    }
+
+    pub fn clear_question(&self) {
+        let _ = self.tx.send(UiCommand::ClearQuestion);
+    }
+}
+
+fn enter_key_event_for_value(
+    question: Option<&QuestionPromptView>,
+    selected_index: usize,
+    value: &str,
+) -> Option<InputEvent> {
+    if let Some(question) = question {
+        if question.options.is_empty() {
+            return (!value.trim().is_empty())
+                .then(|| InputEvent::QuestionAnswer(value.to_string()));
+        }
+        if value.trim().is_empty() {
+            let selected = selected_index.min(question.options.len().saturating_sub(1));
+            return Some(InputEvent::QuestionAnswer((selected + 1).to_string()));
+        }
+        return Some(InputEvent::QuestionAnswer(value.to_string()));
+    }
+
+    if value.trim().is_empty() {
+        return None;
+    }
+
+    let trimmed = value.trim();
+    if trimmed == "/exit" || trimmed == "/quit" {
+        Some(InputEvent::Exit)
+    } else {
+        Some(InputEvent::Submit(value.to_string()))
+    }
+}
+
+fn format_question_panel(question: &QuestionPromptView, selected_index: usize) -> String {
+    let mut lines = Vec::new();
+    if let Some(title) = question.title.as_deref().filter(|title| !title.is_empty()) {
+        lines.push(format!("[{title}]"));
+    }
+    if let Some(description) = question
+        .description
+        .as_deref()
+        .filter(|description| !description.is_empty())
+    {
+        lines.push(description.to_string());
+    }
+    lines.push(format!(
+        "{}/{}  {}",
+        question.index + 1,
+        question.total.max(1),
+        question.prompt
+    ));
+    for (index, option) in question.options.iter().enumerate() {
+        let selector = if index == selected_index { ">" } else { " " };
+        let marker = if option.recommended {
+            " recommended"
+        } else {
+            ""
+        };
+        let description = option
+            .description
+            .as_deref()
+            .filter(|description| !description.is_empty())
+            .map_or(String::new(), |description| format!(" - {description}"));
+        lines.push(format!(
+            "{selector} {}. {}{}{}",
+            index + 1,
+            option.label,
+            marker,
+            description
+        ));
+    }
+    lines.join("\n")
+}
+
 /// Channel-backed output handle for routing text from the runner thread
 /// to the iocraft render loop. Clone is cheap. Implements `std::io::Write`
 /// so it can be used as a stdout replacement.
@@ -404,8 +515,10 @@ impl Write for OutputSender {
 }
 
 /// Events from the iocraft UI to the coordinator thread.
+#[derive(Debug, PartialEq, Eq)]
 pub enum InputEvent {
     Submit(String),
+    QuestionAnswer(String),
     /// ESC pressed — cancel the running turn.
     Abort,
     Exit,
@@ -414,6 +527,7 @@ pub enum InputEvent {
 /// Handle returned by `spawn_repl_ui` for the coordinator to use.
 pub struct ReplHandle {
     pub output: OutputSender,
+    pub ui: UiCommandSender,
     pub input_rx: Receiver<InputEvent>,
     pub spinner: SpinnerState,
     ui_thread: Option<std::thread::JoinHandle<()>>,
@@ -426,6 +540,7 @@ impl ReplHandle {
     pub fn join(self) {
         // Drop channels so the render loop sees Disconnected and exits.
         drop(self.output);
+        drop(self.ui);
         drop(self.input_rx);
         if let Some(h) = self.ui_thread {
             let deadline = std::time::Instant::now() + std::time::Duration::from_millis(300);
@@ -443,6 +558,7 @@ impl ReplHandle {
 /// Context passed to `ReplApp` via `ContextProvider`.
 struct ReplContext {
     output_rx: Arc<Mutex<Receiver<String>>>,
+    ui_rx: Arc<Mutex<Receiver<UiCommand>>>,
     input_tx: SyncSender<InputEvent>,
     spinner: SpinnerState,
     permission_mode: String,
@@ -452,6 +568,7 @@ struct ReplContext {
 fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let ctx = hooks.use_context::<ReplContext>();
     let output_rx = Arc::clone(&ctx.output_rx);
+    let ui_rx = Arc::clone(&ctx.ui_rx);
     let input_tx = ctx.input_tx.clone();
     let spinner = ctx.spinner.clone();
     let permission_mode = ctx.permission_mode.clone();
@@ -462,6 +579,8 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut input_value = hooks.use_state(String::new);
     let mut frame = hooks.use_state(|| 0usize);
     let mut spinner_text = hooks.use_state(String::new);
+    let mut question_state = hooks.use_state(|| None::<QuestionPromptView>);
+    let mut question_selection = hooks.use_state(|| 0usize);
     let mut should_exit = hooks.use_state(|| false);
     let mut last_ctrlc = hooks.use_state(|| None::<Instant>);
 
@@ -469,8 +588,9 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let stdout_for_future = stdout.clone();
     let spinner_for_future = spinner.clone();
     let output_rx_for_future = Arc::clone(&output_rx);
+    let ui_rx_for_future = Arc::clone(&ui_rx);
 
-    // 80ms tick loop: drain output channel, update spinner text.
+    // 80ms tick loop: drain output/control channels, update spinner text.
     hooks.use_future(async move {
         loop {
             smol::Timer::after(Duration::from_millis(80)).await;
@@ -480,6 +600,25 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 loop {
                     match rx.try_recv() {
                         Ok(text) => stdout_for_future.println(text),
+                        Err(TryRecvError::Empty) => break,
+                        Err(TryRecvError::Disconnected) => break,
+                    }
+                }
+            }
+
+            if let Ok(rx) = ui_rx_for_future.lock() {
+                loop {
+                    match rx.try_recv() {
+                        Ok(UiCommand::ShowQuestion(question)) => {
+                            question_state.set(Some(question));
+                            question_selection.set(0);
+                            input_value.set(String::new());
+                        }
+                        Ok(UiCommand::ClearQuestion) => {
+                            question_state.set(None);
+                            question_selection.set(0);
+                            input_value.set(String::new());
+                        }
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => break,
                     }
@@ -509,16 +648,68 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 match code {
                     KeyCode::Enter if !modifiers.contains(KeyModifiers::SHIFT) => {
                         let val = input_value.read().clone();
-                        if !val.trim().is_empty() {
-                            let trimmed = val.trim();
-                            if trimmed == "/exit" || trimmed == "/quit" {
-                                let _ = input_tx_for_events.send(InputEvent::Exit);
-                                should_exit.set(true);
-                            } else {
-                                // Echo the input above.
-                                stdout_for_events.println(format!("\x1b[1m\u{276f} {val}\x1b[0m"));
-                                let _ = input_tx_for_events.send(InputEvent::Submit(val));
+                        let question = question_state.read().clone();
+                        let selected_index = *question_selection.read();
+                        if let Some(event) =
+                            enter_key_event_for_value(question.as_ref(), selected_index, &val)
+                        {
+                            match event {
+                                InputEvent::Exit => {
+                                    let _ = input_tx_for_events.send(InputEvent::Exit);
+                                    should_exit.set(true);
+                                }
+                                InputEvent::Submit(_) => {
+                                    stdout_for_events
+                                        .println(format!("\x1b[1m\u{276f} {val}\x1b[0m"));
+                                    let _ = input_tx_for_events.send(InputEvent::Submit(val));
+                                }
+                                InputEvent::QuestionAnswer(_) => {
+                                    let _ =
+                                        input_tx_for_events.send(InputEvent::QuestionAnswer(val));
+                                }
+                                InputEvent::Abort => {}
                             }
+                            input_value.set(String::new());
+                        }
+                    }
+                    KeyCode::Up
+                        if question_state
+                            .read()
+                            .as_ref()
+                            .is_some_and(|q| !q.options.is_empty()) =>
+                    {
+                        let current = *question_selection.read();
+                        question_selection.set(current.saturating_sub(1));
+                    }
+                    KeyCode::Down
+                        if question_state
+                            .read()
+                            .as_ref()
+                            .is_some_and(|q| !q.options.is_empty()) =>
+                    {
+                        let option_count = question_state
+                            .read()
+                            .as_ref()
+                            .map_or(0, |question| question.options.len());
+                        let current = *question_selection.read();
+                        question_selection.set((current + 1).min(option_count.saturating_sub(1)));
+                    }
+                    KeyCode::Char(ch)
+                        if question_state.read().as_ref().is_some_and(|q| {
+                            q.options.len() >= 2
+                                && ch.is_ascii_digit()
+                                && !modifiers.contains(KeyModifiers::CONTROL)
+                                && !modifiers.contains(KeyModifiers::ALT)
+                        }) =>
+                    {
+                        let digit = ch.to_digit(10).unwrap_or(0) as usize;
+                        let option_count = question_state
+                            .read()
+                            .as_ref()
+                            .map_or(0, |question| question.options.len());
+                        if digit >= 1 && digit <= option_count {
+                            let _ = input_tx_for_events
+                                .send(InputEvent::QuestionAnswer(digit.to_string()));
                             input_value.set(String::new());
                         }
                     }
@@ -568,6 +759,16 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
     let st = spinner_text.read().clone();
     let val = input_value.read().clone();
+    let question = question_state.read().clone();
+    let selected_index = *question_selection.read();
+    let question_panel = question
+        .as_ref()
+        .map(|question| format_question_panel(question, selected_index));
+    let prompt_label = if question.is_some() {
+        "\u{2753} "
+    } else {
+        "\u{276f} "
+    };
     let perm = permission_mode.clone();
 
     element! {
@@ -577,9 +778,12 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             } else {
                 None
             })
+            #(question_panel.map(|panel| element! {
+                Text(content: panel, color: Color::Cyan)
+            }))
             Text(content: "\u{2500}".repeat(60), color: Color::DarkGrey)
             View(flex_direction: FlexDirection::Row) {
-                Text(content: "\u{276f} ")
+                Text(content: prompt_label)
                 TextInput(
                     value: val,
                     has_focus: true,
@@ -605,11 +809,13 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 /// shared so the runner thread can update it atomically.
 pub fn spawn_repl_ui(permission_mode: &str, startup_banner: &str) -> ReplHandle {
     let (output_tx, output_rx) = mpsc::sync_channel::<String>(512);
+    let (ui_tx, ui_rx) = mpsc::sync_channel::<UiCommand>(16);
     let (input_tx, input_rx) = mpsc::sync_channel::<InputEvent>(16);
     let spinner = SpinnerState::new_inactive();
 
     let ctx = ReplContext {
         output_rx: Arc::new(Mutex::new(output_rx)),
+        ui_rx: Arc::new(Mutex::new(ui_rx)),
         input_tx: input_tx.clone(),
         spinner: spinner.clone(),
         permission_mode: permission_mode.to_string(),
@@ -641,8 +847,86 @@ pub fn spawn_repl_ui(permission_mode: &str, startup_banner: &str) -> ReplHandle 
 
     ReplHandle {
         output: OutputSender { tx: output_tx },
+        ui: UiCommandSender { tx: ui_tx },
         input_rx,
         spinner,
         ui_thread: Some(join_handle),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn question_with_options() -> QuestionPromptView {
+        QuestionPromptView {
+            title: Some("Setup".to_string()),
+            description: None,
+            index: 0,
+            total: 1,
+            prompt: "Pick one".to_string(),
+            options: vec![
+                QuestionOptionView {
+                    label: "Project".to_string(),
+                    value: "project".to_string(),
+                    description: None,
+                    recommended: true,
+                },
+                QuestionOptionView {
+                    label: "User".to_string(),
+                    value: "user".to_string(),
+                    description: None,
+                    recommended: false,
+                },
+            ],
+            allow_custom_input: false,
+            custom_input_hint: None,
+        }
+    }
+
+    #[test]
+    fn enter_in_question_mode_routes_answer_instead_of_prompt() {
+        let question = QuestionPromptView {
+            title: None,
+            description: None,
+            index: 0,
+            total: 1,
+            prompt: "Paste content".to_string(),
+            options: vec![],
+            allow_custom_input: true,
+            custom_input_hint: None,
+        };
+
+        assert_eq!(
+            enter_key_event_for_value(Some(&question), 0, "answer"),
+            Some(InputEvent::QuestionAnswer("answer".to_string()))
+        );
+    }
+
+    #[test]
+    fn enter_in_normal_mode_routes_submit() {
+        assert_eq!(
+            enter_key_event_for_value(None, 0, "hello"),
+            Some(InputEvent::Submit("hello".to_string()))
+        );
+    }
+
+    #[test]
+    fn enter_in_option_question_confirms_selected_option() {
+        let question = question_with_options();
+
+        assert_eq!(
+            enter_key_event_for_value(Some(&question), 1, ""),
+            Some(InputEvent::QuestionAnswer("2".to_string()))
+        );
+    }
+
+    #[test]
+    fn question_panel_marks_selected_option() {
+        let panel = format_question_panel(&question_with_options(), 1);
+
+        assert!(panel.contains("[Setup]"));
+        assert!(panel.contains("  1. Project recommended"));
+        assert!(panel.contains("> 2. User"));
     }
 }


### PR DESCRIPTION
## Summary
- Route iocraft AskUserQuestion responses through explicit UI question-answer events instead of stdin reads.
- Add a first-class question panel for text prompts and option prompts, including arrow-key selection and numeric shortcuts.
- Clear pending question state on abort, exit, and UI disconnect so Windows raw-mode terminals do not hang.

## Test Plan
- cargo test -p rusty-sudocode-cli --bin scode
- git diff --check