### PR TITLE
fix(runtime): compaction_persist test + cargo fmt

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -9,8 +9,8 @@ use plugins::{
     PluginLoadFailure, PluginLoadOutcome, PluginManager, PluginSummary,
 };
 use runtime::{
-    compact_session_sync, CompactionConfig, ConfigLoader, ConfigSource, McpOAuthConfig, McpServerConfig,
-    ScopedMcpServerConfig, Session,
+    compact_session_sync, CompactionConfig, ConfigLoader, ConfigSource, McpOAuthConfig,
+    McpServerConfig, ScopedMcpServerConfig, Session,
 };
 use serde_json::{json, Value};
 

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -1163,10 +1163,9 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 }),
             ),
         },
-        Scenario::LlmCompactionRoundtrip => text_message_response(
-            "msg_llm_compaction",
-            CANNED_COMPACTION_SUMMARY,
-        ),
+        Scenario::LlmCompactionRoundtrip => {
+            text_message_response("msg_llm_compaction", CANNED_COMPACTION_SUMMARY)
+        }
     }
 }
 

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -96,7 +96,8 @@ When summarizing the conversation focus on typescript code changes and also reme
 When you are using compact - please focus on test output and code changes. Include file reads verbatim.\n\
 </example>";
 
-const NO_TOOLS_TRAILER: &str = "\n\nREMINDER: Do NOT call any tools. Respond with plain text only — \
+const NO_TOOLS_TRAILER: &str =
+    "\n\nREMINDER: Do NOT call any tools. Respond with plain text only — \
 an <analysis> block followed by a <summary> block. \
 Tool calls will be rejected and you will fail the task.";
 
