### PR TITLE
refactor(cli): semantic ColorTheme with dark/light auto-detection

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -123,9 +123,10 @@ pub(crate) fn format_box(title: &str, content: &str) -> String {
     let border_chars = header_min.max(content_max + 2).min(max_border);
     let inner = border_chars.saturating_sub(2);
 
-    let g = "\x1b[38;5;245m";
-    let r = "\x1b[0m";
-    let ct = "\x1b[1;36m";
+    let t = crate::render::theme();
+    let g = t.border_fg();
+    let ct = crate::render::ansi_bold_fg(t.primary);
+    let r = crate::render::RESET;
 
     let header_fill = border_chars.saturating_sub(title_width + 3);
     let header = format!("  {g}╭─ {ct}{title}{r}{g} {}╮{r}", "─".repeat(header_fill));

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -42,6 +42,7 @@ fn strip_ansi_codes(input: &str) -> String {
     output
 }
 
+use crate::render::{ansi_bold_fg, ansi_fg, theme, BOLD, DIM, RESET};
 use crate::{
     load_sudocode_config_for_current_dir, GitWorkspaceSummary, InternalPromptProgressEvent,
     InternalPromptProgressState, BUILD_TARGET, DEFAULT_DATE, GIT_SHA, LATEST_SESSION_REFERENCE,
@@ -76,7 +77,7 @@ fn wrap_ansi(text: &str, width: usize) -> Vec<String> {
             } else {
                 let ch_w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1);
                 if vis + ch_w > width {
-                    current.push_str("\x1b[0m");
+                    current.push_str(RESET);
                     result.push(current);
                     current = String::new();
                     vis = 0;
@@ -171,7 +172,7 @@ pub(crate) fn render_message(
             if text.is_empty() {
                 return None;
             }
-            let sep = format!("\x1b[2m{}\x1b[0m", "─".repeat(term_width));
+            let sep = format!("{DIM}{}{RESET}", "─".repeat(term_width));
             out.push_str(&sep);
             out.push('\n');
             let (echo, _) = format_input_echo(&text, term_width);
@@ -727,6 +728,7 @@ pub(crate) fn format_internal_prompt_progress_line(
 /// the call site did `replace('\n', " ")`. We now preserve every line so the
 /// echo matches what the user actually typed.
 pub(crate) fn format_input_echo(input: &str, term_width: usize) -> (String, usize) {
+    let t = theme();
     let trimmed = input.trim();
     // `split('\n')` (not `lines()`) so an input that ends with `\n` still
     // contributes a trailing empty echo row — rustyline drew one for it.
@@ -735,6 +737,7 @@ pub(crate) fn format_input_echo(input: &str, term_width: usize) -> (String, usiz
     } else {
         trimmed.split('\n').collect()
     };
+    let code_bg = t.code_bg_seq();
     let mut rendered = String::new();
     for (idx, line) in raw_lines.iter().enumerate() {
         let prefix = if idx == 0 { " › " } else { "   " };
@@ -744,12 +747,12 @@ pub(crate) fn format_input_echo(input: &str, term_width: usize) -> (String, usiz
         if idx > 0 {
             rendered.push('\n');
         }
-        rendered.push_str("\x1b[48;5;236m");
+        rendered.push_str(&code_bg);
         rendered.push_str(&body);
         if pad > 0 {
             rendered.push_str(&" ".repeat(pad));
         }
-        rendered.push_str("\x1b[0m");
+        rendered.push_str(RESET);
     }
     (rendered, raw_lines.len())
 }
@@ -907,6 +910,7 @@ pub(crate) fn format_context_window_blocked_error(
 }
 
 pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
+    let t = theme();
     let parsed: serde_json::Value =
         serde_json::from_str(input).unwrap_or(serde_json::Value::String(input.to_string()));
 
@@ -914,7 +918,7 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
         "bash" | "Bash" => format_bash_call(&parsed),
         "read_file" | "Read" => {
             let path = extract_tool_path(&parsed);
-            format!("\x1b[2m📄 Reading {path}…\x1b[0m")
+            format!("{DIM}📄 Reading {path}…{RESET}")
         }
         "write_file" | "Write" => {
             let path = extract_tool_path(&parsed);
@@ -922,7 +926,8 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
                 .get("content")
                 .and_then(|value| value.as_str())
                 .map_or(0, |content| content.lines().count());
-            format!("\x1b[1;32m✏️ Writing {path}\x1b[0m \x1b[2m({lines} lines)\x1b[0m")
+            let success = ansi_bold_fg(t.success);
+            format!("{success}✏️ Writing {path}{RESET} {DIM}({lines} lines){RESET}")
         }
         "edit_file" | "Edit" => {
             let path = extract_tool_path(&parsed);
@@ -936,8 +941,9 @@ pub(crate) fn format_tool_call_start(name: &str, input: &str) -> String {
                 .or_else(|| parsed.get("newString"))
                 .and_then(|value| value.as_str())
                 .unwrap_or_default();
+            let warning = ansi_bold_fg(t.warning);
             format!(
-                "\x1b[1;33m📝 Editing {path}\x1b[0m{}",
+                "{warning}📝 Editing {path}{RESET}{}",
                 format_patch_preview(old_value, new_value)
                     .map(|preview| format!("\n{preview}"))
                     .unwrap_or_default()
@@ -972,37 +978,41 @@ pub(crate) fn split_hook_feedback(output: &str) -> (&str, Option<&str>) {
 }
 
 pub(crate) fn format_tool_result(name: &str, output: &str, is_error: bool) -> String {
+    let t = theme();
     let icon = if is_error {
-        "\x1b[1;31m⏺\x1b[0m"
+        format!("{}⏺{RESET}", ansi_bold_fg(t.error))
     } else {
-        "\x1b[1;32m⏺\x1b[0m"
+        format!("{}⏺{RESET}", ansi_bold_fg(t.success))
     };
     let (payload, hook_feedback) = split_hook_feedback(output);
+    let muted = t.muted_fg();
     let base = if is_error {
         let summary = truncate_for_summary(output.trim(), 160);
+        let removed = ansi_fg(t.diff_removed);
         if summary.is_empty() {
-            format!("{icon} \x1b[38;5;245m{name}\x1b[0m")
+            format!("{icon} {muted}{name}{RESET}")
         } else {
-            format!("{icon} \x1b[38;5;245m{name}\x1b[0m\n  \x1b[38;5;203m{summary}\x1b[0m")
+            format!("{icon} {muted}{name}{RESET}\n  {removed}{summary}{RESET}")
         }
     } else {
         let parsed: serde_json::Value =
             serde_json::from_str(payload).unwrap_or(serde_json::Value::String(payload.to_string()));
         match name {
-            "bash" | "Bash" => format_bash_result(icon, &parsed),
-            "repl" | "REPL" => format_repl_result(icon, &parsed),
-            "read_file" | "Read" => format_read_result(icon, &parsed),
-            "write_file" | "Write" => format_write_result(icon, &parsed),
-            "edit_file" | "Edit" => format_edit_result(icon, &parsed),
-            "glob_search" | "Glob" => format_glob_result(icon, &parsed),
-            "grep_search" | "Grep" => format_grep_result(icon, &parsed),
-            _ => format_generic_tool_result(icon, name, &parsed),
+            "bash" | "Bash" => format_bash_result(&icon, &parsed),
+            "repl" | "REPL" => format_repl_result(&icon, &parsed),
+            "read_file" | "Read" => format_read_result(&icon, &parsed),
+            "write_file" | "Write" => format_write_result(&icon, &parsed),
+            "edit_file" | "Edit" => format_edit_result(&icon, &parsed),
+            "glob_search" | "Glob" => format_glob_result(&icon, &parsed),
+            "grep_search" | "Grep" => format_grep_result(&icon, &parsed),
+            _ => format_generic_tool_result(&icon, name, &parsed),
         }
     };
     match hook_feedback {
         Some(feedback) if !is_error => {
             let indented = feedback.replace('\n', "\n  ");
-            format!("{base}\n  \x1b[38;5;214m{indented}\x1b[0m")
+            let hook = ansi_fg(t.hook_feedback);
+            format!("{base}\n  {hook}{indented}{RESET}")
         }
         _ => base,
     }
@@ -1027,21 +1037,25 @@ pub(crate) fn format_search_start(label: &str, parsed: &serde_json::Value) -> St
         .get("path")
         .and_then(|value| value.as_str())
         .unwrap_or(".");
-    format!("{label} {pattern}\n\x1b[2min {scope}\x1b[0m")
+    format!("{label} {pattern}\n{DIM}in {scope}{RESET}")
 }
 
 pub(crate) fn format_patch_preview(old_value: &str, new_value: &str) -> Option<String> {
     if old_value.is_empty() && new_value.is_empty() {
         return None;
     }
+    let t = theme();
+    let removed = ansi_fg(t.diff_removed);
+    let added = ansi_fg(t.diff_added);
     Some(format!(
-        "\x1b[38;5;203m- {}\x1b[0m\n\x1b[38;5;70m+ {}\x1b[0m",
+        "{removed}- {}{RESET}\n{added}+ {}{RESET}",
         truncate_for_summary(first_visible_line(old_value), 72),
         truncate_for_summary(first_visible_line(new_value), 72)
     ))
 }
 
 pub(crate) fn format_bash_call(parsed: &serde_json::Value) -> String {
+    let t = theme();
     let command = parsed
         .get("command")
         .and_then(|value| value.as_str())
@@ -1049,8 +1063,9 @@ pub(crate) fn format_bash_call(parsed: &serde_json::Value) -> String {
     if command.is_empty() {
         String::new()
     } else {
+        let code_bg = t.code_bg_seq();
         format!(
-            "\x1b[48;5;236;38;5;255m $ {} \x1b[0m",
+            "{code_bg}\x1b[38;5;255m $ {} {RESET}",
             truncate_for_summary(command, 160)
         )
     }
@@ -1065,6 +1080,8 @@ pub(crate) fn first_visible_line(text: &str) -> &str {
 pub(crate) fn format_bash_result(icon: &str, parsed: &serde_json::Value) -> String {
     use std::fmt::Write as _;
 
+    let muted = theme().muted_fg();
+
     // Extract command from input for the header.
     let command = parsed
         .get("command")
@@ -1072,10 +1089,10 @@ pub(crate) fn format_bash_result(icon: &str, parsed: &serde_json::Value) -> Stri
         .unwrap_or_default();
 
     let mut header = if command.is_empty() {
-        format!("{icon} \x1b[38;5;245mBash\x1b[0m")
+        format!("{icon} {muted}Bash{RESET}")
     } else {
         format!(
-            "{icon} \x1b[38;5;245mBash\x1b[0m({})",
+            "{icon} {muted}Bash{RESET}({})",
             truncate_for_summary(command, 120)
         )
     };
@@ -1115,15 +1132,17 @@ pub(crate) fn format_bash_result(icon: &str, parsed: &serde_json::Value) -> Stri
 pub(crate) fn format_repl_result(icon: &str, parsed: &serde_json::Value) -> String {
     use std::fmt::Write as _;
 
+    let muted = theme().muted_fg();
+
     let language = parsed
         .get("language")
         .and_then(|value| value.as_str())
         .unwrap_or_default();
 
     let mut header = if language.is_empty() {
-        format!("{icon} \x1b[38;5;245mREPL\x1b[0m")
+        format!("{icon} {muted}REPL{RESET}")
     } else {
-        format!("{icon} \x1b[38;5;245mREPL\x1b[0m({language})")
+        format!("{icon} {muted}REPL{RESET}({language})")
     };
 
     if let Some(exit_code) = parsed
@@ -1186,7 +1205,7 @@ fn render_stdout_stderr_block(header: String, stdout: &str, stderr: &str) -> Str
         let line_or_lines = if remaining == 1 { "line" } else { "lines" };
         write!(
             &mut result,
-            "\n  \x1b[2m… +{remaining} more {line_or_lines} · full output preserved in session\x1b[0m"
+            "\n  {DIM}… +{remaining} more {line_or_lines} · full output preserved in session{RESET}"
         )
         .expect("write to string");
     }
@@ -1231,7 +1250,7 @@ pub(crate) fn format_read_result(icon: &str, parsed: &serde_json::Value) -> Stri
         .get("totalLines")
         .or_else(|| file.get("total_lines"))
         .and_then(serde_json::Value::as_u64);
-    let header = format!("{icon} \x1b[2mRead {path}\x1b[0m");
+    let header = format!("{icon} {DIM}Read {path}{RESET}");
     if content.is_empty() {
         return header;
     }
@@ -1289,7 +1308,7 @@ pub(crate) fn format_read_result(icon: &str, parsed: &serde_json::Value) -> Stri
         };
         let _ = write!(
             indented,
-            "\n  \x1b[2m… +{remaining_lines} more {line_or_lines} · full output preserved in session\x1b[0m"
+            "\n  {DIM}… +{remaining_lines} more {line_or_lines} · full output preserved in session{RESET}"
         );
     } else if char_truncated {
         let _ = write!(indented, "\n  {DISPLAY_TRUNCATION_NOTICE}");
@@ -1298,7 +1317,7 @@ pub(crate) fn format_read_result(icon: &str, parsed: &serde_json::Value) -> Stri
     let mut out = String::with_capacity(header.len() + indented.len() + 8);
     out.push_str(&header);
     if let Some(total) = total_lines {
-        let _ = write!(out, " \x1b[2m({total} lines)\x1b[0m");
+        let _ = write!(out, " {DIM}({total} lines){RESET}");
     }
     out.push('\n');
     out.push_str(&indented);
@@ -1322,6 +1341,8 @@ pub(crate) const DIFF_PREVIEW_MAX_BODY_LINES: usize = 8;
 pub(crate) const DIFF_PREVIEW_CONTEXT_LINES: usize = 3;
 
 pub(crate) fn format_write_result(icon: &str, parsed: &serde_json::Value) -> String {
+    let t = theme();
+    let success = ansi_bold_fg(t.success);
     let path = extract_tool_path(parsed);
     let kind = parsed
         .get("type")
@@ -1344,11 +1365,11 @@ pub(crate) fn format_write_result(icon: &str, parsed: &serde_json::Value) -> Str
                 std::cmp::Ordering::Equal => String::new(),
             };
             format!(
-                "{icon} \x1b[1;32m✏️ {verb} {path}\x1b[0m \x1b[2m({new_line_count} lines, was {prev_lines}{delta_str})\x1b[0m",
+                "{icon} {success}✏️ {verb} {path}{RESET} {DIM}({new_line_count} lines, was {prev_lines}{delta_str}){RESET}",
             )
         }
         _ => format!(
-            "{icon} \x1b[1;32m✏️ {verb} {path}\x1b[0m \x1b[2m({new_line_count} lines)\x1b[0m",
+            "{icon} {success}✏️ {verb} {path}{RESET} {DIM}({new_line_count} lines){RESET}",
         ),
     };
     match original {
@@ -1401,6 +1422,7 @@ pub(crate) fn format_full_replace_diff_preview(original: &str, updated: &str) ->
 }
 
 pub(crate) fn format_edit_result(icon: &str, parsed: &serde_json::Value) -> String {
+    let t = theme();
     let path = extract_tool_path(parsed);
     let replace_all = parsed
         .get("replaceAll")
@@ -1437,12 +1459,13 @@ pub(crate) fn format_edit_result(icon: &str, parsed: &serde_json::Value) -> Stri
     let preview = format_edit_diff_preview(original, old_value, new_value)
         .or_else(|| format_patch_preview(old_value, new_value));
 
+    let warning = ansi_bold_fg(t.warning);
     match preview {
         Some(preview) => {
             let indented = preview.replace('\n', "\n  ");
-            format!("{icon} \x1b[1;33m📝 Edited {path}{suffix}\x1b[0m\n  {indented}")
+            format!("{icon} {warning}📝 Edited {path}{suffix}{RESET}\n  {indented}")
         }
-        None => format!("{icon} \x1b[1;33m📝 Edited {path}{suffix}\x1b[0m"),
+        None => format!("{icon} {warning}📝 Edited {path}{suffix}{RESET}"),
     }
 }
 
@@ -1506,6 +1529,10 @@ fn render_diff_window(
     pre_context_start: usize,
     edit_start_line_1based: usize,
 ) -> String {
+    let t = theme();
+    let muted = t.muted_fg();
+    let removed = ansi_fg(t.diff_removed);
+    let added = ansi_fg(t.diff_added);
     let mut out: Vec<String> = Vec::new();
     let pre_context = &original_lines
         [pre_context_start..pre_context_start + (edit_start_line_1based - 1 - pre_context_start)];
@@ -1520,19 +1547,19 @@ fn render_diff_window(
     };
 
     out.push(format!(
-        "\x1b[38;5;245m@@ -{},{} +{},{} @@\x1b[0m",
+        "{muted}@@ -{},{} +{},{} @@{RESET}",
         edit_start_line_1based,
         old_body.len(),
         edit_start_line_1based,
         new_body.len(),
     ));
     for line in pre_context {
-        out.push(format!("\x1b[2m  {line}\x1b[0m"));
+        out.push(format!("{DIM}  {line}{RESET}"));
     }
-    push_body_lines(&mut out, old_body, '-', "\x1b[38;5;203m");
-    push_body_lines(&mut out, new_body, '+', "\x1b[38;5;70m");
+    push_body_lines(&mut out, old_body, '-', &removed);
+    push_body_lines(&mut out, new_body, '+', &added);
     for line in post_context {
-        out.push(format!("\x1b[2m  {line}\x1b[0m"));
+        out.push(format!("{DIM}  {line}{RESET}"));
     }
     out.join("\n")
 }
@@ -1541,15 +1568,15 @@ fn push_body_lines(out: &mut Vec<String>, body: &[&str], sign: char, color: &str
     let limit = DIFF_PREVIEW_MAX_BODY_LINES;
     if body.len() <= limit {
         for line in body {
-            out.push(format!("{color}{sign} {line}\x1b[0m"));
+            out.push(format!("{color}{sign} {line}{RESET}"));
         }
     } else {
         let head = limit.saturating_sub(1);
         for line in &body[..head] {
-            out.push(format!("{color}{sign} {line}\x1b[0m"));
+            out.push(format!("{color}{sign} {line}{RESET}"));
         }
         out.push(format!(
-            "\x1b[2m{sign} … +{} more lines\x1b[0m",
+            "{DIM}{sign} … +{} more lines{RESET}",
             body.len() - head,
         ));
     }
@@ -1574,7 +1601,7 @@ pub(crate) fn format_glob_result(icon: &str, parsed: &serde_json::Value) -> Stri
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
 
-    format!("{icon} \x1b[2mFound {num_files} files\x1b[0m")
+    format!("{icon} {DIM}Found {num_files} files{RESET}")
 }
 
 pub(crate) fn format_grep_result(icon: &str, parsed: &serde_json::Value) -> String {
@@ -1587,7 +1614,7 @@ pub(crate) fn format_grep_result(icon: &str, parsed: &serde_json::Value) -> Stri
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
 
-    format!("{icon} \x1b[2m{num_matches} matches across {num_files} files\x1b[0m")
+    format!("{icon} {DIM}{num_matches} matches across {num_files} files{RESET}")
 }
 
 pub(crate) fn format_generic_tool_result(
@@ -1595,6 +1622,7 @@ pub(crate) fn format_generic_tool_result(
     name: &str,
     parsed: &serde_json::Value,
 ) -> String {
+    let muted = theme().muted_fg();
     let rendered_output = match parsed {
         serde_json::Value::String(text) => text.clone(),
         serde_json::Value::Null => String::new(),
@@ -1610,12 +1638,12 @@ pub(crate) fn format_generic_tool_result(
     );
 
     if preview.is_empty() {
-        format!("{icon} \x1b[38;5;245m{name}\x1b[0m")
+        format!("{icon} {muted}{name}{RESET}")
     } else if preview.contains('\n') {
         let indented = preview.replace('\n', "\n  ");
-        format!("{icon} \x1b[38;5;245m{name}\x1b[0m\n  {indented}")
+        format!("{icon} {muted}{name}{RESET}\n  {indented}")
     } else {
-        format!("{icon} \x1b[38;5;245m{name}:\x1b[0m {preview}")
+        format!("{icon} {muted}{name}:{RESET} {preview}")
     }
 }
 
@@ -1709,7 +1737,7 @@ pub(crate) fn format_turn_status_line_with_branch(
     if let Some(branch) = branch.filter(|b| !b.is_empty()) {
         segments.push(branch.to_string());
     }
-    format!("\x1b[2m{}\x1b[0m", segments.join(" · "))
+    format!("{DIM}{}{RESET}", segments.join(" · "))
 }
 
 /// Render the box that frames an interactive permission-approval prompt.
@@ -1756,11 +1784,12 @@ pub(crate) fn format_permission_prompt_box(
         .max(title.chars().count() + 4);
     let border = "─".repeat(inner_width + 2);
 
-    let grey = "\x1b[38;5;245m";
-    let reset = "\x1b[0m";
-    let bold_yellow = "\x1b[1;33m";
-    let bold_cyan = "\x1b[1;36m";
-    let dim = "\x1b[2m";
+    let t = theme();
+    let grey = t.border_fg();
+    let reset = RESET;
+    let bold_yellow = ansi_bold_fg(t.warning);
+    let bold_cyan = ansi_bold_fg(t.primary);
+    let dim = DIM;
 
     let mut out = String::new();
     let title_dashes = "─".repeat(inner_width.saturating_sub(title.chars().count() + 2));
@@ -1816,23 +1845,26 @@ pub(crate) fn format_tool_timeline(
         return None;
     }
     let count = entries.len();
+    let t = theme();
+    let success_fg = ansi_fg(t.success);
+    let error_fg = ansi_fg(t.error);
     let parts: Vec<String> = entries
         .into_iter()
         .map(|(name, ok)| {
             // Bold tool name; green check or red cross.
             let glyph = if ok {
-                "\x1b[32m✓\x1b[0m"
+                format!("{success_fg}✓{RESET}")
             } else {
-                "\x1b[31m✗\x1b[0m"
+                format!("{error_fg}✗{RESET}")
             };
-            format!("\x1b[1m{name}\x1b[0m {glyph}")
+            format!("{BOLD}{name}{RESET} {glyph}")
         })
         .collect();
     let body = parts.join("  ");
     let plural = if count == 1 { "tool" } else { "tools" };
     let secs = elapsed.as_secs_f64();
     Some(format!(
-        "🔧 {body} \x1b[2m({count} {plural}, {secs:.1}s)\x1b[0m"
+        "🔧 {body} {DIM}({count} {plural}, {secs:.1}s){RESET}"
     ))
 }
 
@@ -1888,7 +1920,7 @@ pub(crate) fn truncate_output_for_display(
             let remaining = total_lines - shown_lines;
             let _ = write!(
                 preview,
-                "\x1b[2m… +{remaining} more {line_or_lines} · full output preserved in session\x1b[0m",
+                "{DIM}… +{remaining} more {line_or_lines} · full output preserved in session{RESET}",
                 line_or_lines = if remaining == 1 { "line" } else { "lines" },
             );
         } else {

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -1368,9 +1368,9 @@ pub(crate) fn format_write_result(icon: &str, parsed: &serde_json::Value) -> Str
                 "{icon} {success}✏️ {verb} {path}{RESET} {DIM}({new_line_count} lines, was {prev_lines}{delta_str}){RESET}",
             )
         }
-        _ => format!(
-            "{icon} {success}✏️ {verb} {path}{RESET} {DIM}({new_line_count} lines){RESET}",
-        ),
+        _ => {
+            format!("{icon} {success}✏️ {verb} {path}{RESET} {DIM}({new_line_count} lines){RESET}",)
+        }
     };
     match original {
         Some(prev) if kind != "create" => match format_full_replace_diff_preview(prev, new_content)

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -112,7 +112,7 @@ use init::initialize_repo;
 use plugins::{
     render_plugin_capabilities_section, PluginLoadOutcome, PluginManager, PluginRegistry,
 };
-use render::{MarkdownStreamState, SpinnerHandle, TerminalRenderer};
+use render::{ansi_fg, ansi_bold_fg, theme, MarkdownStreamState, SpinnerHandle, TerminalRenderer, DIM, RESET};
 use runtime::{
     check_base_commit, compact_session_sync, estimate_block_tokens, estimate_session_tokens,
     format_stale_base_warning, format_usd, load_oauth_credentials, load_system_prompt,
@@ -1023,10 +1023,10 @@ fn run_resume(
         let mode = input_queue::QueueMode::from_env();
         if !matches!(mode, input_queue::QueueMode::Off) {
             if let Err(e) = run_repl_iocraft_dispatch(cli, mode) {
-                eprintln!("\x1b[31m{e}\x1b[0m");
+                eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
             }
         } else if let Err(e) = run_repl_loop(cli) {
-            eprintln!("\x1b[31m{e}\x1b[0m");
+            eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
         }
         return;
     }
@@ -1667,19 +1667,19 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
                         match cli.handle_repl_command(command) {
                             Ok(true) => {
                                 if let Err(e) = cli.persist_session() {
-                                    eprintln!("\x1b[31m{e}\x1b[0m");
+                                    eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
                                 }
                             }
                             Ok(false) => {}
                             Err(e) => {
-                                eprintln!("\x1b[31m{e}\x1b[0m");
+                                eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
                             }
                         }
                         continue;
                     }
                     Ok(None) => {}
                     Err(error) => {
-                        eprintln!("\x1b[31m{error}\x1b[0m");
+                        eprintln!("{}{error}{}", ansi_fg(theme().error), RESET);
                         continue;
                     }
                 }
@@ -1694,13 +1694,13 @@ fn run_repl_loop(mut cli: LiveCli) -> Result<(), Box<dyn std::error::Error>> {
                 ) {
                     cli.record_prompt_history(&trimmed);
                     if let Err(e) = cli.run_turn(&prompt) {
-                        eprintln!("\x1b[31m{e}\x1b[0m");
+                        eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
                     }
                     continue;
                 }
                 cli.record_prompt_history(&trimmed);
                 if let Err(e) = cli.run_turn(&trimmed) {
-                    eprintln!("\x1b[31m{e}\x1b[0m");
+                    eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
                 }
             }
             input::ReadOutcome::Exit => {
@@ -1835,17 +1835,17 @@ impl repl_async::TurnDriver for LiveCliDriver {
                 match cli.handle_repl_command(command) {
                     Ok(true) => {
                         if let Err(e) = cli.persist_session() {
-                            eprintln!("\x1b[31m{e}\x1b[0m");
+                            eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
                         }
                     }
                     Ok(false) => {}
-                    Err(e) => eprintln!("\x1b[31m{e}\x1b[0m"),
+                    Err(e) => eprintln!("{}{e}{}", ansi_fg(theme().error), RESET),
                 }
                 true
             }
             Ok(None) => false,
             Err(error) => {
-                eprintln!("\x1b[31m{error}\x1b[0m");
+                eprintln!("{}{error}{}", ansi_fg(theme().error), RESET);
                 true
             }
         }
@@ -1854,7 +1854,7 @@ impl repl_async::TurnDriver for LiveCliDriver {
     fn run_turn(&self, prompt: &str) {
         let mut cli = self.cli.lock().expect("LiveCli mutex poisoned");
         if let Err(e) = cli.run_turn(prompt) {
-            eprintln!("\x1b[31m{e}\x1b[0m");
+            eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
         }
     }
 
@@ -1865,7 +1865,7 @@ impl repl_async::TurnDriver for LiveCliDriver {
         // sync run_repl's /exit branch).
         let cli = self.cli.lock().expect("LiveCli mutex poisoned");
         if let Err(e) = cli.persist_session() {
-            eprintln!("\x1b[31m{e}\x1b[0m");
+            eprintln!("{}{e}{}", ansi_fg(theme().error), RESET);
         }
     }
 
@@ -2151,7 +2151,7 @@ fn run_repl_iocraft_dispatch(
                 }
                 let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
                 if let Err(e) = cli_lock.persist_session() {
-                    repl.output.println(&format!("\x1b[31m{e}\x1b[0m"));
+                    repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
                 }
                 break;
             }
@@ -2174,7 +2174,7 @@ fn run_repl_iocraft_dispatch(
                     }
                     let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
                     if let Err(e) = cli_lock.persist_session() {
-                        repl.output.println(&format!("\x1b[31m{e}\x1b[0m"));
+                        repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
                     }
                     break;
                 }
@@ -2219,11 +2219,11 @@ fn run_repl_iocraft_dispatch(
                                 match cli_lock.set_model(Some(model_name)) {
                                     Ok(true) => {
                                         if let Err(e) = cli_lock.persist_session() {
-                                            out.println(&format!("\x1b[31m{e}\x1b[0m"));
+                                            out.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
                                         }
                                     }
                                     Ok(false) => {}
-                                    Err(e) => out.println(&format!("\x1b[31m{e}\x1b[0m")),
+                                    Err(e) => out.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET)),
                                 }
                             },
                         ));
@@ -2234,17 +2234,17 @@ fn run_repl_iocraft_dispatch(
                         match cli_lock.handle_repl_command(command) {
                             Ok(true) => {
                                 if let Err(e) = cli_lock.persist_session() {
-                                    repl.output.println(&format!("\x1b[31m{e}\x1b[0m"));
+                                    repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
                                 }
                             }
                             Ok(false) => {}
-                            Err(e) => repl.output.println(&format!("\x1b[31m{e}\x1b[0m")),
+                            Err(e) => repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET)),
                         }
                         true
                     }
                     Ok(None) => false,
                     Err(error) => {
-                        repl.output.println(&format!("\x1b[31m{error}\x1b[0m"));
+                        repl.output.println(&format!("{}{error}{}", ansi_fg(theme().error), RESET));
                         true
                     }
                 };
@@ -2278,7 +2278,7 @@ fn run_repl_iocraft_dispatch(
                         }
                         input_queue::SubmitOutcome::Rejected => {
                             repl.output.println(
-                                "\x1b[2m(a turn is running; set SUDOCODE_INTERRUPT_QUEUE_MODE=queue to queue instead)\x1b[0m",
+                                &format!("{DIM}(a turn is running; set SUDOCODE_INTERRUPT_QUEUE_MODE=queue to queue instead){RESET}"),
                             );
                         }
                     }
