### PR TITLE
api: add HTTP timeouts, transient-400 retry, and non-SSE error surfacing

### DIFF
--- a/rust/crates/api/src/error.rs
+++ b/rust/crates/api/src/error.rs
@@ -441,7 +441,7 @@ fn looks_like_context_window_error(text: &str) -> bool {
 /// Truncate `body` so the resulting snippet contains at most `max_chars`
 /// characters (counted by Unicode scalar values, not bytes), preserving the
 /// leading slice of the body that the caller most often needs to inspect.
-fn truncate_body_snippet(body: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_body_snippet(body: &str, max_chars: usize) -> String {
     let mut taken_chars = 0;
     let mut byte_end = 0;
     for (offset, character) in body.char_indices() {

--- a/rust/crates/api/src/http_client.rs
+++ b/rust/crates/api/src/http_client.rs
@@ -1,8 +1,86 @@
+use std::time::Duration;
+
 use crate::error::ApiError;
 
 const HTTP_PROXY_KEYS: [&str; 2] = ["HTTP_PROXY", "http_proxy"];
 const HTTPS_PROXY_KEYS: [&str; 2] = ["HTTPS_PROXY", "https_proxy"];
 const NO_PROXY_KEYS: [&str; 2] = ["NO_PROXY", "no_proxy"];
+
+const CONNECT_TIMEOUT_ENV: &str = "SUDOCODE_API_CONNECT_TIMEOUT";
+const READ_TIMEOUT_ENV: &str = "SUDOCODE_API_READ_TIMEOUT";
+
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Timeout configuration for the outbound HTTP client.
+///
+/// Deliberately *not* a whole-request timeout: streaming responses may
+/// legitimately run for many minutes while tokens arrive, so an overall
+/// deadline would kill long answers. Instead we bound the two ways a dead
+/// connection can hang forever: establishing the TCP connection, and
+/// waiting for the next byte to arrive.
+///
+/// A `None` field disables that timeout entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeoutConfig {
+    /// Maximum time to establish a TCP connection. Defaults to 30 seconds.
+    pub connect_timeout: Option<Duration>,
+    /// Maximum time between successive reads from the socket (an idle
+    /// timeout, reset every time a byte arrives — safe for long streaming
+    /// responses). Defaults to 300 seconds, which comfortably exceeds the
+    /// keep-alive ping cadence of streaming providers while still unblocking
+    /// a session stuck on a dead connection.
+    pub read_timeout: Option<Duration>,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
+            read_timeout: Some(DEFAULT_READ_TIMEOUT),
+        }
+    }
+}
+
+impl TimeoutConfig {
+    /// Read timeout settings from the process environment.
+    /// - `SUDOCODE_API_CONNECT_TIMEOUT` — connect timeout in whole seconds
+    /// - `SUDOCODE_API_READ_TIMEOUT` — idle read timeout in whole seconds
+    ///
+    /// A value of `0` disables that timeout. Unset or unparseable values
+    /// fall back to the defaults.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    fn from_lookup<F>(mut lookup: F) -> Self
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let mut parse = |key: &str, default: Duration| -> Option<Duration> {
+            match lookup(key).and_then(|value| value.trim().parse::<u64>().ok()) {
+                Some(0) => None,
+                Some(seconds) => Some(Duration::from_secs(seconds)),
+                None => Some(default),
+            }
+        };
+        Self {
+            connect_timeout: parse(CONNECT_TIMEOUT_ENV, DEFAULT_CONNECT_TIMEOUT),
+            read_timeout: parse(READ_TIMEOUT_ENV, DEFAULT_READ_TIMEOUT),
+        }
+    }
+
+    /// Create from explicit second values. `0` disables that timeout.
+    #[must_use]
+    pub fn from_seconds(connect_secs: u64, read_secs: u64) -> Self {
+        let to_timeout = |seconds: u64| (seconds > 0).then(|| Duration::from_secs(seconds));
+        Self {
+            connect_timeout: to_timeout(connect_secs),
+            read_timeout: to_timeout(read_secs),
+        }
+    }
+}
 
 /// Snapshot of the proxy-related environment variables that influence the
 /// outbound HTTP client. Captured up front so callers can inspect, log, and
@@ -64,24 +142,21 @@ pub fn build_http_client() -> Result<reqwest::Client, ApiError> {
     build_http_client_with(&ProxyConfig::from_env())
 }
 
