### PR TITLE
refactor(skills): drop legacy commands/ discovery, unify skill lookup

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -2305,29 +2305,12 @@ struct SkillSummary {
     description: Option<String>,
     source: DefinitionSource,
     shadowed_by: Option<DefinitionSource>,
-    origin: SkillOrigin,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SkillOrigin {
-    SkillsDir,
-    LegacyCommandsDir,
-}
-
-impl SkillOrigin {
-    fn detail_label(self) -> Option<&'static str> {
-        match self {
-            Self::SkillsDir => None,
-            Self::LegacyCommandsDir => Some("legacy /commands"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SkillRoot {
     source: DefinitionSource,
     path: PathBuf,
-    origin: SkillOrigin,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2786,48 +2769,22 @@ pub fn resolve_skill_path_with_plugins(
         let mut entries = Vec::new();
         for entry in fs::read_dir(&root.path)? {
             let entry = entry?;
-            match root.origin {
-                SkillOrigin::SkillsDir => {
-                    if !entry.path().is_dir() {
-                        continue;
-                    }
-                    let skill_path = entry.path().join("SKILL.md");
-                    if !skill_path.is_file() {
-                        continue;
-                    }
-                    let contents = fs::read_to_string(&skill_path)?;
-                    let (name, _) = parse_skill_frontmatter(&contents);
-                    entries.push((
-                        name.unwrap_or_else(|| entry.file_name().to_string_lossy().to_string()),
-                        skill_path,
-                    ));
-                }
-                SkillOrigin::LegacyCommandsDir => {
-                    let path = entry.path();
-                    let markdown_path = if path.is_dir() {
-                        let skill_path = path.join("SKILL.md");
-                        if !skill_path.is_file() {
-                            continue;
-                        }
-                        skill_path
-                    } else if path
-                        .extension()
-                        .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("md"))
-                    {
-                        path
-                    } else {
-                        continue;
-                    };
-
-                    let contents = fs::read_to_string(&markdown_path)?;
-                    let fallback_name = markdown_path.file_stem().map_or_else(
-                        || entry.file_name().to_string_lossy().to_string(),
-                        |stem| stem.to_string_lossy().to_string(),
-                    );
-                    let (name, _) = parse_skill_frontmatter(&contents);
-                    entries.push((name.unwrap_or(fallback_name), markdown_path));
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let skill_path = entry.path().join("SKILL.md");
+            if !skill_path.is_file() {
+                continue;
+            }
+            let contents = fs::read_to_string(&skill_path)?;
+            let (name, _) = parse_skill_frontmatter(&contents);
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            if let Some(name) = name {
+                if !name.eq_ignore_ascii_case(&dir_name) {
+                    entries.push((name, skill_path.clone()));
                 }
             }
+            entries.push((dir_name, skill_path));
         }
         entries.sort_by(|left, right| left.0.cmp(&right.0));
         if let Some((_, path)) = entries
@@ -3347,49 +3304,26 @@ fn discover_skill_roots_with_plugins(
             &mut roots,
             DefinitionSource::ProjectClaw,
             ancestor.join(".nexus").join("sudocode").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::ProjectClaw,
             ancestor.join(".omc").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::ProjectClaw,
             ancestor.join(".agents").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::ProjectCodex,
             ancestor.join(".codex").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::ProjectClaude,
             ancestor.join(".claude").join("skills"),
-            SkillOrigin::SkillsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::ProjectClaw,
-            ancestor.join(".nexus").join("sudocode").join("commands"),
-            SkillOrigin::LegacyCommandsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::ProjectCodex,
-            ancestor.join(".codex").join("commands"),
-            SkillOrigin::LegacyCommandsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::ProjectClaude,
-            ancestor.join(".claude").join("commands"),
-            SkillOrigin::LegacyCommandsDir,
         );
     }
 
@@ -3399,13 +3333,6 @@ fn discover_skill_roots_with_plugins(
             &mut roots,
             DefinitionSource::UserClawConfigHome,
             sudocode_config_home.join("skills"),
-            SkillOrigin::SkillsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::UserClawConfigHome,
-            sudocode_config_home.join("commands"),
-            SkillOrigin::LegacyCommandsDir,
         );
     }
 
@@ -3415,88 +3342,56 @@ fn discover_skill_roots_with_plugins(
             &mut roots,
             DefinitionSource::UserCodexHome,
             codex_home.join("skills"),
-            SkillOrigin::SkillsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::UserCodexHome,
-            codex_home.join("commands"),
-            SkillOrigin::LegacyCommandsDir,
         );
     }
 
-    if let Some(home) = env::var_os("HOME") {
+    if let Some(home) = env::var_os("HOME").or_else(|| env::var_os("USERPROFILE")) {
         let home = PathBuf::from(home);
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserClaw,
             home.join(".nexus").join("sudocode").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserClaw,
             home.join(".omc").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserClaw,
-            home.join(".nexus").join("sudocode").join("commands"),
-            SkillOrigin::LegacyCommandsDir,
+            home.join(".agents").join("skills"),
+        );
+        push_unique_skill_root(
+            &mut roots,
+            DefinitionSource::UserClaw,
+            home.join(".config").join("opencode").join("skills"),
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserCodex,
             home.join(".codex").join("skills"),
-            SkillOrigin::SkillsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::UserCodex,
-            home.join(".codex").join("commands"),
-            SkillOrigin::LegacyCommandsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserClaude,
             home.join(".claude").join("skills"),
-            SkillOrigin::SkillsDir,
         );
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserClaude,
             home.join(".claude").join("skills").join("omc-learned"),
-            SkillOrigin::SkillsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::UserClaude,
-            home.join(".claude").join("commands"),
-            SkillOrigin::LegacyCommandsDir,
         );
     }
 
     if let Ok(claude_config_dir) = env::var("CLAUDE_CONFIG_DIR") {
         let claude_config_dir = PathBuf::from(claude_config_dir);
         let skills_dir = claude_config_dir.join("skills");
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::UserClaude,
-            skills_dir.clone(),
-            SkillOrigin::SkillsDir,
-        );
+        push_unique_skill_root(&mut roots, DefinitionSource::UserClaude, skills_dir.clone());
         push_unique_skill_root(
             &mut roots,
             DefinitionSource::UserClaude,
             skills_dir.join("omc-learned"),
-            SkillOrigin::SkillsDir,
-        );
-        push_unique_skill_root(
-            &mut roots,
-            DefinitionSource::UserClaude,
-            claude_config_dir.join("commands"),
-            SkillOrigin::LegacyCommandsDir,
         );
     }
 
@@ -3506,12 +3401,7 @@ fn discover_skill_roots_with_plugins(
                 continue;
             }
             for skill_root in &plugin.skill_roots {
-                push_unique_skill_root(
-                    &mut roots,
-                    DefinitionSource::Plugin,
-                    skill_root.clone(),
-                    SkillOrigin::SkillsDir,
-                );
+                push_unique_skill_root(&mut roots, DefinitionSource::Plugin, skill_root.clone());
             }
         }
     }
