### PR TITLE
docs(roadmap): re-validate system-prompt tables against CC 2.1.229

### DIFF
--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -1119,49 +1119,50 @@ automated in <a href="https://github.com/sudoprivacy/sudocode/blob/main/scripts/
 Verbatim CC prompt text is kept local (not committed), treated like the private
 CC snapshot in <a href="#reference-sources">Reference sources</a>.</p>
 
-<p class="table-title"><strong>Table A — what CC serves each model</strong> (SSOT reference, CC&nbsp;2.1.207).</p>
+<p class="table-title"><strong>Table A — what CC serves each model</strong> (SSOT reference, captured CC&nbsp;2.1.229, 2026-08-06).</p>
 
 <table>
   <thead><tr><th>Model</th><th>CC variant</th><th>System-prompt size</th><th>Memory block</th><th>Distinctive sections</th></tr></thead>
   <tbody>
-    <tr><td><code>opus-4-8</code>, <code>opus-5</code></td><td data-status="covered"><strong>Lean</strong></td><td>~5.9 KB</td><td><code># Memory</code> (2,099)</td><td><code># Harness</code> only — no Doing&nbsp;tasks / Actions / Using&nbsp;tools / Tone / Text&nbsp;output</td></tr>
-    <tr><td><code>opus-4-1</code>, <code>opus-4</code></td><td data-status="covered"><strong>Lean</strong></td><td>~5.9 KB</td><td><code># Memory</code> (2,099)</td><td>Request model is <em>remapped</em> to <code>opus-4-8</code> in the body → lean</td></tr>
-    <tr><td><code>fable-5</code></td><td data-status="gap-l2"><strong>Mid</strong></td><td>~10.4 KB</td><td><code># Memory</code> (2,099)</td><td><code># Harness</code> (661) + extra <code># Communicating with the user</code> (3,734) — explicit comms scaffolding the top opus models don't get</td></tr>
-    <tr><td><code>sonnet-5</code>, <code>sonnet-4-5</code>, <code>sonnet-4</code>, <code>sonnet-3-7</code>, <code>sonnet-3-5</code></td><td data-status="gap"><strong>Full</strong></td><td>~27.4 KB</td><td><code># auto memory</code> (12,834)</td><td>All 10 verbose sections</td></tr>
-    <tr><td><code>opus-4-6</code> — <strong>current default</strong> (<code>config.rs</code> primary)</td><td data-status="gap"><strong>Full</strong></td><td>~27.4 KB</td><td><code># auto memory</code> (12,834)</td><td>Captured CC&nbsp;2.1.207 → <strong>Full</strong>, byte-identical to opus-4-5. CC reserves Lean for opus-4-8/opus-5 only, so <strong>the default stays Full — no silent cut for default users</strong>. Do <em>not</em> extrapolate "frontier → Lean": 4-6 is newer than 4-5 yet both are Full.</td></tr>
-    <tr><td><code>opus-4-5</code>, <code>haiku-4-5</code>, <code>haiku-3-5</code></td><td data-status="gap"><strong>Full</strong></td><td>~27.4 KB</td><td><code># auto memory</code> (12,834)</td><td>All 10 verbose sections — newest haiku still gets the full prompt</td></tr>
-    <tr><td><strong>non-Anthropic</strong> — GPT / qwen / DeepSeek / local (via sudorouter + openai-compat)</td><td data-status="gap-l2"><strong>scode's own</strong></td><td>n/a</td><td>n/a</td><td>CC does not run these, so there is <em>no CC prompt to mirror</em>. scode decides the tier itself — <strong>Lean by default</strong> (they never carried CC's verbose baggage; capable models do better with the lean prompt). This is roughly half the models scode runs in production.</td></tr>
+    <tr><td><code>opus-4-8</code></td><td data-status="covered"><strong>Lean</strong></td><td>~6.3 KB</td><td><code># Memory</code> (2,092)</td><td><code># Harness</code> + 4 core sections only — no Doing&nbsp;tasks / Actions / Using&nbsp;tools / Tone / Text&nbsp;output. The <em>only</em> true-Lean model.</td></tr>
+    <tr><td><code>opus-5</code></td><td data-status="gap-l2"><strong>Mid</strong></td><td>~9.6 KB</td><td><code># Memory</code> (2,092)</td><td>Lean's 5 sections <em>plus</em> <code># Delivering work</code> (2,002) + <code># Corrections</code> (1,355). <strong>Moved Lean→Mid since 2.1.207.</strong></td></tr>
+    <tr><td><code>fable-5</code></td><td data-status="gap-l2"><strong>Mid</strong></td><td>~10.7 KB</td><td><code># Memory</code> (2,092)</td><td>Short <code># Harness</code> (661) + <code># Communicating with the user</code> (4,105) — a <em>different</em> Mid from opus-5.</td></tr>
+    <tr><td><code>opus-4-6</code> — <strong>current default</strong> (<code>config.rs</code> primary)</td><td data-status="gap"><strong>Full</strong></td><td>~27.8 KB</td><td><code># auto memory</code> (12,833)</td><td>Captured CC&nbsp;2.1.229 → <strong>Full</strong>, byte-identical to opus-4-5. <strong>Default stays Full — no silent cut for default users.</strong> Do <em>not</em> extrapolate "frontier → Lean": 4-6 is newer than 4-5 yet both are Full.</td></tr>
+    <tr><td><code>opus-4-5</code>, <code>sonnet-5</code>, <code>sonnet-4-5</code>, <code>haiku-4-5</code>, older</td><td data-status="gap"><strong>Full</strong></td><td>~27.8 KB</td><td><code># auto memory</code> (12,833)</td><td>All 10 verbose sections — newest sonnet/haiku still get the full prompt</td></tr>
+    <tr><td><strong>non-Anthropic</strong> — GPT / qwen / DeepSeek / local (via sudorouter + openai-compat)</td><td data-status="gap-l2"><strong>scode's own</strong></td><td>n/a</td><td>n/a</td><td>CC does not run these, so there is <em>no CC prompt to mirror</em>. scode decides the tier itself — <strong>Lean by default</strong> (no CC baggage to shed). Roughly half the models scode runs in production.</td></tr>
   </tbody>
 </table>
 