-/// Infallible counterpart to [`build_http_client`] for constructors that
-/// historically returned `Self` rather than `Result<Self, _>`. When the proxy
-/// configuration is malformed we fall back to a default client so that
-/// callers retain the previous behaviour and the failure surfaces on the
-/// first outbound request instead of at construction time.
-#[must_use]
-pub fn build_http_client_or_default() -> reqwest::Client {
-    build_http_client().unwrap_or_else(|_| reqwest::Client::new())
-}
-
-/// Build a `reqwest::Client` from an explicit [`ProxyConfig`]. Used by tests
-/// and by callers that want to override process-level environment lookups.
-///
-/// When `config.proxy_url` is set it overrides the per-scheme `http_proxy`
-/// and `https_proxy` fields and is registered as both an HTTP and HTTPS
-/// proxy so a single value can route every outbound request.
-pub fn build_http_client_with(config: &ProxyConfig) -> Result<reqwest::Client, ApiError> {
+/// Build a `reqwest::Client` from explicit [`ProxyConfig`] and
+/// [`TimeoutConfig`]. Used by callers (and tests) that need to control both
+/// proxy routing and timeout behaviour.
+pub fn build_http_client_with_opts(
+    config: &ProxyConfig,
+    timeout: &TimeoutConfig,
+) -> Result<reqwest::Client, ApiError> {
     let mut builder = reqwest::Client::builder().no_proxy();
+
+    if let Some(connect_timeout) = timeout.connect_timeout {
+        builder = builder.connect_timeout(connect_timeout);
+    }
+    if let Some(read_timeout) = timeout.read_timeout {
+        builder = builder.read_timeout(read_timeout);
+    }
 
     let no_proxy = config
         .no_proxy
@@ -110,6 +185,32 @@ pub fn build_http_client_with(config: &ProxyConfig) -> Result<reqwest::Client, A
     }
 
     Ok(builder.build()?)
+}
+
+/// Infallible counterpart to [`build_http_client`] for constructors that
+/// historically returned `Self` rather than `Result<Self, _>`. When the proxy
+/// configuration is malformed we fall back to a default client so that
+/// callers retain the previous behaviour and the failure surfaces on the
+/// first outbound request instead of at construction time.
+#[must_use]
+pub fn build_http_client_or_default() -> reqwest::Client {
+    build_http_client().unwrap_or_else(|_| {
+        // Proxy config was malformed — drop the proxy but keep the timeout
+        // protection so a dead connection still cannot hang the session.
+        build_http_client_with_opts(&ProxyConfig::default(), &TimeoutConfig::from_env())
+            .unwrap_or_else(|_| reqwest::Client::new())
+    })
+}
+
+/// Build a `reqwest::Client` from an explicit [`ProxyConfig`]. Used by tests
+/// and by callers that want to override process-level environment lookups.
+/// Timeouts come from the environment ([`TimeoutConfig::from_env`]).
+///
+/// When `config.proxy_url` is set it overrides the per-scheme `http_proxy`
+/// and `https_proxy` fields and is registered as both an HTTP and HTTPS
+/// proxy so a single value can route every outbound request.
+pub fn build_http_client_with(config: &ProxyConfig) -> Result<reqwest::Client, ApiError> {
+    build_http_client_with_opts(config, &TimeoutConfig::from_env())
 }
 
 fn first_non_empty<F>(keys: &[&str], lookup: &mut F) -> Option<String>

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -14,7 +14,8 @@ pub use client::{
 };
 pub use error::ApiError;
 pub use http_client::{
-    build_http_client, build_http_client_or_default, build_http_client_with, ProxyConfig,
+    build_http_client, build_http_client_or_default, build_http_client_with,
+    build_http_client_with_opts, ProxyConfig, TimeoutConfig,
 };
 pub use http_transport::{
     parse_retry_after, request_id_from_headers, HttpRequestResult, HttpTransport, RetryNotifier,

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -954,7 +954,7 @@ async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response
     let retry_after = parse_retry_after(response.headers());
     let body = response.text().await.unwrap_or_else(|_| String::new());
     let parsed_error = serde_json::from_str::<AnthropicErrorEnvelope>(&body).ok();
-    let retryable = is_retryable_status(status);
+    let retryable = is_retryable_status(status) || is_retryable_400(status, &body);
 
     Err(ApiError::Api {
         status,
@@ -974,6 +974,23 @@ async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response
 
 const fn is_retryable_status(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 408 | 409 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// Some gateways and proxies return HTTP 400 with a body like "HTTP 400 from
+/// backend (no parseable body)" when a transient network blip corrupts the
+/// exchange. These are gateway errors wearing a 400 mask, not real bad
+/// requests, so they deserve the same retry treatment as a 502. Genuine
+/// client errors (bad parameter, unknown model, oversized prompt) never
+/// contain these phrases and still fail immediately.
+fn is_retryable_400(status: reqwest::StatusCode, body: &str) -> bool {
+    if status != reqwest::StatusCode::BAD_REQUEST {
+        return false;
+    }
+    let lowered = body.to_ascii_lowercase();
+    lowered.contains("no parseable body")
+        || lowered.contains("connection reset")
+        || lowered.contains("broken pipe")
+        || lowered.contains("empty reply from server")
 }
 
 /// Anthropic API keys (`sk-ant-*`) are accepted over the `x-api-key` header

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -481,6 +481,16 @@ impl MessageStream {
                     }
                 }
                 Ok(None) => {
+                    // Flush any trailing non-SSE body (HTML error page, bare
+                    // JSON error) so it surfaces instead of being dropped.
+                    if let (MessageStreamParser::Chat(parser), MessageStreamState::Chat(state)) =
+                        (&mut self.parser, &mut self.state)
+                    {
+                        for parsed in parser.finish()? {
+                            self.sse_events_read += 1;
+                            self.pending.extend(state.ingest_chunk(parsed)?);
+                        }
+                    }
                     self.done = true;
                 }
                 Err(error) => {
@@ -600,6 +610,26 @@ impl OpenAiSseParser {
         }
 
         Ok(events)
+    }
+
+    /// Flush whatever is left in the buffer once the HTTP stream ends. A
+    /// well-formed SSE stream ends on a frame separator, so leftovers are
+    /// usually a non-SSE body (HTML error page, bare JSON error) that never
+    /// contained a separator — parse it so the error surfaces instead of
+    /// being dropped.
+    fn finish(&mut self) -> Result<Vec<ChatCompletionChunk>, ApiError> {
+        if self.buffer.is_empty() {
+            return Ok(Vec::new());
+        }
+        let trailing = std::mem::take(&mut self.buffer);
+        match parse_sse_frame(
+            &String::from_utf8_lossy(&trailing),
+            &self.provider,
+            &self.model,
+        )? {
+            Some(event) => Ok(vec![event]),
+            None => Ok(Vec::new()),
+        }
     }
 }
 
@@ -2348,8 +2378,13 @@ fn parse_sse_frame(
     }
 
     let mut data_lines = Vec::new();
+    let mut has_event_line = false;
     for line in trimmed.lines() {
         if line.starts_with(':') {
+            continue;
+        }
+        if line.starts_with("event:") {
+            has_event_line = true;
             continue;
         }
         if let Some(data) = line.strip_prefix("data:") {
@@ -2357,6 +2392,15 @@ fn parse_sse_frame(
         }
     }
     if data_lines.is_empty() {
+        // No `data:` lines at all. If the frame is not even SSE-shaped the
+        // server sent something else entirely (an HTML error page from a
+        // proxy, or a bare JSON error body). Surface it instead of silently
+        // dropping it.
+        if !has_event_line {
+            if let Some(error) = crate::sse::detect_non_sse_error(trimmed) {
+                return Err(error);
+            }
+        }
         return Ok(None);
     }
     let payload = data_lines.join("\n");
@@ -2447,7 +2491,7 @@ async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response
     let retry_after = parse_retry_after(response.headers());
     let body = response.text().await.unwrap_or_default();
     let parsed_error = serde_json::from_str::<ErrorEnvelope>(&body).ok();
-    let retryable = is_retryable_status(status);
+    let retryable = is_retryable_status(status) || is_retryable_400(status, &body);
 
     let suggested_action = suggested_action_for_status(status);
 
@@ -2469,6 +2513,23 @@ async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response
 
 const fn is_retryable_status(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 408 | 409 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// Some gateways and proxies return HTTP 400 with a body like "HTTP 400 from
+/// backend (no parseable body)" when a transient network blip corrupts the
+/// exchange. These are gateway errors wearing a 400 mask, not real bad
+/// requests, so they deserve the same retry treatment as a 502. Genuine
+/// client errors (bad parameter, unknown model, oversized prompt) never
+/// contain these phrases and still fail immediately.
+fn is_retryable_400(status: reqwest::StatusCode, body: &str) -> bool {
+    if status != reqwest::StatusCode::BAD_REQUEST {
+        return false;
+    }
+    let lowered = body.to_ascii_lowercase();
+    lowered.contains("no parseable body")
+        || lowered.contains("connection reset")
+        || lowered.contains("broken pipe")
+        || lowered.contains("empty reply from server")
 }
 
 /// Generate a suggested user action based on the HTTP status code and error context.

--- a/rust/crates/api/src/sse.rs
+++ b/rust/crates/api/src/sse.rs
@@ -114,6 +114,16 @@ pub(crate) fn parse_frame_with_provider(
     }
 
     if data_lines.is_empty() {
+        // No `data:` lines at all. If the frame is not even SSE-shaped the
+        // server sent something else entirely (an HTML error page from a
+        // proxy, or a bare JSON error body). Surface it instead of silently
+        // dropping it — otherwise the user sees an empty response with no
+        // hint of what went wrong.
+        if event_name.is_none() {
+            if let Some(error) = detect_non_sse_error(trimmed) {
+                return Err(error);
+            }
+        }
         return Ok(None);
     }
 
@@ -125,6 +135,56 @@ pub(crate) fn parse_frame_with_provider(
     serde_json::from_str::<StreamEvent>(&payload)
         .map(Some)
         .map_err(|error| ApiError::json_deserialize(provider, model, &payload, error))
+}
+
+/// Detect a response body that is not an SSE stream at all: an HTML error
+/// page (misconfigured endpoint, proxy outage page) or a bare JSON error
+/// envelope sent without SSE framing. Returns an error carrying a short body
+/// snippet so the failure is visible to the user; returns `None` for
+/// anything that still looks like benign SSE noise (comments, keep-alives).
+pub(crate) fn detect_non_sse_error(trimmed: &str) -> Option<ApiError> {
+    if trimmed.starts_with('<') {
+        let snippet = crate::error::truncate_body_snippet(trimmed, 200);
+        return Some(ApiError::Api {
+            status: reqwest::StatusCode::BAD_GATEWAY,
+            error_type: Some("invalid_response".to_string()),
+            message: Some(format!(
+                "provider returned HTML instead of an SSE stream (check the endpoint URL): {snippet}"
+            )),
+            request_id: None,
+            body: snippet,
+            retryable: false,
+            suggested_action: Some("verify the API endpoint URL is correct".to_string()),
+            retry_after: None,
+        });
+    }
+
+    let raw = serde_json::from_str::<serde_json::Value>(trimmed).ok()?;
+    let err_obj = raw.get("error")?;
+    let message = err_obj
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("provider returned an error instead of an SSE stream")
+        .to_string();
+    let status = err_obj
+        .get("code")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|code| u16::try_from(code).ok())
+        .and_then(|code| reqwest::StatusCode::from_u16(code).ok())
+        .unwrap_or(reqwest::StatusCode::BAD_GATEWAY);
+    Some(ApiError::Api {
+        status,
+        error_type: err_obj
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        message: Some(message),
+        request_id: None,
+        body: crate::error::truncate_body_snippet(trimmed, 500),
+        retryable: false,
+        suggested_action: None,
+        retry_after: None,
+    })
 }
 
 #[cfg(test)]

--- a/rust/crates/api/tests/reliability_integration.rs
+++ b/rust/crates/api/tests/reliability_integration.rs
@@ -1,0 +1,411 @@
+//! Regression tests for the three API reliability holes:
+//! 1. no connect/read timeout — a dead connection hung the session forever,
+//! 2. transient gateway errors delivered as HTTP 400 were never retried,
+//! 3. non-SSE error responses (HTML pages, bare JSON) were silently dropped.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use api::{
+    AnthropicClient, InputContentBlock, InputMessage, MessageRequest, OpenAiCompatClient,
+    OpenAiCompatConfig, ProxyConfig, SseParser, TimeoutConfig,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Read an entire HTTP request (headers + content-length body) so the client
+/// never sees the connection close mid-write (which would surface as a
+/// transport error and muddy retry counting). Returns the request line.
+async fn read_full_request(sock: &mut TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let request_line = |bytes: &[u8]| {
+            String::from_utf8_lossy(bytes)
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .to_string()
+        };
+        let Ok(n) = sock.read(&mut chunk).await else {
+            return request_line(&buf);
+        };
+        if n == 0 {
+            return request_line(&buf);
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        let Some(header_end) = buf
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+        else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&buf[..header_end]).to_ascii_lowercase();
+        let content_length = headers
+            .lines()
+            .find_map(|line| line.strip_prefix("content-length:"))
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        if buf.len() >= header_end + content_length {
+            return request_line(&buf);
+        }
+    }
+}
+
+fn http_response(status: &str, content_type: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+/// Spawn a server that answers each `POST /v1/messages` with the next queued
+/// response (repeating the last one) and answers every other path (e.g. the
+/// `count_tokens` preflight) with 404. Returns the bound address and a counter
+/// of `/v1/messages` hits.
+async fn spawn_scripted_server(responses: Vec<String>) -> (std::net::SocketAddr, Arc<AtomicUsize>) {
+    spawn_scripted_server_for_path("POST /v1/messages ", responses).await
+}
+
+/// Like [`spawn_scripted_server`] but counting hits on an arbitrary
+/// request-line prefix (e.g. the OpenAI-compat `POST /chat/completions `).
+async fn spawn_scripted_server_for_path(
+    request_line_prefix: &'static str,
+    responses: Vec<String>,
+) -> (std::net::SocketAddr, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server_hits = hits.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let hits = server_hits.clone();
+            let responses = responses.clone();
+            tokio::spawn(async move {
+                let request_line = read_full_request(&mut sock).await;
+                let response = if request_line.starts_with(request_line_prefix) {
+                    let hit = hits.fetch_add(1, Ordering::SeqCst);
+                    responses[hit.min(responses.len() - 1)].clone()
+                } else {
+                    http_response("404 Not Found", "text/plain", "not found")
+                };
+                let _ = sock.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    (addr, hits)
+}
+
+fn sample_request() -> MessageRequest {
+    MessageRequest {
+        model: "claude-sonnet-4-6".to_string(),
+        max_tokens: 16,
+        messages: vec![InputMessage {
+            role: "user".to_string(),
+            content: vec![InputContentBlock::Text {
+                text: "hi".to_string(),
+            }],
+        }],
+        ..Default::default()
+    }
+}
+
+/// Fix 1: with a read timeout configured, a request to a server that accepts
+/// the TCP connection but never responds fails with a timeout error instead
+/// of hanging the session forever.
+#[tokio::test]
+async fn read_timeout_unblocks_request_to_silent_server() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((sock, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let _hold = sock;
+                std::future::pending::<()>().await;
+            });
+        }
+    });
+
+    let client = api::build_http_client_with_opts(
+        &ProxyConfig::default(),
+        &TimeoutConfig::from_seconds(5, 1),
+    )
+    .expect("client builds");
+    let pending = client
+        .post(format!("http://{addr}/v1/messages"))
+        .json(&serde_json::json!({"model": "m", "max_tokens": 1}))
+        .send();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), pending)
+        .await
+        .expect("request must fail fast instead of hanging");
+    let error = result.expect_err("silent server must produce an error");
+    assert!(
+        error.is_timeout(),
+        "error should be a timeout, got: {error:?}"
+    );
+}
+
+/// Fix 2: HTTP 400 carrying a transient gateway body is retried and can
+/// recover on the next attempt.
+#[tokio::test]
+async fn transient_gateway_400_is_retried_until_success() {
+    let (addr, hits) = spawn_scripted_server(vec![
+        http_response(
+            "400 Bad Request",
+            "text/plain",
+            "HTTP 400 from backend (no parseable body)",
+        ),
+        http_response(
+            "200 OK",
+            "application/json",
+            "{\"id\":\"msg_recovered\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Recovered\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}",
+        ),
+    ])
+    .await;
+
+    let client = AnthropicClient::new("test-key")
+        .with_base_url(format!("http://{addr}"))
+        .with_retry_policy(2, Duration::from_millis(1), Duration::from_millis(2));
+
+    let response = client
+        .send_message(&sample_request(), None)
+        .await
+        .expect("transient gateway 400 should be retried into success");
+    assert_eq!(response.id, "msg_recovered");
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "one failed attempt plus one successful retry"
+    );
+}
+
+/// Fix 2 guard: a genuine client-error 400 (bad request, unknown model,
+/// oversized prompt) is still not retried.
+#[tokio::test]
+async fn genuine_client_error_400_is_not_retried() {
+    let (addr, hits) = spawn_scripted_server(vec![http_response(
+        "400 Bad Request",
+        "application/json",
+        "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"model: field required\"}}",
+    )])
+    .await;
+
+    let client = AnthropicClient::new("test-key")
+        .with_base_url(format!("http://{addr}"))
+        .with_retry_policy(2, Duration::from_millis(1), Duration::from_millis(2));
+
+    let error = client
+        .send_message(&sample_request(), None)
+        .await
+        .expect_err("genuine 400 should fail");
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "client errors get exactly one attempt"
+    );
+    assert!(!error.is_retryable());
+    assert!(error.to_string().contains("model: field required"));
+}
+
+/// Fix 1 config surface: explicit seconds, zero-disables, and env parsing
+/// (zero disables, garbage falls back to the defaults).
+#[test]
+fn timeout_config_resolves_seconds_zero_and_env() {
+    let config = TimeoutConfig::from_seconds(10, 0);
+    assert_eq!(config.connect_timeout, Some(Duration::from_secs(10)));
+    assert_eq!(config.read_timeout, None);
+
+    let default = TimeoutConfig::default();
+    assert_eq!(default.connect_timeout, Some(Duration::from_secs(30)));
+    assert_eq!(default.read_timeout, Some(Duration::from_secs(300)));
+
+    // Env parsing: explicit value, zero-disables, garbage falls back.
+    // Serialized against other env-touching tests via the process env itself
+    // (this is the only test in this binary touching these variables).
+    std::env::set_var("SUDOCODE_API_CONNECT_TIMEOUT", "5");
+    std::env::set_var("SUDOCODE_API_READ_TIMEOUT", "0");
+    let config = TimeoutConfig::from_env();
+    assert_eq!(config.connect_timeout, Some(Duration::from_secs(5)));
+    assert_eq!(config.read_timeout, None);
+
+    std::env::set_var("SUDOCODE_API_CONNECT_TIMEOUT", "soon");
+    std::env::remove_var("SUDOCODE_API_READ_TIMEOUT");
+    let config = TimeoutConfig::from_env();
+    assert_eq!(config, TimeoutConfig::default());
+
+    std::env::remove_var("SUDOCODE_API_CONNECT_TIMEOUT");
+}
+
+/// Fix 2 (OpenAI-compat path): the same transient gateway 400 is retried.
+#[tokio::test]
+async fn openai_transient_gateway_400_is_retried_until_success() {
+    let (addr, _hits) = spawn_scripted_server_for_path(
+        "POST /chat/completions ",
+        vec![
+            http_response(
+                "400 Bad Request",
+                "text/plain",
+                "HTTP 400 from backend (no parseable body)",
+            ),
+            http_response(
+                "200 OK",
+                "application/json",
+                "{\"id\":\"chatcmpl_ok\",\"model\":\"grok-3\",\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"Recovered\",\"tool_calls\":[]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":2}}",
+            ),
+        ],
+    )
+    .await;
+
+    let client = OpenAiCompatClient::new("xai-test-key", OpenAiCompatConfig::xai())
+        .with_base_url(format!("http://{addr}"))
+        .with_retry_policy(2, Duration::from_millis(1), Duration::from_millis(2));
+
+    let mut request = sample_request();
+    request.model = "grok-3".to_string();
+    let response = client
+        .send_message(&request, None)
+        .await
+        .expect("transient gateway 400 should be retried into success");
+    assert_eq!(response.total_tokens(), 5);
+}
+
+/// Fix 3 (OpenAI-compat path): a 200 response carrying an HTML body instead
+/// of an SSE stream surfaces an error — including when the body has no SSE
+/// frame separator at all (exercises the end-of-stream parser flush).
+#[tokio::test]
+async fn openai_streaming_html_response_surfaces_error() {
+    let (addr, _hits) = spawn_scripted_server_for_path(
+        "POST /chat/completions ",
+        vec![http_response(
+            "200 OK",
+            "text/html",
+            "<html><head><title>504 Gateway Time-out</title></head><body>nginx</body></html>",
+        )],
+    )
+    .await;
+
+    let client = OpenAiCompatClient::new("xai-test-key", OpenAiCompatConfig::xai())
+        .with_base_url(format!("http://{addr}"));
+
+    let mut request = sample_request();
+    request.model = "grok-3".to_string();
+    request.stream = true;
+    let mut stream = client
+        .stream_message(&request, None)
+        .await
+        .expect("HTTP handshake succeeds; the body is the problem");
+
+    let error = loop {
+        match stream.next_event().await {
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("stream ended silently; the HTML error was swallowed"),
+            Err(error) => break error,
+        }
+    };
+    assert!(
+        error.to_string().contains("504 Gateway Time-out"),
+        "error should carry the HTML snippet: {error}"
+    );
+}
+
+/// Fix 3 parser-level behavior through the public `SseParser` API: HTML and
+/// bare JSON error bodies surface errors (mid-stream and at finish), while
+/// benign SSE noise stays ignored.
+#[test]
+fn sse_parser_surfaces_non_sse_bodies_and_ignores_benign_frames() {
+    // HTML with a frame separator errors mid-stream.
+    let mut parser = SseParser::new().with_context("Anthropic", "claude-sonnet-4-6");
+    let error = parser
+        .push(b"<html><head><title>502 Bad Gateway</title></head>\n\n<body>nginx</body></html>")
+        .expect_err("HTML body must surface an error");
+    assert!(
+        error.to_string().contains("502 Bad Gateway"),
+        "error should carry the HTML snippet: {error}"
+    );
+    assert!(!error.is_retryable());
+
+    // HTML without any separator errors on finish.
+    let mut parser = SseParser::new().with_context("Anthropic", "claude-sonnet-4-6");
+    assert!(parser
+        .push(b"<!DOCTYPE html><html><body>504 Gateway Time-out</body></html>")
+        .expect("no full frame yet")
+        .is_empty());
+    let error = parser
+        .finish()
+        .expect_err("trailing HTML must surface an error");
+    assert!(error.to_string().contains("504 Gateway Time-out"));
+
+    // A bare JSON error envelope surfaces its type and message.
+    let mut parser = SseParser::new().with_context("Anthropic", "claude-sonnet-4-6");
+    assert!(parser
+        .push(br#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#)
+        .expect("no full frame yet")
+        .is_empty());
+    let error = parser
+        .finish()
+        .expect_err("bare JSON error must surface an error");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("overloaded_error") && rendered.contains("Overloaded"),
+        "error should carry type and message: {rendered}"
+    );
+
+    // Benign inputs keep their previous behavior: no events, no errors.
+    let mut parser = SseParser::new();
+    assert!(parser
+        .push(b": keepalive\n\nevent: ping\ndata: {\"type\":\"ping\"}\n\ndata: [DONE]\n\n")
+        .expect("benign frames parse")
+        .is_empty());
+    assert!(parser
+        .push(b"{\"type\":\"message\"}")
+        .expect("JSON without an error member is not an error")
+        .is_empty());
+    assert!(parser
+        .finish()
+        .expect("JSON without an error member is not an error")
+        .is_empty());
+}
+
+/// Fix 3: a 200 response whose body is an HTML error page (instead of an SSE
+/// stream) surfaces an error carrying a body snippet, rather than ending the
+/// stream silently with no events.
+#[tokio::test]
+async fn streaming_html_response_surfaces_error() {
+    let (addr, _hits) = spawn_scripted_server(vec![http_response(
+        "200 OK",
+        "text/html",
+        "<html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>",
+    )])
+    .await;
+
+    let client = AnthropicClient::new("test-key").with_base_url(format!("http://{addr}"));
+
+    let mut request = sample_request();
+    request.stream = true;
+    let mut stream = client
+        .stream_message(&request, None)
+        .await
+        .expect("HTTP handshake succeeds; the body is the problem");
+
+    let error = loop {
+        match stream.next_event().await {
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("stream ended silently; the HTML error was swallowed"),
+            Err(error) => break error,
+        }
+    };
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("502 Bad Gateway"),
+        "error should carry the HTML snippet: {rendered}"
+    );
+}