@@ -3731,18 +3621,9 @@ fn push_unique_root(
     }
 }
 
-fn push_unique_skill_root(
-    roots: &mut Vec<SkillRoot>,
-    source: DefinitionSource,
-    path: PathBuf,
-    origin: SkillOrigin,
-) {
+fn push_unique_skill_root(roots: &mut Vec<SkillRoot>, source: DefinitionSource, path: PathBuf) {
     if path.is_dir() && !roots.iter().any(|existing| existing.path == path) {
-        roots.push(SkillRoot {
-            source,
-            path,
-            origin,
-        });
+        roots.push(SkillRoot { source, path });
     }
 }
 
@@ -3797,58 +3678,21 @@ fn load_skills_from_roots(roots: &[SkillRoot]) -> std::io::Result<Vec<SkillSumma
         let mut root_skills = Vec::new();
         for entry in fs::read_dir(&root.path)? {
             let entry = entry?;
-            match root.origin {
-                SkillOrigin::SkillsDir => {
-                    if !entry.path().is_dir() {
-                        continue;
-                    }
-                    let skill_path = entry.path().join("SKILL.md");
-                    if !skill_path.is_file() {
-                        continue;
-                    }
-                    let contents = fs::read_to_string(skill_path)?;
-                    let (name, description) = parse_skill_frontmatter(&contents);
-                    root_skills.push(SkillSummary {
-                        name: name
-                            .unwrap_or_else(|| entry.file_name().to_string_lossy().to_string()),
-                        description,
-                        source: root.source,
-                        shadowed_by: None,
-                        origin: root.origin,
-                    });
-                }
-                SkillOrigin::LegacyCommandsDir => {
-                    let path = entry.path();
-                    let markdown_path = if path.is_dir() {
-                        let skill_path = path.join("SKILL.md");
-                        if !skill_path.is_file() {
-                            continue;
-                        }
-                        skill_path
-                    } else if path
-                        .extension()
-                        .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("md"))
-                    {
-                        path
-                    } else {
-                        continue;
-                    };
-
-                    let contents = fs::read_to_string(&markdown_path)?;
-                    let fallback_name = markdown_path.file_stem().map_or_else(
-                        || entry.file_name().to_string_lossy().to_string(),
-                        |stem| stem.to_string_lossy().to_string(),
-                    );
-                    let (name, description) = parse_skill_frontmatter(&contents);
-                    root_skills.push(SkillSummary {
-                        name: name.unwrap_or(fallback_name),
-                        description,
-                        source: root.source,
-                        shadowed_by: None,
-                        origin: root.origin,
-                    });
-                }
+            if !entry.path().is_dir() {
+                continue;
             }
+            let skill_path = entry.path().join("SKILL.md");
+            if !skill_path.is_file() {
+                continue;
+            }
+            let contents = fs::read_to_string(skill_path)?;
+            let (name, description) = parse_skill_frontmatter(&contents);
+            root_skills.push(SkillSummary {
+                name: name.unwrap_or_else(|| entry.file_name().to_string_lossy().to_string()),
+                description,
+                source: root.source,
+                shadowed_by: None,
+            });
         }
         root_skills.sort_by(|left, right| left.name.cmp(&right.name));
 
@@ -4044,9 +3888,6 @@ fn render_skills_report(skills: &[SkillSummary]) -> String {
             let mut parts = vec![skill.name.clone()];
             if let Some(description) = &skill.description {
                 parts.push(description.clone());
-            }
-            if let Some(detail) = skill.origin.detail_label() {
-                parts.push(detail.to_string());
             }
             let detail = parts.join(" · ");
             match skill.shadowed_by {
@@ -4337,7 +4178,7 @@ fn render_skills_usage(unexpected: Option<&str>) -> String {
         "  Direct CLI       scode skills [list|install <path>|help|<skill> [args]]".to_string(),
         "  Invoke           /skills help overview -> $help overview".to_string(),
         "  Install root     $SUDO_CODE_CONFIG_HOME/skills or ~/.nexus/sudocode/skills".to_string(),
-        "  Sources          .nexus/sudocode/skills, .omc/skills, .agents/skills, .codex/skills, .claude/skills, ~/.nexus/sudocode/skills, ~/.omc/skills, ~/.claude/skills/omc-learned, ~/.codex/skills, ~/.claude/skills, legacy /commands".to_string(),
+        "  Sources          .nexus/sudocode/skills, .omc/skills, .agents/skills, .codex/skills, .claude/skills, ~/.nexus/sudocode/skills, ~/.omc/skills, ~/.agents/skills, ~/.config/opencode/skills, ~/.claude/skills/omc-learned, ~/.codex/skills, ~/.claude/skills".to_string(),
     ];
     if let Some(args) = unexpected {
         lines.push(format!("  Unexpected       {args}"));
@@ -4363,11 +4204,11 @@ fn render_skills_usage_json(unexpected: Option<&str>) -> Value {
                 ".claude/skills",
                 "~/.nexus/sudocode/skills",
                 "~/.omc/skills",
+                "~/.agents/skills",
+                "~/.config/opencode/skills",
                 "~/.claude/skills/omc-learned",
                 "~/.codex/skills",
-                "~/.claude/skills",
-                "legacy /commands",
-                "legacy fallback dirs still load automatically"
+                "~/.claude/skills"
             ],
         },
         "unexpected": unexpected,
@@ -4524,26 +4365,11 @@ fn agent_summary_json(agent: &AgentSummary) -> Value {
     })
 }
 
-fn skill_origin_id(origin: SkillOrigin) -> &'static str {
-    match origin {
-        SkillOrigin::SkillsDir => "skills_dir",
-        SkillOrigin::LegacyCommandsDir => "legacy_commands_dir",
-    }
-}
-
-fn skill_origin_json(origin: SkillOrigin) -> Value {
-    json!({
-        "id": skill_origin_id(origin),
-        "detail_label": origin.detail_label(),
-    })
-}
-
 fn skill_summary_json(skill: &SkillSummary) -> Value {
     json!({
         "name": &skill.name,
         "description": &skill.description,
         "source": definition_source_json(skill.source),
-        "origin": skill_origin_json(skill.origin),
         "active": skill.shadowed_by.is_none(),
         "shadowed_by": skill.shadowed_by.map(definition_source_json),
     })
@@ -4746,7 +4572,7 @@ mod tests {
         render_slash_command_help_detail, resolve_skill_invocation_with_plugins,
         resolve_skill_path, resolve_skill_path_with_plugins, resume_supported_slash_commands,
         slash_command_specs, suggest_slash_commands, validate_slash_command_input,
-        DefinitionSource, SkillOrigin, SkillRoot, SkillSlashDispatch, SlashCommand,
+        DefinitionSource, SkillRoot, SkillSlashDispatch, SlashCommand,
     };
     use plugins::{
         LoadedPlugin, MarketplaceDiscoveryError, PluginCapabilityMetadata, PluginCapabilitySummary,
@@ -5724,12 +5550,10 @@ mod tests {
     fn lists_skills_from_project_and_user_roots() {
         let workspace = temp_dir("skills-workspace");
         let project_skills = workspace.join(".codex").join("skills");
-        let project_commands = workspace.join(".claude").join("commands");
         let user_home = temp_dir("skills-home");
         let user_skills = user_home.join(".codex").join("skills");
 
         write_skill(&project_skills, "plan", "Project planning guidance");
-        write_legacy_command(&project_commands, "deploy", "Legacy deployment guidance");
         write_skill(&user_skills, "plan", "User planning guidance");
         write_skill(&user_skills, "help", "Help guidance");
 
@@ -5737,27 +5561,19 @@ mod tests {
             SkillRoot {
                 source: DefinitionSource::ProjectCodex,
                 path: project_skills,
-                origin: SkillOrigin::SkillsDir,
-            },
-            SkillRoot {
-                source: DefinitionSource::ProjectClaude,
-                path: project_commands,
-                origin: SkillOrigin::LegacyCommandsDir,
             },
             SkillRoot {
                 source: DefinitionSource::UserCodex,
                 path: user_skills,
-                origin: SkillOrigin::SkillsDir,
             },
         ];
         let report =
             render_skills_report(&load_skills_from_roots(&roots).expect("skill roots should load"));
 
         assert!(report.contains("Skills"));
-        assert!(report.contains("3 available skills"));
+        assert!(report.contains("2 available skills"));
         assert!(report.contains("Project roots:"));
         assert!(report.contains("plan · Project planning guidance"));
-        assert!(report.contains("deploy · Legacy deployment guidance · legacy /commands"));
         assert!(report.contains("User home roots:"));
         assert!(report.contains("(shadowed by Project roots) plan · User planning guidance"));
         assert!(report.contains("help · Help guidance"));
@@ -5767,7 +5583,7 @@ mod tests {
     }
 
     #[test]
-    fn resolves_project_skills_and_legacy_commands_from_shared_registry() {
+    fn resolves_project_skills_but_not_legacy_commands_markdown() {
         let workspace = temp_dir("resolve-project-skills");
         let project_skills = workspace.join(".nexus").join("sudocode").join("skills");
         let legacy_commands = workspace.join(".nexus").join("sudocode").join("commands");
@@ -5779,9 +5595,9 @@ mod tests {
             resolve_skill_path(&workspace, "$plan").expect("project skill should resolve"),
             project_skills.join("plan").join("SKILL.md")
         );
-        assert_eq!(
-            resolve_skill_path(&workspace, "/handoff").expect("legacy command should resolve"),
-            legacy_commands.join("handoff.md")
+        assert!(
+            resolve_skill_path(&workspace, "/handoff").is_err(),
+            "commands/*.md must no longer resolve as a skill"
         );
     }
 
@@ -5850,12 +5666,10 @@ mod tests {
     fn renders_skills_reports_as_json() {
         let workspace = temp_dir("skills-json-workspace");
         let project_skills = workspace.join(".codex").join("skills");
-        let project_commands = workspace.join(".claude").join("commands");
         let user_home = temp_dir("skills-json-home");
         let user_skills = user_home.join(".codex").join("skills");
 
         write_skill(&project_skills, "plan", "Project planning guidance");
-        write_legacy_command(&project_commands, "deploy", "Legacy deployment guidance");
         write_skill(&user_skills, "plan", "User planning guidance");
         write_skill(&user_skills, "help", "Help guidance");
 
@@ -5863,17 +5677,10 @@ mod tests {
             SkillRoot {
                 source: DefinitionSource::ProjectCodex,
                 path: project_skills,
-                origin: SkillOrigin::SkillsDir,
-            },
-            SkillRoot {
-                source: DefinitionSource::ProjectClaude,
-                path: project_commands,
-                origin: SkillOrigin::LegacyCommandsDir,
             },
             SkillRoot {
                 source: DefinitionSource::UserCodex,
                 path: user_skills,
-                origin: SkillOrigin::SkillsDir,
             },
         ];
         let report = super::render_skills_report_json(
@@ -5881,13 +5688,13 @@ mod tests {
         );
         assert_eq!(report["kind"], "skills");
         assert_eq!(report["action"], "list");
-        assert_eq!(report["summary"]["active"], 3);
+        assert_eq!(report["summary"]["active"], 2);
         assert_eq!(report["summary"]["shadowed"], 1);
         assert_eq!(report["skills"][0]["name"], "plan");
         assert_eq!(report["skills"][0]["source"]["id"], "project_scode");
-        assert_eq!(report["skills"][1]["name"], "deploy");
-        assert_eq!(report["skills"][1]["origin"]["id"], "legacy_commands_dir");
-        assert_eq!(report["skills"][3]["shadowed_by"]["id"], "project_scode");
+        assert_eq!(report["skills"][1]["name"], "help");
+        assert_eq!(report["skills"][2]["name"], "plan");
+        assert_eq!(report["skills"][2]["shadowed_by"]["id"], "project_scode");
 
         let help = handle_skills_slash_command_json(Some("help"), &workspace).expect("skills help");
         assert_eq!(help["kind"], "skills");
@@ -5929,7 +5736,7 @@ mod tests {
         assert!(skills_help.contains(".omc/skills"));
         assert!(skills_help.contains(".agents/skills"));
         assert!(skills_help.contains("~/.claude/skills/omc-learned"));
-        assert!(skills_help.contains("legacy /commands"));
+        assert!(!skills_help.contains("legacy /commands"));
 
         let skills_unexpected =
             super::handle_skills_slash_command(Some("show help"), &cwd).expect("skills usage");
@@ -6006,7 +5813,10 @@ mod tests {
         assert!(report.contains("trace · Compatibility skill guidance"));
         assert!(report.contains("cancel · OMC cancel guidance"));
         assert!(report.contains("statusline · Claude config skill guidance"));
-        assert!(report.contains("doctor-check · Claude config command guidance · legacy /commands"));
+        assert!(
+            !report.contains("doctor-check"),
+            "commands/*.md must no longer be listed as skills"
+        );
         assert!(report.contains("learned · Learned skill guidance"));
 
         let help =
@@ -6578,7 +6388,6 @@ mod tests {
         let roots = vec![SkillRoot {
             source: DefinitionSource::UserCodexHome,
             path: install_root.clone(),
-            origin: SkillOrigin::SkillsDir,
         }];
         let listed = render_skills_report(
             &load_skills_from_roots(&roots).expect("installed skills should load"),

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -4495,10 +4495,8 @@ fn todo_store_path() -> Result<std::path::PathBuf, String> {
 fn resolve_skill_path(skill: &str) -> Result<std::path::PathBuf, String> {
     let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
     let plugin_load_outcome = load_plugin_outcome_for_cwd(&cwd);
-    match commands::resolve_skill_path_with_plugins(&cwd, skill, plugin_load_outcome.as_ref()) {
-        Ok(path) => Ok(path),
-        Err(_) => resolve_skill_path_from_compat_roots(skill),
-    }
+    commands::resolve_skill_path_with_plugins(&cwd, skill, plugin_load_outcome.as_ref())
+        .map_err(|error| error.to_string())
 }
 
 fn load_plugin_outcome_for_cwd(cwd: &Path) -> Option<PluginLoadOutcome> {
@@ -4512,259 +4510,6 @@ fn load_plugin_outcome_for_cwd(cwd: &Path) -> Option<PluginLoadOutcome> {
         .plugin_registry_report()
         .ok()
         .map(|report| report.load_outcome())
-}
-
-fn resolve_skill_path_from_compat_roots(skill: &str) -> Result<std::path::PathBuf, String> {
-    let requested = skill.trim().trim_start_matches('/').trim_start_matches('$');
-    if requested.is_empty() {
-        return Err(String::from("skill must not be empty"));
-    }
-
-    for root in skill_lookup_roots() {
-        if let Some(path) = resolve_skill_path_in_root(&root, requested) {
-            return Ok(path);
-        }
-    }
-
-    Err(format!("unknown skill: {requested}"))
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SkillLookupOrigin {
-    SkillsDir,
-    LegacyCommandsDir,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SkillLookupRoot {
-    path: std::path::PathBuf,
-    origin: SkillLookupOrigin,
-}
-
-fn skill_lookup_roots() -> Vec<SkillLookupRoot> {
-    let mut roots = Vec::new();
-
-    if let Ok(cwd) = std::env::current_dir() {
-        push_project_skill_lookup_roots(&mut roots, &cwd);
-    }
-
-    if let Ok(sudocode_config_home) = std::env::var("SUDO_CODE_CONFIG_HOME") {
-        push_prefixed_skill_lookup_roots(&mut roots, std::path::Path::new(&sudocode_config_home));
-    }
-    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
-        push_prefixed_skill_lookup_roots(&mut roots, std::path::Path::new(&codex_home));
-    }
-    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        push_home_skill_lookup_roots(&mut roots, std::path::Path::new(&home));
-    }
-    if let Ok(claude_config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
-        let claude_config_dir = std::path::PathBuf::from(claude_config_dir);
-        push_skill_lookup_root(
-            &mut roots,
-            claude_config_dir.join("skills"),
-            SkillLookupOrigin::SkillsDir,
-        );
-        push_skill_lookup_root(
-            &mut roots,
-            claude_config_dir.join("skills").join("omc-learned"),
-            SkillLookupOrigin::SkillsDir,
-        );
-        push_skill_lookup_root(
-            &mut roots,
-            claude_config_dir.join("commands"),
-            SkillLookupOrigin::LegacyCommandsDir,
-        );
-    }
-    push_skill_lookup_root(
-        &mut roots,
-        std::path::PathBuf::from("/home/bellman/.nexus/sudocode/skills"),
-        SkillLookupOrigin::SkillsDir,
-    );
-    push_skill_lookup_root(
-        &mut roots,
-        std::path::PathBuf::from("/home/bellman/.codex/skills"),
-        SkillLookupOrigin::SkillsDir,
-    );
-
-    roots
-}
-
-fn push_project_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, cwd: &std::path::Path) {
-    for ancestor in cwd.ancestors() {
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".omc"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".agents"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".nexus").join("sudocode"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".codex"));
-        push_prefixed_skill_lookup_roots(roots, &ancestor.join(".claude"));
-    }
-}
-
-fn push_home_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, home: &std::path::Path) {
-    push_prefixed_skill_lookup_roots(roots, &home.join(".omc"));
-    push_prefixed_skill_lookup_roots(roots, &home.join(".nexus").join("sudocode"));
-    push_prefixed_skill_lookup_roots(roots, &home.join(".codex"));
-    push_prefixed_skill_lookup_roots(roots, &home.join(".claude"));
-    push_skill_lookup_root(
-        roots,
-        home.join(".agents").join("skills"),
-        SkillLookupOrigin::SkillsDir,
-    );
-    push_skill_lookup_root(
-        roots,
-        home.join(".config").join("opencode").join("skills"),
-        SkillLookupOrigin::SkillsDir,
-    );
-    push_skill_lookup_root(
-        roots,
-        home.join(".claude").join("skills").join("omc-learned"),
-        SkillLookupOrigin::SkillsDir,
-    );
-}
-
-fn push_prefixed_skill_lookup_roots(roots: &mut Vec<SkillLookupRoot>, prefix: &std::path::Path) {
-    push_skill_lookup_root(roots, prefix.join("skills"), SkillLookupOrigin::SkillsDir);
-    push_skill_lookup_root(
-        roots,
-        prefix.join("commands"),
-        SkillLookupOrigin::LegacyCommandsDir,
-    );
-}
-
-fn push_skill_lookup_root(
-    roots: &mut Vec<SkillLookupRoot>,
-    path: std::path::PathBuf,
-    origin: SkillLookupOrigin,
-) {
-    if path.is_dir() && !roots.iter().any(|existing| existing.path == path) {
-        roots.push(SkillLookupRoot { path, origin });
-    }
-}
-
-fn resolve_skill_path_in_root(
-    root: &SkillLookupRoot,
-    requested: &str,
-) -> Option<std::path::PathBuf> {
-    match root.origin {
-        SkillLookupOrigin::SkillsDir => resolve_skill_path_in_skills_dir(&root.path, requested),
-        SkillLookupOrigin::LegacyCommandsDir => {
-            resolve_skill_path_in_legacy_commands_dir(&root.path, requested)
-        }
-    }
-}
-
-fn resolve_skill_path_in_skills_dir(
-    root: &std::path::Path,
-    requested: &str,
-) -> Option<std::path::PathBuf> {
-    let direct = root.join(requested).join("SKILL.md");
-    if direct.is_file() {
-        return Some(direct);
-    }
-
-    let entries = std::fs::read_dir(root).ok()?;
-    for entry in entries.flatten() {
-        if !entry.path().is_dir() {
-            continue;
-        }
-        let skill_path = entry.path().join("SKILL.md");
-        if !skill_path.is_file() {
-            continue;
-        }
-        if entry
-            .file_name()
-            .to_string_lossy()
-            .eq_ignore_ascii_case(requested)
-            || skill_frontmatter_name_matches(&skill_path, requested)
-        {
-            return Some(skill_path);
-        }
-    }
-
-    None
-}
-
-fn resolve_skill_path_in_legacy_commands_dir(
-    root: &std::path::Path,
-    requested: &str,
-) -> Option<std::path::PathBuf> {
-    let direct_dir = root.join(requested).join("SKILL.md");
-    if direct_dir.is_file() {
-        return Some(direct_dir);
-    }
-
-    let direct_markdown = root.join(format!("{requested}.md"));
-    if direct_markdown.is_file() {
-        return Some(direct_markdown);
-    }
-
-    let entries = std::fs::read_dir(root).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let candidate_path = if path.is_dir() {
-            let skill_path = path.join("SKILL.md");
-            if !skill_path.is_file() {
-                continue;
-            }
-            skill_path
-        } else if path
-            .extension()
-            .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("md"))
-        {
-            path
-        } else {
-            continue;
-        };
-
-        let matches_entry_name = candidate_path
-            .file_stem()
-            .is_some_and(|stem| stem.to_string_lossy().eq_ignore_ascii_case(requested))
-            || entry
-                .file_name()
-                .to_string_lossy()
-                .trim_end_matches(".md")
-                .eq_ignore_ascii_case(requested);
-        if matches_entry_name || skill_frontmatter_name_matches(&candidate_path, requested) {
-            return Some(candidate_path);
-        }
-    }
-
-    None
-}
-
-fn skill_frontmatter_name_matches(path: &std::path::Path, requested: &str) -> bool {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|contents| parse_skill_name(&contents))
-        .is_some_and(|name| name.eq_ignore_ascii_case(requested))
-}
-
-fn parse_skill_name(contents: &str) -> Option<String> {
-    parse_skill_frontmatter_value(contents, "name")
-}
-
-fn parse_skill_frontmatter_value(contents: &str, key: &str) -> Option<String> {
-    let mut lines = contents.lines();
-    if lines.next().map(str::trim) != Some("---") {
-        return None;
-    }
-
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            break;
-        }
-        if let Some(value) = trimmed.strip_prefix(&format!("{key}:")) {
-            let value = value
-                .trim()
-                .trim_matches(|ch| matches!(ch, '"' | '\''))
-                .trim();
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-
-    None
 }
 
 const DEFAULT_AGENT_MODEL: &str = "claude-opus-4-6";
@@ -9671,7 +9416,7 @@ mod tests {
     }
 
     #[test]
-    fn skill_resolves_project_local_skills_and_legacy_commands() {
+    fn skill_resolves_project_local_skills_but_not_legacy_commands() {
         let _guard = env_guard();
         let root = temp_path("project-skills");
         let skill_dir = root
@@ -9706,15 +9451,8 @@ mod tests {
             .replace('\\', "/")
             .ends_with(".nexus/sudocode/skills/plan/SKILL.md"));
 
-        let command_result = execute_tool("Skill", &json!({ "skill": "/handoff" }))
-            .expect("legacy command should resolve");
-        let command_output: serde_json::Value =
-            serde_json::from_str(&command_result).expect("valid json");
-        assert!(command_output["path"]
-            .as_str()
-            .expect("path")
-            .replace('\\', "/")
-            .ends_with(".nexus/sudocode/commands/handoff.md"));
+        execute_tool("Skill", &json!({ "skill": "/handoff" }))
+            .expect_err("commands/*.md must no longer resolve as a skill");
 
         std::env::set_current_dir(&original_dir).expect("restore cwd");
         fs::remove_dir_all(root).expect("temp project should clean up");
@@ -9981,7 +9719,7 @@ mod tests {
     }
 
     #[test]
-    fn skill_loads_direct_skill_and_legacy_command_from_claude_config_dir() {
+    fn skill_loads_direct_skill_but_not_legacy_command_from_claude_config_dir() {
         let _guard = env_guard();
         let root = temp_path("claude-config-direct-skill");
         let home = root.join("home");
@@ -10021,19 +9759,8 @@ mod tests {
             .ends_with("skills/statusline/SKILL.md"));
         assert_eq!(direct_skill_output["description"], "Claude config skill");
 
-        let legacy_command =
-            execute_tool("Skill", &json!({ "skill": "doctor-check" })).expect("direct command");
-        let legacy_command_output: serde_json::Value =
-            serde_json::from_str(&legacy_command).expect("valid command json");
-        assert!(legacy_command_output["path"]
-            .as_str()
-            .expect("path")
-            .replace('\\', "/")
-            .ends_with("commands/doctor-check.md"));
-        assert_eq!(
-            legacy_command_output["description"],
-            "Claude config command"
-        );
+        execute_tool("Skill", &json!({ "skill": "doctor-check" }))
+            .expect_err("commands/*.md must no longer resolve as a skill");
 
         match original_home {
             Some(value) => std::env::set_var("HOME", value),
@@ -10055,7 +9782,7 @@ mod tests {
     }
 
     #[test]
-    fn skill_loads_project_local_legacy_command_markdown() {
+    fn skill_rejects_project_local_legacy_command_markdown() {
         let _guard = env_guard();
         let root = temp_path("project-legacy-command");
         let home = root.join("home");
@@ -10079,16 +9806,8 @@ mod tests {
         std::env::remove_var("CODEX_HOME");
         std::env::set_current_dir(&nested).expect("set cwd");
 
-        let result = execute_tool("Skill", &json!({ "skill": "team" }))
-            .expect("legacy command markdown should resolve");
-
-        let output: serde_json::Value = serde_json::from_str(&result).expect("valid json");
-        assert!(output["path"]
-            .as_str()
-            .expect("path")
-            .replace('\\', "/")
-            .ends_with(".claude/commands/team.md"));
-        assert_eq!(output["description"], "Legacy team workflow");
+        execute_tool("Skill", &json!({ "skill": "team" }))
+            .expect_err("commands/*.md must no longer resolve as a skill");
 
         std::env::set_current_dir(&original_dir).expect("restore cwd");
         match original_home {


### PR DESCRIPTION
Removes the legacy `commands/`-as-skills compatibility layer, deletes two hardcoded developer paths that were committed to `main`, and collapses two parallel skill-discovery implementations into one.

**Net −404 lines** (539 deleted / 135 added) across `commands` and `tools`.

## 1. Legacy `commands/` skill discovery removed

`SkillOrigin::LegacyCommandsDir` accepted both `commands/<name>/SKILL.md` and bare `commands/<name>.md` as skills. Both forms are gone.

Full removal (rather than dropping only the bare-`.md` half) because the `commands/` directories — `.claude/commands`, `.codex/commands`, `.nexus/sudocode/commands`, `$SUDO_CODE_CONFIG_HOME/commands`, `$CLAUDE_CONFIG_DIR/commands` — are referenced **only** by this compat layer. Slash commands come from the built-in registry (`SlashCommand` / `slash_command_specs`), not from these directories, so nothing else depends on them. Keeping only the `SKILL.md` half would preserve a directory with no other purpose.

The `SkillOrigin` enum, `detail_label()`, `skill_origin_id()`, `skill_origin_json()` and the `origin` field on `SkillSummary`/`SkillRoot` are deleted rather than left as single-variant.

## 2. Hardcoded developer paths removed

`tools/src/lib.rs` unconditionally probed:

```rust
push_skill_lookup_root(&mut roots, PathBuf::from("/home/bellman/.nexus/sudocode/skills"), ...);
push_skill_lookup_root(&mut roots, PathBuf::from("/home/bellman/.codex/skills"), ...);
```

Not behind any condition — every user stat'd these paths on every lookup. Traced to `e089c07` (2026-03-31), added directly below the correct `CODEX_HOME` env-var handling; survived a later cleanup and was reintroduced by "Restore compatibility skill lookup fallback".

## 3. Duplicate discovery implementations merged

`tools` carried a parallel implementation (`resolve_skill_path_from_compat_roots` + `skill_lookup_roots` + `SkillLookupOrigin` + per-root resolvers, ~250 lines) used only as a fallback when `commands::resolve_skill_path_with_plugins` failed. Both sides had their own `LegacyCommandsDir` notion — removing it in one place only would have left them drifting.

After the legacy removal, the fallback differed from `commands` discovery in exactly four ways:

1. also probed `~/.agents/skills` and `~/.config/opencode/skills`
2. fell back to `USERPROFILE` when `HOME` is unset (Windows)
3. matched a skill by directory name **as well as** frontmatter `name:`
4. the `/home/bellman/*` probes (a bug)

Items 1–3 were ported into `commands`; the entire `tools` fallback stack was deleted. `tools::resolve_skill_path` is now a thin delegation. **One implementation, no origin enum on either side, no future drift.**

### Intentional behavior deltas from the merge

- `scode skills` now also lists `~/.agents/skills` and `~/.config/opencode/skills` — previously the Skill tool could resolve them but the listing didn't show them.
- Skills whose frontmatter `name:` differs from their directory name are now invocable by either name through the slash/`$` path too.
- **Breaking**: the `origin` field is dropped from the `scode skills` JSON envelope. It carried no information once every skill is `skills_dir`, and nothing in the repo consumes it — but external scripts reading that field would be affected.

## Tests

Legacy-behavior tests were converted to negative assertions rather than deleted, so the removal stays locked in: `resolves_project_skills_but_not_legacy_commands_markdown`, `skill_rejects_project_local_legacy_command_markdown`, and three more now assert that `commands/*.md` **fails** to resolve or is **not** listed.

`cargo test --workspace`: exit 0, all suites green (655 passed in `commands` alone; 0 failed workspace-wide).

`cargo fmt`: clean.

`cargo clippy --workspace --all-targets -- -D warnings`: fails on pre-existing pedantic lints in the untouched `telemetry` crate under local clippy 1.92.0 — present identically on clean `origin/main`. Every diagnostic in `commands` and `tools` is in code this change did not touch.

## Behavior check

Temp workspace with `.claude/commands/foo.md` (legacy) and `.claude/skills/bar/SKILL.md`, isolated `HOME`, config-home env vars unset, freshly built binary:

```
$ scode skills
Skills
  2 available skills

Project roots:
  bar · Real bar skill

SudoCode plugin roots:
  browser · AI-native browser...
```

`bar` is listed, `foo` no longer appears.

## Suggested follow-up (not in this PR)

Users with `commands/*.md` skills lose them **silently** — discovery simply stops seeing the files. A one-line notice in `scode skills` when a sibling `commands/` directory contains `.md` files would cost one extra dir probe on the list command and self-retires once users migrate. Left out deliberately; invoking an unknown skill already prints `Unknown skill: <name>` plus the available list.
