### PR TITLE
refactor(cli): redesign iocraft REPL chrome with ChromeSlot pattern

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3947,15 +3947,12 @@ impl LiveCli {
             })
             .collect();
 
-        let hint = "  Type \x1b[1m/help\x1b[0m for commands · \x1b[1m/status\x1b[0m for live context · \x1b[2m/resume latest\x1b[0m jumps back to the newest session · \x1b[1m/diff\x1b[0m then \x1b[1m/commit\x1b[0m to ship · \x1b[2mTab\x1b[0m for /command completions";
-
         format!(
-            "{}\n\n{}\n{}\n{}\n\n{}",
+            "{}\n\n{}\n{}\n{}",
             logo,
             top,
             boxed_lines.join("\n"),
             bottom,
-            hint,
         )
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -4209,7 +4209,7 @@ impl LiveCli {
                     let branch = env::current_dir()
                         .ok()
                         .and_then(|cwd| resolve_git_branch_for(&cwd));
-                    ui.set_status_line(&format_turn_status_line_with_branch(
+                    ui.set_turn_result(&format_turn_status_line_with_branch(
                         &self.config.model,
                         turns,
                         &usage,

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -15,6 +15,7 @@
 //! [StatusSlot]    ← spinner | turn_result (auto-dismiss) | tips (first-run) | empty
 //! ──── separator ────
 //! [InputSlot]     ← text_input | question_panel   (Option<QuestionPromptView>)
+//! ──── separator ────
 //! [FooterSlot]    ← full | minimal | turn_active
 //! ```
 
@@ -788,7 +789,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 StatusSlot::Empty => None,
             })
             // Separator
-            Text(content: sep, color: Color::DarkGrey)
+            Text(content: sep.clone(), color: Color::DarkGrey)
             // InputSlot
             #(question_panel.map(|panel| element! {
                 Text(content: panel, color: Color::Cyan)
@@ -805,6 +806,8 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     },
                 )
             }
+            // Separator
+            Text(content: sep, color: Color::DarkGrey)
             // FooterSlot
             Text(content: footer_text, color: Color::DarkGrey)
         }

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -4,6 +4,19 @@
 //! replaces rustyline for interactive input.  Shows a persistent prompt
 //! with spinner overlay.  The coordinator thread reads `InputEvent`s from
 //! the returned `ReplHandle` and dispatches turns.
+//!
+//! # ChromeSlot pattern
+//!
+//! The REPL chrome uses a **ChromeSlot** convention: each position in the
+//! layout is an enum that renders exactly one variant at a time.  The enum
+//! + match makes the contract visible to any reader:
+//!
+//! ```text
+//! [StatusSlot]    ← spinner | turn_result (auto-dismiss) | tips (first-run) | empty
+//! ──── separator ────
+//! [InputSlot]     ← text_input | question_panel   (Option<QuestionPromptView>)
+//! [FooterSlot]    ← full | minimal | turn_active
+//! ```
 
 use std::fmt::Write as FmtWrite;
 use std::io::{self, Write};
@@ -149,6 +162,46 @@ fn format_compact_tokens(tokens: u32) -> String {
     }
 }
 
