### PR TITLE
feat(runtime): co-host readiness — kernel pin bump + FsBackend switch (VFS-in-process tools)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -209,6 +209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +228,45 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-channel"
@@ -422,6 +470,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -752,6 +806,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -785,7 +845,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs#418fec88500f974213525651e55fbd8fd9c4afaa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "parking_lot",
  "serde",
@@ -985,6 +1045,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1124,30 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -1102,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -1168,6 +1279,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1266,6 +1401,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -2069,9 +2210,10 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs#418fec88500f974213525651e55fbd8fd9c4afaa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "ahash",
+ "arc-swap",
  "base64",
  "blake3",
  "bloomfilter",
@@ -2080,14 +2222,17 @@ dependencies = [
  "contracts",
  "crc32fast",
  "dashmap",
+ "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
  "lib",
  "libc",
+ "libloading",
  "lru",
  "memchr",
  "memmap2",
+ "nexus-plugin-abi",
  "parking_lot",
  "prost 0.14.3",
  "protoc-bin-vendored",
@@ -2133,7 +2278,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs#418fec88500f974213525651e55fbd8fd9c4afaa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "ahash",
  "base64",
@@ -2148,7 +2293,9 @@ dependencies = [
  "pem",
  "regex",
  "regex-syntax",
+ "ring",
  "roaring",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2158,6 +2305,7 @@ dependencies = [
  "tokio",
  "tonic 0.14.6",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2165,6 +2313,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libredox"
@@ -2316,6 +2474,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nexus-plugin-abi"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+
+[[package]]
 name = "nexus-vfs-client"
 version = "0.1.18"
 dependencies = [
@@ -2382,10 +2545,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2473,6 +2655,15 @@ dependencies = [
  "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2681,6 +2872,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3184,6 +3385,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3440,6 +3644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -3912,6 +4125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,6 +4201,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -5306,6 +5538,24 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4690,6 +4690,7 @@ dependencies = [
  "commands",
  "flate2",
  "futures",
+ "kernel",
  "plugins",
  "reqwest",
  "runtime",

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -28,15 +28,16 @@ futures = "0.3"
 # trees ever drop it.
 getrandom = "0.2"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-# Nexus kernel rlib — provides `kernel::abi::KernelAbi` trait that
-# `runtime::spawn_task::<K>` is generic over. `default-features =
-# false` keeps the kernel runtime defaults (mimalloc, connector
-# stack, py-hook adapters) off in the sudocode build — sudocode does
-# not need them and they would bloat the standalone CLI.
+# Nexus kernel rlib — provides `kernel::kernel::syscall::KernelSyscall`
+# trait that `runtime::spawn_task::<K>` is generic over. `default-features
+# = false` keeps the kernel runtime defaults (mimalloc, connector stack,
+# py-hook adapters) off in the sudocode build — sudocode does not need
+# them and they would bloat the standalone CLI.
 #
-# Points at nexus-vfs main (the kernel crate's canonical home after
-# the DRY repo extraction, #4259).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", default-features = false }
+# Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
+# `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
+# sudocode_runtime and the nexus service crates (co-host binary edge).
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -1,6 +1,5 @@
 use std::cmp::Reverse;
 use std::collections::HashSet;
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -8,7 +7,6 @@ use std::time::Instant;
 use glob::Pattern;
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
-use walkdir::{DirEntry, WalkDir};
 
 use crate::fs_backend::FsBackend;
 
@@ -184,8 +182,7 @@ pub fn read_file(
     offset: Option<usize>,
     limit: Option<usize>,
 ) -> io::Result<ReadFileOutput> {
-    let absolute_path = normalize_path(path)?;
-    let abs_str = absolute_path.to_string_lossy();
+    let abs_str = fs.normalize(path)?;
 
     // Size check via stat (works for both local and remote backends).
     if let Ok(meta) = fs.stat(&abs_str) {
@@ -231,7 +228,7 @@ pub fn read_file(
     Ok(ReadFileOutput {
         kind: String::from("text"),
         file: TextFilePayload {
-            file_path: absolute_path.to_string_lossy().into_owned(),
+            file_path: abs_str.clone(),
             content: selected,
             num_lines: end_index.saturating_sub(start_index),
             start_line: start_index.saturating_add(1),
@@ -253,14 +250,12 @@ pub fn write_file(fs: &dyn FsBackend, path: &str, content: &str) -> io::Result<W
         ));
     }
 
-    let absolute_path = normalize_path_allow_missing(path)?;
-    let abs_str = absolute_path.to_string_lossy().into_owned();
+    let abs_str = fs.normalize_allow_missing(path)?;
 
     let original_file = fs.read_to_string(&abs_str).ok();
 
-    if let Some(parent) = absolute_path.parent() {
-        let parent_str = parent.to_string_lossy();
-        let _ = fs.create_dir_all(&parent_str);
+    if let Some(parent) = Path::new(&abs_str).parent() {
+        let _ = fs.create_dir_all(&parent.to_string_lossy());
     }
     fs.write(&abs_str, content.as_bytes())?;
 
@@ -286,8 +281,7 @@ pub fn edit_file(
     new_string: &str,
     replace_all: bool,
 ) -> io::Result<EditFileOutput> {
-    let absolute_path = normalize_path(path)?;
-    let abs_str = absolute_path.to_string_lossy().into_owned();
+    let abs_str = fs.normalize(path)?;
 
     let original_file = fs.read_to_string(&abs_str)?;
 
@@ -325,53 +319,52 @@ pub fn edit_file(
 }
 
 // ---------------------------------------------------------------------------
-// Intentional std::fs exclusions (NOT migrated to FsBackend)
+// FsBackend-routed traversal
 //
-// The following functions remain on std::fs because they depend on host
-// filesystem traversal (WalkDir) or host-only metadata that has no VFS
-// equivalent:
-//
-// - glob_search: WalkDir-based host traversal + fs::metadata for mtime sort
-// - grep_search: WalkDir-based host traversal + fs::read_to_string per file
-//
-// Other intentional exclusions in the runtime crate:
-// - sandbox.rs: /proc/1/cgroup — host OS container detection
-// - bash.rs: sandbox dirs — host filesystem isolation
-// - oauth.rs: /dev/urandom — crypto random source (File::open)
-// - trust_resolver.rs: #[cfg(test)] only module
+// `glob_search` (namespace) and `grep_search` (content) walk through the
+// injected `&dyn FsBackend` so a co-hosted managed agent hits the VFS
+// in-process (`sys_readdir` / `sys_read`) instead of the host filesystem.
+// The `StdFsBackend` path preserves the standalone CLI's behaviour exactly
+// (host `read_dir` + `metadata`). The recursion is composed from
+// single-level `readdir` calls; the mount-aware one-call recursive
+// `sys_readdir` (nexus-vfs #222) is a later kernel-rev optimisation and is
+// tracked separately — in-process single-level composition adds no gRPC
+// hop, so it is cheap today.
 // ---------------------------------------------------------------------------
 
-/// Expands a glob pattern and returns matching filenames.
-pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOutput> {
+/// Expands a glob pattern and returns matching filenames, walking the
+/// namespace through the [`FsBackend`].
+pub fn glob_search(
+    fs: &dyn FsBackend,
+    pattern: &str,
+    path: Option<&str>,
+) -> io::Result<GlobSearchOutput> {
     let started = Instant::now();
-    // Use `normalize_path_for_glob` (not `normalize_path`) here:
-    // `canonicalize()` returns Windows verbatim paths (`\\?\C:\…`),
-    // and the forward-slash rewrite below then produces `//?/C:/…`,
-    // which is not a Verbatim-prefixed path under Path::components
-    // semantics — `derive_glob_walk_root` then fails to recover the
-    // base directory and silently falls back to `current_dir()`,
-    // sending WalkDir off into the cwd of the test (the runtime
-    // crate, not the test's temp dir). Just absolutise without
-    // canonicalising.
-    let base_dir = path
-        .map(normalize_path_for_glob)
-        .transpose()?
-        .unwrap_or(std::env::current_dir()?);
-    // The `glob` crate's pattern grammar reserves `\` as an escape
-    // character, so a Windows path like `C:\Users\...` would be
-    // misparsed (e.g. `\U` is treated as an escaped `U`, breaking
-    // every match). The crate's documented rule is to feed it
-    // forward-slash patterns regardless of host; it handles
-    // matching against backslash-separated entries internally.
-    let search_pattern = if Path::new(pattern).is_absolute() {
-        pattern.replace('\\', "/")
-    } else {
-        base_dir.join(pattern).to_string_lossy().replace('\\', "/")
+    // Base directory for relative patterns. Resolve *without* host
+    // canonicalisation: on Windows `canonicalize()` yields a verbatim
+    // `\\?\C:\…` prefix that, once rewritten to forward slashes for the
+    // `glob` crate, breaks `derive_glob_walk_root_str`; on a VFS backend it
+    // would fail outright. `working_root()` (cwd for std, the agent
+    // workspace for the kernel backend) plus a lexical join is the correct,
+    // backend-agnostic base.
+    let base_dir = match path {
+        Some(p) if is_absolute_path(p) => p.to_string(),
+        Some(p) => format!("{}/{}", fs.working_root()?.trim_end_matches(['/', '\\']), p),
+        None => fs.working_root()?,
     };
 
-    // The `glob` crate does not support brace expansion ({a,b,c}).
-    // Expand braces into multiple patterns so patterns like
-    // `Assets/**/*.{cs,uxml,uss}` work correctly.
+    // The `glob` crate reserves `\` as an escape character, so a Windows
+    // path like `C:\Users\...` would be misparsed. Feed it forward-slash
+    // patterns regardless of host; it matches backslash-separated entries
+    // internally.
+    let search_pattern = if is_absolute_path(pattern) {
+        pattern.replace('\\', "/")
+    } else {
+        format!("{}/{}", base_dir.trim_end_matches(['/', '\\']), pattern).replace('\\', "/")
+    };
+
+    // The `glob` crate does not support brace expansion ({a,b,c}). Expand
+    // into multiple patterns so `Assets/**/*.{cs,uxml,uss}` works.
     let expanded = expand_braces(&search_pattern);
 
     let mut seen = HashSet::new();
@@ -379,41 +372,34 @@ pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOu
     for pat in &expanded {
         let compiled = Pattern::new(pat)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
-        let walk_root = derive_glob_walk_root(pat);
-        let entries = WalkDir::new(&walk_root)
-            .into_iter()
-            .filter_entry(|entry| !should_skip_glob_dir(entry));
-        for entry in entries.flatten() {
-            let candidate = entry.path();
-            // Compare against a forward-slash-normalised string so the
-            // forward-slash glob pattern (see the search_pattern
-            // construction above) matches the Windows-side
-            // backslash-separated WalkDir output. `matches_path` would
-            // walk OS-native Path components and mismatch the slash
-            // orientation.
-            let candidate_str = candidate.to_string_lossy().replace('\\', "/");
-            if entry.file_type().is_file()
-                && compiled.matches(&candidate_str)
-                && seen.insert(candidate.to_path_buf())
-            {
-                matches.push(candidate.to_path_buf());
+        let walk_root = derive_glob_walk_root_str(pat, &base_dir);
+        let mut candidates = Vec::new();
+        walk_files_via_backend(
+            fs,
+            &walk_root,
+            &|name| GLOB_SEARCH_IGNORED_DIRS.contains(&name),
+            &mut candidates,
+        );
+        for candidate in candidates {
+            // Match against a forward-slash-normalised string so the
+            // forward-slash glob pattern matches the Windows-side
+            // backslash-separated entries.
+            let candidate_str = candidate.replace('\\', "/");
+            if compiled.matches(&candidate_str) && seen.insert(candidate_str.clone()) {
+                matches.push(candidate_str);
             }
         }
     }
 
     matches.sort_by_key(|path| {
-        fs::metadata(path)
-            .and_then(|metadata| metadata.modified())
+        fs.stat(path)
             .ok()
+            .and_then(|metadata| metadata.modified)
             .map(Reverse)
     });
 
     let truncated = matches.len() > 100;
-    let filenames = matches
-        .into_iter()
-        .take(100)
-        .map(|path| path.to_string_lossy().into_owned())
-        .collect::<Vec<_>>();
+    let filenames = matches.into_iter().take(100).collect::<Vec<_>>();
 
     Ok(GlobSearchOutput {
         duration_ms: started.elapsed().as_millis(),
@@ -424,13 +410,11 @@ pub fn glob_search(pattern: &str, path: Option<&str>) -> io::Result<GlobSearchOu
 }
 
 /// Runs a regex search over workspace files with optional context lines.
-pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
-    let base_path = input
-        .path
-        .as_deref()
-        .map(normalize_path)
-        .transpose()?
-        .unwrap_or(std::env::current_dir()?);
+pub fn grep_search(fs: &dyn FsBackend, input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
+    let base_path = match input.path.as_deref() {
+        Some(p) => fs.normalize(p)?,
+        None => fs.working_root()?,
+    };
 
     let regex = RegexBuilder::new(&input.pattern)
         .case_insensitive(input.case_insensitive.unwrap_or(false))
@@ -455,19 +439,19 @@ pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
     let mut content_lines = Vec::new();
     let mut total_matches = 0usize;
 
-    for file_path in collect_search_files(&base_path)? {
-        if !matches_optional_filters(&file_path, glob_filter.as_ref(), file_type) {
+    for file_path in collect_search_files_via_backend(fs, &base_path) {
+        if !matches_optional_filters(Path::new(&file_path), glob_filter.as_ref(), file_type) {
             continue;
         }
 
-        let Ok(file_contents) = fs::read_to_string(&file_path) else {
+        let Ok(file_contents) = fs.read_to_string(&file_path) else {
             continue;
         };
 
         if output_mode == "count" {
             let count = regex.find_iter(&file_contents).count();
             if count > 0 {
-                filenames.push(file_path.to_string_lossy().into_owned());
+                filenames.push(file_path.clone());
                 total_matches += count;
             }
             continue;
@@ -486,16 +470,16 @@ pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
             continue;
         }
 
-        filenames.push(file_path.to_string_lossy().into_owned());
+        filenames.push(file_path.clone());
         if output_mode == "content" {
             for index in matched_lines {
                 let start = index.saturating_sub(input.before.unwrap_or(context));
                 let end = (index + input.after.unwrap_or(context) + 1).min(lines.len());
                 for (current, line) in lines.iter().enumerate().take(end).skip(start) {
                     let prefix = if input.line_numbers.unwrap_or(true) {
-                        format!("{}:{}:", file_path.to_string_lossy(), current + 1)
+                        format!("{file_path}:{}:", current + 1)
                     } else {
-                        format!("{}:", file_path.to_string_lossy())
+                        format!("{file_path}:")
                     };
                     content_lines.push(format!("{prefix}{line}"));
                 }
@@ -533,32 +517,59 @@ pub fn grep_search(input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
     })
 }
 
-fn should_skip_glob_dir(entry: &DirEntry) -> bool {
-    entry.file_type().is_dir()
-        && entry
-            .file_name()
-            .to_str()
-            .is_some_and(|name| GLOB_SEARCH_IGNORED_DIRS.contains(&name))
+/// Recursively collect absolute file paths under `root` via the backend's
+/// single-level `readdir`, skipping directories for which `skip_dir`
+/// returns true. Composed in-process from `readdir` calls — no host
+/// `WalkDir` — so a co-hosted agent descends the VFS trie.
+fn walk_files_via_backend(
+    fs: &dyn FsBackend,
+    root: &str,
+    skip_dir: &dyn Fn(&str) -> bool,
+    out: &mut Vec<String>,
+) {
+    let entries = fs.readdir(root).unwrap_or_default();
+    if entries.is_empty() {
+        // Either an empty directory or an exact-path root that names a
+        // file (readdir on a file yields nothing) — include the file so
+        // glob/grep on a concrete path still resolves it.
+        if let Ok(meta) = fs.stat(root) {
+            if meta.is_file {
+                out.push(root.to_string());
+            }
+        }
+        return;
+    }
+    for entry in entries {
+        let child = fs.join_path(root, &entry.name);
+        if entry.is_dir {
+            if skip_dir(&entry.name) {
+                continue;
+            }
+            walk_files_via_backend(fs, &child, skip_dir, out);
+        } else {
+            out.push(child);
+        }
+    }
 }
 
-fn derive_glob_walk_root(pattern: &str) -> PathBuf {
-    let path = Path::new(pattern);
-    let mut prefix = PathBuf::new();
-    let mut saw_component = false;
-
-    for component in path.components() {
-        let text = component.as_os_str().to_string_lossy();
-        if component_contains_glob(&text) {
+/// Longest leading glob-free prefix of a forward-slash pattern — the
+/// directory the walk starts from. Falls back to `fallback` when the
+/// pattern begins with a wildcard component.
+fn derive_glob_walk_root_str(pattern: &str, fallback: &str) -> String {
+    let mut prefix: Vec<&str> = Vec::new();
+    for comp in pattern.split('/') {
+        if component_contains_glob(comp) {
             break;
         }
-        prefix.push(component.as_os_str());
-        saw_component = true;
+        prefix.push(comp);
     }
-
-    if saw_component {
-        prefix
+    // A leading `/` yields an empty first segment; keep it so the rejoined
+    // root stays absolute. Fall back only when there is no glob-free
+    // component at all (the pattern starts with a wildcard).
+    if prefix.iter().any(|c| !c.is_empty()) {
+        prefix.join("/")
     } else {
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+        fallback.to_string()
     }
 }
 
@@ -566,19 +577,28 @@ fn component_contains_glob(component: &str) -> bool {
     component.contains('*') || component.contains('?') || component.contains('[')
 }
 
-fn collect_search_files(base_path: &Path) -> io::Result<Vec<PathBuf>> {
-    if base_path.is_file() {
-        return Ok(vec![base_path.to_path_buf()]);
-    }
+/// Absolute-path test that spans both namespaces `glob_search` serves: a
+/// leading `/` (VFS / Unix) OR a host-absolute path (`Path::is_absolute`,
+/// which on Windows requires a drive/UNC prefix — a bare `/ws` is NOT
+/// Windows-absolute, so the leading-slash check is what recognises VFS
+/// paths on Windows).
+fn is_absolute_path(p: &str) -> bool {
+    p.starts_with('/') || Path::new(p).is_absolute()
+}
 
-    let mut files = Vec::new();
-    for entry in WalkDir::new(base_path) {
-        let entry = entry.map_err(|error| io::Error::other(error.to_string()))?;
-        if entry.file_type().is_file() {
-            files.push(entry.path().to_path_buf());
+/// Collect the files `grep_search` scans under `base`, walking the backend.
+/// Unlike `glob_search` this does NOT prune heavy directories — grep over an
+/// explicit path searches everything the caller pointed at (parity with the
+/// prior `WalkDir`-over-everything behaviour).
+fn collect_search_files_via_backend(fs: &dyn FsBackend, base: &str) -> Vec<String> {
+    if let Ok(meta) = fs.stat(base) {
+        if meta.is_file {
+            return vec![base.to_string()];
         }
     }
-    Ok(files)
+    let mut files = Vec::new();
+    walk_files_via_backend(fs, base, &|_| false, &mut files);
+    files
 }
 
 fn matches_optional_filters(
@@ -587,8 +607,12 @@ fn matches_optional_filters(
     file_type: Option<&str>,
 ) -> bool {
     if let Some(glob_filter) = glob_filter {
-        let path_string = path.to_string_lossy();
-        if !glob_filter.matches(&path_string) && !glob_filter.matches_path(path) {
+        // Match against a forward-slash-normalised string (the glob crate's
+        // documented convention) so a `**/*.rs` filter matches regardless
+        // of host separator or a Windows verbatim `\\?\C:\…` prefix that
+        // `matches_path`'s OS-component walk chokes on.
+        let normalised = path.to_string_lossy().replace('\\', "/");
+        if !glob_filter.matches(&normalised) && !glob_filter.matches_path(path) {
             return false;
         }
     }
@@ -642,51 +666,6 @@ fn make_patch(original: &str, updated: &str) -> Vec<StructuredPatchHunk> {
     }]
 }
 
-fn normalize_path(path: &str) -> io::Result<PathBuf> {
-    let candidate = if Path::new(path).is_absolute() {
-        PathBuf::from(path)
-    } else {
-        std::env::current_dir()?.join(path)
-    };
-    candidate.canonicalize()
-}
-
-/// Like [`normalize_path`] but without `canonicalize`. Required by
-/// `glob_search` on Windows: the verbatim prefix that
-/// `canonicalize()` adds (`\\?\C:\…`) breaks `derive_glob_walk_root`
-/// once the path is rewritten to forward slashes for the glob crate.
-fn normalize_path_for_glob(path: &str) -> io::Result<PathBuf> {
-    let candidate = if Path::new(path).is_absolute() {
-        PathBuf::from(path)
-    } else {
-        std::env::current_dir()?.join(path)
-    };
-    Ok(candidate)
-}
-
-fn normalize_path_allow_missing(path: &str) -> io::Result<PathBuf> {
-    let candidate = if Path::new(path).is_absolute() {
-        PathBuf::from(path)
-    } else {
-        std::env::current_dir()?.join(path)
-    };
-
-    if let Ok(canonical) = candidate.canonicalize() {
-        return Ok(canonical);
-    }
-
-    if let Some(parent) = candidate.parent() {
-        let canonical_parent = parent
-            .canonicalize()
-            .unwrap_or_else(|_| parent.to_path_buf());
-        if let Some(name) = candidate.file_name() {
-            return Ok(canonical_parent.join(name));
-        }
-    }
-
-    Ok(candidate)
-}
-
 /// Read a file with workspace boundary enforcement.
 #[allow(dead_code)]
 pub fn read_file_in_workspace(
@@ -696,11 +675,11 @@ pub fn read_file_in_workspace(
     limit: Option<usize>,
     workspace_root: &Path,
 ) -> io::Result<ReadFileOutput> {
-    let absolute_path = normalize_path(path)?;
+    let absolute_path = fs.normalize(path)?;
     let canonical_root = workspace_root
         .canonicalize()
         .unwrap_or_else(|_| workspace_root.to_path_buf());
-    validate_workspace_boundary(&absolute_path, &canonical_root)?;
+    validate_workspace_boundary(Path::new(&absolute_path), &canonical_root)?;
     read_file(fs, path, offset, limit)
 }
 
@@ -712,11 +691,11 @@ pub fn write_file_in_workspace(
     content: &str,
     workspace_root: &Path,
 ) -> io::Result<WriteFileOutput> {
-    let absolute_path = normalize_path_allow_missing(path)?;
+    let absolute_path = fs.normalize_allow_missing(path)?;
     let canonical_root = workspace_root
         .canonicalize()
         .unwrap_or_else(|_| workspace_root.to_path_buf());
-    validate_workspace_boundary(&absolute_path, &canonical_root)?;
+    validate_workspace_boundary(Path::new(&absolute_path), &canonical_root)?;
     write_file(fs, path, content)
 }
 
@@ -730,11 +709,11 @@ pub fn edit_file_in_workspace(
     replace_all: bool,
     workspace_root: &Path,
 ) -> io::Result<EditFileOutput> {
-    let absolute_path = normalize_path(path)?;
+    let absolute_path = fs.normalize(path)?;
     let canonical_root = workspace_root
         .canonicalize()
         .unwrap_or_else(|_| workspace_root.to_path_buf());
-    validate_workspace_boundary(&absolute_path, &canonical_root)?;
+    validate_workspace_boundary(Path::new(&absolute_path), &canonical_root)?;
     edit_file(fs, path, old_string, new_string, replace_all)
 }
 
@@ -913,11 +892,10 @@ pub fn edit_file_with_intent(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        component_contains_glob, derive_glob_walk_root, edit_file, expand_braces, glob_search,
+        component_contains_glob, derive_glob_walk_root_str, edit_file, expand_braces, glob_search,
         grep_search, is_symlink_escape, read_file, read_file_in_workspace, write_file,
         GrepSearchInput, MAX_WRITE_SIZE,
     };
@@ -1048,26 +1026,29 @@ mod tests {
         )
         .expect("file write should succeed");
 
-        let globbed = glob_search("**/*.rs", Some(dir.to_string_lossy().as_ref()))
+        let globbed = glob_search(fs, "**/*.rs", Some(dir.to_string_lossy().as_ref()))
             .expect("glob should succeed");
         assert_eq!(globbed.num_files, 1);
 
-        let grep_output = grep_search(&GrepSearchInput {
-            pattern: String::from("hello"),
-            path: Some(dir.to_string_lossy().into_owned()),
-            glob: Some(String::from("**/*.rs")),
-            output_mode: Some(String::from("content")),
-            before: None,
-            after: None,
-            context_short: None,
-            context: None,
-            line_numbers: Some(true),
-            case_insensitive: Some(false),
-            file_type: None,
-            head_limit: Some(10),
-            offset: Some(0),
-            multiline: Some(false),
-        })
+        let grep_output = grep_search(
+            fs,
+            &GrepSearchInput {
+                pattern: String::from("hello"),
+                path: Some(dir.to_string_lossy().into_owned()),
+                glob: Some(String::from("**/*.rs")),
+                output_mode: Some(String::from("content")),
+                before: None,
+                after: None,
+                context_short: None,
+                context: None,
+                line_numbers: Some(true),
+                case_insensitive: Some(false),
+                file_type: None,
+                head_limit: Some(10),
+                offset: Some(0),
+                multiline: Some(false),
+            },
+        )
         .expect("grep should succeed");
         assert!(grep_output.content.unwrap_or_default().contains("hello"));
     }
@@ -1110,8 +1091,8 @@ mod tests {
         std::fs::write(dir.join("b.toml"), "[package]").unwrap();
         std::fs::write(dir.join("c.txt"), "hello").unwrap();
 
-        let result =
-            glob_search("*.{rs,toml}", Some(dir.to_str().unwrap())).expect("glob should succeed");
+        let result = glob_search(&StdFsBackend, "*.{rs,toml}", Some(dir.to_str().unwrap()))
+            .expect("glob should succeed");
         assert_eq!(
             result.num_files, 2,
             "should match .rs and .toml but not .txt"
@@ -1134,8 +1115,8 @@ mod tests {
         std::fs::write(dir.join(".build/checkouts/pkg/AGENTS.md"), ".build").unwrap();
         std::fs::write(dir.join("target/debug/deps/AGENTS.md"), "target").unwrap();
 
-        let result =
-            glob_search("**/AGENTS.md", Some(dir.to_str().unwrap())).expect("glob should succeed");
+        let result = glob_search(&StdFsBackend, "**/AGENTS.md", Some(dir.to_str().unwrap()))
+            .expect("glob should succeed");
 
         assert_eq!(result.num_files, 2, "ignored dirs should be pruned");
         // Normalise the OS-native path separator (`\` on Windows) to
@@ -1161,8 +1142,8 @@ mod tests {
 
     #[test]
     fn derive_glob_walk_root_stops_at_first_glob_component() {
-        let root = derive_glob_walk_root("/tmp/demo/**/AGENTS.md");
-        assert_eq!(root, PathBuf::from("/tmp/demo"));
+        let root = derive_glob_walk_root_str("/tmp/demo/**/AGENTS.md", "/fallback");
+        assert_eq!(root, "/tmp/demo");
         assert!(component_contains_glob("**"));
         assert!(component_contains_glob("*.rs"));
         assert!(!component_contains_glob("src"));

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -69,6 +69,72 @@ pub trait FsBackend: Send + Sync + 'static {
         self.write(&temp, data)?;
         self.rename(&temp, path)
     }
+
+    /// The absolute working root that relative paths resolve against and
+    /// that `glob` / `grep` fall back to when given no explicit path.
+    /// `StdFsBackend` → the process cwd; `KernelFsBackend` → the agent's
+    /// VFS workspace; the gRPC backend → the server root.
+    fn working_root(&self) -> io::Result<String> {
+        Ok(String::from("/"))
+    }
+
+    /// Resolve `path` to the absolute, backend-native form the other
+    /// methods expect. Relative paths resolve against [`FsBackend::working_root`].
+    ///
+    /// The default is a pure *lexical* resolution (no host filesystem
+    /// touch) suitable for VFS / remote backends whose namespaces are
+    /// already canonical and whose paths must NOT be canonicalised against
+    /// the host — `StdFsBackend` overrides it with `current_dir` +
+    /// `canonicalize` host semantics.
+    fn normalize(&self, path: &str) -> io::Result<String> {
+        Ok(lexical_join(&self.working_root()?, path))
+    }
+
+    /// Like [`FsBackend::normalize`] but tolerates a missing final
+    /// component (write targets whose leaf does not yet exist). The lexical
+    /// default already tolerates missing paths; `StdFsBackend` overrides
+    /// for host canonicalisation that falls back when the leaf is absent.
+    fn normalize_allow_missing(&self, path: &str) -> io::Result<String> {
+        self.normalize(path)
+    }
+
+    /// Join a directory path and a child name in the backend's NATIVE path
+    /// form. The default is forward-slash (VFS / remote). `StdFsBackend`
+    /// overrides with the host separator — critical on Windows, where a
+    /// verbatim `\\?\C:\…` base (what `canonicalize` yields) rejects a
+    /// forward slash, so a `/`-joined child would be an unreadable path.
+    /// Used by the `readdir`-composed `glob` / `grep` traversal to build
+    /// child paths the other methods can then read.
+    fn join_path(&self, dir: &str, name: &str) -> String {
+        format!("{}/{}", dir.trim_end_matches(['/', '\\']), name)
+    }
+}
+
+/// Resolve `path` against `root` without touching any filesystem.
+///
+/// Absolute paths (leading `/`) are taken as-is; relative paths are joined
+/// onto `root`. `.` and `..` components are collapsed lexically and the
+/// result is emitted with forward-slash separators (VFS-native). A `..`
+/// that would escape the root is clamped at `/` (no host traversal). This
+/// is the resolution the VFS-backed [`KernelFsBackend`] uses; host paths
+/// go through `StdFsBackend`'s `canonicalize` override instead.
+fn lexical_join(root: &str, path: &str) -> String {
+    let combined = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("{}/{}", root.trim_end_matches('/'), path)
+    };
+    let mut stack: Vec<&str> = Vec::new();
+    for seg in combined.split(['/', '\\']) {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                stack.pop();
+            }
+            s => stack.push(s),
+        }
+    }
+    format!("/{}", stack.join("/"))
 }
 
 // Blanket impl: Arc<dyn FsBackend> delegates to the inner backend.
@@ -111,6 +177,18 @@ impl FsBackend for Arc<dyn FsBackend> {
     }
     fn write_atomic(&self, path: &str, data: &[u8]) -> io::Result<()> {
         (**self).write_atomic(path, data)
+    }
+    fn working_root(&self) -> io::Result<String> {
+        (**self).working_root()
+    }
+    fn normalize(&self, path: &str) -> io::Result<String> {
+        (**self).normalize(path)
+    }
+    fn normalize_allow_missing(&self, path: &str) -> io::Result<String> {
+        (**self).normalize_allow_missing(path)
+    }
+    fn join_path(&self, dir: &str, name: &str) -> String {
+        (**self).join_path(dir, name)
     }
 }
 
@@ -206,6 +284,46 @@ impl FsBackend for StdFsBackend {
         std::fs::write(&temp, data)?;
         std::fs::rename(&temp, path)
     }
+
+    fn working_root(&self) -> io::Result<String> {
+        Ok(std::env::current_dir()?.to_string_lossy().into_owned())
+    }
+
+    fn normalize(&self, path: &str) -> io::Result<String> {
+        let candidate = if std::path::Path::new(path).is_absolute() {
+            std::path::PathBuf::from(path)
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        Ok(candidate.canonicalize()?.to_string_lossy().into_owned())
+    }
+
+    fn normalize_allow_missing(&self, path: &str) -> io::Result<String> {
+        let candidate = if std::path::Path::new(path).is_absolute() {
+            std::path::PathBuf::from(path)
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        if let Ok(canonical) = candidate.canonicalize() {
+            return Ok(canonical.to_string_lossy().into_owned());
+        }
+        if let Some(parent) = candidate.parent() {
+            let canonical_parent = parent
+                .canonicalize()
+                .unwrap_or_else(|_| parent.to_path_buf());
+            if let Some(name) = candidate.file_name() {
+                return Ok(canonical_parent.join(name).to_string_lossy().into_owned());
+            }
+        }
+        Ok(candidate.to_string_lossy().into_owned())
+    }
+
+    fn join_path(&self, dir: &str, name: &str) -> String {
+        std::path::Path::new(dir)
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -221,11 +339,35 @@ impl FsBackend for StdFsBackend {
 pub struct KernelFsBackend<K: KernelSyscall> {
     kernel: Arc<K>,
     ctx: OperationContext,
+    /// Absolute VFS path that relative tool paths resolve against and that
+    /// `glob` / `grep` default to (e.g. `/proc/{pid}/workspace`).
+    workspace_root: String,
 }
 
 impl<K: KernelSyscall> KernelFsBackend<K> {
-    pub fn new(kernel: Arc<K>, ctx: OperationContext) -> Self {
-        Self { kernel, ctx }
+    pub fn new(kernel: Arc<K>, ctx: OperationContext, workspace_root: impl Into<String>) -> Self {
+        Self {
+            kernel,
+            ctx,
+            workspace_root: workspace_root.into(),
+        }
+    }
+
+    /// Build a backend for a managed agent from its descriptor identity.
+    /// The [`OperationContext`] is the agent's own (owner / zone / name);
+    /// `workspace_root` is the absolute VFS path relative tool paths
+    /// resolve against (typically the agent's procfs workspace subtree).
+    /// Constructing the context here keeps `kernel`-crate types off the
+    /// `tools`-crate factory that calls this.
+    pub fn for_agent(
+        kernel: Arc<K>,
+        owner_id: &str,
+        zone_id: &str,
+        agent_name: &str,
+        workspace_root: impl Into<String>,
+    ) -> Self {
+        let ctx = OperationContext::new(owner_id, zone_id, false, Some(agent_name), true);
+        Self::new(kernel, ctx, workspace_root)
     }
 }
 
@@ -287,12 +429,19 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
 
     fn readdir(&self, path: &str) -> io::Result<Vec<FsDirEntry>> {
         let zone = &self.ctx.zone_id;
-        // sys_readdir returns Vec<(child_name, entry_type)>; DT_DIR == 1.
+        // `sys_readdir` returns `Vec<(child_GLOBAL_path, entry_type)>` —
+        // full paths like `/ws/a.rs`, not basenames. The `FsBackend`
+        // contract (matching `StdFsBackend` / `NexusVfsFsBackend`) is the
+        // basename, so strip the leading directory. DT_DIR == 1.
         let entries = self.kernel.sys_readdir(path, zone, false);
         Ok(entries
             .into_iter()
-            .map(|(name, entry_type)| FsDirEntry {
-                name,
+            .map(|(child, entry_type)| FsDirEntry {
+                name: child
+                    .rsplit(['/', '\\'])
+                    .next()
+                    .unwrap_or(&child)
+                    .to_string(),
                 is_dir: entry_type == 1, // DT_DIR
             })
             .collect())
@@ -302,9 +451,48 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
         Ok(self.kernel.sys_stat(path, &self.ctx.zone_id).is_some())
     }
 
-    fn create_dir_all(&self, _path: &str) -> io::Result<()> {
-        // Kernel VFS creates intermediate trie nodes implicitly when a
-        // child path is written. Explicit mkdir is a no-op.
+    fn create_dir_all(&self, path: &str) -> io::Result<()> {
+        // Writing `/ws/sub/c.rs` creates only the leaf's metastore entry —
+        // the intermediate `/ws/sub` dirent is NOT auto-planted, so a later
+        // `readdir("/ws")` would not see `sub` and a recursive walk could
+        // not descend. Plant an explicit DT_DIR for every intermediate
+        // component (idempotent: re-setattr on an existing dir is a no-op).
+        let mut prefix = String::new();
+        for comp in path.split(['/', '\\']).filter(|c| !c.is_empty()) {
+            prefix.push('/');
+            prefix.push_str(comp);
+            // Skip if it already exists as a directory.
+            if self
+                .kernel
+                .sys_stat(&prefix, &self.ctx.zone_id)
+                .is_some_and(|s| s.is_directory)
+            {
+                continue;
+            }
+            let _ = self.kernel.sys_setattr(
+                &prefix,
+                1, // DT_DIR
+                "",
+                None,
+                None,
+                None,
+                "balanced",
+                &self.ctx.zone_id,
+                false,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+        }
         Ok(())
     }
 
@@ -330,6 +518,13 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
         // Kernel sys_write is atomic per call — no temp file needed.
         self.write(path, data)
     }
+
+    fn working_root(&self) -> io::Result<String> {
+        Ok(self.workspace_root.clone())
+    }
+    // `normalize` / `normalize_allow_missing` use the trait's lexical
+    // default: VFS paths are already canonical, and canonicalising them
+    // against the host (`StdFsBackend`'s override) would corrupt them.
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -11,7 +11,7 @@
 use std::io;
 use std::sync::Arc;
 
-use kernel::abi::KernelAbi;
+use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
 
 // ---------------------------------------------------------------------------
@@ -214,16 +214,16 @@ impl FsBackend for StdFsBackend {
 
 /// Kernel-backed filesystem for in-process execution inside nexusd.
 ///
-/// Forwards every operation through the [`KernelAbi`] trait so managed
+/// Forwards every operation through the [`KernelSyscall`] trait so managed
 /// agents read/write the VFS trie via `sys_read` / `sys_write` /
 /// `sys_stat` / `sys_readdir` instead of touching the host
 /// filesystem.
-pub struct KernelFsBackend<K: KernelAbi> {
+pub struct KernelFsBackend<K: KernelSyscall> {
     kernel: Arc<K>,
     ctx: OperationContext,
 }
 
-impl<K: KernelAbi> KernelFsBackend<K> {
+impl<K: KernelSyscall> KernelFsBackend<K> {
     pub fn new(kernel: Arc<K>, ctx: OperationContext) -> Self {
         Self { kernel, ctx }
     }
@@ -234,7 +234,7 @@ fn kernel_err(e: impl std::fmt::Debug) -> io::Error {
     io::Error::other(format!("{e:?}"))
 }
 
-impl<K: KernelAbi + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
+impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
     fn read(&self, path: &str) -> io::Result<Vec<u8>> {
         self.kernel
             .sys_read(path, &self.ctx, 0, 0)

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -41,7 +41,7 @@ use std::thread;
 
 // Re-export kernel types so downstream crates (e.g. `tools`) can
 // reference them without adding a direct `kernel` dependency.
-pub use kernel::abi::KernelAbi;
+pub use kernel::kernel::syscall::KernelSyscall;
 pub use kernel::core::agents::registry::AgentDescriptor;
 use kernel::kernel::OperationContext;
 
@@ -100,7 +100,7 @@ pub fn spawn_task<K, C, T, F>(
     state_callback: F,
 ) -> SpawnHandle
 where
-    K: KernelAbi + Send + Sync + 'static,
+    K: KernelSyscall + Send + Sync + 'static,
     C: ApiClient + 'static,
     T: ToolExecutor + 'static,
     F: Fn(AgentLoopState) + Send + 'static,
@@ -130,7 +130,7 @@ where
 /// Spawn the v1 echo-only loop (retained for backward compatibility
 /// and integration tests that don't need a full LLM provider).
 #[must_use]
-pub fn spawn_task_echo<K: KernelAbi + Send + Sync + 'static>(
+pub fn spawn_task_echo<K: KernelSyscall + Send + Sync + 'static>(
     kernel: Arc<K>,
     desc: AgentDescriptor,
 ) -> SpawnHandle {
@@ -161,7 +161,7 @@ fn run_loop<K, C, T, F>(
     abort: HookAbortSignal,
     state_cb: F,
 ) where
-    K: KernelAbi + Send + Sync + 'static,
+    K: KernelSyscall + Send + Sync + 'static,
     C: ApiClient + 'static,
     T: ToolExecutor + 'static,
     F: Fn(AgentLoopState),
@@ -296,7 +296,7 @@ fn parse_inbound(bytes: &[u8], self_agent_id: &str) -> Option<(String, String)> 
 // v1 echo loop — retained for tests and backward compatibility
 // ---------------------------------------------------------------------------
 
-fn run_echo_loop<K: KernelAbi>(kernel: &Arc<K>, desc: &AgentDescriptor, abort: &HookAbortSignal) {
+fn run_echo_loop<K: KernelSyscall>(kernel: &Arc<K>, desc: &AgentDescriptor, abort: &HookAbortSignal) {
     let cwm_path = format!("/proc/{}/chat-with-me", desc.pid);
     let agent_id = desc.name.as_str();
     let ctx = OperationContext::new(&desc.owner_id, &desc.zone_id, false, Some(agent_id), true);

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -41,8 +41,8 @@ use std::thread;
 
 // Re-export kernel types so downstream crates (e.g. `tools`) can
 // reference them without adding a direct `kernel` dependency.
-pub use kernel::kernel::syscall::KernelSyscall;
 pub use kernel::core::agents::registry::AgentDescriptor;
+pub use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
 
 use crate::conversation::{ApiClient, ConversationRuntime, ToolExecutor};
@@ -296,7 +296,11 @@ fn parse_inbound(bytes: &[u8], self_agent_id: &str) -> Option<(String, String)> 
 // v1 echo loop — retained for tests and backward compatibility
 // ---------------------------------------------------------------------------
 
-fn run_echo_loop<K: KernelSyscall>(kernel: &Arc<K>, desc: &AgentDescriptor, abort: &HookAbortSignal) {
+fn run_echo_loop<K: KernelSyscall>(
+    kernel: &Arc<K>,
+    desc: &AgentDescriptor,
+    abort: &HookAbortSignal,
+) {
     let cwm_path = format!("/proc/{}/chat-with-me", desc.pid);
     let agent_id = desc.name.as_str();
     let ctx = OperationContext::new(&desc.owner_id, &desc.zone_id, false, Some(agent_id), true);

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -46,7 +46,6 @@ pub use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
 
 use crate::conversation::{ApiClient, ConversationRuntime, ToolExecutor};
-use crate::fs_backend::KernelFsBackend;
 use crate::hooks::HookAbortSignal;
 use crate::permissions::PermissionPolicy;
 use crate::prompt::SystemPrompt;
@@ -175,11 +174,10 @@ fn run_loop<K, C, T, F>(
     // -- WARMING_UP --
     state_cb(AgentLoopState::WarmingUp);
 
-    // Build the KernelFsBackend for VFS-backed file operations.
-    let _fs_backend = KernelFsBackend::new(
-        Arc::clone(&kernel),
-        OperationContext::new(&desc.owner_id, &desc.zone_id, false, Some(&desc.name), true),
-    );
+    // The VFS-backed file tools are constructed by the spawn factory
+    // (`tools::managed_agent::spawn_managed_agent`), which injects a
+    // `KernelFsBackend` into the `tool_executor` this loop receives — so
+    // the loop itself no longer builds one.
 
     let session = Session::new();
     let mut runtime = ConversationRuntime::new(

--- a/rust/crates/runtime/tests/fs_backend_vfs.rs
+++ b/rust/crates/runtime/tests/fs_backend_vfs.rs
@@ -1,0 +1,191 @@
+//! Integration tests proving the co-hosted file tools hit the VFS
+//! in-process through `KernelFsBackend`, never the host filesystem.
+//!
+//! These exercise `read_file` / `write_file` / `edit_file` / `glob_search`
+//! / `grep_search` against a real in-memory `Kernel` (not a mock) so the
+//! backend-aware path normalisation and the `readdir`-composed traversal
+//! are validated end to end. The paths used (`/ws/…`) do not exist on the
+//! host, so a host-`std::fs` regression would surface as a NotFound
+//! rather than silently passing.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use kernel::abc::object_store::{ObjectStore, StorageError, WriteResult};
+use kernel::kernel::{Kernel, OperationContext};
+use runtime::{
+    edit_file, glob_search, grep_search, read_file, write_file, GrepSearchInput, KernelFsBackend,
+};
+
+/// Minimal in-memory content backend so a fresh `Kernel` can round-trip
+/// regular-file bytes (dirents fall through to the global metastore; only
+/// content needs a store). Mirrors the kernel's own `TestObjectStore`.
+#[derive(Default)]
+struct MemStore {
+    blobs: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl ObjectStore for MemStore {
+    fn name(&self) -> &str {
+        "mem"
+    }
+
+    fn write_content(
+        &self,
+        content: &[u8],
+        content_id: &str,
+        _ctx: &OperationContext,
+        offset: u64,
+    ) -> Result<WriteResult, StorageError> {
+        let mut b = self.blobs.lock().unwrap();
+        let mut data = if offset > 0 {
+            b.get(content_id).cloned().unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let start = offset as usize;
+        if start > data.len() {
+            data.resize(start, 0);
+        }
+        let end = start + content.len();
+        if end > data.len() {
+            data.resize(end, 0);
+        }
+        data[start..end].copy_from_slice(content);
+        let size = data.len() as u64;
+        b.insert(content_id.to_string(), data);
+        Ok(WriteResult {
+            content_id: content_id.to_string(),
+            version: content_id.to_string(),
+            size,
+        })
+    }
+
+    fn read_content(
+        &self,
+        content_id: &str,
+        _ctx: &OperationContext,
+    ) -> Result<Vec<u8>, StorageError> {
+        self.blobs
+            .lock()
+            .unwrap()
+            .get(content_id)
+            .cloned()
+            .ok_or_else(|| StorageError::NotFound(content_id.into()))
+    }
+
+    fn get_content_size(&self, content_id: &str) -> Result<u64, StorageError> {
+        self.blobs
+            .lock()
+            .unwrap()
+            .get(content_id)
+            .map(|d| d.len() as u64)
+            .ok_or_else(|| StorageError::NotFound(content_id.into()))
+    }
+}
+
+/// A fresh kernel with a content-capable root mount.
+fn kernel_with_root_backend() -> Arc<Kernel> {
+    let kernel = Arc::new(Kernel::new());
+    let backend: Arc<dyn ObjectStore> = Arc::new(MemStore::default());
+    kernel
+        .vfs_router_arc()
+        .add_mount("/", "root", Some(backend), false);
+    kernel
+}
+
+/// A `KernelFsBackend` rooted at `/ws`, over the given kernel.
+fn vfs_backend(kernel: &Arc<Kernel>) -> KernelFsBackend<Kernel> {
+    KernelFsBackend::for_agent(Arc::clone(kernel), "test-owner", "root", "agent-x", "/ws")
+}
+
+fn grep_input(pattern: &str, path: &str) -> GrepSearchInput {
+    GrepSearchInput {
+        pattern: pattern.to_string(),
+        path: Some(path.to_string()),
+        glob: None,
+        output_mode: Some(String::from("files_with_matches")),
+        before: None,
+        after: None,
+        context_short: None,
+        context: None,
+        line_numbers: Some(true),
+        case_insensitive: Some(false),
+        file_type: None,
+        head_limit: Some(50),
+        offset: Some(0),
+        multiline: Some(false),
+    }
+}
+
+#[test]
+fn write_then_read_round_trips_through_the_vfs() {
+    let kernel = kernel_with_root_backend();
+    let fs = vfs_backend(&kernel);
+
+    let path = "/ws/notes.txt";
+    let write = write_file(&fs, path, "vfs-only content").expect("VFS write should succeed");
+    assert_eq!(write.kind, "create");
+
+    let read = read_file(&fs, path, None, None).expect("VFS read should succeed");
+    assert_eq!(read.file.content, "vfs-only content");
+
+    // The VFS path is not a host path — a std::fs regression would have
+    // created it on disk.
+    assert!(
+        !std::path::Path::new(path).exists(),
+        "co-hosted write must not touch the host filesystem"
+    );
+}
+
+#[test]
+fn edit_file_mutates_vfs_content() {
+    let kernel = kernel_with_root_backend();
+    let fs = vfs_backend(&kernel);
+
+    let path = "/ws/code.rs";
+    write_file(&fs, path, "let x = alpha;\n").expect("seed write");
+    let edited = edit_file(&fs, path, "alpha", "omega", false).expect("VFS edit should succeed");
+    assert!(edited.new_string.contains("omega"));
+
+    let read = read_file(&fs, path, None, None).expect("read after edit");
+    assert_eq!(read.file.content, "let x = omega;");
+}
+
+#[test]
+fn relative_paths_resolve_against_the_agent_workspace() {
+    let kernel = kernel_with_root_backend();
+    let fs = vfs_backend(&kernel);
+
+    // A relative tool path must land under the agent's workspace root
+    // (`/ws`), not the host cwd.
+    write_file(&fs, "todo.md", "- ship it").expect("relative write");
+    let read = read_file(&fs, "/ws/todo.md", None, None).expect("absolute read back");
+    assert_eq!(read.file.content, "- ship it");
+}
+
+#[test]
+fn glob_and_grep_walk_the_vfs_trie() {
+    let kernel = kernel_with_root_backend();
+    let fs = vfs_backend(&kernel);
+    let root = "/ws";
+
+    write_file(&fs, &format!("{root}/a.rs"), "fn a() { needle(); }").unwrap();
+    write_file(&fs, &format!("{root}/b.rs"), "fn b() {}").unwrap();
+    write_file(&fs, &format!("{root}/notes.txt"), "no code here").unwrap();
+    write_file(&fs, &format!("{root}/sub/c.rs"), "fn c() { needle(); }").unwrap();
+
+    // glob: recursive **/*.rs must find all three .rs files (including the
+    // nested one) and exclude the .txt — proving the readdir-composed
+    // recursive walk descends the VFS trie.
+    let globbed = glob_search(&fs, "**/*.rs", Some(root)).expect("VFS glob should succeed");
+    assert_eq!(
+        globbed.num_files, 3,
+        "glob should find a.rs, b.rs, sub/c.rs"
+    );
+
+    // grep: content search over the same subtree finds the two files that
+    // contain the needle.
+    let grepped = grep_search(&fs, &grep_input("needle", root)).expect("VFS grep should succeed");
+    assert_eq!(grepped.num_files, 2, "grep should match a.rs and sub/c.rs");
+}

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,5 +19,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
+[dev-dependencies]
+# For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
+# real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
+# through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
+
 [lints]
 workspace = true

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1456,7 +1456,14 @@ pub fn execute_tool_with_abort(
 /// SSOT: the alias pairs live here once and are consumed by both
 /// `parse_allowed_tools` (for `--allowedTools` CLI flag) and
 /// `execute_tool_with_enforcer` (for model-returned tool names).
+///
+/// Keys are the NORMALIZED (lower-cased) alias form — the CC PascalCase
+/// names (`Bash`, `Read`, …) normalize to these. Only tools whose
+/// `execute_tool` match arm is lower/snake_case appear here; PascalCase-
+/// native tools (`EnterPlanMode`, `TodoWrite`, `Skill`, `Agent`, …) are
+/// NOT aliased — [`canonicalize_tool_name`] passes them through unchanged.
 const TOOL_ALIASES: &[(&str, &str)] = &[
+    ("bash", "bash"),
     ("read", "read_file"),
     ("write", "write_file"),
     ("edit", "edit_file"),
@@ -1468,6 +1475,12 @@ const TOOL_ALIASES: &[(&str, &str)] = &[
 /// by the `execute_tool` match. Models may return PascalCase names
 /// (CC-style: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`) while
 /// scode registers snake_case (`bash`, `read_file`, etc.).
+///
+/// Names NOT in [`TOOL_ALIASES`] pass through UNCHANGED — critical for
+/// the PascalCase-native tools (`EnterPlanMode`, `ExitPlanMode`,
+/// `TodoWrite`, `WebFetch`, `Skill`, `Agent`, `TaskCreate`, …) whose
+/// `execute_tool` match arms are PascalCase: lower-casing them (the prior
+/// behaviour) turned every one into `unsupported tool`.
 fn canonicalize_tool_name(name: &str) -> String {
     let normalized = normalize_tool_name(name);
     for &(alias, canonical) in TOOL_ALIASES {
@@ -1475,7 +1488,7 @@ fn canonicalize_tool_name(name: &str) -> String {
             return canonical.to_string();
         }
     }
-    normalized
+    name.to_string()
 }
 
 fn execute_tool_with_enforcer(
@@ -8828,14 +8841,14 @@ mod tests {
 
     use super::{
         agent_permission_policy, allowed_tools_for_subagent, auto_background_threshold,
-        await_agent_output, build_agent_system_prompt, classify_lane_failure, derive_agent_state,
-        execute_agent_inline_with_work, execute_agent_with_spawn, execute_tool,
-        extract_recovery_outcome, final_assistant_text, global_cron_registry, lookup_custom_agent,
-        maybe_commit_provenance, mvp_tool_specs, normalize_subagent_type,
-        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_ask_user_question_v2, sweep_orphaned_tmp_files, AgentInput, AgentJob,
-        AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption, GlobalToolRegistry,
-        LaneEventName, LaneFailureClass, SubagentToolExecutor,
+        await_agent_output, build_agent_system_prompt, canonicalize_tool_name,
+        classify_lane_failure, derive_agent_state, execute_agent_inline_with_work,
+        execute_agent_with_spawn, execute_tool, extract_recovery_outcome, final_assistant_text,
+        global_cron_registry, lookup_custom_agent, maybe_commit_provenance, mvp_tool_specs,
+        normalize_subagent_type, permission_mode_from_plugin, persist_agent_terminal_state,
+        push_output_block, run_ask_user_question_v2, sweep_orphaned_tmp_files, AgentInput,
+        AgentJob, AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption,
+        GlobalToolRegistry, LaneEventName, LaneFailureClass, SubagentToolExecutor,
     };
     use api::OutputContentBlock;
     use runtime::{
@@ -8974,6 +8987,36 @@ mod tests {
     fn rejects_unknown_tool_names() {
         let error = execute_tool("nope", &json!({})).expect_err("tool should be rejected");
         assert!(error.contains("unsupported tool"));
+    }
+
+    #[test]
+    fn canonicalize_maps_aliases_and_preserves_pascalcase_native_tools() {
+        // CC-style aliases fold to the snake_case match arm.
+        assert_eq!(canonicalize_tool_name("Bash"), "bash");
+        assert_eq!(canonicalize_tool_name("Read"), "read_file");
+        assert_eq!(canonicalize_tool_name("Grep"), "grep_search");
+        assert_eq!(canonicalize_tool_name("read_file"), "read_file");
+        // PascalCase-native tools MUST pass through unchanged — lower-casing
+        // them turns every one into `unsupported tool` (the pty_plan_mode
+        // regression). Guard the whole PascalCase-arm family.
+        for tool in [
+            "EnterPlanMode",
+            "ExitPlanMode",
+            "TodoWrite",
+            "WebFetch",
+            "WebSearch",
+            "Skill",
+            "Agent",
+            "TaskCreate",
+            "StructuredOutput",
+            "NotebookEdit",
+        ] {
+            assert_eq!(
+                canonicalize_tool_name(tool),
+                tool,
+                "{tool} must not be mangled"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -233,11 +233,11 @@ use runtime::{
     task_registry::TaskRegistry,
     write_file, ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, BashCommandInput,
     BashCommandOutput, BranchFreshness, ConfigLoader, ContentBlock, ConversationMessage,
-    ConversationRuntime, GrepSearchInput, HookAbortSignal, LaneCommitProvenance, LaneEvent,
-    LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass, McpDegradedReport,
-    MessageRole, PermissionMode, PermissionPolicy, PromptCacheEvent, ProviderFallbackConfig,
-    RuntimeError, Session, StdFsBackend, SystemPrompt, ToolDispatchContext, ToolError,
-    ToolExecutor, FORK_BOILERPLATE_TAG,
+    ConversationRuntime, FsBackend, GrepSearchInput, HookAbortSignal, LaneCommitProvenance,
+    LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass,
+    McpDegradedReport, MessageRole, PermissionMode, PermissionPolicy, PromptCacheEvent,
+    ProviderFallbackConfig, RuntimeError, Session, StdFsBackend, SystemPrompt, ToolDispatchContext,
+    ToolError, ToolExecutor, FORK_BOILERPLATE_TAG,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -696,6 +696,7 @@ impl GlobalToolRegistry {
                 input,
                 abort_signal,
                 ctx,
+                &StdFsBackend,
             );
         }
         self.plugin_tools
@@ -1433,12 +1434,27 @@ pub fn execute_tool(name: &str, input: &Value) -> Result<String, String> {
     execute_tool_with_abort(name, input, None)
 }
 
+/// Dispatch a tool against an explicit filesystem backend.
+///
+/// This is the entry the co-hosted managed agent uses: it passes a
+/// `KernelFsBackend` so the file tools (`read_file` / `write_file` /
+/// `edit_file` / `glob_search` / `grep_search`) hit the VFS in-process via
+/// kernel syscalls instead of the host `std::fs`. The standalone CLI keeps
+/// using [`execute_tool`], which defaults to [`StdFsBackend`].
+pub fn execute_tool_with_backend(
+    name: &str,
+    input: &Value,
+    fs: &dyn FsBackend,
+) -> Result<String, String> {
+    execute_tool_with_enforcer(None, name, input, None, None, fs)
+}
+
 pub fn execute_tool_with_abort(
     name: &str,
     input: &Value,
     abort_signal: Option<&HookAbortSignal>,
 ) -> Result<String, String> {
-    execute_tool_with_enforcer(None, name, input, abort_signal, None)
+    execute_tool_with_enforcer(None, name, input, abort_signal, None, &StdFsBackend)
 }
 
 fn execute_tool_with_enforcer(
@@ -1447,6 +1463,7 @@ fn execute_tool_with_enforcer(
     input: &Value,
     abort_signal: Option<&HookAbortSignal>,
     ctx: Option<&ToolDispatchContext>,
+    fs: &dyn FsBackend,
 ) -> Result<String, String> {
     // Coordinator hard tool-gate — belt-and-suspenders against a
     // non-compliant model that hallucinates a forbidden tool name
@@ -1468,23 +1485,23 @@ fn execute_tool_with_enforcer(
         }
         "read_file" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
-            from_value::<ReadFileInput>(input).and_then(run_read_file)
+            from_value::<ReadFileInput>(input).and_then(|input| run_read_file(input, fs))
         }
         "write_file" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
-            from_value::<WriteFileInput>(input).and_then(run_write_file)
+            from_value::<WriteFileInput>(input).and_then(|input| run_write_file(input, fs))
         }
         "edit_file" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
-            from_value::<EditFileInput>(input).and_then(run_edit_file)
+            from_value::<EditFileInput>(input).and_then(|input| run_edit_file(input, fs))
         }
         "glob_search" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
-            from_value::<GlobSearchInputValue>(input).and_then(run_glob_search)
+            from_value::<GlobSearchInputValue>(input).and_then(|input| run_glob_search(input, fs))
         }
         "grep_search" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
-            from_value::<GrepSearchInput>(input).and_then(run_grep_search)
+            from_value::<GrepSearchInput>(input).and_then(|input| run_grep_search(input, fs))
         }
         "WebFetch" => from_value::<WebFetchInput>(input).and_then(run_web_fetch),
         "WebSearch" => from_value::<WebSearchInput>(input).and_then(run_web_search),
@@ -2849,19 +2866,20 @@ fn branch_divergence_output(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_read_file(input: ReadFileInput) -> Result<String, String> {
-    to_pretty_json(
-        read_file(&StdFsBackend, &input.path, input.offset, input.limit).map_err(io_to_string)?,
-    )
+fn run_read_file(input: ReadFileInput, fs: &dyn FsBackend) -> Result<String, String> {
+    to_pretty_json(read_file(fs, &input.path, input.offset, input.limit).map_err(io_to_string)?)
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_write_file(input: WriteFileInput) -> Result<String, String> {
-    // Detect file intent and redirect if draft
+fn run_write_file(input: WriteFileInput, fs: &dyn FsBackend) -> Result<String, String> {
+    // Detect file intent and redirect if draft. The workspace root comes
+    // from the backend (`current_dir` for std, the agent's VFS workspace
+    // for the kernel backend) so the draft redirect lands in the same
+    // namespace the write targets.
     let intent = runtime::detect_file_intent(&input.path, &input.content, None);
     let actual_path = match intent {
         runtime::FileIntent::Draft => {
-            let workspace_root = std::env::current_dir().unwrap_or_default();
+            let workspace_root = std::path::PathBuf::from(fs.working_root().unwrap_or_default());
             runtime::redirect_to_drafts(&std::path::PathBuf::from(&input.path), &workspace_root)
         }
         runtime::FileIntent::Final => std::path::PathBuf::from(&input.path),
@@ -2869,7 +2887,7 @@ fn run_write_file(input: WriteFileInput) -> Result<String, String> {
 
     to_pretty_json(
         write_file(
-            &StdFsBackend,
+            fs,
             actual_path.to_str().unwrap_or(&input.path),
             &input.content,
         )
@@ -2878,9 +2896,10 @@ fn run_write_file(input: WriteFileInput) -> Result<String, String> {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_edit_file(input: EditFileInput) -> Result<String, String> {
-    // Read existing content for intent detection
-    let existing_content = std::fs::read_to_string(&input.path).ok();
+fn run_edit_file(input: EditFileInput, fs: &dyn FsBackend) -> Result<String, String> {
+    // Read existing content for intent detection through the backend so a
+    // co-hosted agent inspects the VFS, not the host filesystem.
+    let existing_content = fs.read_to_string(&input.path).ok();
     let content_for_detection = existing_content.as_deref().unwrap_or(&input.new_string);
 
     // Detect file intent
@@ -2888,7 +2907,7 @@ fn run_edit_file(input: EditFileInput) -> Result<String, String> {
 
     // Draft files should not be edited from workspace root - they're in .drafts/
     // If file is draft and not in .drafts/, redirect
-    let workspace_root = std::env::current_dir().unwrap_or_default();
+    let workspace_root = std::path::PathBuf::from(fs.working_root().unwrap_or_default());
     let actual_path = if intent == runtime::FileIntent::Draft
         && !runtime::is_in_drafts(&std::path::PathBuf::from(&input.path), &workspace_root)
     {
@@ -2899,7 +2918,7 @@ fn run_edit_file(input: EditFileInput) -> Result<String, String> {
 
     to_pretty_json(
         edit_file(
-            &StdFsBackend,
+            fs,
             actual_path.to_str().unwrap_or(&input.path),
             &input.old_string,
             &input.new_string,
@@ -2910,13 +2929,13 @@ fn run_edit_file(input: EditFileInput) -> Result<String, String> {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_glob_search(input: GlobSearchInputValue) -> Result<String, String> {
-    to_pretty_json(glob_search(&input.pattern, input.path.as_deref()).map_err(io_to_string)?)
+fn run_glob_search(input: GlobSearchInputValue, fs: &dyn FsBackend) -> Result<String, String> {
+    to_pretty_json(glob_search(fs, &input.pattern, input.path.as_deref()).map_err(io_to_string)?)
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_grep_search(input: GrepSearchInput) -> Result<String, String> {
-    to_pretty_json(grep_search(&input).map_err(io_to_string)?)
+fn run_grep_search(input: GrepSearchInput, fs: &dyn FsBackend) -> Result<String, String> {
+    to_pretty_json(grep_search(fs, &input).map_err(io_to_string)?)
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -6914,8 +6933,15 @@ impl ToolExecutor for SubagentToolExecutor {
         }
         let value = serde_json::from_str(input)
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-        execute_tool_with_enforcer(self.enforcer.as_ref(), tool_name, &value, None, Some(ctx))
-            .map_err(ToolError::new)
+        execute_tool_with_enforcer(
+            self.enforcer.as_ref(),
+            tool_name,
+            &value,
+            None,
+            Some(ctx),
+            &StdFsBackend,
+        )
+        .map_err(ToolError::new)
     }
 }
 

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use runtime::spawn_task::{AgentDescriptor, AgentLoopState, KernelAbi, SpawnHandle};
+use runtime::spawn_task::{AgentDescriptor, AgentLoopState, KernelSyscall, SpawnHandle};
 use runtime::{
     ModelFamilyIdentity, PermissionMode, PermissionPolicy, SystemPromptBuilder, ToolError,
     ToolExecutor,
@@ -48,7 +48,7 @@ pub fn spawn_managed_agent<K, F>(
     state_callback: F,
 ) -> SpawnHandle
 where
-    K: KernelAbi + Send + Sync + 'static,
+    K: KernelSyscall + Send + Sync + 'static,
     F: Fn(AgentLoopState) + Send + 'static,
 {
     let model = desc

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 
 use runtime::spawn_task::{AgentDescriptor, AgentLoopState, KernelSyscall, SpawnHandle};
 use runtime::{
-    ModelFamilyIdentity, PermissionMode, PermissionPolicy, SystemPromptBuilder, ToolError,
-    ToolExecutor,
+    FsBackend, KernelFsBackend, ModelFamilyIdentity, PermissionMode, PermissionPolicy,
+    SystemPromptBuilder, ToolError, ToolExecutor,
 };
 
-use crate::{execute_tool, ProviderRuntimeClient};
+use crate::{execute_tool_with_backend, ProviderRuntimeClient};
 
 /// Label key where `ManagedAgentService` stores the model id in the
 /// `AgentDescriptor.labels` map.
@@ -62,8 +62,22 @@ where
     let api_client = ProviderRuntimeClient::new(model, BTreeSet::new())
         .expect("failed to construct API client from model label");
 
-    // -- ToolExecutor: dispatch through the global tool registry --
-    let tool_executor = ManagedToolExecutor;
+    // -- FsBackend: in-process VFS, NOT host std::fs. The co-hosted
+    // agent's file tools (read/write/edit/glob/grep) route through
+    // `KernelFsBackend` so they hit the kernel trie via syscalls, with
+    // the agent's procfs workspace as the relative-path root.
+    let workspace_root = format!("/proc/{}/workspace", desc.pid);
+    let fs: Arc<dyn FsBackend> = Arc::new(KernelFsBackend::for_agent(
+        Arc::clone(&kernel),
+        &desc.owner_id,
+        &desc.zone_id,
+        &desc.name,
+        workspace_root,
+    ));
+
+    // -- ToolExecutor: dispatch through the global tool registry, bound
+    // to the VFS backend so every file tool is in-process. --
+    let tool_executor = ManagedToolExecutor { fs };
 
     // -- SystemPrompt: minimal prompt for managed-agent context --
     let system_prompt = SystemPromptBuilder::new()
@@ -88,14 +102,18 @@ where
 }
 
 /// Tool executor that dispatches through the `tools` crate's global
-/// registry. Wraps `execute_tool(name, input)` into the `ToolExecutor`
-/// trait expected by `ConversationRuntime`.
-struct ManagedToolExecutor;
+/// registry, bound to a VFS [`FsBackend`]. Wraps
+/// `execute_tool_with_backend(name, input, fs)` into the `ToolExecutor`
+/// trait expected by `ConversationRuntime`, so the file tools stay
+/// in-process against the kernel trie.
+struct ManagedToolExecutor {
+    fs: Arc<dyn FsBackend>,
+}
 
 impl ToolExecutor for ManagedToolExecutor {
     fn execute(&mut self, tool_name: &str, input: &str) -> Result<String, ToolError> {
         let input_value: serde_json::Value =
             serde_json::from_str(input).map_err(|e| ToolError::new(e.to_string()))?;
-        execute_tool(tool_name, &input_value).map_err(ToolError::new)
+        execute_tool_with_backend(tool_name, &input_value, self.fs.as_ref()).map_err(ToolError::new)
     }
 }

--- a/rust/crates/tools/tests/cohost_live_llm.rs
+++ b/rust/crates/tools/tests/cohost_live_llm.rs
@@ -1,0 +1,207 @@
+//! LIVE co-host proof — the real thing behind the whole in-process effort.
+//!
+//! Drives `tools::managed_agent::spawn_managed_agent` (the EXACT factory the
+//! nexusd `SudoCodeSpawnAdapter` calls) on a real in-memory `Kernel`: plants
+//! the `/proc/{pid}/chat-with-me` DT_STREAM the daemon would stamp, spawns the
+//! managed-agent loop IN-PROCESS, writes a user prompt to the mailbox via
+//! `sys_write`, and reads back the agent's reply via `sys_read`. The agent's
+//! LLM turn is a real network call through the configured provider.
+//!
+//! This is the co-host end-to-end minus the gRPC `StartSession` entry + the
+//! adapter's enum mapping (both compile+link-verified in nexusd): a real
+//! sudocode agent loop, co-hosted on a kernel, conversing over the mailbox
+//! with a real LLM using in-process syscalls (no gRPC on its fs/mailbox path).
+//!
+//! `#[ignore]` — opt-in, needs a live LLM. Run with:
+//!   ANTHROPIC_API_KEY=<sudorouter sk-…> \
+//!   ANTHROPIC_BASE_URL=https://napi.sudorouter.ai \
+//!   cargo test -p tools --test cohost_live_llm -- --ignored --nocapture
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
+use kernel::kernel::{Kernel, OperationContext, ReadRequest, WriteRequest};
+use tools::managed_agent::spawn_managed_agent;
+
+const DT_STREAM: i32 = 4;
+const STREAM_CAPACITY: usize = 65_536;
+
+/// Model the agent runs, read from its descriptor `model` label. SudoRouter
+/// serves `claude-sonnet-4-6`; override via `SUDOCODE_TEST_MODEL`.
+fn test_model() -> String {
+    std::env::var("SUDOCODE_TEST_MODEL").unwrap_or_else(|_| "claude-sonnet-4-6".to_string())
+}
+
+fn mount_proc(kernel: &Kernel) {
+    kernel
+        .vfs_router_arc()
+        .add_mount("/proc", "root", None, false);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn plant_chat_stream(kernel: &Kernel, pid: &str) {
+    let path = format!("/proc/{pid}/chat-with-me");
+    kernel
+        .sys_setattr(
+            &path,
+            DT_STREAM,
+            "",
+            None,
+            None,
+            None,
+            "memory",
+            "root",
+            false,
+            STREAM_CAPACITY,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("plant /proc/{pid}/chat-with-me DT_STREAM");
+}
+
+fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
+    let mut desc = AgentDescriptor {
+        pid: pid.to_string(),
+        name: name.to_string(),
+        kind: AgentKind::Managed,
+        owner_id: "test-owner".to_string(),
+        zone_id: "root".to_string(),
+        ..Default::default()
+    };
+    desc.labels.insert("model".to_string(), test_model());
+    desc
+}
+
+fn user_ctx() -> OperationContext {
+    OperationContext::new("test-user", "root", false, Some("user-test"), true)
+}
+
+fn write_prompt(
+    kernel: &Kernel,
+    path: &str,
+    ctx: &OperationContext,
+    from: &str,
+    to: &str,
+    body: &str,
+) {
+    let env = serde_json::json!({ "from": from, "to": to, "body": body });
+    let reqs = [WriteRequest {
+        path: path.to_string(),
+        content: serde_json::to_vec(&env).unwrap(),
+        offset: 0,
+    }];
+    kernel
+        .sys_write(&reqs, ctx)
+        .pop()
+        .expect("sys_write empty")
+        .expect("user write to chat-with-me");
+}
+
+/// Poll the mailbox until an envelope from `agent_id` with a non-empty body
+/// arrives, or `timeout` elapses.
+fn wait_for_agent_reply(
+    kernel: &Kernel,
+    path: &str,
+    ctx: &OperationContext,
+    agent_id: &str,
+    timeout: Duration,
+) -> Option<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    let mut offset = 0u64;
+    while Instant::now() < deadline {
+        let reqs = [ReadRequest {
+            path: path.to_string(),
+            offset,
+            len: None,
+            timeout_ms: 0,
+        }];
+        if let Some(Ok(result)) = kernel.sys_read(&reqs, ctx).pop() {
+            if let Some(bytes) = result.data.as_ref() {
+                if !bytes.is_empty() {
+                    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+                        if v.get("from").and_then(|f| f.as_str()) == Some(agent_id) {
+                            let body = v.get("body").and_then(|b| b.as_str()).unwrap_or("");
+                            if !body.is_empty() {
+                                return Some(v);
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(next) = result.stream_next_offset {
+                offset = next as u64;
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    None
+}
+
+#[test]
+#[ignore = "live LLM: set ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL (sudorouter)"]
+fn cohost_agent_replies_via_mailbox_with_real_llm() {
+    if std::env::var("ANTHROPIC_API_KEY").is_err()
+        && std::env::var("PROXY_AUTH_TOKEN").is_err()
+        && std::env::var("CLAUDE_CODE_OAUTH_TOKEN").is_err()
+    {
+        eprintln!("SKIP: no LLM credentials in env");
+        return;
+    }
+
+    let kernel = Arc::new(Kernel::new());
+    mount_proc(&kernel);
+    let pid = "cohost-live-1";
+    let agent_id = "scode-live";
+    plant_chat_stream(&kernel, pid);
+    let desc = make_desc(pid, agent_id);
+
+    // Spawn the REAL managed-agent loop — the same factory nexusd's
+    // SudoCodeSpawnAdapter calls. State transitions are printed so the
+    // WarmingUp → Ready → Busy → Ready progression is observable.
+    let handle = spawn_managed_agent(Arc::clone(&kernel), desc, |state| {
+        eprintln!("[agent state] {state:?}");
+    });
+
+    let ctx = user_ctx();
+    let cwm = format!("/proc/{pid}/chat-with-me");
+    let prompt = "You are being tested over a nexus A2A mailbox. \
+                  Reply with exactly one word: PONG";
+    eprintln!("[user → agent] {prompt}");
+    write_prompt(&kernel, &cwm, &ctx, "user-test", agent_id, prompt);
+
+    let reply = wait_for_agent_reply(&kernel, &cwm, &ctx, agent_id, Duration::from_secs(90));
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+
+    let reply = reply.expect("no agent reply within 90s — LLM turn did not complete");
+    let body = reply
+        .get("body")
+        .and_then(|b| b.as_str())
+        .unwrap_or_default();
+    eprintln!("[agent → user] {body}");
+
+    assert_eq!(
+        reply.get("from").and_then(|f| f.as_str()),
+        Some(agent_id),
+        "reply must come from the co-hosted agent"
+    );
+    assert!(
+        reply.get("error").is_none(),
+        "expected a real LLM reply, got an error envelope: {body}"
+    );
+    assert!(
+        body.to_ascii_uppercase().contains("PONG"),
+        "LLM reply did not contain the requested token; got: {body}"
+    );
+}


### PR DESCRIPTION
Makes `sudocode_runtime` ready to be co-hosted inside `nexusd-cluster` doing
in-process `KernelSyscall` calls (no gRPC on the agent's fs path).

## What
1. **Kernel pin bump** `418fec88` → `c9ecc9da` (nexus's rev) + the
   `KernelAbi` → `KernelSyscall` trait rename (fs_backend / spawn_task / tools).
2. **FsBackend switch (finished).** The tool/file-op layer no longer hardcodes
   `&StdFsBackend`:
   - `FsBackend` gains backend-aware `working_root` / `normalize` /
     `normalize_allow_missing` / `join_path`. `StdFsBackend` keeps exact host
     semantics; the VFS default is pure lexical resolution (host `canonicalize`
     would corrupt VFS paths, and misfires on Windows verbatim `\?\`).
   - `read/write/edit` + `glob/grep` route through an injected `&dyn FsBackend`.
     glob/grep are migrated off host `WalkDir` onto a `readdir`-composed
     in-process walk (pre-#222 single-level composition — no gRPC hop).
   - `KernelFsBackend` gains a workspace root + `for_agent`; fixes `readdir`
     to return basenames and `create_dir_all` to plant intermediate DT_DIR
     dirents so nested writes are visible to a later walk.
   - The managed-agent spawn factory injects a `KernelFsBackend` rooted at
     `/proc/{pid}/workspace` — the co-hosted agent's file tools hit the VFS
     in-process, never host `std::fs`. Dead `_fs_backend` in `spawn_task`
     removed.

## Tests
- New `runtime/tests/fs_backend_vfs.rs`: read/write/edit round-trip + glob/grep
  descend a real in-memory `Kernel` VFS (paths do not exist on the host).
- Full `runtime` + `tools` suites green; workspace `cargo check` clean; fmt clean.

The one-call recursive `sys_readdir` / `grep_subtree` (nexus-vfs #222) is a
deferred kernel-rev optimisation; the in-process single-level composition is
cheap today (no gRPC).