-<p class="table-caption">The lean/full boundary is <em>model-specific, not
-generational</em> — sonnet-5 and haiku-4-5 are new but still get the full
-27&nbsp;KB prompt. <strong>The production default is <code>opus-4-6</code> →
-Full</strong> (captured); Lean is reserved for opus-4-8/opus-5, so default users
-are unaffected by the trim. scode must support all models, not just Anthropic's: CC maps
-only its own models, so it's a reference for the Anthropic rows only — for
-non-Anthropic models (last row) there's nothing to mirror and scode picks the
-tier itself. CC's three variants share the same lean <code># Memory</code>
-(2,099) across Lean+Mid, but sonnet/haiku/older keep the full
-<code># auto memory</code> (12,834). CC's cut for its lean models: delete
-<code># Doing tasks</code> / <code># Executing actions with care</code> /
-<code># Using your tools</code> / <code># Tone and style</code> /
-<code># Text output</code> entirely, collapse <code># auto memory</code> →
-<code># Memory</code>. Net 27,385 → 5,889 chars (−78.5%).</p>
+<p class="table-caption"><strong>As of CC 2.1.229 there are FOUR variants, not
+three</strong> (re-captured 2026-08-06 on an isolated 2.1.229 install; 2.1.207
+had three): true Lean is <code>opus-4-8</code> only; <code>opus-5</code> and
+<code>fable-5</code> each get a <em>different</em> Mid; everything else is Full.
+The boundary is <em>model-specific, not generational</em> — sonnet-5 and
+haiku-4-5 are new but still Full. The production default <code>opus-4-6</code> is
+Full, so default users are unaffected by the trim. scode must support all
+models: CC maps only its own, so it's a reference for the Anthropic rows only —
+non-Anthropic (last row) has nothing to mirror. CC's Lean+Mid variants share the
+collapsed <code># Memory</code> (2,092); Full keeps <code># auto memory</code>
+(12,833). CC's Lean cut vs Full: delete <code># Doing tasks</code> /
+<code># Executing actions</code> / <code># Using your tools</code> /
+<code># Tone and style</code> / <code># Text output</code>, collapse
+<code># auto memory</code> → <code># Memory</code>. Net 27,768 → 6,273 chars
+(−77%). (<code>opus-4-1</code>/<code>opus-4</code> requests are remapped to
+opus-4-8 by CC → Lean; that remap is CC's, not scode's concern.)</p>
 
 <p class="table-title"><strong>Table B — scode section-by-section, exhaustive.</strong></p>
 
 <table>