### PR DESCRIPTION
Fixes three reliability holes in the API layer (full analysis, upstream comparison, and verification log in `CHANGES.md`).

## Problems (all verified against `origin/main` with minimal repros)

1. **No timeouts anywhere** — a TCP connection that dies mid-request hangs the session forever: no error, no timeout, only Ctrl-C. Repro: request to a silent-accept port still pending after 5s.
2. **Transient gateway 400s never retried** — proxies sometimes return HTTP 400 with bodies like `no parseable body` / `connection reset` during network blips; these hard-failed on the first attempt.
3. **Non-SSE error responses silently dropped** — a 2xx response carrying an HTML error page or a bare JSON error (instead of an SSE stream) produced an empty stream with no diagnostics. The OpenAI chat stream also never flushed its parser buffer at end-of-stream, so separator-less bodies were always lost.

## Fixes

1. `TimeoutConfig` in `http_client.rs`: connect timeout (default 30s) + **idle read timeout** (default 300s, reset per received byte — deliberately *not* an overall deadline, so long streaming answers are never killed). Configurable via `SUDOCODE_API_CONNECT_TIMEOUT` / `SUDOCODE_API_READ_TIMEOUT` (seconds, `0` disables). All providers inherit through `HttpTransport`; timeout errors are retryable so the existing retry loop takes over.
2. `is_retryable_400` wired into both `expect_success` paths (Anthropic + OpenAI-compat). Phrase list follows upstream claw-code `414a1ac` — where the equivalent function was defined but **never called**; here it is actually part of the retry decision. Genuine client errors (bad parameter, unknown model, oversized prompt) still fail immediately.
3. `sse::detect_non_sse_error` shared by both SSE parsers: HTML → 502 with a truncated body snippet (the `<title>` usually names the real error); bare JSON error envelopes surface their `type`/`message`/`code`. `OpenAiSseParser::finish()` flushes trailing bytes at stream end. Benign frames (comments, pings, `[DONE]`, data-less events) unchanged. No credentials and no full bodies in errors or logs.

