### PR TITLE
fix(cli): persist turn result until next turn + extract format_box

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -93,6 +93,55 @@ fn wrap_ansi(text: &str, width: usize) -> Vec<String> {
     result
 }
 
+/// Render a closed box with a titled header for scrollback output.
+///
+/// ```text
+///   ╭─ Title ─────────────╮
+///   │ content line 1      │
+///   │ content line 2      │
+///   ╰─────────────────────╯
+/// ```
+///
+/// Box width is capped at terminal width. Content lines that exceed
+/// the inner area are wrapped (height grows instead of overflow).
+#[inline]
+pub(crate) fn format_box(title: &str, content: &str) -> String {
+    let term_w = crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize);
+    let title_width = display_width(title);
+    // Total visible line = 2 (indent) + 1 (╭) + border_chars + 1 (╮).
+    let max_border = term_w.saturating_sub(4);
+    let header_min = title_width + 4; // "─ Title ─"
+    let content_area = max_border.saturating_sub(2);
+
+    let wrapped = wrap_ansi(content, content_area);
+
+    let content_max = wrapped
+        .iter()
+        .map(|line| display_width(&strip_ansi_codes(line)))
+        .max()
+        .unwrap_or(0);
+    let border_chars = header_min.max(content_max + 2).min(max_border);
+    let inner = border_chars.saturating_sub(2);
+
+    let g = "\x1b[38;5;245m";
+    let r = "\x1b[0m";
+    let ct = "\x1b[1;36m";
+
+    let header_fill = border_chars.saturating_sub(title_width + 3);
+    let header = format!("  {g}╭─ {ct}{title}{r}{g} {}╮{r}", "─".repeat(header_fill));
+
+    let mut body = String::new();
+    for line in &wrapped {
+        let vis = display_width(&strip_ansi_codes(line));
+        let pad = inner.saturating_sub(vis);
+        body.push_str(&format!("\n  {g}│{r} {line}{}{g} │{r}", " ".repeat(pad)));
+    }
+
+    let bottom = format!("  {g}╰{}╯{r}", "─".repeat(border_chars));
+
+    format!("{header}{body}\n{bottom}")
+}
+
 // ---------------------------------------------------------------------------
 // Unified message rendering pipeline
 // ---------------------------------------------------------------------------
@@ -903,48 +952,7 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
         _ => summarize_tool_payload(input),
     };
 
-    // Closed box drawing:
-    //   ╭─ Name ───────────────╮
-    //   │ content line 1       │
-    //   │ wrapped continuation │
-    //   ╰──────────────────────╯
-    //
-    // Box width is capped at terminal width. Content lines that exceed
-    // the inner area are wrapped (height grows).
-    let term_w = crossterm::terminal::size().map_or(80, |(cols, _)| cols as usize);
-    let name_width = display_width(name);
-    // Total visible line = 2 (indent) + 1 (╭) + border_chars + 1 (╮).
-    let max_border = term_w.saturating_sub(4);
-    let header_min = name_width + 4; // "─ Name ─"
-    let content_area = max_border.saturating_sub(2);
-
-    let wrapped = wrap_ansi(&detail, content_area);
-
-    let content_max = wrapped
-        .iter()
-        .map(|line| display_width(&strip_ansi_codes(line)))
-        .max()
-        .unwrap_or(0);
-    let border_chars = header_min.max(content_max + 2).min(max_border);
-    let inner = border_chars.saturating_sub(2);
-
-    let g = "\x1b[38;5;245m";
-    let r = "\x1b[0m";
-    let cn = "\x1b[1;36m";
-
-    let header_fill = border_chars.saturating_sub(name_width + 3);
-    let header = format!("  {g}╭─ {cn}{name}{r}{g} {}╮{r}", "─".repeat(header_fill));
-
-    let mut body = String::new();
-    for line in &wrapped {
-        let vis = display_width(&strip_ansi_codes(line));
-        let pad = inner.saturating_sub(vis);
-        body.push_str(&format!("\n  {g}│{r} {line}{}{g} │{r}", " ".repeat(pad)));
-    }
-
-    let bottom = format!("  {g}╰{}╯{r}", "─".repeat(border_chars));
-
-    format!("{header}{body}\n{bottom}")
+    format_box(name, &detail)
 }
 
 /// Split a `ToolResult.output` string into its JSON-payload prefix and any

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -172,7 +172,7 @@ fn format_compact_tokens(tokens: u32) -> String {
 enum StatusSlot {
     /// Animated progress during a turn.
     Spinner(String),
-    /// Turn result (tokens/cost/ctx). Auto-dismisses after ~5 seconds.
+    /// Turn result (tokens/cost/ctx). Cleared when the next turn starts.
     TurnResult(String),
     /// First-run tips. Dismissed on first submit.
     Tips,
@@ -514,7 +514,6 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut frame = hooks.use_state(|| 0usize);
     let mut spinner_text = hooks.use_state(String::new);
     let mut turn_result = hooks.use_state(|| None::<String>);
-    let mut turn_result_time = hooks.use_state(|| None::<Instant>);
     let mut has_submitted = hooks.use_state(|| false);
     let mut question_state = hooks.use_state(|| None::<QuestionPromptView>);
     let mut question_selection = hooks.use_state(|| 0usize);
@@ -567,7 +566,6 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         }
                         Ok(UiCommand::SetTurnResult(text)) => {
                             turn_result.set(Some(text));
-                            turn_result_time.set(Some(Instant::now()));
                         }
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => break,
@@ -575,19 +573,15 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 }
             }
 
-            // Auto-dismiss turn result after 5 seconds.
-            if turn_result_time
-                .read()
-                .is_some_and(|t| t.elapsed() >= Duration::from_secs(5))
-            {
-                turn_result.set(None);
-                turn_result_time.set(None);
-            }
-
-            // Update spinner.
+            // Update spinner.  When a new turn starts (spinner becomes
+            // active), clear the previous turn's result — the spinner
+            // takes priority in the StatusSlot and the old result is stale.
             let idx = frame.get();
             frame.set(idx.wrapping_add(1));
             let text = spinner_for_future.render_frame(idx);
+            if !text.is_empty() && turn_result.read().is_some() {
+                turn_result.set(None);
+            }
             spinner_text.set(text);
         }
     });


### PR DESCRIPTION
## Summary

- Remove 5-second auto-dismiss timer for StatusSlot::TurnResult (CC parity — status line stays until next turn starts)
- Clear turn_result when spinner activates, not on timer
- Extract closed-box rendering into reusable `#[inline] format_box(title, content)` helper

## Test plan

- [x] `cargo test -p rusty-sudocode-cli --bin scode -- repl_ui` (10 pass)
- [x] `cargo test -p rusty-sudocode-cli --bin scode -- format` (34 pass)
- [ ] Manual: turn result visible after long turn, persists until next submit