@@ -2289,7 +2289,7 @@ fn run_repl_iocraft_dispatch(
                     handler(&text, &cli_shared, &repl.output);
                 } else if !consume_pending_question_answer(&pending_question_answer, text) {
                     repl.output
-                        .println("\x1b[2m(no question is waiting for an answer)\x1b[0m");
+                        .println(&format!("{DIM}(no question is waiting for an answer){RESET}"));
                 }
             }
         }
@@ -2361,7 +2361,7 @@ fn spawn_iocraft_turn(
             if let Err(e) =
                 cli.run_turn_iocraft(&prompt, &output, &ui, &spinner, pending_question_answer)
             {
-                output.println(&format!("\x1b[31m{e}\x1b[0m"));
+                output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
             }
             let _ = done_tx.send(());
         })
@@ -3998,34 +3998,37 @@ impl LiveCli {
         .map(|r| r.base_url)
         .unwrap_or_default();
 
-        let logo = "\x1b[38;5;117m\
+        let t = theme();
+        let logo_fg = ansi_fg(t.logo);
+        let accent_fg = ansi_fg(t.logo_accent);
+        let logo = format!("{logo_fg}\
 ███████╗██╗   ██╗██████╗  ██████╗ \n\
 ██╔════╝██║   ██║██╔══██╗██╔═══██╗\n\
 ███████╗██║   ██║██║  ██║██║   ██║\n\
 ╚════██║██║   ██║██║  ██║██║   ██║\n\
 ███████║╚██████╔╝██████╔╝╚██████╔╝\n\
-╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝\x1b[0m \x1b[38;5;208mCode\x1b[0m";
+╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝{RESET} {accent_fg}Code{RESET}");
 
         let lines = [
-            format!("  \x1b[2mModel\x1b[0m            {}", self.config.model),
-            format!("  \x1b[2mAuth mode\x1b[0m        {}", auth_mode_str),
-            format!("  \x1b[2mEndpoint\x1b[0m         {}", endpoint),
+            format!("  {DIM}Model{RESET}            {}", self.config.model),
+            format!("  {DIM}Auth mode{RESET}        {}", auth_mode_str),
+            format!("  {DIM}Endpoint{RESET}         {}", endpoint),
             format!(
-                "  \x1b[2mPermissions\x1b[0m      {}",
+                "  {DIM}Permissions{RESET}      {}",
                 self.config.permission_mode.as_str()
             ),
-            format!("  \x1b[2mBranch\x1b[0m           {}", git_branch),
-            format!("  \x1b[2mWorkspace\x1b[0m        {}", workspace),
-            format!("  \x1b[2mDirectory\x1b[0m        {}", cwd),
-            format!("  \x1b[2mSession\x1b[0m          {}", self.session.id),
-            format!("  \x1b[2mAuto-save\x1b[0m        {}", session_path),
+            format!("  {DIM}Branch{RESET}           {}", git_branch),
+            format!("  {DIM}Workspace{RESET}        {}", workspace),
+            format!("  {DIM}Directory{RESET}        {}", cwd),
+            format!("  {DIM}Session{RESET}          {}", self.session.id),
+            format!("  {DIM}Auto-save{RESET}        {}", session_path),
         ];
 
         let max_width = lines.iter().map(|l| strip_ansi_width(l)).max().unwrap_or(0);
         let box_width = max_width + 2; // 1 space padding on each side
 
-        let grey = "\x1b[38;5;245m";
-        let reset = "\x1b[0m";
+        let grey = t.border_fg();
+        let reset = RESET;
 
         let top = format!("{grey}╭{}╮{reset}", "─".repeat(box_width));
         let bottom = format!("{grey}╰{}╯{reset}", "─".repeat(box_width));
@@ -4281,7 +4284,7 @@ impl LiveCli {
             Ok(summary) => {
                 self.replace_runtime(runtime)?;
                 if summary.cancelled {
-                    output.println("\x1b[31m\u{23f9} Cancelled\x1b[0m");
+                    output.println(&format!("{}\u{23f9} Cancelled{}", ansi_fg(theme().error), RESET));
                 } else {
                     if let Some(event) = summary.auto_compaction {
                         output.println(&format_auto_compaction_notice(event.removed_message_count));
@@ -4991,7 +4994,7 @@ impl LiveCli {
                     };
                     shared.store(new_mode.to_u8(), Ordering::Relaxed);
                     self.out_println(format!(
-                        "\x1b[2mauto-interrupt: {}\x1b[0m",
+                        "{DIM}auto-interrupt: {}{RESET}",
                         if on { "on" } else { "off" }
                     ));
                 } else {
@@ -5020,7 +5023,7 @@ impl LiveCli {
                     };
                     shared.store(new_mode.to_u8(), Ordering::Relaxed);
                     self.out_println(format!(
-                        "\x1b[2mqueue: {}\x1b[0m",
+                        "{DIM}queue: {}{RESET}",
                         if on { "on" } else { "off" }
                     ));
                 } else {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -112,7 +112,9 @@ use init::initialize_repo;
 use plugins::{
     render_plugin_capabilities_section, PluginLoadOutcome, PluginManager, PluginRegistry,
 };
-use render::{ansi_fg, ansi_bold_fg, theme, MarkdownStreamState, SpinnerHandle, TerminalRenderer, DIM, RESET};
+use render::{
+    ansi_bold_fg, ansi_fg, theme, MarkdownStreamState, SpinnerHandle, TerminalRenderer, DIM, RESET,
+};
 use runtime::{
     check_base_commit, compact_session_sync, estimate_block_tokens, estimate_session_tokens,
     format_stale_base_warning, format_usd, load_oauth_credentials, load_system_prompt,
@@ -2151,7 +2153,8 @@ fn run_repl_iocraft_dispatch(
                 }
                 let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
                 if let Err(e) = cli_lock.persist_session() {
-                    repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
+                    repl.output
+                        .println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
                 }
                 break;
             }
@@ -2174,7 +2177,8 @@ fn run_repl_iocraft_dispatch(
                     }
                     let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
                     if let Err(e) = cli_lock.persist_session() {
-                        repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
+                        repl.output
+                            .println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
                     }
                     break;
                 }
@@ -2219,11 +2223,19 @@ fn run_repl_iocraft_dispatch(
                                 match cli_lock.set_model(Some(model_name)) {
                                     Ok(true) => {
                                         if let Err(e) = cli_lock.persist_session() {
-                                            out.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
+                                            out.println(&format!(
+                                                "{}{e}{}",
+                                                ansi_fg(theme().error),
+                                                RESET
+                                            ));
                                         }
                                     }
                                     Ok(false) => {}
-                                    Err(e) => out.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET)),
+                                    Err(e) => out.println(&format!(
+                                        "{}{e}{}",
+                                        ansi_fg(theme().error),
+                                        RESET
+                                    )),
                                 }
                             },
                         ));
@@ -2234,17 +2246,26 @@ fn run_repl_iocraft_dispatch(
                         match cli_lock.handle_repl_command(command) {
                             Ok(true) => {
                                 if let Err(e) = cli_lock.persist_session() {
-                                    repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
+                                    repl.output.println(&format!(
+                                        "{}{e}{}",
+                                        ansi_fg(theme().error),
+                                        RESET
+                                    ));
                                 }
                             }
                             Ok(false) => {}
-                            Err(e) => repl.output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET)),
+                            Err(e) => repl.output.println(&format!(
+                                "{}{e}{}",
+                                ansi_fg(theme().error),
+                                RESET
+                            )),
                         }
                         true
                     }
                     Ok(None) => false,
                     Err(error) => {
-                        repl.output.println(&format!("{}{error}{}", ansi_fg(theme().error), RESET));
+                        repl.output
+                            .println(&format!("{}{error}{}", ansi_fg(theme().error), RESET));
                         true
                     }
                 };