## Tests

Per the test policy (no unit tests), everything lives in `crates/api/tests/reliability_integration.rs` — 8 tests against real TCP fake servers: silent-accept for the timeout, scripted 400→200 for exact retry counts on both provider paths, `text/html` responses for error surfacing (including the end-of-stream flush), and public `SseParser` behavior incl. benign-frame regressions.

## Verification

- `cargo fmt` clean; `cargo test --workspace`: 105 suites, 1601 passed, 0 failed.
- `clippy --workspace --all-targets -- -D warnings` already fails on `main` (pre-existing `telemetry` lints). Fresh-target-dir before/after comparison shows **no new warnings introduced** (details in `CHANGES.md`).
- E2E with the real binary: live query via sudorouter (`claude-sonnet-4-6`) unchanged; fake-endpoint runs show the timeout firing after 2s into the retry loop (previously an infinite hang) and a 400→400→200 sequence recovering after exactly 3 attempts with backoff.

Known limitations (see `CHANGES.md` §六/§七): OpenAI Responses-format stream keeps its old behavior; Gemini/Codex get timeouts but not the 400 phrase check (matches upstream scope); timeout config is env-only for now (`settings.json` plumbing would leave `crates/api/`); PTY-layer coverage deferred for the same reason.

---

## 更新（2026-08-17）