-  <thead><tr><th>scode section (file)</th><th>Now</th><th>CC-full</th><th>CC-mid (fable-5)</th><th>CC-lean (opus-4-8/5)</th><th>Action</th></tr></thead>
+  <thead><tr><th>scode section (file)</th><th>Now</th><th>CC-full</th><th>CC-mid (opus-5 / fable-5)</th><th>CC-lean (opus-4-8)</th><th>Action</th></tr></thead>
   <tbody>
     <tr><td><code>get_simple_intro_section</code> — identity + safety (<code>prompt.rs:621</code>)</td><td>910</td><td>preamble</td><td>→ <code># Harness</code></td><td>→ <code># Harness</code></td><td data-status="covered">Keep — core identity/safety</td></tr>
-    <tr><td><code>get_simple_system_section</code> — <code># System</code> (<code>:637</code>)</td><td>1,239</td><td><code># System</code> 1,619</td><td><code># Harness</code> 661</td><td><code># Harness</code> 1,334</td><td data-status="gap-l2">Slim + reframe to <code># Harness</code></td></tr>
+    <tr><td><code>get_simple_system_section</code> — <code># System</code> (<code>:637</code>)</td><td>1,239</td><td><code># System</code> 1,619</td><td><code># Harness</code> 661–1,638</td><td><code># Harness</code> 1,692</td><td data-status="gap-l2">Slim + reframe to <code># Harness</code></td></tr>
     <tr><td><code>get_simple_doing_tasks_section</code> — <code># Doing tasks</code> (<code>:648</code>)</td><td>2,196</td><td>3,308</td><td>removed</td><td>removed</td><td data-status="gap">Drop for lean + mid</td></tr>
     <tr><td><code>get_actions_section</code> — <code># Executing actions with care</code> (<code>:664</code>)</td><td>1,575</td><td>3,556</td><td>removed</td><td>removed</td><td data-status="gap">Drop (incl. the <code>Examples:</code> block — examples hurt newest models)</td></tr>
     <tr><td><code>get_using_tools_section</code> — <code># Using your tools</code> + git-commit + PR procedure (<code>:676</code>)</td><td><strong>3,657</strong></td><td>746 (scode is 5× larger)</td><td>removed</td><td>removed</td><td data-status="gap">Drop procedure; keep one "prefer dedicated tools / batch independent calls" line in Harness; move git/PR steps to a <code>/commit</code> skill / dynamic injection</td></tr>
     <tr><td><code>get_tone_style_section</code> — <code># Tone and style</code> (<code>:715</code>)</td><td>564</td><td>541</td><td>≈ <code># Communicating</code> ✦</td><td>removed</td><td data-status="gap">Drop for lean; <strong>mid keeps a comms block</strong> — scode's tone/output already fill that role, so a Mid-tier scode model should retain them</td></tr>
