### PR TITLE
fix(acp): unblock permission bridge recv + fold CC tool aliases at registry gate

### DIFF
--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -668,11 +668,22 @@ impl PermissionPrompter for AcpPermissionBridge {
                 reason: "permission bridge closed".to_string(),
             };
         }
-        response_rx
-            .blocking_recv()
-            .unwrap_or(PermissionPromptDecision::Deny {
-                reason: "permission response channel closed".to_string(),
-            })
+        // `decide()` is reached from inside the conversation runtime's
+        // `tokio_runtime.block_on(run_turn)`, so this thread is driving
+        // asynchronous tasks. Plain `blocking_recv()` there triggers tokio's
+        // "Cannot block the current thread from within a runtime" panic,
+        // which aborts the prompt task and surfaces to the client as a
+        // generic "blocking task failed" Internal error. `block_in_place`
+        // tells the multi-thread scheduler this thread is about to block,
+        // allowing the recv to complete safely (same pattern as
+        // `AcpQuestionBridge::ask` below).
+        tokio::task::block_in_place(|| {
+            response_rx
+                .blocking_recv()
+                .unwrap_or(PermissionPromptDecision::Deny {
+                    reason: "permission response channel closed".to_string(),
+                })
+        })
     }
 }
 

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -683,7 +683,14 @@ impl GlobalToolRegistry {
         abort_signal: Option<&HookAbortSignal>,
         ctx: Option<&ToolDispatchContext>,
     ) -> Result<String, String> {
-        if mvp_tool_specs().iter().any(|spec| spec.name == name) {
+        // Gate on the CANONICAL name: models may return CC-style
+        // PascalCase aliases (`Bash` → `bash`, `Read` → `read_file`, …)
+        // which `execute_tool_with_enforcer` folds via
+        // `canonicalize_tool_name`. Comparing the raw name here sent
+        // every aliased call down the plugin lookup and out as
+        // `unsupported tool: Bash`.
+        let canonical = canonicalize_tool_name(name);
+        if mvp_tool_specs().iter().any(|spec| spec.name == canonical) {
             return execute_tool_with_enforcer(
                 self.enforcer.as_ref(),
                 name,
@@ -9038,6 +9045,35 @@ mod tests {
 
         // then
         assert!(error.contains("requires workspace-write permission"));
+    }
+
+    #[test]
+    fn global_tool_registry_folds_cc_alias_before_mvp_gate() {
+        // given — `Bash` is a CC-style alias for the `bash` match arm. The
+        // registry gate must compare the CANONICAL name against
+        // `mvp_tool_specs`; gating on the raw name sent every aliased call
+        // down the plugin lookup and out as `unsupported tool: Bash` (the
+        // ACP-mode regression: permission prompt approved, then dispatch
+        // rejected the tool anyway).
+        let policy = permission_policy_for_mode(PermissionMode::ReadOnly);
+        let registry = GlobalToolRegistry::builtin().with_enforcer(PermissionEnforcer::new(policy));
+
+        // when — a write-classified command under a read-only policy is
+        // denied by the enforcer INSIDE the bash arm, proving dispatch got
+        // past the gate without ever spawning a shell.
+        let error = registry
+            .execute("Bash", &json!({ "command": "touch blocked.txt" }))
+            .expect_err("write-classified bash should be denied by the enforcer");
+
+        // then
+        assert!(
+            !error.contains("unsupported tool"),
+            "alias fell through the mvp gate: {error}"
+        );
+        assert!(
+            error.contains("permission"),
+            "expected permission denial: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Every Bash tool call fails in ACP mode (`scode acp --permission-mode workspace-write`). The client sees the `session/request_permission`, approves `allow_once`, and still gets back:

```
thread 'tokio-rt-worker' panicked at crates/runtime/src/acp_sdk_server.rs:672:14:
Cannot block the current thread from within a runtime. This happens because a function
attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```

followed by a `session/update` of "发生错误：blocking task failed" and the prompt ending with `-32603 Internal error`. Reproduced 3/3 on current main (4bbb2f2); same behavior as the homebrew 0.1.18 report.

## Root cause — two stacked bugs

**1. Permission bridge blocks inside the runtime.** `AcpPermissionBridge::decide()` calls `oneshot::Receiver::blocking_recv()` from the thread driving `tokio_runtime.block_on(run_turn)` (the conversation tool loop checks permission *before* dispatch — `conversation.rs` → `permissions.rs::prompt_or_deny` → `decide()`). tokio panics on the blocking call, the panic aborts the `spawn_blocking` prompt task, and the client's approval lands on a dropped channel. `AcpQuestionBridge::ask` hit this exact panic and was fixed with `block_in_place` in 25f0a27; the permission bridge never got the same treatment.

**2. Registry gate compares the raw tool name.** With the panic fixed, dispatch still failed with `unsupported tool: Bash`: models return CC-style PascalCase names, but `GlobalToolRegistry::execute_with_abort_and_context` gated the raw name against snake_case `mvp_tool_specs`, so `Bash` fell through to plugin lookup — *after* the user had already approved the permission prompt. `canonicalize_tool_name` exists precisely to fold these aliases (ca9e0f9) but the gate bypassed it.

## Fix

- `decide()` wraps `blocking_recv()` in `tokio::task::block_in_place` — same pattern as `AcpQuestionBridge::ask` directly below it.
- The registry gate compares the **canonical** name, matching what `execute_tool_with_enforcer` already does internally.

## Verification

- End-to-end NDJSON JSON-RPC driver against the real binary: `initialize` → `session/new` → `session/prompt` ("run `echo hello-from-repro`") → approve `allow_once`. **Before:** panic + `blocking task failed`, 3/3 runs. **After:** no panic, permission round-trip completes, Bash executes, agent replies with the actual output (`输出是 hello-from-repro`), 3/3 runs (+1 verify run).
- `cargo fmt --all --check` ✅
- `cargo clippy -p runtime -p tools --all-targets -- -D warnings` ✅ (workspace-wide clippy fails on pre-existing pedantic lints in `crates/telemetry`, untouched by this PR — see note below)
- `cargo test --workspace` ✅ exit 0, 104 test targets, 0 failures
- Added a regression test locking the registry-gate alias folding, following the precedent of ca9e0f9's canonicalize test in the same module.

## Notes for reviewers

- `cargo clippy --workspace --all-targets -- -D warnings` currently fails on main itself: `crates/telemetry` has ~14 pedantic lint violations (doc_markdown, uninlined_format_args, too_many_lines, …), presumably inherited via the cohost-kernel bump. Left out of scope here.
- Unrelated leftover spotted while tracing: `acp_sdk_server.rs` writes an `[ACP-DIAG]` debug log to `/tmp/scode-acp-diag.log` on every prompt (added around the question-prompter wiring). Worth removing in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