@@ -431,7 +432,12 @@ pub async fn compact_session<C: ApiClient>(
 
     // Call the LLM
     let llm_summary = api_client
-        .send_compaction(model, COMPACTION_SYSTEM_PROMPT, compaction_messages, max_tokens)
+        .send_compaction(
+            model,
+            COMPACTION_SYSTEM_PROMPT,
+            compaction_messages,
+            max_tokens,
+        )
         .await
         .map_err(|e| CompactionError::ApiError(e.to_string()))?;
 
@@ -1167,8 +1173,8 @@ mod tests {
 
     #[tokio::test]
     async fn async_compact_session_uses_llm_summary() {
-        use async_trait::async_trait;
         use crate::conversation::{ApiClient, ApiRequest, AssistantEventStream, RuntimeError};
+        use async_trait::async_trait;
 
         struct MockCompactionClient;
 
@@ -1218,20 +1224,19 @@ mod tests {
         };
 
         let mut client = MockCompactionClient;
-        let result = super::compact_session(
-            &session,
-            config,
-            &mut client,
-            "claude-sonnet-4-6",
-            None,
-        )
-        .await
-        .expect("LLM compaction should succeed");
+        let result =
+            super::compact_session(&session, config, &mut client, "claude-sonnet-4-6", None)
+                .await
+                .expect("LLM compaction should succeed");
 
         assert!(result.removed_message_count > 0);
-        assert!(result.formatted_summary.contains("User asked to test compaction"));
-        assert!(!result.formatted_summary.contains("Mock analysis"),
-            "analysis block should be stripped");
+        assert!(result
+            .formatted_summary
+            .contains("User asked to test compaction"));
+        assert!(
+            !result.formatted_summary.contains("Mock analysis"),
+            "analysis block should be stripped"
+        );
         assert_eq!(
             result.compacted_session.messages[0].role,
             MessageRole::System,
@@ -1240,8 +1245,8 @@ mod tests {
 
     #[tokio::test]
     async fn async_compact_session_falls_through_on_not_supported() {
-        use async_trait::async_trait;
         use crate::conversation::{ApiClient, ApiRequest, AssistantEventStream, RuntimeError};
+        use async_trait::async_trait;
 
         // Use the default ApiClient impl which returns "not supported"
         struct NoCompactionClient;
@@ -1274,14 +1279,8 @@ mod tests {
         };
 
         let mut client = NoCompactionClient;
-        let result = super::compact_session(
-            &session,
-            config,
-            &mut client,
-            "claude-sonnet-4-6",
-            None,
-        )
-        .await;
+        let result =
+            super::compact_session(&session, config, &mut client, "claude-sonnet-4-6", None).await;
 
         // Should fail with ApiError since default impl returns "not supported"
         assert!(result.is_err());

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -117,7 +117,9 @@ pub trait ApiClient: Send {
         _messages: Vec<ConversationMessage>,
         _max_tokens: u32,
     ) -> Result<String, RuntimeError> {
-        Err(RuntimeError::new("compaction not supported by this API client"))
+        Err(RuntimeError::new(
+            "compaction not supported by this API client",
+        ))
     }
 }
 
@@ -1426,20 +1428,27 @@ where
             .unwrap_or_else(|| "claude-sonnet-4-6".to_string());
 
         // Try LLM-based compaction first; fall back to sync if unsupported
-        let result =
-            match compact_session(&self.session, config, &mut self.api_client, &model, None).await {
-                Ok(result) => result,
-                Err(crate::compact::CompactionError::NothingToCompact) => {
-                    self.consecutive_auto_compact_noops =
-                        self.consecutive_auto_compact_noops.saturating_add(1);
-                    return None;
-                }
-                Err(_) => {
-                    // LLM compaction failed (not supported or API error) — fall
-                    // back to the synchronous local heuristic.
-                    compact_session_sync(&self.session, config)
-                }
-            };
+        let result = match compact_session(
+            &self.session,
+            config,
+            &mut self.api_client,
+            &model,
+            None,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(crate::compact::CompactionError::NothingToCompact) => {
+                self.consecutive_auto_compact_noops =
+                    self.consecutive_auto_compact_noops.saturating_add(1);
+                return None;
+            }
+            Err(_) => {
+                // LLM compaction failed (not supported or API error) — fall
+                // back to the synchronous local heuristic.
+                compact_session_sync(&self.session, config)
+            }
+        };
 
         if result.removed_message_count == 0 {
             self.consecutive_auto_compact_noops =

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -87,9 +87,8 @@ pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};
 pub use compact::{
     compact_session, compact_session_sync, estimate_block_tokens, estimate_session_tokens,
-    format_compact_summary, get_compact_continuation_message, should_compact,
-    CompactionConfig, CompactionError, CompactionResult,
-    AUTOCOMPACT_BUFFER_TOKENS, COMPACT_MAX_OUTPUT_TOKENS,
+    format_compact_summary, get_compact_continuation_message, should_compact, CompactionConfig,
+    CompactionError, CompactionResult, AUTOCOMPACT_BUFFER_TOKENS, COMPACT_MAX_OUTPUT_TOKENS,
 };
 pub use config::{
     default_config_home, load_plugin_mcp_servers, ConfigEntry, ConfigError, ConfigLoader,

--- a/rust/crates/runtime/tests/compaction_persist.rs
+++ b/rust/crates/runtime/tests/compaction_persist.rs
@@ -11,7 +11,7 @@
 use std::fs;
 
 use runtime::{
-    compact_session, CompactionConfig, ContentBlock, ConversationMessage, MessageRole, Session,
+    compact_session_sync, CompactionConfig, ContentBlock, ConversationMessage, MessageRole, Session,
 };
 
 fn temp_path(label: &str) -> std::path::PathBuf {
@@ -42,7 +42,7 @@ fn compacted_summary_survives_save_and_reload() {
     let original_len = session.messages.len();
 
     // when — force compaction, keeping only the last 2 messages.
-    let result = compact_session(
+    let result = compact_session_sync(
         &session,
         CompactionConfig {
             preserve_recent_messages: 2,

--- a/rust/crates/rusty-sudocode-cli/tests/compact_output.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/compact_output.rs
@@ -227,7 +227,15 @@ fn piped_stdin_with_compact_flag_produces_clean_output() {
         .env("HOME", &home)
         .env("NO_COLOR", "1")
         .env("PATH", "/usr/bin:/bin")
-        .args(["--auth", "api-key", "--model", "sonnet", "--permission-mode", "read-only", "--compact"])
+        .args([
+            "--auth",
+            "api-key",
+            "--model",
+            "sonnet",
+            "--permission-mode",
+            "read-only",
+            "--compact",
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary

- Fix compaction_persist.rs integration test that broke in #384 squash merge (still calling old 2-arg `compact_session` which is now async with 5 args — switch to `compact_session_sync`)
- Run `cargo fmt` to fix formatting diffs missed in the squash

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --test compaction_persist` passes
- [x] `cargo check --workspace` clean