-    <tr><td><code>get_output_efficiency_section</code> — <code># Output efficiency</code> (<code>:724</code>)</td><td>749</td><td>≈ <code># Text output</code> 1,298</td><td>≈ <code># Communicating</code> ✦</td><td>removed</td><td data-status="gap">Drop for lean; keep for mid (see above)</td></tr>
-    <tr><td><code># auto memory</code> (<code>memory/mod.rs:180</code>) — 6 subsections + <code>&lt;examples&gt;</code></td><td><strong>12,525</strong></td><td><code># auto memory</code> 12,834</td><td><code># Memory</code> 2,099</td><td><code># Memory</code> 2,099</td><td data-status="gap">Collapse to lean <code># Memory</code> for lean + mid — drop all <code>&lt;examples&gt;</code> + spelled-out 2-step walkthroughs; keep frontmatter format + 4 type one-liners + condensed what-not / access rules</td></tr>
+    <tr><td><code>get_output_efficiency_section</code> — <code># Output efficiency</code> (<code>:724</code>)</td><td>749</td><td>≈ <code># Text output</code> 1,657</td><td>≈ <code># Communicating</code> ✦</td><td>removed</td><td data-status="gap">Drop for lean; keep for mid (see above)</td></tr>
+    <tr><td><code># auto memory</code> (<code>memory/mod.rs:180</code>) — 6 subsections + <code>&lt;examples&gt;</code></td><td><strong>12,525</strong></td><td><code># auto memory</code> 12,833</td><td><code># Memory</code> 2,092</td><td><code># Memory</code> 2,092</td><td data-status="gap">Collapse to lean <code># Memory</code> for lean + mid — drop all <code>&lt;examples&gt;</code> + spelled-out 2-step walkthroughs; keep frontmatter format + 4 type one-liners + condensed what-not / access rules</td></tr>
     <tr><td><code># Environment context</code> (dynamic, <code>:278</code>)</td><td>dynamic</td><td><code># Environment</code></td><td><code># Environment</code></td><td><code># Environment</code></td><td data-status="covered">Keep — aligned with CC, not bloat</td></tr>
     <tr><td><code># Project context</code> — AGENTS.md injection (dynamic, <code>:387</code>)</td><td>dynamic</td><td>CC: CLAUDE.md injection</td><td>same</td><td>same</td><td data-status="covered">Keep — scode-specific, same concept as CC, not bloat</td></tr>
     <tr><td><code># Project instructions</code> (dynamic, <code>:408</code>)</td><td>dynamic</td><td>—</td><td>—</td><td>—</td><td data-status="covered">Keep — runtime-injected, not a static-mirror surface</td></tr>
@@ -1174,19 +1175,22 @@ tier itself. CC's three variants share the same lean <code># Memory</code>
 
 <p class="table-caption">Every section <code>build()</code> can emit is listed
 (static + dynamic), with the size of each Rust prompt literal and what each CC
-variant does with it. <code>CC-mid</code> = what <code>fable-5</code> gets. Rows
-marked <em>keep</em> are aligned or scode-specific — not bloat.<br>
-✦ <code>fable-5</code>'s Mid variant drops the same five sections as Lean but
-<em>adds</em> <code># Communicating with the user</code> (3,734) — comms
-scaffolding the cheaper/faster model benefits from and the top opus models don't
-get. scode's <code># Tone and style</code> + <code># Output efficiency</code>
-already occupy that role, so the Mid tier is where they stay rather than being
-cut.</p>
+variant does with it. <code>CC-mid</code> spans <em>two distinct variants</em>
+(opus-5 / fable-5). Rows marked <em>keep</em> are aligned or scode-specific — not
+bloat.<br>
+✦ The two Mid variants differ in what they <em>add</em> on top of Lean's five
+sections: <code>fable-5</code> adds <code># Communicating with the user</code>
+(4,105); <code>opus-5</code> instead adds <code># Delivering work</code> (2,002)
++ <code># Corrections</code> (1,355). Both drop the same five sections as Lean
+and share the collapsed <code># Memory</code>. scode's <code># Tone and style</code>
++ <code># Output efficiency</code> overlap the comms role, so a Mid-tier scode
+model retains them rather than cutting them — and see Table&nbsp;C ① for the new
+CC sections worth adopting outright.</p>
 
 <p><strong>Net for lean models:</strong> main prompt 10,890 → ~2,120 (−80.5%)
 + memory 12,525 → ~2,100 (−83%) ⇒ root prompt ~23,400 → ~4,220 (−82%), landing
-on CC's ~5,889. Because every sub-agent reuses <code>build()</code> via
-<code>load_system_prompt_for_agent</code>, the saving multiplies across each
+near CC's lean ~6,273 (2.1.229). Because every sub-agent reuses <code>build()</code>
+via <code>load_system_prompt_for_agent</code>, the saving multiplies across each
 spawn.</p>
 
 <p class="table-title"><strong>Table C — lean-CC ↔ scode content-level two-way diff.</strong></p>
