### PR TITLE
fix(ci): stabilize 3 flaky CI tests

### DIFF
--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -1628,10 +1628,12 @@ mod tests {
         );
 
         for _ in 0..5 {
-            // Sleep 2ms between iterations so each rotated_log_path()
-            // gets a distinct timestamp. Without this, fast machines
-            // produce duplicate paths and the test becomes flaky.
-            std::thread::sleep(std::time::Duration::from_millis(2));
+            // Sleep 10ms between iterations so each rotated_log_path()
+            // gets a distinct timestamp and modification time. CI VMs
+            // may have coarse timers where 2ms is not enough to produce
+            // distinct filesystem timestamps, causing cleanup to
+            // non-deterministically skip files during dedup/sort.
+            std::thread::sleep(std::time::Duration::from_millis(10));
             let rotated = super::rotated_log_path(&path);
             fs::write(&rotated, "old").expect("rotated file should write");
         }

--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -305,6 +305,21 @@ impl Drop for HarnessWorkspace {
     }
 }
 
+/// Read a file with retries — handles the race where a child process has
+/// exited but the OS file cache hasn't flushed yet (common on CI VMs).
+/// Returns `None` if the file still doesn't exist after all retries.
+pub fn read_file_with_retry(path: &std::path::Path, retries: u32, interval: Duration) -> Option<String> {
+    for _ in 0..retries {
+        if let Ok(content) = fs::read_to_string(path) {
+            if !content.trim().is_empty() {
+                return Some(content);
+            }
+        }
+        std::thread::sleep(interval);
+    }
+    fs::read_to_string(path).ok().filter(|s| !s.trim().is_empty())
+}
+
 /// Spawn scode under a PTY via `env VAR=val ... scode <args>`.
 ///
 /// `config_home_override`: if `Some`, sets `SUDO_CODE_CONFIG_HOME`

--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -308,7 +308,11 @@ impl Drop for HarnessWorkspace {
 /// Read a file with retries — handles the race where a child process has
 /// exited but the OS file cache hasn't flushed yet (common on CI VMs).
 /// Returns `None` if the file still doesn't exist after all retries.
-pub fn read_file_with_retry(path: &std::path::Path, retries: u32, interval: Duration) -> Option<String> {
+pub fn read_file_with_retry(
+    path: &std::path::Path,
+    retries: u32,
+    interval: Duration,
+) -> Option<String> {
     for _ in 0..retries {
         if let Ok(content) = fs::read_to_string(path) {
             if !content.trim().is_empty() {
@@ -317,7 +321,9 @@ pub fn read_file_with_retry(path: &std::path::Path, retries: u32, interval: Dura
         }
         std::thread::sleep(interval);
     }
-    fs::read_to_string(path).ok().filter(|s| !s.trim().is_empty())
+    fs::read_to_string(path)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
 }
 
 /// Spawn scode under a PTY via `env VAR=val ... scode <args>`.

--- a/rust/crates/rusty-sudocode-cli/tests/pty_plan_mode.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_plan_mode.rs
@@ -61,11 +61,7 @@ fn plan_mode_state(env: &TestEnv) -> PathBuf {
 fn read_json_or_empty(path: &std::path::Path) -> Value {
     // Use retry to handle the race where the child process has exited
     // but the OS file cache hasn't flushed yet (common on CI VMs).
-    let text = common::read_file_with_retry(
-        path,
-        10,
-        std::time::Duration::from_millis(100),
-    );
+    let text = common::read_file_with_retry(path, 10, std::time::Duration::from_millis(100));
     match text {
         Some(t) => serde_json::from_str::<Value>(&t).unwrap_or(Value::Object(Default::default())),
         None => Value::Object(Default::default()),

--- a/rust/crates/rusty-sudocode-cli/tests/pty_plan_mode.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_plan_mode.rs
@@ -59,14 +59,17 @@ fn plan_mode_state(env: &TestEnv) -> PathBuf {
 }
 
 fn read_json_or_empty(path: &std::path::Path) -> Value {
-    if !path.exists() {
-        return Value::Object(Default::default());
+    // Use retry to handle the race where the child process has exited
+    // but the OS file cache hasn't flushed yet (common on CI VMs).
+    let text = common::read_file_with_retry(
+        path,
+        10,
+        std::time::Duration::from_millis(100),
+    );
+    match text {
+        Some(t) => serde_json::from_str::<Value>(&t).unwrap_or(Value::Object(Default::default())),
+        None => Value::Object(Default::default()),
     }
-    let text = fs::read_to_string(path).unwrap_or_default();
-    if text.trim().is_empty() {
-        return Value::Object(Default::default());
-    }
-    serde_json::from_str::<Value>(&text).unwrap_or(Value::Object(Default::default()))
 }
 
 fn default_mode_of(settings: &Value) -> Option<&str> {
@@ -136,8 +139,16 @@ fn enter_plan_mode_writes_settings_and_state_from_fresh_workspace() {
         "settings.local.json must have permissions.defaultMode = \"plan\" after EnterPlanMode; got: {settings}"
     );
 
+    // Retry: the child may have exited before the OS flushed the file.
+    let state_exists = (0..10).any(|_| {
+        if plan_mode_state(&env).exists() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        false
+    }) || plan_mode_state(&env).exists();
     assert!(
-        plan_mode_state(&env).exists(),
+        state_exists,
         "tool-state/plan-mode.json must be created so ExitPlanMode can restore"
     );
     let state = read_json_or_empty(&plan_mode_state(&env));

--- a/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
@@ -30,6 +30,8 @@
 
 mod common;
 
+use std::time::Duration;
+
 use common::TestEnv;
 
 /// Spawn the iocraft REPL — the only path that puts the terminal in raw
@@ -40,6 +42,8 @@ fn spawn_iocraft_repl(env: &TestEnv, permission_mode: &str) -> pty_expect::PtySe
         &["--permission-mode", permission_mode],
         &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
     );
+    // Generous timeout for CI VMs where PTY output can be slow.
+    sess.set_default_timeout(Duration::from_secs(30));
     // A tall, wide screen keeps the turn's output from scrolling away and
     // gives a runaway staircase room to be unmistakable.
     sess.resize(50, 100).expect("resize pty");


### PR DESCRIPTION
## Summary

Fixes the 3 most disruptive pre-existing flaky tests that fail intermittently on CI:

| Test | Platform | Root cause | Fix |
|------|----------|-----------|-----|
| `pty_plan_mode` (2 tests) | All | OS file cache not flushed after child exit | `read_file_with_retry()` helper (10×100ms) |
| `bash_turn_uses_crlf` | macOS | 10s PTY timeout too tight for CI VMs | Increase to 30s |
| `rotates_and_cleans_up_large_session_logs` | Ubuntu | 2ms sleep not enough for coarse CI timers | Increase to 10ms |

## Test plan

- [x] `cargo test --test pty_plan_mode -- --test-threads=1` (3/3 pass)
- [x] `cargo test -p runtime --lib -- rotates` (1/1 pass)
- [ ] CI: all 3 platforms green (the real validation)