- **移除了 `CHANGES.md`**：per-change 的记录归 PR 描述，仓库里不该出现被每个分支轮流覆盖的报告文件（#418 也这么处理的）。完整分析已并入下方折叠块。
- **rebase 到最新 main，零代码冲突**（原先的 CONFLICTING 只来自 `CHANGES.md` 的 add/add）。现在 7 个文件 `+672/-21`。
- `cargo test --workspace`：**1653 passed / 0 failed**；`crates/api` 的 8 个可靠性测试全绿。

### 独立复现：问题在今天的 main 上确实存在

不依赖本 PR 的测试文件，直接在 main 上构造「接受连接但永不回数据」的服务器：
```
main（无修复）
  HANG CONFIRMED: 8 秒内既没返回也没超时 (elapsed 8.001120167s)
  test result: FAILED

本分支（SUDOCODE_API_READ_TIMEOUT=3）
  客户端在 3.00274175s 后返回: Err(reqwest::Error { kind: Request, source: TimedOut })
  test result: ok
```

main 上 `build_http_client_with` 是 `reqwest::Client::builder().no_proxy()`，整个 api crate 搜不到任何 timeout 配置 —— reqwest 默认无超时，所以半开连接会一直挂着。

> 补充一点边界：这**不是**不可恢复的死锁。`conversation.rs` 把模型流和 abort 信号 `select!` 起来了，前端点「停止」会丢弃流并关闭连接。所以本 PR 的价值是**把「用户干等到自己放弃」变成「自动重试、多半无感恢复」**，而不是「防止永久卡死」。