+// ── ChromeSlot enums ──────────────────────────────────────────────────
+
+/// ChromeSlot: status area above the separator. One variant renders at a time.
+///
+/// Priority: Spinner > TurnResult > Tips > Empty.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StatusSlot {
+    /// Animated progress during a turn.
+    Spinner(String),
+    /// Turn result (tokens/cost/ctx). Auto-dismisses after ~5 seconds.
+    TurnResult(String),
+    /// First-run tips. Dismissed on first submit.
+    Tips,
+    /// Nothing — slot not rendered, saves vertical space.
+    Empty,
+}
+
+/// ChromeSlot: bottom hint line. Content varies by lifecycle phase.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FooterSlot {
+    /// Before first submit — full hints.
+    Full,
+    /// After first submit — just permission mode + essentials.
+    Minimal,
+    /// During turn — permission mode only.
+    TurnActive,
+}
+
+fn format_footer_text(slot: &FooterSlot, perm: &str) -> String {
+    match slot {
+        FooterSlot::Full => format!(
+            "  \u{23f5}\u{23f5} {perm} \u{00b7} /help for commands \u{00b7} /exit to quit \u{00b7} Tab for /commands"
+        ),
+        FooterSlot::Minimal => format!(
+            "  \u{23f5}\u{23f5} {perm} \u{00b7} /help \u{00b7} /exit to quit"
+        ),
+        FooterSlot::TurnActive => format!("  \u{23f5}\u{23f5} {perm}"),
+    }
+}
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // iocraft REPL — replaces rustyline for interactive input
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -177,7 +230,7 @@ pub struct QuestionPromptView {
 pub enum UiCommand {
     ShowQuestion(QuestionPromptView),
     ClearQuestion,
-    SetStatusLine(String),
+    SetTurnResult(String),
 }
 
 #[derive(Clone)]
@@ -194,8 +247,8 @@ impl UiCommandSender {
         let _ = self.tx.send(UiCommand::ClearQuestion);
     }
 
-    pub fn set_status_line(&self, text: &str) {
-        let _ = self.tx.send(UiCommand::SetStatusLine(text.to_string()));
+    pub fn set_turn_result(&self, text: &str) {
+        let _ = self.tx.send(UiCommand::SetTurnResult(text.to_string()));
     }
 }
 
@@ -374,6 +427,7 @@ struct ReplContext {
     input_tx: SyncSender<InputEvent>,
     spinner: SpinnerState,
     permission_mode: String,
+    tips_line: String,
 }
 
 #[component]
@@ -384,6 +438,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let input_tx = ctx.input_tx.clone();
     let spinner = ctx.spinner.clone();
     let permission_mode = ctx.permission_mode.clone();
+    let tips_text = ctx.tips_line.clone();
     drop(ctx);
 
     // use_terminal_size must be called before use_future and use_terminal_events
@@ -395,7 +450,9 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut input_value = hooks.use_state(String::new);
     let mut frame = hooks.use_state(|| 0usize);
     let mut spinner_text = hooks.use_state(String::new);
-    let mut status_line = hooks.use_state(String::new);
+    let mut turn_result = hooks.use_state(|| None::<String>);
+    let mut turn_result_time = hooks.use_state(|| None::<Instant>);
+    let mut has_submitted = hooks.use_state(|| false);
     let mut question_state = hooks.use_state(|| None::<QuestionPromptView>);
     let mut question_selection = hooks.use_state(|| 0usize);
     let mut should_exit = hooks.use_state(|| false);
@@ -422,7 +479,21 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 loop {
                     match rx.try_recv() {
                         Ok(OutputMsg::Line(text)) => stdout_for_future.println(text),
-                        Ok(OutputMsg::Raw(text)) => stdout_for_future.print(text),
+                        Ok(OutputMsg::Raw(text)) => {
+                            // Raw chunks from the streaming markdown renderer
+                            // contain bare \n. In raw mode iocraft needs \r\n.
+                            // StdoutHandle::println handles \r\n conversion for
+                            // the trailing newline but not for internal ones.
+                            // Split on \n and println each line individually.
+                            let mut lines = text.split('\n').peekable();
+                            while let Some(line) = lines.next() {
+                                if lines.peek().is_some() {
+                                    stdout_for_future.println(line);
+                                } else if !line.is_empty() {
+                                    stdout_for_future.print(line);
+                                }
+                            }
+                        }
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => break,
                     }
@@ -442,13 +513,23 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             question_selection.set(0);
                             input_value.set(String::new());
                         }
-                        Ok(UiCommand::SetStatusLine(text)) => {
-                            status_line.set(text);
+                        Ok(UiCommand::SetTurnResult(text)) => {
+                            turn_result.set(Some(text));
+                            turn_result_time.set(Some(Instant::now()));
                         }
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => break,
                     }
                 }
+            }
+
+            // Auto-dismiss turn result after 5 seconds.
+            if turn_result_time
+                .read()
+                .is_some_and(|t| t.elapsed() >= Duration::from_secs(5))
+            {
+                turn_result.set(None);
+                turn_result_time.set(None);
             }
 
             // Update spinner.
