### PR TITLE
fix(cli): raw-mode line endings + markdown block spacing in the iocraft REPL

### DIFF
--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -156,6 +156,7 @@ enum Scenario {
     TaskListEmptyRoundtrip,
     TaskCreateThenListRoundtrip,
     SleepShortRoundtrip,
+    MarkdownRenderingShowcase,
     SleepOverMaxRoundtrip,
     ForkSubagentRecursionGuardRoundtrip,
     LlmCompactionRoundtrip,
@@ -190,6 +191,7 @@ impl Scenario {
             "task_list_empty_roundtrip" => Some(Self::TaskListEmptyRoundtrip),
             "task_create_then_list_roundtrip" => Some(Self::TaskCreateThenListRoundtrip),
             "sleep_short_roundtrip" => Some(Self::SleepShortRoundtrip),
+            "markdown_rendering_showcase" => Some(Self::MarkdownRenderingShowcase),
             "sleep_over_max_roundtrip" => Some(Self::SleepOverMaxRoundtrip),
             "fork_subagent_recursion_guard_roundtrip" => {
                 Some(Self::ForkSubagentRecursionGuardRoundtrip)
@@ -227,6 +229,7 @@ impl Scenario {
             Self::TaskListEmptyRoundtrip => "task_list_empty_roundtrip",
             Self::TaskCreateThenListRoundtrip => "task_create_then_list_roundtrip",
             Self::SleepShortRoundtrip => "sleep_short_roundtrip",
+            Self::MarkdownRenderingShowcase => "markdown_rendering_showcase",
             Self::SleepOverMaxRoundtrip => "sleep_over_max_roundtrip",
             Self::ForkSubagentRecursionGuardRoundtrip => "fork_subagent_recursion_guard_roundtrip",
             Self::LlmCompactionRoundtrip => "llm_compaction_roundtrip",
@@ -465,6 +468,7 @@ fn build_http_response(request: &MessageRequest, scenario: Scenario) -> String {
 fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
     match scenario {
         Scenario::StreamingText => streaming_text_sse(),
+        Scenario::MarkdownRenderingShowcase => markdown_showcase_sse(),
         Scenario::ReadFileRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => final_text_sse(&format!(
                 "read_file roundtrip complete: {}",
@@ -776,6 +780,9 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
 #[allow(clippy::too_many_lines)]
 fn build_message_response(request: &MessageRequest, scenario: Scenario) -> MessageResponse {
     match scenario {
+        Scenario::MarkdownRenderingShowcase => {
+            text_message_response("msg_markdown_showcase", MARKDOWN_SHOWCASE_DOC)
+        }
         Scenario::StreamingText => text_message_response(
             "msg_streaming_text",
             "Mock streaming says hello from the parity harness.",
@@ -1172,6 +1179,7 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
 fn request_id_for(scenario: Scenario) -> &'static str {
     match scenario {
         Scenario::StreamingText => "req_streaming_text",
+        Scenario::MarkdownRenderingShowcase => "req_markdown_showcase",
         Scenario::ReadFileRoundtrip => "req_read_file_roundtrip",
         Scenario::GrepChunkAssembly => "req_grep_chunk_assembly",
         Scenario::WriteFileAllowed => "req_write_file_allowed",
@@ -1314,6 +1322,85 @@ fn tool_message_response_many(id: &str, tool_uses: &[ToolUseMessage<'_>]) -> Mes
         },
         request_id: None,
     }
+}
+
+/// Markdown document exercising the terminal renderer's block-spacing and
+/// list-marker rules: an adjacent label+list (must bind), a heading (exactly
+/// one blank line before it), an author-written blank line before a list
+/// (must survive), a bullet nested under an ordered item (must align under
+/// the parent's text), and a nested list with a following sibling (no blank
+/// hole). Consumed by `pty_raw_mode_line_endings.rs`.
+pub const MARKDOWN_SHOWCASE_DOC: &str = "Intro:\n- alpha\n- beta\n\n## Section\n\nAfter blank:\n\n- gamma\n\n1. parent\n   - child\n\n- outer\n  - inner\n- second\n\nDone.";
+
+/// Stream `MARKDOWN_SHOWCASE_DOC` as several text deltas with boundaries that
+/// deliberately fall mid-line, so the CLI's blank-line chunker — not the
+/// delta framing — decides how the renderer sees the text.
+fn markdown_showcase_sse() -> String {
+    let mut body = String::new();
+    append_sse(
+        &mut body,
+        "message_start",
+        json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_markdown_showcase",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": DEFAULT_MODEL,
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": usage_json(11, 0)
+            }
+        }),
+    );
+    append_sse(
+        &mut body,
+        "content_block_start",
+        json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""}
+        }),
+    );
+    // Cut roughly every 25 bytes at char boundaries — mid-word, mid-line.
+    let mut rest = MARKDOWN_SHOWCASE_DOC;
+    while !rest.is_empty() {
+        let mut cut = rest.len().min(25);
+        while !rest.is_char_boundary(cut) {
+            cut += 1;
+        }
+        let (delta, tail) = rest.split_at(cut);
+        rest = tail;
+        append_sse(
+            &mut body,
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": delta}
+            }),
+        );
+    }
+    append_sse(
+        &mut body,
+        "content_block_stop",
+        json!({
+            "type": "content_block_stop",
+            "index": 0
+        }),
+    );
+    append_sse(
+        &mut body,
+        "message_delta",
+        json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+            "usage": usage_json(11, 60)
+        }),
+    );
+    append_sse(&mut body, "message_stop", json!({"type": "message_stop"}));
+    body
 }
 
 fn streaming_text_sse() -> String {

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -513,6 +513,18 @@ struct RenderState {
     heading_level: Option<u8>,
     quote: usize,
     list_stack: Vec<ListKind>,
+    /// Column where markers of the list at each `list_stack` level start.
+    /// Top-level lists start at 0; a nested list starts at its parent item's
+    /// content column, so its markers align under the parent's text
+    /// regardless of the parent marker's width ("• " = 2, "10. " = 4).
+    list_indents: Vec<usize>,
+    /// Column where the current item's content starts (marker column plus
+    /// marker width). Continuation lines inside the item (soft/hard breaks)
+    /// indent to this column so they align under the first line's text.
+    item_content_col: usize,
+    /// Set by the driver loop at `Start(Tag::List)`: true when the source has
+    /// no blank line between the previous block and this top-level list.
+    bind_top_level_list: bool,
     link_stack: Vec<LinkState>,
     table: Option<TableState>,
 }
@@ -625,7 +637,18 @@ impl TerminalRenderer {
         let mut code_buffer = String::new();
         let mut in_code_block = false;
 
-        for event in Parser::new_ext(&normalized, Options::all()) {
+        for (event, range) in Parser::new_ext(&normalized, Options::all()).into_offset_iter() {
+            // Decide top-level list binding from the SOURCE, not from the
+            // rendered output: pulldown-cmark emits identical events for
+            // "Label\n- a" and "Label\n\n- a", but the byte offset lets us
+            // look at what the author actually wrote. Keying on the source
+            // keeps the behaviour identical across every caller — streamed
+            // chunks, non-streaming blocks, and transcript replay — where an
+            // output-based heuristic diverged between them.
+            if let Event::Start(Tag::List(_)) = &event {
+                state.bind_top_level_list = state.list_stack.is_empty()
+                    && !Self::blank_line_precedes_impl(&normalized, range.start);
+            }
             self.render_event(
                 event,
                 &mut state,
@@ -642,6 +665,26 @@ impl TerminalRenderer {
     #[must_use]
     pub fn markdown_to_ansi(&self, markdown: &str) -> String {
         self.render_markdown(markdown)
+    }
+
+    /// Whether the source has a blank line immediately before byte offset
+    /// `start` (the start of a block, as reported by pulldown-cmark's offset
+    /// iterator). Walks back over the block's own leading indentation and any
+    /// whitespace-only lines; two or more newlines mean the author separated
+    /// the blocks with a blank line.
+    fn blank_line_precedes_impl(source: &str, start: usize) -> bool {
+        let bytes = source.as_bytes();
+        let mut newlines = 0usize;
+        for &byte in bytes[..start].iter().rev() {
+            match byte {
+                b'\n' => newlines += 1,
+                // Trailing spaces/tabs on the prior line, indentation of this
+                // one, and CRs of CRLF endings don't affect blankness.
+                b' ' | b'\t' | b'\r' => {}
+                _ => break,
+            }
+        }
+        newlines >= 2
     }
 
     #[allow(clippy::too_many_lines)]
@@ -673,19 +716,66 @@ impl TerminalRenderer {
                 state.heading_level = None;
                 output.push_str("\n\n");
             }
-            Event::End(TagEnd::Item) | Event::SoftBreak | Event::HardBreak => {
+            Event::End(TagEnd::Item) => {
+                // A nested list that just closed inside this item already
+                // ends with its own newline; pushing another here opened a
+                // blank hole between the nested items and the next sibling.
+                if !output.ends_with('\n') {
+                    state.append_raw(output, "\n");
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
                 state.append_raw(output, "\n");
+                // Inside a list item, align the continuation line under the
+                // item's text — without this it landed at column 0, hanging
+                // left of the marker.
+                if !state.list_stack.is_empty() && state.item_content_col > 0 {
+                    state.append_raw(output, &" ".repeat(state.item_content_col));
+                }
             }
             Event::Start(Tag::List(first_item)) => {
+                let indent = if state.list_stack.is_empty() {
+                    // Bind a top-level list to the block that introduces it:
+                    // `End(Paragraph)` emitted "\n\n", which put a blank line
+                    // between a label and its own bullets even when the
+                    // author wrote them adjacent. `bind_top_level_list` is
+                    // decided from the source text by the driver loop, so an
+                    // author-written blank line is never collapsed.
+                    if state.bind_top_level_list && output.ends_with("\n\n") {
+                        output.truncate(output.len() - 1);
+                    }
+                    0
+                } else {
+                    // A nested list opens while its parent item's text is
+                    // still on the current line, and only `End(Item)` emits a
+                    // break — so without this the child items rendered inline
+                    // after their parent ("• outer  • inner" on one row).
+                    if !output.ends_with('\n') {
+                        output.push('\n');
+                    }
+                    // Nested markers start at the parent item's content
+                    // column, aligning under its text whatever the parent
+                    // marker's width.
+                    state.item_content_col
+                };
                 let kind = match first_item {
                     Some(index) => ListKind::Ordered { next_index: index },
                     None => ListKind::Unordered,
                 };
                 state.list_stack.push(kind);
+                state.list_indents.push(indent);
             }
             Event::End(TagEnd::List(..)) => {
                 state.list_stack.pop();
-                output.push('\n');
+                state.list_indents.pop();
+                // Only a top-level list closes the block (its last item's
+                // newline plus this one separate it from what follows). A
+                // nested close leaves the newline to the enclosing
+                // `End(Item)` — emitting one here as well stacked up into
+                // blank lines in the middle of the outer list.
+                if state.list_stack.is_empty() {
+                    output.push('\n');
+                }
             }
             Event::Start(Tag::Item) => Self::start_item(state, output),
             Event::Start(Tag::CodeBlock(kind)) => {
@@ -803,7 +893,24 @@ impl TerminalRenderer {
 
     fn start_heading(state: &mut RenderState, level: u8, output: &mut String) {
         state.heading_level = Some(level);
-        if !output.is_empty() {
+        if output.is_empty() {
+            return;
+        }
+        if output.ends_with('\n') {
+            // Normalise to exactly one blank line before the heading.
+            //
+            // Pushing a newline unconditionally used to stack on top of the
+            // separator the previous block had already emitted —
+            // `End(Paragraph)` writes `\n\n`, and a list writes `\n` from
+            // `End(Item)` plus `\n` from `End(List)` — so every heading ended
+            // up preceded by `\n\n\n`, i.e. two blank lines.
+            let content_len = output.trim_end_matches('\n').len();
+            output.truncate(content_len);
+            output.push_str("\n\n");
+        } else {
+            // Mid-line (e.g. after a blockquote's "│ " prefix): just break
+            // the line, exactly as before — normalising here would insert a
+            // blank row that never used to exist.
             output.push('\n');
         }
     }
@@ -814,8 +921,8 @@ impl TerminalRenderer {
     }
 
     fn start_item(state: &mut RenderState, output: &mut String) {
-        let depth = state.list_stack.len().saturating_sub(1);
-        output.push_str(&"  ".repeat(depth));
+        let indent = state.list_indents.last().copied().unwrap_or(0);
+        output.push_str(&" ".repeat(indent));
 
         let marker = match state.list_stack.last_mut() {
             Some(ListKind::Ordered { next_index }) => {
@@ -823,8 +930,17 @@ impl TerminalRenderer {
                 *next_index += 1;
                 format!("{value}. ")
             }
-            _ => String::new(),
+            // Unordered items used to render with no marker at all, so a
+            // bulleted list came out as a wall of bare lines indistinguishable
+            // from consecutive paragraphs. Indentation alone carries nesting;
+            // the bullet is what marks the line as a list item.
+            Some(ListKind::Unordered) => String::from("\u{2022} "),
+            None => String::new(),
         };
+        // Content column = marker column + marker width; nested lists and
+        // continuation lines align to this. `chars().count()` is the right
+        // width here — both marker shapes are single-column characters.
+        state.item_content_col = indent + marker.chars().count();
         output.push_str(&marker);
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -279,6 +279,68 @@ enum OutputMsg {
     Raw(String),
 }
 
+/// A single call to iocraft's stdout handle. Borrows from the message being
+/// split — the only allocation on this per-delta path is the one iocraft's
+/// own `ToString` bound makes when the op is issued.
+#[derive(Debug, PartialEq, Eq)]
+enum OutputOp<'a> {
+    /// `StdoutHandle::println` — iocraft appends the line terminator itself,
+    /// choosing `\r\n` in raw mode and `\n` otherwise.
+    Println(&'a str),
+    /// `StdoutHandle::print` — written verbatim, no terminator.
+    Print(&'a str),
+}
+
+/// Split one output message into the sequence of iocraft stdout calls that
+/// renders it with correct line endings.
+///
+/// **Why this exists.** The iocraft render loop holds the terminal in raw
+/// mode, where `OPOST`/`ONLCR` are off and a bare `\n` moves the cursor down
+/// *without* returning it to column 0. iocraft handles that for its own
+/// canvas, and `StdoutHandle::println` terminates the message it is given —
+/// but only the *end* of it: interior `\n` are passed through untouched, and
+/// `StdoutHandle::print` writes its argument completely verbatim. Since
+/// streaming markdown arrives as `Raw` chunks full of interior newlines,
+/// every line after the first started where the previous one ended and the
+/// response walked off the right edge of the screen as a staircase.
+///
+/// Splitting on `\n` and handing iocraft one line at a time makes iocraft
+/// terminate each of them. That deliberately keeps raw-mode detection inside
+/// iocraft — this crate links crossterm 0.28 while iocraft links 0.29, so the
+/// two hold separate raw-mode statics and a local
+/// `is_raw_mode_enabled()` query would never observe iocraft's state.
+///
+/// `terminated` distinguishes `Line` (the whole message is a line, so every
+/// segment is `println`) from `Raw` (the tail is a partial line still being
+/// streamed, so it is `print`).
+///
+/// Splitting is per-message and stateless: a literal `\r\n` straddling two
+/// `Raw` chunks would come out as `…\r` + `\r\n`. That renders identically
+/// (carriage returns are idempotent) and no current writer emits `\r\n` at
+/// all — the markdown renderer and the tool formatters produce bare `\n`,
+/// and `str::lines()` strips the `\r` from embedded tool output — so the
+/// cost of carrying cross-message state isn't paid.
+fn split_for_iocraft(text: &str, terminated: bool, mut issue: impl FnMut(OutputOp<'_>)) {
+    let mut segments = text.split('\n').peekable();
+    while let Some(segment) = segments.next() {
+        let is_last = segments.peek().is_none();
+        if is_last && !terminated {
+            // Partial trailing line — no terminator yet.
+            if !segment.is_empty() {
+                issue(OutputOp::Print(segment));
+            }
+        } else {
+            // `strip_suffix`, not `trim_end_matches`: this drops the `\r` of an
+            // existing `\r\n` so iocraft's terminator does not produce `\r\r\n`,
+            // while leaving any other carriage returns (e.g. the `\r\x1b[2K`
+            // that rewrites the spinner line) intact.
+            issue(OutputOp::Println(
+                segment.strip_suffix('\r').unwrap_or(segment),
+            ));
+        }
+    }
+}
+
 /// Channel-backed output handle for routing text from the runner thread
 /// to the iocraft render loop. Clone is cheap. Implements `std::io::Write`
 /// so it can be used as a stdout replacement.
@@ -420,12 +482,15 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             // Drain output channel.
             if let Ok(rx) = output_rx_for_future.lock() {
                 loop {
-                    match rx.try_recv() {
-                        Ok(OutputMsg::Line(text)) => stdout_for_future.println(text),
-                        Ok(OutputMsg::Raw(text)) => stdout_for_future.print(text),
-                        Err(TryRecvError::Empty) => break,
-                        Err(TryRecvError::Disconnected) => break,
-                    }
+                    let (text, terminated) = match rx.try_recv() {
+                        Ok(OutputMsg::Line(text)) => (text, true),
+                        Ok(OutputMsg::Raw(text)) => (text, false),
+                        Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+                    };
+                    split_for_iocraft(&text, terminated, |op| match op {
+                        OutputOp::Println(line) => stdout_for_future.println(line),
+                        OutputOp::Print(chunk) => stdout_for_future.print(chunk),
+                    });
                 }
             }
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
@@ -1,0 +1,143 @@
+//! PTY regression tests for raw-mode line endings in the iocraft REPL.
+//!
+//! **Line endings.** The iocraft render loop holds the terminal in raw mode,
+//! where `OPOST`/`ONLCR` are off and a bare `\n` moves the cursor down
+//! **without** returning it to column 0. iocraft terminates its own canvas
+//! rows correctly, and `StdoutHandle::println` terminates the *end* of the
+//! message it is handed — but interior newlines pass through untouched, and
+//! `StdoutHandle::print` writes its argument completely verbatim. Tool
+//! results arrive as multi-line `println` messages and streaming markdown as
+//! raw `print` chunks, so before `split_for_iocraft` every line after the
+//! first started where the previous one ended and the output walked off the
+//! right edge of the screen as a staircase.
+//!
+//! Both tests assert on the rendered screen — "what the user actually sees" —
+//! because that is the layer these bugs live at. Synchronization is on the
+//! turn status line (`ctx `), which the CLI prints after all turn output has
+//! been flushed through the same FIFO channel; no sleeps.
+//!
+//! ```bash
+//! cargo test --test pty_raw_mode_line_endings                          # mock (CI)
+//! SCODE_TEST_BACKEND=live cargo test --test pty_raw_mode_line_endings  # real API
+//! ```
+
+mod common;
+
+use common::TestEnv;
+
+/// Spawn the iocraft REPL — the only path that puts the terminal in raw
+/// mode. The shared harness defaults `SUDOCODE_INTERRUPT_QUEUE_MODE` to
+/// `off` (the rustyline REPL), so `queue` must be set explicitly.
+fn spawn_iocraft_repl(env: &TestEnv, permission_mode: &str) -> pty_expect::PtySession {
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", permission_mode],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    // A tall, wide screen keeps the turn's output from scrolling away and
+    // gives a runaway staircase room to be unmistakable.
+    sess.resize(50, 100).expect("resize pty");
+    sess.expect("❯").expect("initial prompt");
+    sess
+}
+
+/// Leading-space counts of every rendered row containing `needle`.
+fn indents_of_rows_containing(sess: &pty_expect::PtySession, needle: &str) -> Vec<usize> {
+    sess.render(|screen| {
+        screen
+            .contents()
+            .lines()
+            .filter(|line| line.contains(needle))
+            .map(|line| line.len() - line.trim_start().len())
+            .collect()
+    })
+}
+
+/// The rendered screen as trimmed rows.
+fn screen_rows(sess: &pty_expect::PtySession) -> Vec<String> {
+    sess.render(|screen| {
+        screen
+            .contents()
+            .lines()
+            .map(|line| line.trim_end().to_string())
+            .collect()
+    })
+}
+
+/// One bash turn through the raw-mode REPL, asserting all line-ending
+/// properties of the same final screen:
+///
+/// 1. the tool-call box's interior newlines are CRLF on the raw stream;
+/// 2. the tool-result body's interior newline is CRLF on the raw stream;
+/// 3. neither stair-steps on the rendered screen;
+/// 4. iocraft's own full-width separator rules stay at column 0 (the fix
+///    must not add carriage returns that shift iocraft's canvas).
+///
+/// Anchors are chosen to be absent from the echoed prompt: the prompt
+/// contains `printf 'alpha from bash'`, so `alpha from bash` would match the
+/// echo — `─╮`, `└ `, and `ctx ` cannot.
+#[test]
+fn bash_turn_uses_crlf_and_does_not_staircase() {
+    let env = TestEnv::new("raw-lf-bash");
+    let mut sess = spawn_iocraft_repl(&env, "danger-full-access");
+
+    let prompt = env.prompt(
+        "Run this bash command: printf 'alpha from bash'",
+        "bash_stdout_roundtrip",
+    );
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+
+    // Raw-stream assertions double as sync points: with a bare LF (the bug)
+    // `[^\n]*` cannot reach a `\r\n` and the expect times out.
+    sess.expect("─╮[^\n]*\r\n")
+        .expect("tool-call box top line should end with CRLF, not a bare LF");
+    sess.expect("└ [^\n]*\r\n")
+        .expect("tool-result body line should end with CRLF, not a bare LF");
+    // The status line is the last turn output through the FIFO channel —
+    // once it is on the stream, the whole turn has rendered.
+    sess.expect("ctx ").expect("turn status line");
+
+    let mut box_indents = indents_of_rows_containing(&sess, "╭─ ");
+    box_indents.extend(indents_of_rows_containing(&sess, "$ printf"));
+    box_indents.extend(indents_of_rows_containing(&sess, "└ "));
+    assert!(
+        !box_indents.is_empty(),
+        "expected the tool-call box and tool-result rows on screen"
+    );
+    for indent in &box_indents {
+        assert!(
+            *indent <= 4,
+            "tool output row indented {indent} columns instead of ~2 — the \
+             raw-mode staircase is back (all indents: {box_indents:?})"
+        );
+    }
+
+    // Only iocraft's full-width separator rules: rows made up entirely of
+    // `─`. (A bare "────" substring would also match the tool box's
+    // `╰────────╯` border, which is legitimately indented.)
+    let rule_indents: Vec<usize> = sess.render(|screen| {
+        screen
+            .contents()
+            .lines()
+            .map(str::trim_end)
+            .filter(|line| {
+                let t = line.trim_start();
+                !t.is_empty() && t.chars().all(|c| c == '─')
+            })
+            .map(|line| line.len() - line.trim_start().len())
+            .collect()
+    });
+    assert!(
+        !rule_indents.is_empty(),
+        "expected iocraft separator rules on screen"
+    );
+    for indent in &rule_indents {
+        assert_eq!(
+            *indent, 0,
+            "iocraft separator rule drifted off column 0 (indents: {rule_indents:?})"
+        );
+    }
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
@@ -1,4 +1,5 @@
-//! PTY regression tests for raw-mode line endings in the iocraft REPL.
+//! PTY regression tests for iocraft-REPL terminal rendering: raw-mode line
+//! endings and markdown block spacing.
 //!
 //! **Line endings.** The iocraft render loop holds the terminal in raw mode,
 //! where `OPOST`/`ONLCR` are off and a bare `\n` moves the cursor down
@@ -10,6 +11,12 @@
 //! raw `print` chunks, so before `split_for_iocraft` every line after the
 //! first started where the previous one ended and the output walked off the
 //! right edge of the screen as a staircase.
+//!
+//! **Markdown spacing.** The renderer used to stack block separators (two
+//! blank lines before headings), drop unordered-list markers entirely, glue
+//! nested lists onto their parent's row, and misalign nested/continuation
+//! lines. The `markdown_rendering_showcase` mock scenario streams a document
+//! exercising each rule; the test asserts the rendered VT100 screen.
 //!
 //! Both tests assert on the rendered screen — "what the user actually sees" —
 //! because that is the layer these bugs live at. Synchronization is on the
@@ -136,6 +143,92 @@ fn bash_turn_uses_crlf_and_does_not_staircase() {
             "iocraft separator rule drifted off column 0 (indents: {rule_indents:?})"
         );
     }
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(exit, 0);
+}
+
+/// Index of the first row containing `needle`, or panic with the screen.
+fn row_of(rows: &[String], needle: &str) -> usize {
+    rows.iter()
+        .position(|r| r.contains(needle))
+        .unwrap_or_else(|| panic!("row containing {needle:?} not on screen: {rows:#?}"))
+}
+
+/// Streams `MARKDOWN_SHOWCASE_DOC` (see mock-anthropic-service) and asserts
+/// the block-spacing and list-marker rules on the rendered screen:
+///
+/// * a label is bound to the list it introduces (no injected blank line);
+/// * an author-written blank line before a list survives;
+/// * a heading is preceded by exactly one blank row;
+/// * unordered items carry a `•` marker;
+/// * a bullet nested under an ordered item aligns under the parent's text;
+/// * a nested list does not open a blank hole before the next sibling.
+#[test]
+fn markdown_showcase_renders_without_spacing_artifacts() {
+    let env = TestEnv::new("md-showcase");
+    let mut sess = spawn_iocraft_repl(&env, "read-only");
+
+    let prompt = env.prompt("Show me formatted markdown", "markdown_rendering_showcase");
+    sess.send(&format!("{prompt}\r")).expect("send prompt");
+
+    sess.expect("second").expect("last list item");
+    sess.expect("ctx ").expect("turn status line");
+
+    let rows = screen_rows(&sess);
+
+    // Binding: "Intro:" introduces the list, so "• alpha" is the very next
+    // row — the blank line the renderer used to inject is gone.
+    let intro = row_of(&rows, "Intro:");
+    assert!(
+        rows[intro + 1].contains("• alpha"),
+        "adjacent list must bind to its label: {rows:#?}"
+    );
+    assert!(
+        rows[intro + 2].contains("• beta"),
+        "list items must be adjacent: {rows:#?}"
+    );
+
+    // Heading: exactly one blank row above "Section".
+    let section = row_of(&rows, "Section");
+    assert!(
+        rows[section - 1].trim().is_empty() && !rows[section - 2].trim().is_empty(),
+        "heading must be preceded by exactly one blank row: {rows:#?}"
+    );
+
+    // Author-written blank line before a list survives.
+    let after_blank = row_of(&rows, "After blank:");
+    assert!(
+        rows[after_blank + 1].trim().is_empty() && rows[after_blank + 2].contains("• gamma"),
+        "author-written blank line before a list must survive: {rows:#?}"
+    );
+
+    // A bullet nested under an ordered item starts at the parent's content
+    // column ("1. " is three columns wide).
+    let parent = row_of(&rows, "1. parent");
+    let child = row_of(&rows, "• child");
+    let parent_indent = rows[parent].len() - rows[parent].trim_start().len();
+    let child_indent = rows[child].len() - rows[child].trim_start().len();
+    assert_eq!(
+        child_indent,
+        parent_indent + 3,
+        "nested bullet must align under the ordered parent's text: {rows:#?}"
+    );
+
+    // Nested list with a following sibling: no blank hole.
+    let outer = row_of(&rows, "• outer");
+    assert!(
+        rows[outer + 1].contains("• inner") && rows[outer + 2].contains("• second"),
+        "nested list must not open a blank hole before the next sibling: {rows:#?}"
+    );
+    let outer_indent = rows[outer].len() - rows[outer].trim_start().len();
+    let inner_indent = rows[outer + 1].len() - rows[outer + 1].trim_start().len();
+    assert_eq!(
+        inner_indent,
+        outer_indent + 2,
+        "nested bullet must be indented under its parent: {rows:#?}"
+    );
 
     sess.send("/exit\r").expect("send /exit");
     let exit = sess.expect_eof().expect("scode should exit");


### PR DESCRIPTION
## What

Two commits fixing the terminal-rendering defects visible in every multi-line assistant response and tool output under the iocraft REPL (the default path since `SUDOCODE_INTERRUPT_QUEUE_MODE` defaulted to `queue`):

| Symptom (v0.1.19, macOS Terminal) | Root cause | Commit |
|---|---|---|
| Output stair-steps rightwards until it wraps mid-word | Raw mode: iocraft's `println` terminates only the END of a message; interior `\n` and all of `print` stay bare, so each line starts where the last ended | `13b678b` |
| Two blank lines before every heading | `End(Paragraph)` emits `\n\n`, `start_heading` stacked another `\n` | `9199018` |
| Bulleted lists render as bare lines (no markers) | Unordered `start_item` emitted no marker at all | `9199018` |
| Nested list glued onto its parent's row (`• outer  • inner`) | Nested `Start(List)` never broke the line | `9199018` |
| Blank line injected between a label and its list | `End(Paragraph)`'s separator; binding decision now taken from the **source** via the offset iterator, so author-written blank lines always survive and streamed/replayed output agree | `9199018` |

Before/after on a real turn ("你能做什么", claude-opus-4-8, 100-col PTY → vt100):

```
BEFORE                                              AFTER
⏺ 我是 Sudo Code…                                   ⏺ 我是一个 AI 编程助手…
                                                    
              我可以帮你处理各种软件工程任务，比如：      代码开发
                                                    • 写新功能、修 bug、重构代码
  写代码 / 改代码 — 实现新功能…                        • 读懂并解释现有代码
              读代码 / 解释代码 — 帮你理解某段逻辑…     • 调试问题、分析报错
                            调试排错 — 定位并修复…
```

## Why the fix lives where it does

- **Line endings are fixed in the REPL drain, not with a local LF→CRLF writer.** This crate links crossterm 0.28 while the iocraft fork links 0.29 — two crate instances, two raw-mode statics — so `is_raw_mode_enabled()` here can never observe the mode iocraft set. Splitting per line and letting iocraft terminate each one keeps mode detection where the mode lives. Verified the sudoprivacy iocraft fork's `use_output.rs` is byte-identical to upstream 0.8.4 in the relevant region.
- **List binding is decided from the source, not the rendered output.** pulldown-cmark emits identical events for `Label\n- a` and `Label\n\n- a`; only the byte offset distinguishes them. An output-based heuristic diverged between streamed chunks and whole-document renders (transcript replay via `format.rs`, non-streaming via `push_output_block`) — the offset-based rule behaves identically everywhere.

## Review process

Self-reviewed with a 28-agent adversarial workflow (finder-per-angle + independent verifier per finding). It confirmed 10 findings against my first draft — including that the original output-based binding heuristic deleted author-written blank lines on replay paths, a nested-list blank-hole, a blockquote-heading regression, and continuation/nesting misalignment. All are fixed in this version except one **pre-existing** limitation kept out of scope: a loose nested list whose blank line falls on a streaming chunk boundary re-parses as top-level (requires cross-chunk parser state; behavior unchanged from main).

## Tests

Per CONTRIBUTING's test policy, coverage is **PTY-only** (no unit tests added):

- `bash_turn_uses_crlf_and_does_not_staircase` — raw-stream CRLF regexes (time out on bare LF), zero staircase on the vt100 screen, iocraft chrome pinned to column 0.
- `markdown_showcase_renders_without_spacing_artifacts` — new `markdown_rendering_showcase` mock scenario streams a document with mid-line delta boundaries; asserts binding, author-blank preservation, heading spacing, bullets, ordered/nested alignment, no blank hole. (Scenario is not in `mock_parity_scenarios.json` by design — the manifest mirrors the harness's 12 hardcoded cases.)

Both tests fail on `main` (box drifted to column 49; body drifted 32 columns) and sync on the turn status line — no sleeps.

## Gates

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace` (CI's invocation) ✅ exit 0; zero diagnostics on changed lines even under `-D warnings -W clippy::pedantic -W clippy::nursery`
- `cargo test --workspace` ✅ 101 binaries, 1579 passed, 0 failed
- Real-API manual verification under a 100-col PTY, before/after above

## Notes for review

- Bullet is `•` (U+2022, East-Asian-Ambiguous width): on ambiguous-wide CJK terminal configs it may occupy 2 columns. Swap to ASCII `-` is a one-liner if you prefer.
- Unrelated flake found while validating: `runtime`'s `memory/mod.rs:339` and `memory/loader.rs:229` each define their own `ENV_LOCK` guarding the same `SUDOCODE_MEMORY_DIR` env var — two different mutexes, no mutual exclusion (`load_default_honors_env_var` failed once in four full-workspace runs). Not touched here; happy to file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