<details>
<summary><b>完整分析</b>（原 CHANGES.md）</summary>

# API 层可靠性修复（fix/api-reliability）

任务：修复 API 层的三个可靠性洞（见 `api-reliability.md`）。改动全部限定在
`rust/crates/api/` 内。

## 一、复核结果（对照 origin/main，三条全部成立）

复核方式：代码检查 + 临时复现测试（`repro_pre_fix.rs`，在未修改代码上运行后删除，
断言反转后固化为 `tests/reliability_integration.rs`）。

| # | 声称 | 结论 | 证据 |
|---|---|---|---|
| 1 | reqwest 完全没有超时 | **成立** | `http_client.rs` / 整个 api crate 无任何 `.timeout` / `.connect_timeout` / `.read_timeout` 调用；复现测试 `repro_1_request_to_silent_server_never_times_out`：对 accept 后不响应的本地端口发请求，5 秒后仍在挂起（`ok`） |
| 2 | 瞬态 400 不重试 | **成立** | 两个 provider 的 `expect_success` 里 `retryable = is_retryable_status(status)`，400 不在 `408\|409\|429\|500\|502\|503\|504` 内，也无按 body 判定的例外；复现测试 `repro_2_transient_gateway_400_is_not_retried`：400 + "no parseable body" body 恰好 1 次尝试、错误分类为不可重试（`ok`） |
| 3 | 非 SSE 错误响应被静默丢弃 | **成立（部分场景）** | `sse.rs::parse_frame_with_provider` 与 `openai_compat.rs::parse_sse_frame` 在没有 `data:` 行时一律 `Ok(None)`：2xx + HTML 错误页 / 裸 JSON 错误体 → 事件为空、无错误，用户只看到空回复；复现测试 `repro_3a`（HTML）与 `repro_3b`（裸 JSON）均确认吞掉（`ok`）。另发现 OpenAI chat 流在流结束时**不 flush parser 缓冲区**（`Ok(None)` 分支只调 `state.finish()`），没有帧分隔符的整段错误体永远留在缓冲区里被丢弃 |

复现测试在未修改代码上的运行输出：

```
running 4 tests
test repro_3b_bare_json_error_body_is_silently_swallowed ... ok
test repro_3a_html_error_page_is_silently_swallowed ... ok
test repro_2_transient_gateway_400_is_not_retried ... ok
test repro_1_request_to_silent_server_never_times_out ... ok
test result: ok. 4 passed; 0 failed; ... finished in 5.01s
```

已披露的注意点：sudocode 的非 2xx 路径本来就会通过 `expect_success` 带 body 报错，
问题 3 实际发生在 **2xx + 非 SSE body**（代理返回 200 的 HTML 错误页、裸 JSON）
的场景；`openai_compat` 对 `data:` 帧内嵌 JSON error 已有处理，缺的是不带 SSE
框架的整段 body。

## 二、"接近可直接 cherry-pick" 的判断是否成立

**不成立，且上游实现有一处实质缺陷。**

- sudocode 的 API 层与上游已明显分叉：sudocode 已有统一的 `HttpTransport`
  重试循环、`RetryPolicy`、`Retry-After` 解析（上游 `04bc5f5` 的很大一部分在
  sudocode 已经存在），直接 cherry-pick 会大面积冲突。
- **上游 `414a1ac` / `04bc5f5` 的 `is_retryable_400` 定义了但从未被调用**（两个
  provider 里 `expect_success` 仍然只用 `is_retryable_status`，grep 上游两个提交
  的完整文件只有函数定义、没有调用点）——上游的瞬态 400 重试实际是死代码，
  没有生效。本仓库采用了上游的判定短语列表，但把它真正接进了
  `retryable` 的计算。
- 上游 `04bc5f5` 的超时用的是 reqwest 的**整体 `.timeout(300s)`**。reqwest 的
  total timeout 覆盖到响应 body 读取（包括流式 chunk），超过 5 分钟的长流式
  回答会被误杀——这正是任务要求避免的做法（上游代码注释声称"仅握手"，与
  reqwest 语义不符）。本仓库改用 `connect_timeout` + `read_timeout`（空闲
  读超时，每收到一个字节就重置），不设整体超时。

