### PR TITLE
chore(acp): remove /tmp/scode-acp-diag.log debug writes

### DIFF
--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -985,25 +985,10 @@ pub(crate) async fn run_acp_on_transport(
                             let question_bridge = AcpQuestionBridge { tx: question_tx };
                             let mut delegate =
                                 d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                            let set_result = delegate.set_question_prompter(
+                            let _ = delegate.set_question_prompter(
                                 &sid_for_blocking,
                                 Box::new(question_bridge),
                             );
-                            {
-                                use std::io::Write as _;
-                                if let Ok(mut f) = std::fs::OpenOptions::new()
-                                    .create(true)
-                                    .append(true)
-                                    .open("/tmp/scode-acp-diag.log")
-                                {
-                                    let _ = writeln!(
-                                        f,
-                                        "[ACP-DIAG] set_question_prompter sid={} ok={}",
-                                        sid_for_blocking,
-                                        set_result.is_ok()
-                                    );
-                                }
-                            }
 
                             // Push image content blocks into the session before
                             // running the prompt so the API client includes them.
@@ -1105,23 +1090,8 @@ pub(crate) async fn run_acp_on_transport(
                                                 .collect(),
                                         };
 
-                                        {
-                                            use std::io::Write as _;
-                                            if let Ok(mut f) = std::fs::OpenOptions::new()
-                                                .create(true)
-                                                .append(true)
-                                                .open("/tmp/scode-acp-diag.log")
-                                            {
-                                                let _ = writeln!(
-                                                    f,
-                                                    "[ACP-DIAG] sending {} request",
-                                                    ACP_ASK_USER_QUESTION_METHOD
-                                                );
-                                            }
-                                        }
                                         let outcome = match serde_json::value::to_raw_value(&payload) {
                                             Ok(raw) => {
-                                                let raw_for_diag = raw.clone();
                                                 match cx_perm
                                                     .send_request(ClientRequest::ExtMethodRequest(
                                                         ExtRequest::new(ACP_ASK_USER_QUESTION_METHOD, StdArc::from(raw)),
@@ -1130,20 +1100,6 @@ pub(crate) async fn run_acp_on_transport(
                                                     .await
                                                 {
                                                     Ok(resp) => {
-                                                        {
-                                                            use std::io::Write;
-                                                            if let Ok(mut f) = std::fs::OpenOptions::new()
-                                                                .create(true)
-                                                                .append(true)
-                                                                .open("/tmp/scode-acp-diag.log")
-                                                            {
-                                                                let _ = writeln!(
-                                                                    f,
-                                                                    "[ACP-DIAG] question raw_resp: {}",
-                                                                    resp,
-                                                                );
-                                                            }
-                                                        }
                                                         serde_json::from_value::<AcpAskUserQuestionResponsePayload>(resp)
                                                             .map_err(|error| format!("deserialize: {}", error))
                                                             .map(|payload| {
@@ -1158,46 +1114,11 @@ pub(crate) async fn run_acp_on_transport(
                                                                     .collect::<Vec<_>>()
                                                             })
                                                     }
-                                                    Err(error) => {
-                                                        {
-                                                            use std::io::Write;
-                                                            if let Ok(mut f) = std::fs::OpenOptions::new()
-                                                                .create(true)
-                                                                .append(true)
-                                                                .open("/tmp/scode-acp-diag.log")
-                                                            {
-                                                                let _ = writeln!(
-                                                                    f,
-                                                                    "[ACP-DIAG] question send_request Err debug: {:?} payload_size={}",
-                                                                    error,
-                                                                    raw_for_diag.get().len(),
-                                                                );
-                                                            }
-                                                        }
-                                                        Err(error.to_string())
-                                                    }
+                                                    Err(error) => Err(error.to_string()),
                                                 }
                                             }
                                             Err(error) => Err(error.to_string()),
                                         };
-                                        {
-                                            use std::io::Write;
-                                            if let Ok(mut f) = std::fs::OpenOptions::new()
-                                                .create(true)
-                                                .append(true)
-                                                .open("/tmp/scode-acp-diag.log")
-                                            {
-                                                let summary = match &outcome {
-                                                    Ok(answers) => format!("Ok n_answers={}", answers.len()),
-                                                    Err(e) => format!("Err {}", e),
-                                                };
-                                                let _ = writeln!(
-                                                    f,
-                                                    "[ACP-DIAG] question outcome: {}",
-                                                    summary
-                                                );
-                                            }
-                                        }
                                         let _ = response_tx.send(outcome);
                                     } else {
                                         break blocking_handle.await


### PR DESCRIPTION
Removes all 5 hardcoded append-writes to `/tmp/scode-acp-diag.log` in `runtime/src/acp_sdk_server.rs`, along with the code that existed only to serve them.

These were debug writes committed to `main`. Every user running ACP mode creates this file.

**One of them is an information leak**: the `question raw_resp` dump wrote the full raw question response to disk, which can contain conversation content. Machines running released builds may already have this file — worth being aware of when triaging.

## What was removed

| Old line | Site |
|---|---|
| 997 | `set_question_prompter` result diag |
| 1113 | "sending session/ask_user_question request" diag |
| 1138 | `question raw_resp` dump (the info leak) |
| 1167 | `send_request` error diag |
| 1188 | "question outcome" summary diag |

Each block carried its own local `use std::io::Write`, so no top-level imports needed cleanup. No empty `if` blocks or orphan comments remain. The diag-only `let raw_for_diag = raw.clone()` was removed with its consumer.

Not converted to structured logging: the `runtime` crate has no logging framework (no `tracing`, no `log`); its only precedent is a bare `eprintln!("[acp] ...")`. Adding one is out of scope here — these can be reintroduced properly if the information turns out to be needed.

## Repo-wide `/tmp/` scan

`grep -rn '"/tmp/' rust/crates --include='*.rs'` after the change: no remaining runtime debug-file writes. Every other hit is in `#[cfg(test)]` modules, integration tests, or benches, using `/tmp/...` as a fixture *path value* (`PathBuf::from("/tmp/project")` etc.) without opening or writing it. Left untouched.

## Verification

`cargo test --workspace`: **104/104 suites, 1593 passed, 0 failed**.

`cargo fmt`: clean.

`cargo clippy --workspace --all-targets -- -D warnings`: fails on pre-existing pedantic lints in the untouched `telemetry` crate under local clippy 1.92.0. Verified by stashing the change and running against clean `origin/main`, which fails identically. Per-crate comparison:

```
clean origin/main   runtime = 181 errors
this branch         runtime = 177 errors
```

The 4 fewer are exactly the sites inside the deleted diag blocks. This change introduces zero new findings and removes four.

> Side note: `.github/workflows/rust-ci.yml` runs `cargo clippy --workspace` **without** `-D warnings`, while `CLAUDE.md` lists `-D warnings` as a required gate. Those two are out of sync — unrelated to this PR, but worth reconciling.

## Behavior check

Rebuilt `scode`, removed any stale log, piped NDJSON `initialize` + `session/new` into `scode acp`:

```
{"jsonrpc":"2.0","result":{...,"agentInfo":{"name":"scode","version":"0.1.20"},...},"id":1}
{"jsonrpc":"2.0","result":{"sessionId":"session-1786638216695-0"},"id":2}

$ ls -la /tmp/scode-acp-diag.log
ls: /tmp/scode-acp-diag.log: No such file or directory

$ pgrep -fl "scode acp"
(no leftover processes)
```

Handshake works, the file is not created, process exits cleanly on stdin EOF.