@@ -479,6 +560,9 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         if let Some(event) =
                             enter_key_event_for_value(question.as_ref(), selected_index, &val)
                         {
+                            if !*has_submitted.read() {
+                                has_submitted.set(true);
+                            }
                             match event {
                                 InputEvent::Exit => {
                                     should_exit.set(true);
@@ -652,10 +736,34 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         system.exit();
     }
 
+    // ── Derive ChromeSlots from state ──────────────────────────────────
     let st = spinner_text.read().clone();
     let val = input_value.read().clone();
     let question = question_state.read().clone();
     let selected_index = *question_selection.read();
+    let submitted = *has_submitted.read();
+
+    // StatusSlot: Spinner > TurnResult > Tips > Empty
+    let status_slot = if !st.is_empty() {
+        StatusSlot::Spinner(st)
+    } else if let Some(ref tr) = *turn_result.read() {
+        StatusSlot::TurnResult(tr.clone())
+    } else if !submitted {
+        StatusSlot::Tips
+    } else {
+        StatusSlot::Empty
+    };
+
+    // FooterSlot
+    let footer_slot = if matches!(status_slot, StatusSlot::Spinner(_)) {
+        FooterSlot::TurnActive
+    } else if submitted {
+        FooterSlot::Minimal
+    } else {
+        FooterSlot::Full
+    };
+
+    // InputSlot (ChromeSlot: text_input | question_panel — driven by question_state)
     let question_panel = question
         .as_ref()
         .map(|question| format_question_panel(question, selected_index));
@@ -664,28 +772,27 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     } else {
         "\u{276f} "
     };
-    let perm = permission_mode.clone();
 
+    let perm = permission_mode.clone();
     let w = term_width as usize;
-    let status = status_line.read().clone();
     let sep = "\u{2500}".repeat(w);
+    let footer_text = format_footer_text(&footer_slot, &perm);
 
     element! {
         View(flex_direction: FlexDirection::Column) {
-            #(if !st.is_empty() {
-                Some(element! { Text(content: st.clone()) })
-            } else {
-                None
+            // StatusSlot
+            #(match &status_slot {
+                StatusSlot::Spinner(s) => Some(element! { Text(content: s.clone()) }),
+                StatusSlot::TurnResult(s) => Some(element! { Text(content: s.clone(), color: Color::DarkGrey) }),
+                StatusSlot::Tips => Some(element! { Text(content: tips_text.clone(), color: Color::DarkGrey) }),
+                StatusSlot::Empty => None,
             })
+            // Separator
+            Text(content: sep, color: Color::DarkGrey)
+            // InputSlot
             #(question_panel.map(|panel| element! {
                 Text(content: panel, color: Color::Cyan)
             }))
-            #(if !status.is_empty() {
-                Some(element! { Text(content: status.clone(), color: Color::DarkGrey) })
-            } else {
-                None
-            })
-            Text(content: sep.clone(), color: Color::DarkGrey)
             View(flex_direction: FlexDirection::Row) {
                 Text(content: prompt_label)
                 TextInput(
@@ -698,11 +805,8 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     },
                 )
             }
-            Text(content: sep, color: Color::DarkGrey)
-            Text(
-                content: format!("  \u{23f5}\u{23f5} {perm} \u{00b7} /help \u{00b7} /exit to quit"),
-                color: Color::DarkGrey,
-            )
+            // FooterSlot
+            Text(content: footer_text, color: Color::DarkGrey)
         }
     }
 }
@@ -725,6 +829,7 @@ pub fn spawn_repl_ui(permission_mode: &str, startup_banner: &str) -> ReplHandle 
         input_tx: input_tx.clone(),
         spinner: spinner.clone(),
         permission_mode: permission_mode.to_string(),
+        tips_line: "Type /help for commands \u{00b7} /status for live context \u{00b7} /resume latest jumps back to the newest session \u{00b7} /diff then /commit to ship \u{00b7} Tab for /command completions".to_string(),
     };
 
     let banner = startup_banner.to_string();


### PR DESCRIPTION
## Summary

- Introduce **ChromeSlot** convention for the iocraft REPL chrome — each position renders exactly one enum variant at a time
- **StatusSlot** (above separator): `Spinner > TurnResult > Tips > Empty` with 5s auto-dismiss for turn results and first-run tips
- **FooterSlot** (below input): `Full | Minimal | TurnActive` — adapts hint density to lifecycle
- Remove bottom separator, move question panel into InputSlot
- Fix raw output `\n` → `\r\n` conversion for correct rendering in iocraft raw terminal mode (fixes stairstepped streaming output)
- Rename `UiCommand::SetStatusLine` → `SetTurnResult` for semantic clarity

## Test plan

- [x] `cargo test -p rusty-sudocode-cli --bin scode -- repl_ui` (10/10 pass)
- [x] `cargo test -p rusty-sudocode-cli --test pty_repl_iocraft_features -- --test-threads=1` (3/3 pass)
- [x] `cargo test -p rusty-sudocode-cli --test pty_iocraft_chrome -- --test-threads=1` (5/5 pass)
- [ ] Manual: tips → first submit → tips gone → spinner during turn → turn result 5s → empty
- [ ] `SCODE_TEST_BACKEND=live` streaming code block test