因此三项均按 sudocode 架构重写，仅复用上游的**取值**（30s/300s）与**短语列表**。

## 三、修复内容

### 修复 1：超时（`http_client.rs`，所有 provider 生效）

- 新增 `TimeoutConfig { connect_timeout, read_timeout }`（`Option<Duration>`，
  `None` 表示禁用）与 `build_http_client_with_opts(proxy, timeout)`。
- 默认值：**connect 30s，read（空闲）300s**。取值依据：上游 `04bc5f5` 用
  connect 30s / request 300s；300s 在这里语义更保守——它是"两次收到字节之间"
  的上限而非总时长，流式响应期间 Anthropic 有周期性 ping 帧，正常流的字节
  间隔是秒级，300s 只有在连接真正死掉时才触发，不会误杀长回答。
- 可配置：环境变量 `SUDOCODE_API_CONNECT_TIMEOUT` / `SUDOCODE_API_READ_TIMEOUT`
  （整秒；`0` 禁用；非法值回退默认）。所有 provider（Anthropic / OpenAI-compat /
  Gemini / Codex）都经 `HttpTransport::new()` → `build_http_client_or_default()`
  构造客户端，自动继承；OAuth 刷新走同一 client，同样覆盖。
- 超时错误是 `reqwest` timeout 错误 → `ApiError::Http` → `is_retryable() == true`，
  请求级重试循环会自动重试，行为闭环。
- 未接 settings.json（上游把 `ApiTimeoutConfig` 放在 runtime config）：为遵守
  "只碰 `rust/crates/api/`" 的约束，配置面先用环境变量；见"没修的部分"。

### 修复 2：瞬态 400 重试（`providers/anthropic.rs`、`providers/openai_compat.rs`）

- 新增 `is_retryable_400(status, body)`：仅当 status==400 且 body（小写化后）
  含以下网关短语之一才判定可重试：`no parseable body` / `connection reset` /
  `broken pipe` / `empty reply from server`（短语列表照抄上游）。
- 接入点：`expect_success` 里
  `retryable = is_retryable_status(status) || is_retryable_400(status, &body)`
  （这是上游漏掉的一步）。
- 真正的客户端错误（参数错、模型名错、prompt 超长）不含这些短语，仍然一次
  失败直接报错；上下文超窗的 400 也不受影响（marker 列表无交集）。

### 修复 3：非 SSE 错误响应透出（`sse.rs`、`providers/openai_compat.rs`）

- 新增 `sse::detect_non_sse_error`（两条解析路径共用）：帧内没有任何 `data:`
  行且不是 SSE 形状（无 `event:` 行）时——
  - body 以 `<` 开头 → 判定 HTML，报 `ApiError::Api`（status 502、
    `invalid_response`），message 内嵌 body 前 200 字符摘要（HTML 错误页的
    `<title>` 通常就是真实错误，如 "502 Bad Gateway"）；
  - body 可解析为带 `error` 对象的 JSON → 透出其 `type` / `message` /
    `code`（code 映射为 HTTP status，缺省 502）。
  - 注释行（`: keepalive`）、`event: ping`、`data: [DONE]`、不含 `error` 的
    JSON 等良性输入行为不变（有测试锁定）。
- OpenAI chat 流补上 `OpenAiSseParser::finish()`：HTTP 流结束时 flush 剩余
  缓冲区走同一解析，无帧分隔符的整段 HTML/裸 JSON 错误体不再被丢弃
  （Anthropic 路径的 `SseParser::finish()` 原本就会被调用，自动获得新检测）。
- 凭据安全：错误里只携带**响应** body 的截断摘要（200/500 字符，
  `truncate_body_snippet` 按字符安全截断），不含请求头/凭据；日志路径复用
  既有的 `mask_sensitive_headers`，未新增任何打印完整 body 的日志。

## 四、测试清单

按 `CONTRIBUTING.md` 的测试分层规则（**禁止单元测试**；集成层为可选的
调试加速层），所有新测试都放在集成层
`rust/crates/api/tests/reliability_integration.rs`（真实 TCP 假服务器 +
公共 API），共 8 个：

- `read_timeout_unblocks_request_to_silent_server` — accept 后不响应的端口，
  1s read timeout，请求快速失败且 `error.is_timeout()`（修复前：临时复现
  测试证明 5s 后仍挂起）
- `timeout_config_resolves_seconds_zero_and_env` — 默认值 30s/300s、
  `from_seconds`、env 解析（`0` 禁用、非法值回退默认）
- `transient_gateway_400_is_retried_until_success` — Anthropic 路径：假端点
  脚本化返回 400(网关 body) → 200，断言恰好 2 次 `/v1/messages` 请求且
  最终成功
- `genuine_client_error_400_is_not_retried` — 真 400 恰好 1 次请求、不可
  重试、错误信息透出
- `openai_transient_gateway_400_is_retried_until_success` — OpenAI-compat
  路径同上（覆盖第二个 `is_retryable_400` 接入点）
- `streaming_html_response_surfaces_error` — Anthropic 流式：200 + text/html，
  `next_event` 报错且携带 "502 Bad Gateway" 摘要（修复前是静默空流）
- `openai_streaming_html_response_surfaces_error` — OpenAI-compat 流式：
  200 + 无帧分隔符的 HTML body，报错携带摘要（同时覆盖流结束时的
  parser flush 新路径）
- `sse_parser_surfaces_non_sse_bodies_and_ignores_benign_frames` — 公共
  `SseParser` API：HTML（帧内/finish 时）、裸 JSON error envelope 均报错；
  注释行、ping、`[DONE]`、不含 `error` 的 JSON 行为不变

## 五、验证命令输出

### cargo fmt / clippy / test

- `cargo fmt`：已跑，无 diff 残留。
- `cargo clippy --workspace --all-targets -- -D warnings`：在 origin/main 上就
  因 `telemetry` crate 的既有 lint 无法通过（`-D` 会传染到 workspace 内的
  path 依赖，`-p api` 也一样挂在 telemetry 上），与任务描述一致。