@@ -2288,8 +2309,9 @@ fn run_repl_iocraft_dispatch(
                 if let Some(handler) = pending_slash_selection.take() {
                     handler(&text, &cli_shared, &repl.output);
                 } else if !consume_pending_question_answer(&pending_question_answer, text) {
-                    repl.output
-                        .println(&format!("{DIM}(no question is waiting for an answer){RESET}"));
+                    repl.output.println(&format!(
+                        "{DIM}(no question is waiting for an answer){RESET}"
+                    ));
                 }
             }
         }
@@ -4001,13 +4023,15 @@ impl LiveCli {
         let t = theme();
         let logo_fg = ansi_fg(t.logo);
         let accent_fg = ansi_fg(t.logo_accent);
-        let logo = format!("{logo_fg}\
+        let logo = format!(
+            "{logo_fg}\
 ███████╗██╗   ██╗██████╗  ██████╗ \n\
 ██╔════╝██║   ██║██╔══██╗██╔═══██╗\n\
 ███████╗██║   ██║██║  ██║██║   ██║\n\
 ╚════██║██║   ██║██║  ██║██║   ██║\n\
 ███████║╚██████╔╝██████╔╝╚██████╔╝\n\
-╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝{RESET} {accent_fg}Code{RESET}");
+╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝{RESET} {accent_fg}Code{RESET}"
+        );
 
         let lines = [
             format!("  {DIM}Model{RESET}            {}", self.config.model),
@@ -4284,7 +4308,11 @@ impl LiveCli {
             Ok(summary) => {
                 self.replace_runtime(runtime)?;
                 if summary.cancelled {
-                    output.println(&format!("{}\u{23f9} Cancelled{}", ansi_fg(theme().error), RESET));
+                    output.println(&format!(
+                        "{}\u{23f9} Cancelled{}",
+                        ansi_fg(theme().error),
+                        RESET
+                    ));
                 } else {
                     if let Some(event) = summary.auto_compaction {
                         output.println(&format_auto_compaction_notice(event.removed_message_count));

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -103,37 +103,206 @@ fn ranges_to_plain(ranges: &[(SyntectStyle, &str)]) -> String {
     out
 }
 
+/// Semantic color theme — coder picks a scenario token, never a raw color.
+///
+/// Two built-in palettes: `dark()` (default) and `light()` for light
+/// terminal backgrounds.  All rendering code references `theme.xxx`;
+/// switching palette changes every color at once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ColorTheme {
-    heading: Color,
-    emphasis: Color,
-    strong: Color,
-    inline_code: Color,
-    link: Color,
-    quote: Color,
-    table_border: Color,
-    code_block_border: Color,
-    spinner_active: Color,
-    spinner_done: Color,
-    spinner_failed: Color,
+    // ── Semantic tokens ──────────────────────────────────────────────
+    /// Primary emphasis — prompt glyph, H1 heading, box title.
+    pub primary: Color,
+    /// Success — tool done, write result, spinner complete.
+    pub success: Color,
+    /// Error — failed, denied, cancelled.
+    pub error: Color,
+    /// Warning — permission prompt title, edit label, stalled spinner.
+    pub warning: Color,
+    /// Info — spinner active, thinking indicator.
+    pub info: Color,
+    /// Muted — footer hints, dim text, labels, separators.
+    pub muted: Color,
+    /// Emphasis — italic text in markdown.
+    pub emphasis: Color,
+    /// Strong — bold text in markdown.
+    pub strong: Color,
+    /// Link — hyperlinks.
+    pub link: Color,
+    /// Inline code — backtick spans.
+    pub code: Color,
+    /// Code block background (256-color index).
+    pub code_bg: u8,
+    /// Border — box/table/code fence chrome.
+    pub border: Color,
+    /// Diff added line.
+    pub diff_added: Color,
+    /// Diff removed line.
+    pub diff_removed: Color,
+    /// Hook feedback text.
+    pub hook_feedback: Color,
+    /// Logo primary color.
+    pub logo: Color,
+    /// Logo accent ("Code" wordmark).
+    pub logo_accent: Color,
+    /// Blockquote prefix.
+    pub quote: Color,
+    /// H2 heading.
+    pub heading_h2: Color,
+    /// H3 heading.
+    pub heading_h3: Color,
+    /// H4+ heading.
+    pub heading_h4: Color,
+}
+
+impl ColorTheme {
+    /// Dark terminal background (default).
+    #[must_use]
+    pub fn dark() -> Self {
+        Self {
+            primary: Color::Cyan,
+            success: Color::Green,
+            error: Color::Red,
+            warning: Color::Yellow,
+            info: Color::Blue,
+            muted: Color::DarkGrey,
+            emphasis: Color::Magenta,
+            strong: Color::Yellow,
+            link: Color::Blue,
+            code: Color::Green,
+            code_bg: 236,
+            border: Color::AnsiValue(245),
+            diff_added: Color::AnsiValue(70),
+            diff_removed: Color::AnsiValue(203),
+            hook_feedback: Color::AnsiValue(214),
+            logo: Color::AnsiValue(117),
+            logo_accent: Color::AnsiValue(208),
+            quote: Color::DarkGrey,
+            heading_h2: Color::White,
+            heading_h3: Color::Blue,
+            heading_h4: Color::Grey,
+        }
+    }
+
+    /// Light terminal background.
+    #[must_use]
+    pub fn light() -> Self {
+        Self {
+            primary: Color::DarkCyan,
+            success: Color::DarkGreen,
+            error: Color::DarkRed,
+            warning: Color::AnsiValue(130), // dark orange
+            info: Color::DarkBlue,
+            muted: Color::Grey,
+            emphasis: Color::DarkMagenta,
+            strong: Color::AnsiValue(130),
+            link: Color::DarkBlue,
+            code: Color::DarkGreen,
+            code_bg: 253, // light grey bg
+            border: Color::AnsiValue(240),
+            diff_added: Color::AnsiValue(22),  // dark green
+            diff_removed: Color::AnsiValue(124), // dark red
+            hook_feedback: Color::AnsiValue(130),
+            logo: Color::AnsiValue(25),  // dark blue
+            logo_accent: Color::AnsiValue(166), // dark orange
+            quote: Color::Grey,
+            heading_h2: Color::Black,
+            heading_h3: Color::DarkBlue,
+            heading_h4: Color::DarkGrey,
+        }
+    }
+
+    /// Detect terminal background and pick the appropriate palette.
+    #[must_use]
+    pub fn detect() -> Self {
+        if Self::is_light_background() {
+            Self::light()
+        } else {
+            Self::dark()
+        }
+    }
+
+    /// ANSI escape for the border color.
+    #[inline]
+    pub fn border_fg(&self) -> String {
+        ansi_fg(self.border)
+    }
+
+    /// ANSI escape for the muted color.
+    #[inline]
+    pub fn muted_fg(&self) -> String {
+        ansi_fg(self.muted)
+    }
+
+    /// ANSI escape for the code block background.
+    #[inline]
+    pub fn code_bg_seq(&self) -> String {
+        format!("\x1b[48;5;{}m", self.code_bg)
+    }
+
+    fn is_light_background() -> bool {
+        // Check COLORFGBG (format: "fg;bg", light if bg >= 8).
+        if let Ok(val) = std::env::var("COLORFGBG") {
+            if let Some(bg) = val.rsplit(';').next().and_then(|s| s.parse::<u8>().ok()) {
+                return bg >= 8 && bg != 8; // 8 = dark grey, not light
+            }
+        }
+        false
+    }
 }
 
 impl Default for ColorTheme {
     fn default() -> Self {
-        Self {
-            heading: Color::Cyan,
-            emphasis: Color::Magenta,
-            strong: Color::Yellow,
-            inline_code: Color::Green,
-            link: Color::Blue,
-            quote: Color::DarkGrey,
-            table_border: Color::DarkCyan,
-            code_block_border: Color::DarkGrey,
-            spinner_active: Color::Blue,
-            spinner_done: Color::Green,
-            spinner_failed: Color::Red,
-        }
+        Self::detect()
     }
+}
+
+/// Convert a `Color` to its ANSI foreground escape sequence.
+#[inline]
+pub fn ansi_fg(color: Color) -> String {
+    match color {
+        Color::Black => "\x1b[30m".to_string(),
+        Color::DarkRed => "\x1b[31m".to_string(),
+        Color::DarkGreen => "\x1b[32m".to_string(),
+        Color::DarkYellow => "\x1b[33m".to_string(),
+        Color::DarkBlue => "\x1b[34m".to_string(),
+        Color::DarkMagenta => "\x1b[35m".to_string(),
+        Color::DarkCyan => "\x1b[36m".to_string(),
+        Color::Grey => "\x1b[37m".to_string(),
+        Color::DarkGrey => "\x1b[90m".to_string(),
+        Color::Red => "\x1b[91m".to_string(),
+        Color::Green => "\x1b[92m".to_string(),
+        Color::Yellow => "\x1b[93m".to_string(),
+        Color::Blue => "\x1b[94m".to_string(),
+        Color::Magenta => "\x1b[95m".to_string(),
+        Color::Cyan => "\x1b[96m".to_string(),
+        Color::White => "\x1b[97m".to_string(),
+        Color::AnsiValue(n) => format!("\x1b[38;5;{n}m"),
+        Color::Rgb { r, g, b } => format!("\x1b[38;2;{r};{g};{b}m"),
+        _ => String::new(),
+    }
+}
+
+/// ANSI bold + fg.
+#[inline]
+pub fn ansi_bold_fg(color: Color) -> String {
+    format!("\x1b[1m{}", ansi_fg(color))
+}
+
+/// ANSI reset.
+pub const RESET: &str = "\x1b[0m";
+/// ANSI dim.
+pub const DIM: &str = "\x1b[2m";
+/// ANSI bold.
+pub const BOLD: &str = "\x1b[1m";
+
+/// Process-wide theme, detected once at startup.
+static THEME: std::sync::OnceLock<ColorTheme> = std::sync::OnceLock::new();
+
+/// Get the global color theme (auto-detected on first call).
+#[inline]
+pub fn theme() -> &'static ColorTheme {
+    THEME.get_or_init(ColorTheme::detect)
 }
 
 /// Shared spinner reference for streaming and tool execution layers.
@@ -548,10 +717,10 @@ impl RenderState {
 
         if let Some(level) = self.heading_level {
             style = match level {
-                1 => style.with(theme.heading),
-                2 => style.white(),
-                3 => style.with(Color::Blue),
-                _ => style.with(Color::Grey),
+                1 => style.with(theme.primary),
+                2 => style.with(theme.heading_h2),
+                3 => style.with(theme.heading_h3),
+                _ => style.with(theme.heading_h4),
             };
         } else if self.strong > 0 {
             style = style.with(theme.strong);
@@ -799,7 +968,7 @@ impl TerminalRenderer {
             Event::End(TagEnd::Strong) => state.strong = state.strong.saturating_sub(1),
             Event::Code(code) => {
                 let rendered =
-                    format!("{}", format!("`{code}`").with(self.color_theme.inline_code));
+                    format!("{}", format!("`{code}`").with(self.color_theme.code));
                 state.append_raw(output, &rendered);
             }
             Event::Rule => output.push_str("---\n"),
@@ -955,7 +1124,7 @@ impl TerminalRenderer {
             "{}",
             format!("╭─ {label}")
                 .bold()
-                .with(self.color_theme.code_block_border)
+                .with(self.color_theme.border)
         );
     }
 
@@ -964,7 +1133,7 @@ impl TerminalRenderer {
         let _ = write!(
             output,
             "{}",
-            "╰─".bold().with(self.color_theme.code_block_border)
+            "╰─".bold().with(self.color_theme.border)
         );
         output.push_str("\n\n");
     }
@@ -1006,12 +1175,12 @@ impl TerminalRenderer {
             })
             .collect::<Vec<_>>();
 
-        let border = format!("{}", "│".with(self.color_theme.table_border));
+        let border = format!("{}", "│".with(self.color_theme.border));
         let separator = widths
             .iter()
             .map(|width| "─".repeat(*width + 2))
             .collect::<Vec<_>>()
-            .join(&format!("{}", "┼".with(self.color_theme.table_border)));
+            .join(&format!("{}", "┼".with(self.color_theme.border)));
         let separator = format!("{border}{separator}{border}");
 
         let mut output = String::new();
@@ -1035,7 +1204,7 @@ impl TerminalRenderer {
     }
 
     fn render_table_row(&self, row: &[String], widths: &[usize], is_header: bool) -> String {
-        let border = format!("{}", "│".with(self.color_theme.table_border));
+        let border = format!("{}", "│".with(self.color_theme.border));
         let mut line = String::new();
         line.push_str(&border);
 
@@ -1043,7 +1212,7 @@ impl TerminalRenderer {
             let cell = row.get(index).map_or("", String::as_str);
             line.push(' ');
             if is_header {
-                let _ = write!(line, "{}", cell.bold().with(self.color_theme.heading));
+                let _ = write!(line, "{}", cell.bold().with(self.color_theme.primary));
             } else {
                 line.push_str(cell);
             }

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -200,10 +200,10 @@ impl ColorTheme {
             code: Color::DarkGreen,
             code_bg: 253, // light grey bg
             border: Color::AnsiValue(240),
-            diff_added: Color::AnsiValue(22),  // dark green
+            diff_added: Color::AnsiValue(22),    // dark green
             diff_removed: Color::AnsiValue(124), // dark red
             hook_feedback: Color::AnsiValue(130),
-            logo: Color::AnsiValue(25),  // dark blue
+            logo: Color::AnsiValue(25),         // dark blue
             logo_accent: Color::AnsiValue(166), // dark orange
             quote: Color::Grey,
             heading_h2: Color::Black,
@@ -967,8 +967,7 @@ impl TerminalRenderer {
             Event::Start(Tag::Strong) => state.strong += 1,
             Event::End(TagEnd::Strong) => state.strong = state.strong.saturating_sub(1),
             Event::Code(code) => {
-                let rendered =
-                    format!("{}", format!("`{code}`").with(self.color_theme.code));
+                let rendered = format!("{}", format!("`{code}`").with(self.color_theme.code));
                 state.append_raw(output, &rendered);
             }
             Event::Rule => output.push_str("---\n"),
@@ -1122,19 +1121,13 @@ impl TerminalRenderer {
         let _ = writeln!(
             output,
             "{}",
-            format!("╭─ {label}")
-                .bold()
-                .with(self.color_theme.border)
+            format!("╭─ {label}").bold().with(self.color_theme.border)
         );
     }
 
     fn finish_code_block(&self, code_buffer: &str, code_language: &str, output: &mut String) {
         output.push_str(&self.highlight_code(code_buffer, code_language));
-        let _ = write!(
-            output,
-            "{}",
-            "╰─".bold().with(self.color_theme.border)
-        );
+        let _ = write!(output, "{}", "╰─".bold().with(self.color_theme.border));
         output.push_str("\n\n");
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -147,9 +147,14 @@ impl SpinnerState {
         }
 
         // Stall detection: yellow when no new bytes for 3+ seconds.
+        let t = crate::render::theme();
         let is_stalled = bytes > 0 && !thinking && elapsed > 3.0;
-        let color_code = if is_stalled { "33" } else { "34" };
-        format!("\x1b[{color_code}m{line}\x1b[0m")
+        let color = if is_stalled {
+            crate::render::ansi_fg(t.warning)
+        } else {
+            crate::render::ansi_fg(t.info)
+        };
+        format!("{color}{line}{}", crate::render::RESET)
     }
 }
 
@@ -340,9 +345,9 @@ impl FuzzySelectState {
             let option = &self.question.options[oi];
             let selector = if abs_vi == self.cursor { ">" } else { " " };
             let marker = if option.recommended {
-                " \x1b[2m(recommended)\x1b[0;36m"
+                format!(" {}(recommended){}", crate::render::DIM, crate::render::RESET)
             } else {
-                ""
+                String::new()
             };
             lines.push(format!("{selector} {}{marker}", option.label));
         }
@@ -780,7 +785,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                                     h.push(trimmed.to_string());
                                                 }
                                             }
-                                            stdout_for_events.println(format!("\x1b[1m\u{276f} {val}\x1b[0m"));
+                                            stdout_for_events.println(format!("{}\u{276f} {val}{}", crate::render::BOLD, crate::render::RESET));
                                             let _ = input_tx_for_events.send(InputEvent::Submit(text));
                                         }
                                         InputEvent::QuestionAnswer(_) | InputEvent::Abort => {}
@@ -901,7 +906,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         } else {
                             last_ctrlc.set(Some(now));
                             let _ = input_tx_for_events.send(InputEvent::Abort);
-                            stdout_for_events.println("  \x1b[2mPress Ctrl-C again to exit\x1b[0m");
+                            stdout_for_events.println(format!("  {}Press Ctrl-C again to exit{}", crate::render::DIM, crate::render::RESET));
                             input_value.set(String::new());
                         }
                     }

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -345,7 +345,11 @@ impl FuzzySelectState {
             let option = &self.question.options[oi];
             let selector = if abs_vi == self.cursor { ">" } else { " " };
             let marker = if option.recommended {
-                format!(" {}(recommended){}", crate::render::DIM, crate::render::RESET)
+                format!(
+                    " {}(recommended){}",
+                    crate::render::DIM,
+                    crate::render::RESET
+                )
             } else {
                 String::new()
             };


### PR DESCRIPTION
## Summary

Replace all hardcoded ANSI color escapes with semantic ColorTheme tokens:

- **15 semantic tokens**: `primary`, `success`, `error`, `warning`, `info`, `muted`, `border`, `code`, `diff_added`, `diff_removed`, etc.
- **Two palettes**: `ColorTheme::dark()` (default) / `ColorTheme::light()`
- **Auto-detection**: `ColorTheme::detect()` reads `COLORFGBG` env var to pick palette
- **Global accessor**: `theme()` via `OnceLock` — no threading needed
- **Helpers**: `ansi_fg()`, `ansi_bold_fg()`, `RESET`, `DIM`, `BOLD`

Migration scope: ~170 ANSI escape replacements across `format.rs` (22 functions), `repl_ui.rs` (spinner, input echo, hints), `main.rs` (errors, banner, status).

## Test plan

- [x] `cargo test -p rusty-sudocode-cli --bin scode` (131 pass)
- [ ] Manual: dark mode (default) — visually identical to before
- [ ] Manual: light mode — `COLORFGBG="0;15" scode`