@@ -1194,12 +1198,15 @@ spawn.</p>
 <table>
   <thead><tr><th>Direction</th><th>Content</th><th>Other side</th><th>Action</th></tr></thead>
   <tbody>
-    <tr><td rowspan="5" data-status="gap-l2"><strong>① In lean-CC,<br>NOT in scode</strong><br>(adopt candidates)</td><td>"Report outcomes <strong>faithfully</strong> — if tests fail say so with output; if a step was skipped say that; state done plainly <strong>without hedging</strong>" (<code># Harness</code>)</td><td>absent</td><td><strong>Adopt (all tiers)</strong> — honesty / anti-hedge instruction</td></tr>
+    <tr><td rowspan="8" data-status="gap-l2"><strong>① In CC,<br>NOT in scode</strong><br>(adopt candidates)</td><td>"Report outcomes <strong>faithfully</strong> — if tests fail say so with output; if a step was skipped say that; state done plainly <strong>without hedging</strong>" (<code># Harness</code>)</td><td>absent</td><td><strong>Adopt (all tiers)</strong> — honesty / anti-hedge instruction</td></tr>
     <tr><td>"Write code that <strong>reads like the surrounding code</strong>: match comment density, naming, idiom" (<code># Harness</code>)</td><td>absent (scode only says "comment where non-obvious")</td><td><strong>Adopt (all tiers)</strong> — idiom matching</td></tr>
     <tr><td><code># Context management</code> behavioral guidance: "when you have enough info, <strong>act</strong>; don't re-derive / re-litigate; give a <strong>recommendation, not an exhaustive survey</strong>"</td><td>absent (scode has only a 1-line auto-compress note)</td><td><strong>Adopt (all tiers)</strong> — also closes the "Context window management" Gap in the Memory table</td></tr>
     <tr><td><code># Session-specific guidance</code>: <code>/&lt;skill-name&gt;</code> → invoke via Skill, only listed skills</td><td>absent</td><td><strong>Adopt (all tiers)</strong> if scode surfaces user-invocable skills</td></tr>
     <tr><td>Dual-use security clause: "C2 frameworks, credential testing, exploit development require clear authorization context: pentesting, CTF, research" (IMPORTANT)</td><td>absent (scode's security line is shorter)</td><td><strong>Adopt (all tiers)</strong> — sharper safety scoping</td></tr>
-    <tr><td rowspan="7" data-status="gap"><strong>② In scode,<br>NOT in lean-CC</strong><br>(cut / compress)</td><td><code># Doing tasks</code> (2,196)</td><td>dropped entirely</td><td>Cut for lean models</td></tr>
+    <tr><td><strong>NEW in 2.1.229</strong> — <code># Delivering work</code> (opus-5 Mid, 2,002): act on the actual request; don't silently narrow/widen scope; finish the <em>whole</em> task; reserve blocking questions for genuinely unsafe cases; a reaffirmed request = the user's decision</td><td>absent (scode has no scope-discipline section)</td><td><strong>Adopt (all tiers)</strong> — strong scope/completion discipline</td></tr>
+    <tr><td><strong>NEW in 2.1.229</strong> — <code># Corrections</code> (opus-5 Mid, 1,355): avoid excessive self-correction; only correct when it changes the user's decisions; no apologies/rumination; a follow-up question ≠ you were wrong. Also <em>"don't call AgentTool / workflows / deep-research unless requested"</em></td><td>absent</td><td><strong>Adopt (all tiers)</strong> — anti-rumination + tool-restraint</td></tr>
+    <tr><td><strong>NEW in 2.1.229</strong> — <code># Communicating with the user</code> (fable-5 Mid, 4,105): write for a teammate catching up; lead with the outcome; everything needed goes in the final message; readable &gt; concise</td><td>partial — scode's <code># Tone</code>/<code># Output efficiency</code> overlap</td><td><strong>Adopt / merge</strong> — supersedes scode's terser tone/output guidance</td></tr>
+    <tr><td rowspan="7" data-status="gap"><strong>② In scode,<br>NOT in CC-lean</strong><br>(cut / compress)</td><td><code># Doing tasks</code> (2,196)</td><td>dropped entirely</td><td>Cut for lean models</td></tr>
     <tr><td><code># Executing actions with care</code> + <code>Examples:</code> list (1,575)</td><td><strong>compressed to one <code># Harness</code> paragraph</strong></td><td>Replace verbose+Examples with the one-liner</td></tr>
     <tr><td><code># Using your tools</code> + git-commit + PR procedure (3,657)</td><td>dropped; kept only "prefer dedicated tools" one-liner</td><td>Cut procedure</td></tr>
     <tr><td><code># Tone and style</code> (564)</td><td>dropped; kept only <code>file_path:line_number</code></td><td>Cut emoji / short / no-colon rules</td></tr>
@@ -1223,15 +1230,20 @@ tier-gated.</p>
 <p><strong>Approach (all models).</strong> Two rules, because scode runs models
 CC never does:</p>
 <ul>
-  <li><strong>Anthropic models</strong> — mirror CC's observed mapping (Table&nbsp;A): Lean to <code>opus-4-8</code>/<code>opus-5</code>, Mid to <code>fable-5</code>, Full to the rest. Don't invent a scode-specific boundary where CC gives one.</li>
+  <li><strong>Anthropic models</strong> — mirror CC's observed mapping (Table&nbsp;A): Lean to <code>opus-4-8</code> only; <code>opus-5</code> and <code>fable-5</code> to Mid; Full to the rest, <em>including the default <code>opus-4-6</code></em>. Don't invent a boundary where CC gives one.</li>
   <li><strong>Non-Anthropic models</strong> (GPT / qwen / DeepSeek / local) — no CC reference exists, so scode picks the tier: <strong>Lean by default</strong> (no CC baggage to shed; capable models do better lean).</li>
-  <li><strong>Group-① additions</strong> — adopt on <em>all</em> tiers; they're small, high-value, and not size trade-offs.</li>
+  <li><strong>Group-① additions</strong> — adopt on <em>all</em> tiers; small, high-value, not size trade-offs. As of 2.1.229 this now includes CC's new <code># Delivering work</code> / <code># Corrections</code> / <code># Communicating</code> sections.</li>
 </ul>
+<p><strong>Open decision (2.1.229):</strong> CC now serves <em>four</em> variants —
+true-Lean (opus-4-8), two <em>different</em> Mids (opus-5 vs fable-5), and Full.
+Does scode mirror all four exactly (opus-5 → Delivering&nbsp;work + Corrections;
+fable-5 → Communicating), or collapse the two Mids into one scode Mid? This is
+the main thing to settle in audit.</p>
 <p>The one hook needed is per-model gating in <code>build()</code> (today
 unconditional): a model→tier resolver + tier-specific section composition.
 Full-tier models keep today's prompt verbatim — <strong>including the current
 default <code>opus-4-6</code></strong> — so the change is zero-risk for default
-users; only opus-4-8/opus-5 (and non-Anthropic) shift to Lean.
+users; only opus-4-8 (and non-Anthropic) shift to Lean, opus-5/fable-5 to Mid.
 Intro/identity, Environment/Project/Runtime context, and tool descriptions
 are already aligned or terse; the <code>opus-4-1</code>→<code>opus-4-8</code>
 remap is CC's, not something scode replicates.</p>


### PR DESCRIPTION
Re-captured the CC per-model mapping on an **isolated CC 2.1.229** install (local binary was 2.1.207, latest is 2.1.229). Material drift found:

- **opus-5 moved Lean → Mid** — now gets Lean's 5 sections + new `# Delivering work` (2,002) + `# Corrections` (1,355). **True-Lean is now opus-4-8 only.**
- **fable-5** still its own Mid; `# Communicating with the user` grew to 4,105. → **four CC variants now, not three.**
- All Full sizes grew ~340 chars; Lean 5,889 → 6,273.
- **opus-4-6 (default) still Full** — the default-stays-Full decision holds.

Table A rewritten to 4 variants; Table B CC sizes + two-Mid footnote; Table C group-① expanded with the 3 new CC sections as adopt candidates; Approach surfaces the new open decision (mirror all four vs collapse the two Mids). Docs-only.

## Test plan
- Tag balance OK; Table C 16 rows (rowspan 8/7); all 2.1.229 content verified.