- **stash 前后对比**（因另一无关 stash 存在，实际用"备份 + `git checkout` +
  恢复"实现同等对比；两次均在全新 target dir 全量跑
  `cargo clippy --workspace --all-targets`，按 warning 文本聚合计数后 diff）：

  修改前 188 类 warning、修改后 189 类。逐行 diff 后真正的差异只有两处，
  且都出自本次新增文件：`item in documentation is missing backticks` 295→296
  （新测试文件的一条 doc 注释）和 `api (test "reliability_integration")
  generated 1 warning`——已修复（补反引号），复查
  `cargo clippy -p api --all-targets` 中 `reliability_integration.rs` 相关
  warning 计数为 0。其余 diff 行全部是 cargo 对既有 warning 的
  "(N duplicates)" 归属随编译顺序漂移，warning 本体与总量不变。
  **结论：未引入任何新 clippy warning。**

- `cargo test --workspace`（最终状态）：

```
105 个测试套件，1601 passed，0 failed（exit 0）
```

（首轮为 1615 passed；随后依 `CONTRIBUTING.md` "禁止单元测试" 的规则把
18 个新加的单元测试移除、其覆盖迁入集成层 4 个新测试：1615 − 18 + 4 = 1601，
数字自洽。）

### 端到端

真实 query（凭据 `~/.nexus/sudocode/sudocode.json`，模型 `claude-sonnet-4-6`，
`--print` 模式）：

```
$ ./rust/target/debug/scode --print --model claude-sonnet-4-6 \
    "Reply with exactly: E2E-OK sudocode reliability check"
⏺ E2E-OK sudocode reliability check

[claude-sonnet-4-6] · turn 1 · 15.1k tokens · $0.23 · 5.5s · ctx 15.1k/200k (8%) · fix/api-reliability
```

（经用户 sudorouter proxy 的 openai-completions 路径，未见异常。）

假端点验证超时真的生效（accept 后不响应的本地端口 + 1s read timeout）：

方法：临时 `SUDO_CODE_CONFIG_HOME` 指向仅含本地假 provider 的配置，假服务器
accept 后永不响应；`SUDOCODE_API_READ_TIMEOUT=2 SUDOCODE_API_CONNECT_TIMEOUT=2`：

```
  ⟳ retry 1/8 in 2s — http error: error sending request for url (http://127.0.0.1:39182/v1/messages)
  ⟳ retry 2/8 in 2s — http error: error sending request for url (http://127.0.0.1:39182/v1/messages)
  ⟳ retry 3/8 in 7s — http error: error sending request for url (http://127.0.0.1:39182/v1/messages)
```

每次尝试约 2s 即被 read timeout 切断并进入既有重试循环（修复前同场景：复现
测试证明 5s 后仍无限挂起、无任何输出，只能 Ctrl-C）。

假端点验证瞬态 400 重试真的生效（脚本化 400→400→200）：

方法：同上配置，假服务器脚本化——前两次 `POST /v1/messages` 返回
`400 + "HTTP 400 from backend (no parseable body)"`，第三次返回正常 SSE 流：

```
$ SUDO_CODE_CONFIG_HOME=… scode --print --model claude-sonnet-4-6 "hi"
  ⟳ retry 1/8 in 1s — 400 Bad Request: unknown error
  ⟳ retry 2/8 in 3s — 400 Bad Request: unknown error
⏺ RECOVERED-AFTER-RETRIES

[claude-sonnet-4-6] · turn 1 · 9 tokens · $0.00 · 4.7s · …

服务器日志（恰好 3 次尝试 + 指数退避）：
hit 1: responding 400 transient gateway body
hit 2: responding 400 transient gateway body
hit 3: responding 200 SSE stream
```

三种模式（`--print` / 交互 / ACP）共用同一条 `HttpTransport` → provider 路径，
本次改动全部位于该路径之下且未改任何调用方签名的语义（`build_http_client_with`
保持原签名，新超时经 `from_env` 注入）；`--print` 已实测，交互/ACP 由
workspace 测试（含 ACP/PTY 集成测试）覆盖回归。

## 六、没修的部分

1. **OpenAI Responses 格式流**（`ResponsesSseParser`）：流结束时同样不 flush
   缓冲区、也没有 HTML/裸 JSON 检测。该路径仅在 `api_format = openai-responses`
   时使用，帧结构不同，改动收益/风险比低，本次未动。
2. **Gemini / Codex provider 的瞬态 400 检测**：与上游同口径（上游也只改
   anthropic + openai_compat）。超时保护两者已覆盖（共用 `HttpTransport`）。
3. **settings.json 的 `apiTimeout` 配置面**：上游放在 runtime config；为守住
   "只碰 `rust/crates/api/`" 约束，本次只提供环境变量。后续要接 settings.json
   时，`TimeoutConfig` 已经是现成的注入点（`build_http_client_with_opts`）。
4. **PTY 层测试**：`CONTRIBUTING.md` 要求用户可见特性配 PTY 测试，但 PTY
   测试位于 `crates/rusty-sudocode-cli/tests/`，超出本任务"只碰
   `rust/crates/api/`"的约束；已用 CLI 级 e2e（假端点 + 真实二进制）人工
   验证同等场景，PTY 固化留给后续。
5. **上游 `ed91a61e`（把 "no parseable body" 加进 context-window markers）**：
   刻意不采纳。它与瞬态 400 重试互相矛盾（同一个 body 既当"请求超大"又当
   "网关抖动"）；本仓库选择重试语义，重试耗尽后错误仍完整透出。

## 七、残留风险

- **短语列表是启发式**：网关若返回其他措辞的瞬态 400（或反之，真错误里恰好
  包含这些短语），会漏重试/误重试。误重试的代价有上限（重试次数封顶，最终
  错误仍透出）。
- **300s 空闲超时对"极慢但活着"的连接**：若服务端超过 300s 一个字节都不发
  （且无 ping），请求会被判超时。可用 `SUDOCODE_API_READ_TIMEOUT` 调大或
  `=0` 禁用。
- **HTML 检测以 `<` 开头为准**：前面带 BOM/空白的 HTML 已被 `trim` 覆盖，
  但极端畸形响应（如以注释外文本开头的非 HTML 垃圾）仍会走原来的
  "静默忽略"分支——不会比修复前更差。
- **`is_retryable_400` 在流式路径**：mid-stream 的错误不经过请求级重试循环
  （与修复前一致），瞬态 400 重试只作用于请求发起阶段（这也是该 bug 的
  实际发生点）。
- 用户侧 sudorouter proxy 会往请求里加自有 envelope：本次改动只影响超时/
  重试/错误透出，不改请求构造；e2e 若经 proxy 出现内容异常，需按任务提示
  先区分是 proxy 还是 sudocode（本次验证未观察到相关异常）。

</details>
