### PR TITLE
feat(cli): spinner frame scrollback fix + SSOT endpoint routing + config UI

### DIFF
--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -176,6 +176,15 @@ impl ProviderClient {
         }
     }
 
+    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+        match self {
+            Self::Anthropic(client) => client.set_retry_notifier(notifier),
+            Self::Xai(client) | Self::OpenAi(client) => client.set_retry_notifier(notifier),
+            Self::Codex(client) => client.set_retry_notifier(notifier),
+            Self::Gemini(client) => client.set_retry_notifier(notifier),
+        }
+    }
+
     #[must_use]
     pub fn with_prompt_cache(self, prompt_cache: PromptCache) -> Self {
         match self {

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -176,7 +176,10 @@ impl ProviderClient {
         }
     }
 
-    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+    pub fn set_retry_notifier(
+        &mut self,
+        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+    ) {
         match self {
             Self::Anthropic(client) => client.set_retry_notifier(notifier),
             Self::Xai(client) | Self::OpenAi(client) => client.set_retry_notifier(notifier),

--- a/rust/crates/api/src/http_transport.rs
+++ b/rust/crates/api/src/http_transport.rs
@@ -14,6 +14,24 @@ use telemetry::{AnalyticsEvent, SessionTracer};
 use crate::error::ApiError;
 use crate::http_client::build_http_client_or_default;
 
+/// Callback interface for surfacing HTTP retry attempts to the UI layer.
+/// Implementors bridge the transport retry loop to spinners, progress bars,
+/// or other visual indicators.
+pub trait RetryNotifier: Send + Sync {
+    fn on_retry(&self, attempt: u32, max_retries: u32, reason: &str);
+    fn on_retry_end(&self);
+}
+
+/// Default notifier that writes to stderr (matches legacy behavior).
+pub struct StderrRetryNotifier;
+
+impl RetryNotifier for StderrRetryNotifier {
+    fn on_retry(&self, attempt: u32, max_retries: u32, reason: &str) {
+        eprintln!("  \u{27f3} retry {attempt}/{max_retries} — {reason}");
+    }
+    fn on_retry_end(&self) {}
+}
+
 const REQUEST_ID_HEADER: &str = "request-id";
 const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
 const ONEAPI_REQUEST_ID_HEADER: &str = "x-oneapi-request-id";
@@ -89,10 +107,21 @@ impl RetryPolicy {
 // HttpTransport
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HttpTransport {
     inner: reqwest::Client,
     session_tracer: Option<SessionTracer>,
+    retry_notifier: Option<std::sync::Arc<dyn RetryNotifier>>,
+}
+
+impl std::fmt::Debug for HttpTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpTransport")
+            .field("inner", &self.inner)
+            .field("session_tracer", &self.session_tracer)
+            .field("retry_notifier", &self.retry_notifier.is_some())
+            .finish()
+    }
 }
 
 impl Default for HttpTransport {
@@ -107,7 +136,12 @@ impl HttpTransport {
         Self {
             inner: build_http_client_or_default(),
             session_tracer: None,
+            retry_notifier: None,
         }
+    }
+
+    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn RetryNotifier>) {
+        self.retry_notifier = Some(notifier);
     }
 
     #[must_use]
@@ -318,15 +352,22 @@ impl HttpTransport {
                     }
                     other => format!("{other}"),
                 };
-                eprintln!(
-                    "  ⟳ retry {}/{} in {:.0}s — {}",
-                    attempts,
-                    retry_policy.max_retries,
-                    delay.as_secs_f64(),
-                    reason,
-                );
+                if let Some(ref notifier) = self.retry_notifier {
+                    notifier.on_retry(attempts, retry_policy.max_retries, &reason);
+                } else {
+                    eprintln!(
+                        "  \u{27f3} retry {}/{} in {:.0}s \u{2014} {}",
+                        attempts,
+                        retry_policy.max_retries,
+                        delay.as_secs_f64(),
+                        reason,
+                    );
+                }
             }
             tokio::time::sleep(delay).await;
+            if let Some(ref notifier) = self.retry_notifier {
+                notifier.on_retry_end();
+            }
         }
 
         Err(ApiError::RetriesExhausted {

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -17,7 +17,8 @@ pub use http_client::{
     build_http_client, build_http_client_or_default, build_http_client_with, ProxyConfig,
 };
 pub use http_transport::{
-    parse_retry_after, request_id_from_headers, HttpRequestResult, HttpTransport, RetryPolicy,
+    parse_retry_after, request_id_from_headers, HttpRequestResult, HttpTransport, RetryNotifier,
+    RetryPolicy,
 };
 pub use prompt_cache::{
     CacheBreakEvent, PromptCache, PromptCacheConfig, PromptCachePaths, PromptCacheRecord,

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -274,7 +274,10 @@ impl AnthropicClient {
         self.http.session_tracer()
     }
 
-    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+    pub fn set_retry_notifier(
+        &mut self,
+        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+    ) {
         self.http.set_retry_notifier(notifier);
     }
 

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -274,6 +274,10 @@ impl AnthropicClient {
         self.http.session_tracer()
     }
 
+    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+        self.http.set_retry_notifier(notifier);
+    }
+
     #[must_use]
     pub fn prompt_cache(&self) -> Option<&PromptCache> {
         self.prompt_cache.as_ref()

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -116,7 +116,10 @@ impl CodexClient {
         self.http.session_tracer()
     }
 
-    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+    pub fn set_retry_notifier(
+        &mut self,
+        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+    ) {
         self.http.set_retry_notifier(notifier);
     }
 

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -116,6 +116,10 @@ impl CodexClient {
         self.http.session_tracer()
     }
 
+    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+        self.http.set_retry_notifier(notifier);
+    }
+
     /// Build from `~/.codex/auth.json`.
     pub fn from_auth_file() -> Result<Self, ApiError> {
         let (access_token, account_id) = read_auth_file()?;

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -131,7 +131,10 @@ impl GeminiClient {
         self.http.session_tracer()
     }
 
-    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+    pub fn set_retry_notifier(
+        &mut self,
+        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+    ) {
         self.http.set_retry_notifier(notifier);
     }
 

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -131,6 +131,10 @@ impl GeminiClient {
         self.http.session_tracer()
     }
 
+    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+        self.http.set_retry_notifier(notifier);
+    }
+
     // -----------------------------------------------------------------------
     // Auth helpers
     // -----------------------------------------------------------------------

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -157,6 +157,10 @@ impl OpenAiCompatClient {
         self.http.session_tracer()
     }
 
+    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+        self.http.set_retry_notifier(notifier);
+    }
+
     #[must_use]
     pub fn with_retry_policy(
         mut self,

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -157,7 +157,10 @@ impl OpenAiCompatClient {
         self.http.session_tracer()
     }
 
-    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>) {
+    pub fn set_retry_notifier(
+        &mut self,
+        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+    ) {
         self.http.set_retry_notifier(notifier);
     }
 

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -375,18 +375,48 @@ fn try_proxy_passthrough(
     let proxy_providers = config.auth_modes.get("proxy")?;
     let (provider_name, connection) = proxy_providers.iter().next()?;
 
-    // Proxy providers default to openai-completions API format.
-    let api_format = ApiFormat::OpenAiCompletions;
+    // Pick API format from model_capabilities SSOT (preferred endpoint
+    // type from sudorouter), falling back to openai-completions.
+    let api_format = runtime::model_capabilities::preferred_endpoint_type(model_id)
+        .as_deref()
+        .map(endpoint_type_to_api_format)
+        .unwrap_or(ApiFormat::OpenAiCompletions);
     let credential = resolve_credential("proxy", provider_name, connection).ok()?;
     let kind = infer_provider_kind(provider_name, api_format);
+
+    // Adjust base_url for the chosen format. Proxy configs typically use
+    // OpenAI convention (base_url ends with `/v1`), but AnthropicClient
+    // appends its own `/v1/messages`. Strip the trailing `/v1` for
+    // Anthropic format to avoid `/v1/v1/messages`.
+    let base_url = match api_format {
+        ApiFormat::AnthropicMessages => connection
+            .base_url
+            .trim_end_matches('/')
+            .strip_suffix("/v1")
+            .unwrap_or(&connection.base_url)
+            .to_string(),
+        _ => connection.base_url.clone(),
+    };
 
     Some(ResolvedProvider {
         kind,
         api_format,
-        base_url: connection.base_url.clone(),
+        base_url,
         credential,
         model_id: model_id.to_string(),
     })
+}
+
+/// Map sudorouter endpoint type string to `ApiFormat`.
+/// This is the single source of truth for the mapping — matches
+/// nova-gateway's `constant/endpoint_type.go` values.
+fn endpoint_type_to_api_format(endpoint_type: &str) -> ApiFormat {
+    match endpoint_type {
+        "anthropic" => ApiFormat::AnthropicMessages,
+        "gemini" => ApiFormat::GeminiGenerateContent,
+        "openai-response" => ApiFormat::OpenAiResponses,
+        _ => ApiFormat::OpenAiCompletions,
+    }
 }
 
 /// Resolve the wire API format.

--- a/rust/crates/runtime/src/config_schema.rs
+++ b/rust/crates/runtime/src/config_schema.rs
@@ -1,0 +1,462 @@
+//! SSOT field-schema registry for `settings.json` and `sudocode.json`.
+//!
+//! Every known configuration key is defined exactly once here.
+//! `config_validate` imports these tables for validation;
+//! the CLI config UI imports them for interactive editing.
+
+/// Expected JSON type for a config field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldType {
+    String,
+    Bool,
+    Object,
+    StringArray,
+    Number,
+}
+
+impl FieldType {
+    /// Human-readable label for error messages.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::String => "a string",
+            Self::Bool => "a boolean",
+            Self::Object => "an object",
+            Self::StringArray => "an array of strings",
+            Self::Number => "a number",
+        }
+    }
+
+    /// Check whether a JSON value conforms to this type.
+    pub fn matches(self, value: &crate::json::JsonValue) -> bool {
+        match self {
+            Self::String => value.as_str().is_some(),
+            Self::Bool => value.as_bool().is_some(),
+            Self::Object => value.as_object().is_some(),
+            Self::StringArray => value
+                .as_array()
+                .is_some_and(|arr| arr.iter().all(|v| v.as_str().is_some())),
+            Self::Number => value.as_i64().is_some(),
+        }
+    }
+}
+
+/// Schema for a single configuration field.
+///
+/// Drives both validation (`config_validate`) and interactive editing (CLI config UI).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldSchema {
+    /// JSON key name (e.g. `"model"`, `"enabled"`).
+    pub key: &'static str,
+    /// Expected JSON value type.
+    pub field_type: FieldType,
+    /// Static enum options (e.g. permission modes). `None` = free-form.
+    pub options: Option<&'static [&'static str]>,
+    /// When `true`, options are fetched at runtime (e.g. model list from SSOT).
+    pub is_dynamic_options: bool,
+    /// Human-readable description shown in the config UI.
+    pub description: &'static str,
+    /// Whether this field is deprecated. When `true`, `deprecated_replacement`
+    /// should name the replacement key path.
+    pub is_deprecated: bool,
+    /// Replacement key for deprecated fields (e.g. `"permissions.defaultMode"`).
+    pub deprecated_replacement: &'static str,
+    /// Child fields for Object types — enables tree navigation in the UI.
+    pub children: Option<&'static [FieldSchema]>,
+}
+
+impl FieldSchema {
+    /// Convenience constructor for a simple leaf field.
+    const fn leaf(key: &'static str, field_type: FieldType, description: &'static str) -> Self {
+        Self {
+            key,
+            field_type,
+            options: None,
+            is_dynamic_options: false,
+            description,
+            is_deprecated: false,
+            deprecated_replacement: "",
+            children: None,
+        }
+    }
+
+    /// Convenience constructor for an enum field (string with known options).
+    const fn enumerated(
+        key: &'static str,
+        options: &'static [&'static str],
+        description: &'static str,
+    ) -> Self {
+        Self {
+            key,
+            field_type: FieldType::String,
+            options: Some(options),
+            is_dynamic_options: false,
+            description,
+            is_deprecated: false,
+            deprecated_replacement: "",
+            children: None,
+        }
+    }
+
+    /// Convenience constructor for an object with known children.
+    const fn object(
+        key: &'static str,
+        children: &'static [FieldSchema],
+        description: &'static str,
+    ) -> Self {
+        Self {
+            key,
+            field_type: FieldType::Object,
+            options: None,
+            is_dynamic_options: false,
+            description,
+            is_deprecated: false,
+            deprecated_replacement: "",
+            children: Some(children),
+        }
+    }
+
+    /// Convenience constructor for a deprecated field.
+    const fn deprecated(key: &'static str, field_type: FieldType, replacement: &'static str) -> Self {
+        Self {
+            key,
+            field_type,
+            options: None,
+            is_dynamic_options: false,
+            description: "deprecated",
+            is_deprecated: true,
+            deprecated_replacement: replacement,
+            children: None,
+        }
+    }
+}
+
+// ── settings.json child schemas ──────────────────────────────────────
+
+const HOOKS_CHILDREN: &[FieldSchema] = &[
+    FieldSchema::leaf("PreToolUse", FieldType::StringArray, "Commands run before a tool call"),
+    FieldSchema::leaf("PostToolUse", FieldType::StringArray, "Commands run after a tool call"),
+    FieldSchema::leaf(
+        "PostToolUseFailure",
+        FieldType::StringArray,
+        "Commands run after a failed tool call",
+    ),
+];
+
+const PERMISSION_MODE_OPTIONS: &[&str] = &["plan", "read-only", "workspace-write", "danger-full-access"];
+
+const PERMISSIONS_CHILDREN: &[FieldSchema] = &[
+    FieldSchema::enumerated("defaultMode", PERMISSION_MODE_OPTIONS, "Default permission mode"),
+    FieldSchema::leaf("allow", FieldType::StringArray, "Allowed tool patterns"),
+    FieldSchema::leaf("deny", FieldType::StringArray, "Denied tool patterns"),
+    FieldSchema::leaf("ask", FieldType::StringArray, "Tools that always prompt"),
+];
+
+const PLUGINS_CHILDREN: &[FieldSchema] = &[
+    FieldSchema::leaf("enabled", FieldType::Object, "Plugin enable/disable map"),
+    FieldSchema::leaf("externalDirectories", FieldType::StringArray, "External plugin directories"),
+    FieldSchema::leaf("installRoot", FieldType::String, "Plugin install root directory"),
+    FieldSchema::leaf("registryPath", FieldType::String, "Plugin registry path"),
+    FieldSchema::leaf("bundledRoot", FieldType::String, "Bundled plugins root"),
+    FieldSchema::leaf("maxOutputTokens", FieldType::Number, "Max output tokens for plugins"),
+];
+
+const FILESYSTEM_MODE_OPTIONS: &[&str] = &["readonly", "readwrite"];
+
+const SANDBOX_CHILDREN: &[FieldSchema] = &[
+    FieldSchema::leaf("enabled", FieldType::Bool, "Enable sandbox isolation"),
+    FieldSchema::leaf("namespaceRestrictions", FieldType::Bool, "Enable namespace restrictions"),
+    FieldSchema::leaf("networkIsolation", FieldType::Bool, "Isolate network access"),
+    FieldSchema::enumerated("filesystemMode", FILESYSTEM_MODE_OPTIONS, "Filesystem isolation mode"),
+    FieldSchema::leaf("allowedMounts", FieldType::StringArray, "Allowed filesystem mounts"),
+];
+
+const OAUTH_CHILDREN: &[FieldSchema] = &[
+    FieldSchema::leaf("clientId", FieldType::String, "OAuth client ID"),
+    FieldSchema::leaf("authorizeUrl", FieldType::String, "OAuth authorization URL"),
+    FieldSchema::leaf("tokenUrl", FieldType::String, "OAuth token endpoint URL"),
+    FieldSchema::leaf("callbackPort", FieldType::Number, "OAuth callback port"),
+    FieldSchema::leaf("manualRedirectUrl", FieldType::String, "Manual redirect URL for headless auth"),
+    FieldSchema::leaf("scopes", FieldType::StringArray, "OAuth scopes"),
+];
+
+// ── settings.json top-level schema ──────────────────────────────────
+
+/// All known fields in `settings.json`.
+pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
+    FieldSchema::leaf("$schema", FieldType::String, "JSON schema URL"),
+    {
+        let mut f = FieldSchema::leaf("model", FieldType::String, "Active model identifier");
+        f.is_dynamic_options = true;
+        f
+    },
+    FieldSchema::object("hooks", HOOKS_CHILDREN, "Lifecycle hook commands"),
+    FieldSchema::object("permissions", PERMISSIONS_CHILDREN, "Permission rules"),
+    FieldSchema::deprecated("permissionMode", FieldType::String, "permissions.defaultMode"),
+    FieldSchema::object("mcpServers", &[], "MCP server configurations"),
+    FieldSchema::object("oauth", OAUTH_CHILDREN, "OAuth configuration"),
+    FieldSchema::deprecated("enabledPlugins", FieldType::Object, "plugins.enabled"),
+    FieldSchema::object("plugins", PLUGINS_CHILDREN, "Plugin configuration"),
+    FieldSchema::object("sandbox", SANDBOX_CHILDREN, "Sandbox isolation settings"),
+    FieldSchema::leaf("env", FieldType::Object, "Environment variable overrides"),
+    FieldSchema::leaf("aliases", FieldType::Object, "Command aliases"),
+    FieldSchema::leaf("providerFallbacks", FieldType::Object, "Provider fallback chain"),
+    FieldSchema::leaf("trustedRoots", FieldType::StringArray, "Trusted project root paths"),
+];
+
+// ── sudocode.json schema ────────────────────────────────────────────
+
+/// All known fields in `sudocode.json`.
+pub const SUDOCODE_SCHEMA: &[FieldSchema] = &[
+    FieldSchema::leaf("auth_modes", FieldType::Object, "Authentication mode configurations"),
+    FieldSchema::leaf("models", FieldType::Object, "Model alias definitions"),
+    FieldSchema::object(
+        "web_search",
+        &[
+            FieldSchema::leaf("provider", FieldType::String, "Search provider name"),
+            FieldSchema::leaf("apiUrl", FieldType::String, "Search API base URL"),
+            FieldSchema::leaf("apiKey", FieldType::String, "Search API key"),
+        ],
+        "Web search provider configuration",
+    ),
+];
+
+// ── lookup helpers ──────────────────────────────────────────────────
+
+/// Find a field schema by key in a flat schema slice.
+pub fn find_field<'a>(schema: &'a [FieldSchema], key: &str) -> Option<&'a FieldSchema> {
+    schema.iter().find(|f| f.key == key)
+}
+
+/// Collect all non-deprecated key names from a schema slice.
+pub fn known_keys(schema: &[FieldSchema]) -> Vec<&'static str> {
+    schema.iter().filter(|f| !f.is_deprecated).map(|f| f.key).collect()
+}
+
+/// Collect deprecated field entries from a schema slice.
+pub fn deprecated_fields(schema: &[FieldSchema]) -> Vec<&FieldSchema> {
+    schema.iter().filter(|f| f.is_deprecated).collect()
+}
+
+/// Determine the UI input kind for a field based on its schema and current value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigInputKind {
+    /// Toggle immediately, no UI needed.
+    BoolToggle,
+    /// Show DialPad with the given static options.
+    Enum(Vec<String>),
+    /// Show FuzzySelect — options fetched dynamically at runtime.
+    DynamicList,
+    /// Show TextInput.
+    Text,
+    /// Show TextInput for number entry.
+    NumberInput,
+    /// Open in $EDITOR (complex object/array).
+    Editor,
+}
+
+/// Resolve the appropriate input kind for a field schema.
+pub fn resolve_input_kind(schema: &FieldSchema) -> ConfigInputKind {
+    if schema.field_type == FieldType::Bool {
+        return ConfigInputKind::BoolToggle;
+    }
+    if schema.is_dynamic_options {
+        return ConfigInputKind::DynamicList;
+    }
+    if let Some(opts) = schema.options {
+        return ConfigInputKind::Enum(opts.iter().map(|s| (*s).to_string()).collect());
+    }
+    match schema.field_type {
+        FieldType::String => ConfigInputKind::Text,
+        FieldType::Number => ConfigInputKind::NumberInput,
+        FieldType::Object | FieldType::StringArray => {
+            if schema.children.is_some() {
+                // Has structured children — navigate into them.
+                ConfigInputKind::Editor
+            } else {
+                ConfigInputKind::Editor
+            }
+        }
+        // Covered above but exhaustiveness requires it.
+        FieldType::Bool => ConfigInputKind::BoolToggle,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_schema_covers_all_validate_fields() {
+        // All field names from config_validate's TOP_LEVEL_FIELDS and DEPRECATED_FIELDS
+        // must appear in SETTINGS_SCHEMA.
+        let expected_keys = [
+            "$schema",
+            "model",
+            "hooks",
+            "permissions",
+            "permissionMode",
+            "mcpServers",
+            "oauth",
+            "enabledPlugins",
+            "plugins",
+            "sandbox",
+            "env",
+            "aliases",
+            "providerFallbacks",
+            "trustedRoots",
+        ];
+        let schema_keys: Vec<&str> = SETTINGS_SCHEMA.iter().map(|f| f.key).collect();
+        for key in &expected_keys {
+            assert!(
+                schema_keys.contains(key),
+                "SETTINGS_SCHEMA missing key: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn settings_schema_no_duplicates() {
+        let mut seen = std::collections::HashSet::new();
+        for field in SETTINGS_SCHEMA {
+            assert!(seen.insert(field.key), "duplicate key in SETTINGS_SCHEMA: {}", field.key);
+        }
+    }
+
+    #[test]
+    fn hooks_children_match_validate() {
+        let expected = ["PreToolUse", "PostToolUse", "PostToolUseFailure"];
+        let keys: Vec<&str> = HOOKS_CHILDREN.iter().map(|f| f.key).collect();
+        for key in &expected {
+            assert!(keys.contains(key), "HOOKS_CHILDREN missing: {key}");
+        }
+    }
+
+    #[test]
+    fn permissions_children_match_validate() {
+        let expected = ["defaultMode", "allow", "deny", "ask"];
+        let keys: Vec<&str> = PERMISSIONS_CHILDREN.iter().map(|f| f.key).collect();
+        for key in &expected {
+            assert!(keys.contains(key), "PERMISSIONS_CHILDREN missing: {key}");
+        }
+    }
+
+    #[test]
+    fn plugins_children_match_validate() {
+        let expected = [
+            "enabled",
+            "externalDirectories",
+            "installRoot",
+            "registryPath",
+            "bundledRoot",
+            "maxOutputTokens",
+        ];
+        let keys: Vec<&str> = PLUGINS_CHILDREN.iter().map(|f| f.key).collect();
+        for key in &expected {
+            assert!(keys.contains(key), "PLUGINS_CHILDREN missing: {key}");
+        }
+    }
+
+    #[test]
+    fn sandbox_children_match_validate() {
+        let expected = [
+            "enabled",
+            "namespaceRestrictions",
+            "networkIsolation",
+            "filesystemMode",
+            "allowedMounts",
+        ];
+        let keys: Vec<&str> = SANDBOX_CHILDREN.iter().map(|f| f.key).collect();
+        for key in &expected {
+            assert!(keys.contains(key), "SANDBOX_CHILDREN missing: {key}");
+        }
+    }
+
+    #[test]
+    fn oauth_children_match_validate() {
+        let expected = [
+            "clientId",
+            "authorizeUrl",
+            "tokenUrl",
+            "callbackPort",
+            "manualRedirectUrl",
+            "scopes",
+        ];
+        let keys: Vec<&str> = OAUTH_CHILDREN.iter().map(|f| f.key).collect();
+        for key in &expected {
+            assert!(keys.contains(key), "OAUTH_CHILDREN missing: {key}");
+        }
+    }
+
+    #[test]
+    fn deprecated_fields_have_replacement() {
+        for field in SETTINGS_SCHEMA {
+            if field.is_deprecated {
+                assert!(
+                    !field.deprecated_replacement.is_empty(),
+                    "deprecated field {} has no replacement",
+                    field.key
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sudocode_schema_covers_known_keys() {
+        let expected = ["auth_modes", "models", "web_search"];
+        let keys: Vec<&str> = SUDOCODE_SCHEMA.iter().map(|f| f.key).collect();
+        for key in &expected {
+            assert!(keys.contains(key), "SUDOCODE_SCHEMA missing key: {key}");
+        }
+    }
+
+    #[test]
+    fn resolve_input_kind_bool() {
+        let schema = FieldSchema::leaf("enabled", FieldType::Bool, "test");
+        assert_eq!(resolve_input_kind(&schema), ConfigInputKind::BoolToggle);
+    }
+
+    #[test]
+    fn resolve_input_kind_enum() {
+        let schema = FieldSchema::enumerated("mode", &["a", "b"], "test");
+        assert!(matches!(resolve_input_kind(&schema), ConfigInputKind::Enum(opts) if opts == vec!["a", "b"]));
+    }
+
+    #[test]
+    fn resolve_input_kind_dynamic() {
+        let mut schema = FieldSchema::leaf("model", FieldType::String, "test");
+        schema.is_dynamic_options = true;
+        assert_eq!(resolve_input_kind(&schema), ConfigInputKind::DynamicList);
+    }
+
+    #[test]
+    fn resolve_input_kind_text() {
+        let schema = FieldSchema::leaf("name", FieldType::String, "test");
+        assert_eq!(resolve_input_kind(&schema), ConfigInputKind::Text);
+    }
+
+    #[test]
+    fn resolve_input_kind_number() {
+        let schema = FieldSchema::leaf("port", FieldType::Number, "test");
+        assert_eq!(resolve_input_kind(&schema), ConfigInputKind::NumberInput);
+    }
+
+    #[test]
+    fn resolve_input_kind_object() {
+        let schema = FieldSchema::leaf("env", FieldType::Object, "test");
+        assert_eq!(resolve_input_kind(&schema), ConfigInputKind::Editor);
+    }
+
+    #[test]
+    fn find_field_returns_match() {
+        assert_eq!(find_field(SETTINGS_SCHEMA, "model").map(|f| f.key), Some("model"));
+        assert!(find_field(SETTINGS_SCHEMA, "nonexistent").is_none());
+    }
+
+    #[test]
+    fn known_keys_excludes_deprecated() {
+        let keys = known_keys(SETTINGS_SCHEMA);
+        assert!(!keys.contains(&"permissionMode"));
+        assert!(!keys.contains(&"enabledPlugins"));
+        assert!(keys.contains(&"model"));
+    }
+}

--- a/rust/crates/runtime/src/config_schema.rs
+++ b/rust/crates/runtime/src/config_schema.rs
@@ -116,7 +116,11 @@ impl FieldSchema {
     }
 
     /// Convenience constructor for a deprecated field.
-    const fn deprecated(key: &'static str, field_type: FieldType, replacement: &'static str) -> Self {
+    const fn deprecated(
+        key: &'static str,
+        field_type: FieldType,
+        replacement: &'static str,
+    ) -> Self {
         Self {
             key,
             field_type,
@@ -133,8 +137,16 @@ impl FieldSchema {
 // ── settings.json child schemas ──────────────────────────────────────
 
 const HOOKS_CHILDREN: &[FieldSchema] = &[
-    FieldSchema::leaf("PreToolUse", FieldType::StringArray, "Commands run before a tool call"),
-    FieldSchema::leaf("PostToolUse", FieldType::StringArray, "Commands run after a tool call"),
+    FieldSchema::leaf(
+        "PreToolUse",
+        FieldType::StringArray,
+        "Commands run before a tool call",
+    ),
+    FieldSchema::leaf(
+        "PostToolUse",
+        FieldType::StringArray,
+        "Commands run after a tool call",
+    ),
     FieldSchema::leaf(
         "PostToolUseFailure",
         FieldType::StringArray,
@@ -142,10 +154,15 @@ const HOOKS_CHILDREN: &[FieldSchema] = &[
     ),
 ];
 
-const PERMISSION_MODE_OPTIONS: &[&str] = &["plan", "read-only", "workspace-write", "danger-full-access"];
+const PERMISSION_MODE_OPTIONS: &[&str] =
+    &["plan", "read-only", "workspace-write", "danger-full-access"];
 
 const PERMISSIONS_CHILDREN: &[FieldSchema] = &[
-    FieldSchema::enumerated("defaultMode", PERMISSION_MODE_OPTIONS, "Default permission mode"),
+    FieldSchema::enumerated(
+        "defaultMode",
+        PERMISSION_MODE_OPTIONS,
+        "Default permission mode",
+    ),
     FieldSchema::leaf("allow", FieldType::StringArray, "Allowed tool patterns"),
     FieldSchema::leaf("deny", FieldType::StringArray, "Denied tool patterns"),
     FieldSchema::leaf("ask", FieldType::StringArray, "Tools that always prompt"),
@@ -153,21 +170,49 @@ const PERMISSIONS_CHILDREN: &[FieldSchema] = &[
 
 const PLUGINS_CHILDREN: &[FieldSchema] = &[
     FieldSchema::leaf("enabled", FieldType::Object, "Plugin enable/disable map"),
-    FieldSchema::leaf("externalDirectories", FieldType::StringArray, "External plugin directories"),
-    FieldSchema::leaf("installRoot", FieldType::String, "Plugin install root directory"),
+    FieldSchema::leaf(
+        "externalDirectories",
+        FieldType::StringArray,
+        "External plugin directories",
+    ),
+    FieldSchema::leaf(
+        "installRoot",
+        FieldType::String,
+        "Plugin install root directory",
+    ),
     FieldSchema::leaf("registryPath", FieldType::String, "Plugin registry path"),
     FieldSchema::leaf("bundledRoot", FieldType::String, "Bundled plugins root"),
-    FieldSchema::leaf("maxOutputTokens", FieldType::Number, "Max output tokens for plugins"),
+    FieldSchema::leaf(
+        "maxOutputTokens",
+        FieldType::Number,
+        "Max output tokens for plugins",
+    ),
 ];
 
 const FILESYSTEM_MODE_OPTIONS: &[&str] = &["readonly", "readwrite"];
 
 const SANDBOX_CHILDREN: &[FieldSchema] = &[
     FieldSchema::leaf("enabled", FieldType::Bool, "Enable sandbox isolation"),
-    FieldSchema::leaf("namespaceRestrictions", FieldType::Bool, "Enable namespace restrictions"),
-    FieldSchema::leaf("networkIsolation", FieldType::Bool, "Isolate network access"),
-    FieldSchema::enumerated("filesystemMode", FILESYSTEM_MODE_OPTIONS, "Filesystem isolation mode"),
-    FieldSchema::leaf("allowedMounts", FieldType::StringArray, "Allowed filesystem mounts"),
+    FieldSchema::leaf(
+        "namespaceRestrictions",
+        FieldType::Bool,
+        "Enable namespace restrictions",
+    ),
+    FieldSchema::leaf(
+        "networkIsolation",
+        FieldType::Bool,
+        "Isolate network access",
+    ),
+    FieldSchema::enumerated(
+        "filesystemMode",
+        FILESYSTEM_MODE_OPTIONS,
+        "Filesystem isolation mode",
+    ),
+    FieldSchema::leaf(
+        "allowedMounts",
+        FieldType::StringArray,
+        "Allowed filesystem mounts",
+    ),
 ];
 
 const OAUTH_CHILDREN: &[FieldSchema] = &[
@@ -175,7 +220,11 @@ const OAUTH_CHILDREN: &[FieldSchema] = &[
     FieldSchema::leaf("authorizeUrl", FieldType::String, "OAuth authorization URL"),
     FieldSchema::leaf("tokenUrl", FieldType::String, "OAuth token endpoint URL"),
     FieldSchema::leaf("callbackPort", FieldType::Number, "OAuth callback port"),
-    FieldSchema::leaf("manualRedirectUrl", FieldType::String, "Manual redirect URL for headless auth"),
+    FieldSchema::leaf(
+        "manualRedirectUrl",
+        FieldType::String,
+        "Manual redirect URL for headless auth",
+    ),
     FieldSchema::leaf("scopes", FieldType::StringArray, "OAuth scopes"),
 ];
 
@@ -191,7 +240,11 @@ pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
     },
     FieldSchema::object("hooks", HOOKS_CHILDREN, "Lifecycle hook commands"),
     FieldSchema::object("permissions", PERMISSIONS_CHILDREN, "Permission rules"),
-    FieldSchema::deprecated("permissionMode", FieldType::String, "permissions.defaultMode"),
+    FieldSchema::deprecated(
+        "permissionMode",
+        FieldType::String,
+        "permissions.defaultMode",
+    ),
     FieldSchema::object("mcpServers", &[], "MCP server configurations"),
     FieldSchema::object("oauth", OAUTH_CHILDREN, "OAuth configuration"),
     FieldSchema::deprecated("enabledPlugins", FieldType::Object, "plugins.enabled"),
@@ -199,15 +252,27 @@ pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
     FieldSchema::object("sandbox", SANDBOX_CHILDREN, "Sandbox isolation settings"),
     FieldSchema::leaf("env", FieldType::Object, "Environment variable overrides"),
     FieldSchema::leaf("aliases", FieldType::Object, "Command aliases"),
-    FieldSchema::leaf("providerFallbacks", FieldType::Object, "Provider fallback chain"),
-    FieldSchema::leaf("trustedRoots", FieldType::StringArray, "Trusted project root paths"),
+    FieldSchema::leaf(
+        "providerFallbacks",
+        FieldType::Object,
+        "Provider fallback chain",
+    ),
+    FieldSchema::leaf(
+        "trustedRoots",
+        FieldType::StringArray,
+        "Trusted project root paths",
+    ),
 ];
 
 // ── sudocode.json schema ────────────────────────────────────────────
 
 /// All known fields in `sudocode.json`.
 pub const SUDOCODE_SCHEMA: &[FieldSchema] = &[
-    FieldSchema::leaf("auth_modes", FieldType::Object, "Authentication mode configurations"),
+    FieldSchema::leaf(
+        "auth_modes",
+        FieldType::Object,
+        "Authentication mode configurations",
+    ),
     FieldSchema::leaf("models", FieldType::Object, "Model alias definitions"),
     FieldSchema::object(
         "web_search",
@@ -229,7 +294,11 @@ pub fn find_field<'a>(schema: &'a [FieldSchema], key: &str) -> Option<&'a FieldS
 
 /// Collect all non-deprecated key names from a schema slice.
 pub fn known_keys(schema: &[FieldSchema]) -> Vec<&'static str> {
-    schema.iter().filter(|f| !f.is_deprecated).map(|f| f.key).collect()
+    schema
+        .iter()
+        .filter(|f| !f.is_deprecated)
+        .map(|f| f.key)
+        .collect()
 }
 
 /// Collect deprecated field entries from a schema slice.
@@ -318,7 +387,11 @@ mod tests {
     fn settings_schema_no_duplicates() {
         let mut seen = std::collections::HashSet::new();
         for field in SETTINGS_SCHEMA {
-            assert!(seen.insert(field.key), "duplicate key in SETTINGS_SCHEMA: {}", field.key);
+            assert!(
+                seen.insert(field.key),
+                "duplicate key in SETTINGS_SCHEMA: {}",
+                field.key
+            );
         }
     }
 
@@ -418,7 +491,9 @@ mod tests {
     #[test]
     fn resolve_input_kind_enum() {
         let schema = FieldSchema::enumerated("mode", &["a", "b"], "test");
-        assert!(matches!(resolve_input_kind(&schema), ConfigInputKind::Enum(opts) if opts == vec!["a", "b"]));
+        assert!(
+            matches!(resolve_input_kind(&schema), ConfigInputKind::Enum(opts) if opts == vec!["a", "b"])
+        );
     }
 
     #[test]
@@ -448,7 +523,10 @@ mod tests {
 
     #[test]
     fn find_field_returns_match() {
-        assert_eq!(find_field(SETTINGS_SCHEMA, "model").map(|f| f.key), Some("model"));
+        assert_eq!(
+            find_field(SETTINGS_SCHEMA, "model").map(|f| f.key),
+            Some("model")
+        );
         assert!(find_field(SETTINGS_SCHEMA, "nonexistent").is_none());
     }
 

--- a/rust/crates/runtime/src/config_validate.rs
+++ b/rust/crates/runtime/src/config_validate.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::config::ConfigError;
+use crate::config_schema::{self, FieldSchema};
 use crate::json::JsonValue;
 
 /// Diagnostic emitted when a config file contains a suspect field.
@@ -83,41 +84,7 @@ impl ValidationResult {
     }
 }
 
-// ---- known-key schema ----
-
-/// Expected type for a config field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FieldType {
-    String,
-    Bool,
-    Object,
-    StringArray,
-    Number,
-}
-
-impl FieldType {
-    fn label(self) -> &'static str {
-        match self {
-            Self::String => "a string",
-            Self::Bool => "a boolean",
-            Self::Object => "an object",
-            Self::StringArray => "an array of strings",
-            Self::Number => "a number",
-        }
-    }
-
-    fn matches(self, value: &JsonValue) -> bool {
-        match self {
-            Self::String => value.as_str().is_some(),
-            Self::Bool => value.as_bool().is_some(),
-            Self::Object => value.as_object().is_some(),
-            Self::StringArray => value
-                .as_array()
-                .is_some_and(|arr| arr.iter().all(|v| v.as_str().is_some())),
-            Self::Number => value.as_i64().is_some(),
-        }
-    }
-}
+// ---- known-key schema (imported from config_schema SSOT) ----
 
 fn json_type_label(value: &JsonValue) -> &'static str {
     match value {
@@ -129,197 +96,6 @@ fn json_type_label(value: &JsonValue) -> &'static str {
         JsonValue::Object(_) => "an object",
     }
 }
-
-struct FieldSpec {
-    name: &'static str,
-    expected: FieldType,
-}
-
-struct DeprecatedField {
-    name: &'static str,
-    replacement: &'static str,
-}
-
-const TOP_LEVEL_FIELDS: &[FieldSpec] = &[
-    FieldSpec {
-        name: "$schema",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "model",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "hooks",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "permissions",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "permissionMode",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "mcpServers",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "oauth",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "enabledPlugins",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "plugins",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "sandbox",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "env",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "aliases",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "providerFallbacks",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "trustedRoots",
-        expected: FieldType::StringArray,
-    },
-];
-
-const HOOKS_FIELDS: &[FieldSpec] = &[
-    FieldSpec {
-        name: "PreToolUse",
-        expected: FieldType::StringArray,
-    },
-    FieldSpec {
-        name: "PostToolUse",
-        expected: FieldType::StringArray,
-    },
-    FieldSpec {
-        name: "PostToolUseFailure",
-        expected: FieldType::StringArray,
-    },
-];
-
-const PERMISSIONS_FIELDS: &[FieldSpec] = &[
-    FieldSpec {
-        name: "defaultMode",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "allow",
-        expected: FieldType::StringArray,
-    },
-    FieldSpec {
-        name: "deny",
-        expected: FieldType::StringArray,
-    },
-    FieldSpec {
-        name: "ask",
-        expected: FieldType::StringArray,
-    },
-];
-
-const PLUGINS_FIELDS: &[FieldSpec] = &[
-    FieldSpec {
-        name: "enabled",
-        expected: FieldType::Object,
-    },
-    FieldSpec {
-        name: "externalDirectories",
-        expected: FieldType::StringArray,
-    },
-    FieldSpec {
-        name: "installRoot",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "registryPath",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "bundledRoot",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "maxOutputTokens",
-        expected: FieldType::Number,
-    },
-];
-
-const SANDBOX_FIELDS: &[FieldSpec] = &[
-    FieldSpec {
-        name: "enabled",
-        expected: FieldType::Bool,
-    },
-    FieldSpec {
-        name: "namespaceRestrictions",
-        expected: FieldType::Bool,
-    },
-    FieldSpec {
-        name: "networkIsolation",
-        expected: FieldType::Bool,
-    },
-    FieldSpec {
-        name: "filesystemMode",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "allowedMounts",
-        expected: FieldType::StringArray,
-    },
-];
-
-const OAUTH_FIELDS: &[FieldSpec] = &[
-    FieldSpec {
-        name: "clientId",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "authorizeUrl",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "tokenUrl",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "callbackPort",
-        expected: FieldType::Number,
-    },
-    FieldSpec {
-        name: "manualRedirectUrl",
-        expected: FieldType::String,
-    },
-    FieldSpec {
-        name: "scopes",
-        expected: FieldType::StringArray,
-    },
-];
-
-const DEPRECATED_FIELDS: &[DeprecatedField] = &[
-    DeprecatedField {
-        name: "permissionMode",
-        replacement: "permissions.defaultMode",
-    },
-    DeprecatedField {
-        name: "enabledPlugins",
-        replacement: "plugins.enabled",
-    },
-];
 
 // ---- line-number resolution ----
 
@@ -344,7 +120,7 @@ fn find_key_line(source: &str, key: &str) -> Option<usize> {
 
 fn validate_object_keys(
     object: &BTreeMap<String, JsonValue>,
-    known_fields: &[FieldSpec],
+    known_fields: &[FieldSchema],
     prefix: &str,
     source: &str,
     path_display: &str,
@@ -354,7 +130,8 @@ fn validate_object_keys(
         warnings: Vec::new(),
     };
 
-    let known_names: Vec<&str> = known_fields.iter().map(|f| f.name).collect();
+    let known_names: Vec<&str> = known_fields.iter().map(|f| f.key).collect();
+    let deprecated = config_schema::deprecated_fields(known_fields);
 
     for (key, value) in object {
         let field_path = if prefix.is_empty() {
@@ -363,21 +140,25 @@ fn validate_object_keys(
             format!("{prefix}.{key}")
         };
 
-        if let Some(spec) = known_fields.iter().find(|f| f.name == key) {
+        if let Some(spec) = known_fields.iter().find(|f| f.key == key.as_str()) {
+            if spec.is_deprecated {
+                // Deprecated key — handled separately, not an unknown-key error.
+                continue;
+            }
             // Type check.
-            if !spec.expected.matches(value) {
+            if !spec.field_type.matches(value) {
                 result.errors.push(ConfigDiagnostic {
                     path: path_display.to_string(),
                     field: field_path,
                     line: find_key_line(source, key),
                     kind: DiagnosticKind::WrongType {
-                        expected: spec.expected.label(),
+                        expected: spec.field_type.label(),
                         got: json_type_label(value),
                     },
                 });
             }
-        } else if DEPRECATED_FIELDS.iter().any(|d| d.name == key) {
-            // Deprecated key — handled separately, not an unknown-key error.
+        } else if deprecated.iter().any(|d| d.key == key.as_str()) {
+            // Deprecated key — handled separately.
         } else {
             // Unknown key.
             let suggestion = suggest_field(key, &known_names);
@@ -438,68 +219,40 @@ pub fn validate_config_file(
     source: &str,
     file_path: &Path,
 ) -> ValidationResult {
+    let schema = config_schema::SETTINGS_SCHEMA;
     let path_display = file_path.display().to_string();
-    let mut result = validate_object_keys(object, TOP_LEVEL_FIELDS, "", source, &path_display);
+    let mut result = validate_object_keys(object, schema, "", source, &path_display);
 
     // Check deprecated fields.
-    for deprecated in DEPRECATED_FIELDS {
-        if object.contains_key(deprecated.name) {
+    for deprecated in config_schema::deprecated_fields(schema) {
+        if object.contains_key(deprecated.key) {
             result.warnings.push(ConfigDiagnostic {
                 path: path_display.clone(),
-                field: deprecated.name.to_string(),
-                line: find_key_line(source, deprecated.name),
+                field: deprecated.key.to_string(),
+                line: find_key_line(source, deprecated.key),
                 kind: DiagnosticKind::Deprecated {
-                    replacement: deprecated.replacement,
+                    replacement: deprecated.deprecated_replacement,
                 },
             });
         }
     }
 
-    // Validate known nested objects.
-    if let Some(hooks) = object.get("hooks").and_then(JsonValue::as_object) {
-        result.merge(validate_object_keys(
-            hooks,
-            HOOKS_FIELDS,
-            "hooks",
-            source,
-            &path_display,
-        ));
-    }
-    if let Some(permissions) = object.get("permissions").and_then(JsonValue::as_object) {
-        result.merge(validate_object_keys(
-            permissions,
-            PERMISSIONS_FIELDS,
-            "permissions",
-            source,
-            &path_display,
-        ));
-    }
-    if let Some(plugins) = object.get("plugins").and_then(JsonValue::as_object) {
-        result.merge(validate_object_keys(
-            plugins,
-            PLUGINS_FIELDS,
-            "plugins",
-            source,
-            &path_display,
-        ));
-    }
-    if let Some(sandbox) = object.get("sandbox").and_then(JsonValue::as_object) {
-        result.merge(validate_object_keys(
-            sandbox,
-            SANDBOX_FIELDS,
-            "sandbox",
-            source,
-            &path_display,
-        ));
-    }
-    if let Some(oauth) = object.get("oauth").and_then(JsonValue::as_object) {
-        result.merge(validate_object_keys(
-            oauth,
-            OAUTH_FIELDS,
-            "oauth",
-            source,
-            &path_display,
-        ));
+    // Validate known nested objects using children from the SSOT.
+    for field in schema {
+        if let Some(children) = field.children {
+            if children.is_empty() {
+                continue;
+            }
+            if let Some(nested) = object.get(field.key).and_then(JsonValue::as_object) {
+                result.merge(validate_object_keys(
+                    nested,
+                    children,
+                    field.key,
+                    source,
+                    &path_display,
+                ));
+            }
+        }
     }
 
     result

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -15,6 +15,7 @@ mod bootstrap;
 pub mod branch_lock;
 mod compact;
 pub mod config;
+pub mod config_schema;
 pub mod config_validate;
 mod conversation;
 pub mod coordinator_mode;
@@ -99,6 +100,9 @@ pub use config::{
     RuntimeFeatureConfig, RuntimeHookConfig, RuntimePermissionRuleConfig, RuntimePluginConfig,
     ScopedMcpServerConfig, SudoCodeConfig, WebSearchConfig, SAMPLE_SUDOCODE_JSON,
     SUDOCODE_SETTINGS_SCHEMA_NAME,
+};
+pub use config_schema::{
+    resolve_input_kind, ConfigInputKind, FieldSchema, FieldType, SETTINGS_SCHEMA, SUDOCODE_SCHEMA,
 };
 pub use config_validate::{
     check_unsupported_format, format_diagnostics, validate_config_file, ConfigDiagnostic,

--- a/rust/crates/runtime/src/model_capabilities.rs
+++ b/rust/crates/runtime/src/model_capabilities.rs
@@ -32,7 +32,7 @@ const TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
 /// 2026-07-01) — until a model's entry lands in the SSOT table, callers use
 /// [`vision_capable`] / [`per_model_image_cap`] which fall back to
 /// optimistic defaults; see those fns' docs.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModelCapability {
     pub context_window: u32,
     pub max_output_tokens: u32,
@@ -48,6 +48,11 @@ pub struct ModelCapability {
     /// [`Self::image_max_bytes`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_max_dimension: Option<u32>,
+    /// Supported API endpoint types from sudorouter (e.g. `["anthropic", "openai"]`).
+    /// First item is preferred. Used by proxy passthrough to pick the optimal
+    /// wire format. `None` when sudorouter hasn't populated this field yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_types: Option<Vec<String>>,
 }
 
 /// The on-disk SSOT file schema.
@@ -94,7 +99,7 @@ pub fn lookup(model_id: &str) -> Option<ModelCapability> {
     caps.models
         .iter()
         .find(|(id, _)| id.eq_ignore_ascii_case(base))
-        .map(|(_, cap)| *cap)
+        .map(|(_, cap)| cap.clone())
 }
 
 /// Returns `true` if the model is known to accept image input. Used by the
@@ -138,6 +143,16 @@ pub fn per_model_image_cap(model_id: &str) -> (Option<u32>, Option<u32>) {
         ),
         None => (None, None),
     }
+}
+
+/// Preferred API endpoint type for a model from the SSOT.
+/// Returns the first entry in `endpoint_types` (preferred by sudorouter).
+/// Returns `None` if the model is unknown or has no endpoint type data.
+#[must_use]
+pub fn preferred_endpoint_type(model_id: &str) -> Option<String> {
+    lookup(model_id)
+        .and_then(|cap| cap.endpoint_types)
+        .and_then(|types| types.into_iter().next())
 }
 
 /// All known model IDs from the capabilities SSOT.
@@ -254,6 +269,7 @@ pub fn merge_and_write(
 
     let mut count = 0usize;
     for entry in api_models {
+        // Models with capability metadata get full entries.
         if let (Some(cw), Some(mo)) = (entry.context_window, entry.max_output_tokens) {
             file.models.insert(
                 entry.id.clone(),
@@ -263,8 +279,17 @@ pub fn merge_and_write(
                     vision_supported: entry.vision_supported,
                     image_max_bytes: entry.image_max_bytes,
                     image_max_dimension: entry.image_max_dimension,
+                    endpoint_types: entry.supported_endpoint_types.clone(),
                 },
             );
+            count += 1;
+        } else if entry.supported_endpoint_types.is_some() {
+            // Models without token metadata but with endpoint types:
+            // merge endpoint_types into existing entry or create with defaults.
+            let existing = file.models.get(&entry.id).cloned();
+            let mut cap = existing.unwrap_or_else(|| file.default.clone());
+            cap.endpoint_types = entry.supported_endpoint_types.clone();
+            file.models.insert(entry.id.clone(), cap);
             count += 1;
         }
     }
@@ -286,6 +311,8 @@ pub struct ApiModelEntry {
     pub image_max_bytes: Option<u32>,
     #[serde(default)]
     pub image_max_dimension: Option<u32>,
+    #[serde(default)]
+    pub supported_endpoint_types: Option<Vec<String>>,
 }
 
 /// Parse the `/v1/models` API response JSON into a vec of model entries.
@@ -319,6 +346,14 @@ pub fn parse_api_response(json: &serde_json::Value) -> Vec<ApiModelEntry> {
                 .get("image_max_dimension")
                 .and_then(|v| v.as_u64())
                 .map(|v| v as u32);
+            let supported_endpoint_types = entry
+                .get("supported_endpoint_types")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                });
             Some(ApiModelEntry {
                 id,
                 context_window,
@@ -326,6 +361,7 @@ pub fn parse_api_response(json: &serde_json::Value) -> Vec<ApiModelEntry> {
                 vision_supported,
                 image_max_bytes,
                 image_max_dimension,
+                supported_endpoint_types,
             })
         })
         .collect()

--- a/rust/crates/rusty-sudocode-cli/Cargo.toml
+++ b/rust/crates/rusty-sudocode-cli/Cargo.toml
@@ -51,5 +51,5 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-tungstenite = "0.29"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["term", "poll", "signal"] }
+nix = { version = "0.29", features = ["term", "poll", "signal", "fs"] }
 

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -25,6 +25,23 @@ use crate::{
     AllowedToolSet, InternalPromptProgressReporter, RuntimeConfig, POST_TOOL_STALL_TIMEOUT,
 };
 
+/// Bridges HTTP retry notifications from the transport layer to the
+/// spinner's `set_retry` / resume methods, so the iocraft TurnRenderer
+/// can display retry status in the spinner overlay.
+struct SpinnerRetryNotifier {
+    spinner: SpinnerRef,
+}
+
+impl api::RetryNotifier for SpinnerRetryNotifier {
+    fn on_retry(&self, attempt: u32, max_retries: u32, reason: &str) {
+        self.spinner.set_retry(attempt, max_retries, reason.to_string());
+    }
+
+    fn on_retry_end(&self) {
+        self.spinner.resume();
+    }
+}
+
 // NOTE: Despite the historical name `AnthropicRuntimeClient`, this struct
 // now holds an `ApiProviderClient` which dispatches to Anthropic, xAI,
 // OpenAI, or DashScope at construction time based on
@@ -89,6 +106,10 @@ impl AnthropicRuntimeClient {
     }
 
     pub(crate) fn set_spinner(&mut self, ref_: SpinnerRef) {
+        let notifier = Arc::new(SpinnerRetryNotifier {
+            spinner: ref_.clone(),
+        });
+        self.client.set_retry_notifier(notifier);
         self.spinner = Some(ref_);
     }
 
@@ -719,11 +740,11 @@ pub(crate) fn render_thinking_block_summary(
     redacted: bool,
 ) -> Result<(), RuntimeError> {
     let summary = if redacted {
-        "\n  ▶ Thinking block hidden by provider\n".to_string()
+        "\n  ▼ Thinking block hidden by provider\n".to_string()
     } else if let Some(char_count) = char_count {
-        format!("\n  ▶ Thinking ({char_count} chars hidden)\n")
+        format!("\n  ▼ Thinking ({char_count} chars hidden)\n")
     } else {
-        "\n  ▶ Thinking hidden\n".to_string()
+        "\n  ▼ Thinking hidden\n".to_string()
     };
     write!(out, "{summary}")
         .and_then(|()| out.flush())

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -34,7 +34,8 @@ struct SpinnerRetryNotifier {
 
 impl api::RetryNotifier for SpinnerRetryNotifier {
     fn on_retry(&self, attempt: u32, max_retries: u32, reason: &str) {
-        self.spinner.set_retry(attempt, max_retries, reason.to_string());
+        self.spinner
+            .set_retry(attempt, max_retries, reason.to_string());
     }
 
     fn on_retry_end(&self) {

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -1066,8 +1066,8 @@ pub(crate) fn try_resolve_bare_skill_prompt_with_plugins(
 
 pub(crate) fn resolve_model_alias(model: &str) -> &str {
     match model {
+        "auto" | "claude-sonnet" | "sonnet" => "claude-sonnet-4-6",
         "claude-opus" | "opus" => "claude-opus-4-6",
-        "claude-sonnet" | "sonnet" => "claude-sonnet-4-6",
         "claude-haiku" | "haiku" => "claude-haiku-4-5-20251213",
         _ => model,
     }

--- a/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
@@ -12,8 +12,8 @@ use runtime::config_schema::{self, ConfigInputKind, FieldSchema, FieldType};
 use runtime::model_capabilities;
 
 use crate::cli::args::load_sudocode_config_for_current_dir;
-use crate::repl_ui::{self, OutputSender, QuestionOptionView, QuestionPromptView, UiCommandSender};
 use crate::render::{ansi_fg, theme, DIM, RESET};
+use crate::repl_ui::{self, OutputSender, QuestionOptionView, QuestionPromptView, UiCommandSender};
 use crate::{LiveCli, SlashSelectionHandler};
 
 // ── public entry point ──────────────────────────────────────────────
@@ -102,10 +102,7 @@ fn show_schema_level(
         .map(|f| {
             let val_summary = current_obj
                 .and_then(|obj| obj.get(f.key))
-                .map_or_else(
-                    || "(not set)".to_string(),
-                    |v| truncate_json_value(v),
-                );
+                .map_or_else(|| "(not set)".to_string(), |v| truncate_json_value(v));
             let hint = if f.children.is_some() && f.field_type == FieldType::Object {
                 " \u{25b8}"
             } else {
@@ -204,8 +201,7 @@ fn handle_leaf_edit(
         ConfigInputKind::BoolToggle => {
             let current_bool = current_val.and_then(|v| v.as_bool()).unwrap_or(false);
             let new_val = !current_bool;
-            match write_config_value(file_path, breadcrumb, field.key, serde_json::json!(new_val))
-            {
+            match write_config_value(file_path, breadcrumb, field.key, serde_json::json!(new_val)) {
                 Ok(()) => out.println(&format!(
                     "{DIM}{}{} = {new_val}{RESET}",
                     breadcrumb_display(breadcrumb),

--- a/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
@@ -1,0 +1,569 @@
+//! Interactive `/config` tree browser.
+//!
+//! Uses `FieldSchema` from `runtime::config_schema` as SSOT to drive
+//! a tree-like navigation UI. Each level renders a DialPad/FuzzySelect
+//! showing fields + current values; selecting a leaf dispatches to the
+//! appropriate InputSlot variant for editing.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use runtime::config_schema::{self, ConfigInputKind, FieldSchema, FieldType};
+use runtime::model_capabilities;
+
+use crate::cli::args::load_sudocode_config_for_current_dir;
+use crate::repl_ui::{self, OutputSender, QuestionOptionView, QuestionPromptView, UiCommandSender};
+use crate::render::{ansi_fg, theme, DIM, RESET};
+use crate::{LiveCli, SlashSelectionHandler};
+
+// ── public entry point ──────────────────────────────────────────────
+
+/// Build the top-level `/config` tree handler.
+///
+/// Returns a `SlashSelectionHandler` that shows a DialPad with two entries:
+/// `[settings.json]` and `[sudocode.json]`.
+pub(crate) fn build_config_tree_handler(
+    ui: &UiCommandSender,
+    settings_path: PathBuf,
+    sudocode_path: PathBuf,
+) -> SlashSelectionHandler {
+    let items = vec!["settings.json".to_string(), "sudocode.json".to_string()];
+    let question = QuestionPromptView {
+        title: Some("Config".to_string()),
+        description: Some("Select config file to browse".to_string()),
+        index: 0,
+        total: 1,
+        prompt: "Config file".to_string(),
+        options: vec![
+            QuestionOptionView {
+                label: format!("settings.json  {DIM}{}{RESET}", settings_path.display()),
+                value: "settings.json".to_string(),
+                description: None,
+                recommended: false,
+            },
+            QuestionOptionView {
+                label: format!("sudocode.json  {DIM}{}{RESET}", sudocode_path.display()),
+                value: "sudocode.json".to_string(),
+                description: None,
+                recommended: false,
+            },
+        ],
+        allow_custom_input: false,
+        custom_input_hint: None,
+        force_fuzzy_select: false,
+    };
+    ui.show_question(question);
+
+    let ui2 = ui.clone();
+    SlashSelectionHandler(Box::new(move |answer: &str, _cli, _out| {
+        let resolved = resolve_answer(answer, &items);
+        match resolved.as_str() {
+            "settings.json" => Some(show_schema_level(
+                &ui2,
+                config_schema::SETTINGS_SCHEMA,
+                &settings_path,
+                "settings.json",
+                Vec::new(),
+            )),
+            "sudocode.json" => Some(show_schema_level(
+                &ui2,
+                config_schema::SUDOCODE_SCHEMA,
+                &sudocode_path,
+                "sudocode.json",
+                Vec::new(),
+            )),
+            _ => None,
+        }
+    }))
+}
+
+// ── schema level navigation ─────────────────────────────────────────
+
+/// Show a DialPad/FuzzySelect for one level of the schema tree.
+fn show_schema_level(
+    ui: &UiCommandSender,
+    schema: &'static [FieldSchema],
+    file_path: &Path,
+    file_label: &str,
+    breadcrumb: Vec<String>,
+) -> SlashSelectionHandler {
+    let json_content = std::fs::read_to_string(file_path).unwrap_or_else(|_| "{}".to_string());
+    let json_root: serde_json::Value =
+        serde_json::from_str(&json_content).unwrap_or(serde_json::json!({}));
+
+    // Navigate to the nested object indicated by breadcrumb.
+    let current_obj = navigate_json(&json_root, &breadcrumb);
+
+    let visible: Vec<&FieldSchema> = schema.iter().filter(|f| !f.is_deprecated).collect();
+    let keys: Vec<String> = visible.iter().map(|f| f.key.to_string()).collect();
+
+    let options: Vec<QuestionOptionView> = visible
+        .iter()
+        .map(|f| {
+            let val_summary = current_obj
+                .and_then(|obj| obj.get(f.key))
+                .map_or_else(
+                    || "(not set)".to_string(),
+                    |v| truncate_json_value(v),
+                );
+            let hint = if f.children.is_some() && f.field_type == FieldType::Object {
+                " \u{25b8}"
+            } else {
+                ""
+            };
+            QuestionOptionView {
+                label: format!("{}{hint}  {DIM}{val_summary}{RESET}", f.key),
+                value: f.key.to_string(),
+                description: Some(f.description.to_string()),
+                recommended: false,
+            }
+        })
+        .collect();
+
+    let title_path = if breadcrumb.is_empty() {
+        file_label.to_string()
+    } else {
+        format!("{file_label} > {}", breadcrumb.join(" > "))
+    };
+
+    let question = QuestionPromptView {
+        title: Some("Config".to_string()),
+        description: Some(title_path),
+        index: 0,
+        total: 1,
+        prompt: "Select field".to_string(),
+        options,
+        allow_custom_input: false,
+        custom_input_hint: None,
+        force_fuzzy_select: visible.len() > 9,
+    };
+    ui.show_question(question);
+
+    let ui2 = ui.clone();
+    let file_path = file_path.to_path_buf();
+    let file_label = file_label.to_string();
+    let breadcrumb2 = breadcrumb.clone();
+
+    SlashSelectionHandler(Box::new(move |answer: &str, cli, out| {
+        let selected = resolve_answer(answer, &keys);
+
+        let Some(field) = schema.iter().find(|f| f.key == selected) else {
+            out.println(&format!("{DIM}Unknown field: {selected}{RESET}"));
+            return None;
+        };
+
+        // If field has children and is Object, drill in.
+        if let Some(children) = field.children {
+            if !children.is_empty() {
+                let mut next_bc = breadcrumb2.clone();
+                next_bc.push(field.key.to_string());
+                return Some(show_schema_level(
+                    &ui2,
+                    children,
+                    &file_path,
+                    &file_label,
+                    next_bc,
+                ));
+            }
+        }
+
+        // Leaf field — dispatch to appropriate editor.
+        let input_kind = config_schema::resolve_input_kind(field);
+        handle_leaf_edit(
+            &ui2,
+            field,
+            &input_kind,
+            &file_path,
+            &file_label,
+            &breadcrumb2,
+            cli,
+            out,
+        )
+    }))
+}
+
+// ── leaf field editing ──────────────────────────────────────────────
+
+fn handle_leaf_edit(
+    ui: &UiCommandSender,
+    field: &'static FieldSchema,
+    input_kind: &ConfigInputKind,
+    file_path: &Path,
+    file_label: &str,
+    breadcrumb: &[String],
+    _cli: &Arc<Mutex<LiveCli>>,
+    out: &OutputSender,
+) -> Option<SlashSelectionHandler> {
+    let json_content = std::fs::read_to_string(file_path).unwrap_or_else(|_| "{}".to_string());
+    let json_root: serde_json::Value =
+        serde_json::from_str(&json_content).unwrap_or(serde_json::json!({}));
+    let current_obj = navigate_json(&json_root, breadcrumb);
+    let current_val = current_obj.and_then(|obj| obj.get(field.key));
+
+    match input_kind {
+        ConfigInputKind::BoolToggle => {
+            let current_bool = current_val.and_then(|v| v.as_bool()).unwrap_or(false);
+            let new_val = !current_bool;
+            match write_config_value(file_path, breadcrumb, field.key, serde_json::json!(new_val))
+            {
+                Ok(()) => out.println(&format!(
+                    "{DIM}{}{} = {new_val}{RESET}",
+                    breadcrumb_display(breadcrumb),
+                    field.key
+                )),
+                Err(e) => out.println(&format!(
+                    "{}Error writing config: {e}{}",
+                    ansi_fg(theme().error),
+                    RESET
+                )),
+            }
+            None
+        }
+        ConfigInputKind::Enum(opts) => {
+            let items: Vec<String> = opts.clone();
+            let current_str = current_val.and_then(|v| v.as_str()).unwrap_or("");
+            let options: Vec<QuestionOptionView> = items
+                .iter()
+                .map(|o| QuestionOptionView {
+                    label: o.clone(),
+                    value: o.clone(),
+                    description: None,
+                    recommended: o == current_str,
+                })
+                .collect();
+            let question = QuestionPromptView {
+                title: Some("Config".to_string()),
+                description: Some(format!(
+                    "{file_label} > {}{}",
+                    breadcrumb_display(breadcrumb),
+                    field.key
+                )),
+                index: 0,
+                total: 1,
+                prompt: format!("Select value for {}", field.key),
+                options,
+                allow_custom_input: false,
+                custom_input_hint: None,
+                force_fuzzy_select: false,
+            };
+            ui.show_question(question);
+            let file_path = file_path.to_path_buf();
+            let breadcrumb = breadcrumb.to_vec();
+            let field_key = field.key;
+            Some(SlashSelectionHandler(Box::new(
+                move |answer: &str, _cli, out| {
+                    let selected = resolve_answer(answer, &items);
+                    match write_config_value(
+                        &file_path,
+                        &breadcrumb,
+                        field_key,
+                        serde_json::json!(selected),
+                    ) {
+                        Ok(()) => out.println(&format!(
+                            "{DIM}{}{field_key} = \"{selected}\"{RESET}",
+                            breadcrumb_display(&breadcrumb)
+                        )),
+                        Err(e) => out.println(&format!(
+                            "{}Error writing config: {e}{}",
+                            ansi_fg(theme().error),
+                            RESET
+                        )),
+                    }
+                    None
+                },
+            )))
+        }
+        ConfigInputKind::DynamicList => {
+            let sudocode_config = load_sudocode_config_for_current_dir();
+            let config_keys: Vec<String> = sudocode_config.models.keys().cloned().collect();
+            let models = model_capabilities::merge_discovery_ids(&config_keys);
+            let current_str = current_val.and_then(|v| v.as_str()).unwrap_or("");
+            let options: Vec<QuestionOptionView> = models
+                .iter()
+                .map(|m| QuestionOptionView {
+                    label: m.clone(),
+                    value: m.clone(),
+                    description: None,
+                    recommended: m == current_str,
+                })
+                .collect();
+            let question = QuestionPromptView {
+                title: Some("Config".to_string()),
+                description: Some(format!(
+                    "{file_label} > {}{} (current: {current_str})",
+                    breadcrumb_display(breadcrumb),
+                    field.key
+                )),
+                index: 0,
+                total: 1,
+                prompt: format!("Select {}", field.key),
+                options,
+                allow_custom_input: true,
+                custom_input_hint: Some("or type a model name".to_string()),
+                force_fuzzy_select: true,
+            };
+            ui.show_question(question);
+            let file_path = file_path.to_path_buf();
+            let breadcrumb = breadcrumb.to_vec();
+            let field_key = field.key;
+            let items = models;
+            Some(SlashSelectionHandler(Box::new(
+                move |answer: &str, _cli, out| {
+                    let selected = resolve_answer(answer, &items);
+                    match write_config_value(
+                        &file_path,
+                        &breadcrumb,
+                        field_key,
+                        serde_json::json!(selected),
+                    ) {
+                        Ok(()) => out.println(&format!(
+                            "{DIM}{}{field_key} = \"{selected}\"{RESET}",
+                            breadcrumb_display(&breadcrumb)
+                        )),
+                        Err(e) => out.println(&format!(
+                            "{}Error writing config: {e}{}",
+                            ansi_fg(theme().error),
+                            RESET
+                        )),
+                    }
+                    None
+                },
+            )))
+        }
+        ConfigInputKind::Text | ConfigInputKind::NumberInput => {
+            let current_str = current_val
+                .map(|v| serde_json::to_string(v).unwrap_or_default())
+                .unwrap_or_default();
+            out.println(&format!(
+                "{DIM}Current {}{} = {current_str}{RESET}",
+                breadcrumb_display(breadcrumb),
+                field.key
+            ));
+            out.println(&format!(
+                "{DIM}Edit the file directly: {}{RESET}",
+                file_path.display()
+            ));
+            None
+        }
+        ConfigInputKind::Editor => {
+            out.println(&format!(
+                "{DIM}Complex value \u{2014} edit the file directly: {}{RESET}",
+                file_path.display()
+            ));
+            None
+        }
+    }
+}
+
+// ── JSON helpers ────────────────────────────────────────────────────
+
+fn navigate_json<'a>(
+    root: &'a serde_json::Value,
+    breadcrumb: &[String],
+) -> Option<&'a serde_json::Value> {
+    let mut current = root;
+    for key in breadcrumb {
+        current = current.get(key.as_str())?;
+    }
+    Some(current)
+}
+
+fn truncate_json_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => {
+            if s.len() > 35 {
+                format!("\"{}…\"", &s[..35])
+            } else {
+                format!("\"{s}\"")
+            }
+        }
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Array(a) => format!("[{} items]", a.len()),
+        serde_json::Value::Object(o) => format!("{{{} keys}}", o.len()),
+    }
+}
+
+/// Build a dot-path prefix for display. Returns `"a.b."` or `""`.
+fn breadcrumb_display(breadcrumb: &[String]) -> String {
+    if breadcrumb.is_empty() {
+        String::new()
+    } else {
+        format!("{}.", breadcrumb.join("."))
+    }
+}
+
+fn resolve_answer(answer: &str, items: &[String]) -> String {
+    answer
+        .parse::<usize>()
+        .ok()
+        .and_then(|idx| items.get(idx.wrapping_sub(1)).cloned())
+        .unwrap_or_else(|| answer.to_string())
+}
+
+/// Atomically write a value to a config JSON file at the given path.
+pub(crate) fn write_config_value(
+    file_path: &Path,
+    breadcrumb: &[String],
+    key: &str,
+    value: serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let content = std::fs::read_to_string(file_path).unwrap_or_else(|_| "{}".to_string());
+    let mut root: serde_json::Value =
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
+
+    let mut current = &mut root;
+    for segment in breadcrumb {
+        if !current.is_object() {
+            *current = serde_json::json!({});
+        }
+        current = current
+            .as_object_mut()
+            .unwrap()
+            .entry(segment.clone())
+            .or_insert_with(|| serde_json::json!({}));
+    }
+
+    if let Some(obj) = current.as_object_mut() {
+        obj.insert(key.to_string(), value);
+    }
+
+    let tmp = file_path.with_extension("json.tmp");
+    let pretty = serde_json::to_string_pretty(&root)?;
+    std::fs::write(&tmp, pretty.as_bytes())?;
+    std::fs::rename(&tmp, file_path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_config_value_top_level() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"model": "old"}"#).unwrap();
+
+        write_config_value(&path, &[], "model", serde_json::json!("new")).unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(result["model"], "new");
+    }
+
+    #[test]
+    fn write_config_value_nested() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"sandbox": {"enabled": false}}"#).unwrap();
+
+        let bc = vec!["sandbox".to_string()];
+        write_config_value(&path, &bc, "enabled", serde_json::json!(true)).unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(result["sandbox"]["enabled"], true);
+    }
+
+    #[test]
+    fn write_config_value_creates_intermediaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "{}").unwrap();
+
+        let bc = vec!["permissions".to_string()];
+        write_config_value(&path, &bc, "defaultMode", serde_json::json!("plan")).unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(result["permissions"]["defaultMode"], "plan");
+    }
+
+    #[test]
+    fn write_config_value_creates_file_from_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.json");
+        // File doesn't exist yet — write_config_value handles missing file.
+        write_config_value(&path, &[], "model", serde_json::json!("test")).unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(result["model"], "test");
+    }
+
+    #[test]
+    fn navigate_json_empty_breadcrumb() {
+        let root = serde_json::json!({"a": 1});
+        let result = navigate_json(&root, &[]);
+        assert_eq!(result, Some(&serde_json::json!({"a": 1})));
+    }
+
+    #[test]
+    fn navigate_json_nested() {
+        let root = serde_json::json!({"sandbox": {"enabled": true}});
+        let bc = vec!["sandbox".to_string()];
+        let result = navigate_json(&root, &bc);
+        assert_eq!(result, Some(&serde_json::json!({"enabled": true})));
+    }
+
+    #[test]
+    fn navigate_json_missing_key() {
+        let root = serde_json::json!({"a": 1});
+        let bc = vec!["b".to_string()];
+        assert!(navigate_json(&root, &bc).is_none());
+    }
+
+    #[test]
+    fn truncate_json_value_short_string() {
+        assert_eq!(
+            truncate_json_value(&serde_json::json!("hello")),
+            "\"hello\""
+        );
+    }
+
+    #[test]
+    fn truncate_json_value_long_string() {
+        let long = "a".repeat(50);
+        let result = truncate_json_value(&serde_json::json!(long));
+        assert!(result.ends_with("…\""));
+        assert!(result.len() < 50);
+    }
+
+    #[test]
+    fn truncate_json_value_object() {
+        let obj = serde_json::json!({"a": 1, "b": 2});
+        assert_eq!(truncate_json_value(&obj), "{2 keys}");
+    }
+
+    #[test]
+    fn truncate_json_value_array() {
+        let arr = serde_json::json!([1, 2, 3]);
+        assert_eq!(truncate_json_value(&arr), "[3 items]");
+    }
+
+    #[test]
+    fn resolve_answer_numeric() {
+        let items = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(resolve_answer("1", &items), "a");
+        assert_eq!(resolve_answer("3", &items), "c");
+    }
+
+    #[test]
+    fn resolve_answer_text() {
+        let items = vec!["a".to_string()];
+        assert_eq!(resolve_answer("custom", &items), "custom");
+    }
+
+    #[test]
+    fn breadcrumb_display_empty() {
+        assert_eq!(breadcrumb_display(&[]), "");
+    }
+
+    #[test]
+    fn breadcrumb_display_nested() {
+        let bc = vec!["sandbox".to_string(), "inner".to_string()];
+        assert_eq!(breadcrumb_display(&bc), "sandbox.inner.");
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/src/cli/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod api_client;
 pub(crate) mod args;
+pub(crate) mod config_ui;
 pub(crate) mod cron;
 pub(crate) mod doctor;
 pub(crate) mod export;

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1908,7 +1908,12 @@ fn cancel_pending_question_answer(pending: &PendingQuestionAnswer) {
 /// Callback type for interactive slash commands that need user selection
 /// via iocraft's InputSlot (replaces dialoguer FuzzySelect/Select in the
 /// iocraft REPL path).
-type SlashSelectionHandler = Box<dyn FnOnce(&str, &Arc<Mutex<LiveCli>>, &repl_ui::OutputSender)>;
+///
+/// Returns `Option<SlashSelectionHandler>` to support chained interactions
+/// (tree navigation). A struct wrapper breaks the recursive type alias cycle.
+struct SlashSelectionHandler(
+    Box<dyn FnOnce(&str, &Arc<Mutex<LiveCli>>, &repl_ui::OutputSender) -> Option<SlashSelectionHandler>>,
+);
 
 /// Show an interactive selection question via iocraft's InputSlot and
 /// register a callback to handle the answer. The coordinator loop routes
@@ -1921,17 +1926,18 @@ fn show_slash_selection(
     ui: &repl_ui::UiCommandSender,
     question: repl_ui::QuestionPromptView,
     items: Vec<String>,
-    on_selected: impl FnOnce(String, &Arc<Mutex<LiveCli>>, &repl_ui::OutputSender) + 'static,
+    on_selected: impl FnOnce(String, &Arc<Mutex<LiveCli>>, &repl_ui::OutputSender) -> Option<SlashSelectionHandler>
+        + 'static,
 ) -> SlashSelectionHandler {
     ui.show_question(question);
-    Box::new(move |answer: &str, cli, out| {
+    SlashSelectionHandler(Box::new(move |answer: &str, cli, out| {
         let resolved = answer
             .parse::<usize>()
             .ok()
             .and_then(|idx| items.get(idx.wrapping_sub(1)).cloned())
             .unwrap_or_else(|| answer.to_string());
-        on_selected(resolved, cli, out);
-    })
+        on_selected(resolved, cli, out)
+    }))
 }
 
 struct IocraftQuestionPrompter {
@@ -2188,87 +2194,18 @@ fn run_repl_iocraft_dispatch(
                 let trimmed = text.trim();
                 let is_slash = match SlashCommand::parse(trimmed) {
                     Ok(Some(SlashCommand::Config { section: None })) => {
-                        // Interactive config picker via iocraft InputSlot.
+                        // Interactive config tree browser via FieldSchema SSOT.
                         let cwd = env::current_dir().unwrap_or_default();
                         let loader = runtime::ConfigLoader::default_for(&cwd);
-                        let user_settings_path = loader.config_home().join("settings.json");
-                        let config = match loader.load() {
-                            Ok(c) => c,
-                            Err(e) => {
-                                repl.output.println(&format!(
-                                    "{}{e}{}",
-                                    ansi_fg(theme().error),
-                                    RESET
-                                ));
-                                continue;
-                            }
-                        };
-                        let merged = config.merged();
-                        let keys: Vec<String> = merged.keys().cloned().collect();
-                        let options: Vec<repl_ui::QuestionOptionView> = keys
-                            .iter()
-                            .map(|k| {
-                                let val = merged.get(k).map_or("null".to_string(), |v| {
-                                    let s = v.render();
-                                    if s.len() > 40 {
-                                        format!("{}…", &s[..40])
-                                    } else {
-                                        s
-                                    }
-                                });
-                                repl_ui::QuestionOptionView {
-                                    label: format!("{k} = {val}"),
-                                    value: k.clone(),
-                                    description: None,
-                                    recommended: false,
-                                }
-                            })
-                            .collect();
-                        let settings_path = user_settings_path.clone();
-                        pending_slash_selection = Some(show_slash_selection(
-                            &repl.ui,
-                            repl_ui::QuestionPromptView {
-                                title: Some("Config".to_string()),
-                                description: Some(format!(
-                                    "Settings: {}",
-                                    user_settings_path.display()
-                                )),
-                                index: 0,
-                                total: 1,
-                                prompt: "Select setting to edit".to_string(),
-                                options,
-                                allow_custom_input: false,
-                                custom_input_hint: None,
-                                force_fuzzy_select: false,
-                            },
-                            keys,
-                            move |key, cli, out| {
-                                // Read current value, show it, and open editor for new value.
-                                let current = std::fs::read_to_string(&settings_path)
-                                    .unwrap_or_else(|_| "{}".to_string());
-                                let mut json: serde_json::Value =
-                                    serde_json::from_str(&current).unwrap_or(serde_json::json!({}));
-                                let current_val = json
-                                    .get(&key)
-                                    .map_or("null".to_string(), |v| {
-                                        serde_json::to_string_pretty(v)
-                                            .unwrap_or_else(|_| v.to_string())
-                                    });
-                                out.println(&format!(
-                                    "{DIM}Current {key} = {current_val}{RESET}\n\
-                                     {DIM}Type new value (JSON), or press Enter to keep current:{RESET}"
-                                ));
-                                // For now, print the current value. Interactive value
-                                // editing requires a second FuzzySelect/TextInput round
-                                // which is complex. The user can use `/config set <key> <value>`
-                                // or edit the file directly.
-                                out.println(&format!(
-                                    "{DIM}Edit: {}{RESET}",
-                                    settings_path.display()
-                                ));
-                                let _ = cli;
-                            },
-                        ));
+                        let settings_path = loader.config_home().join("settings.json");
+                        let sudocode_path = loader.config_home().join("sudocode.json");
+                        pending_slash_selection = Some(
+                            cli::config_ui::build_config_tree_handler(
+                                &repl.ui,
+                                settings_path,
+                                sudocode_path,
+                            ),
+                        );
                         true
                     }
                     Ok(Some(SlashCommand::Model { model: None })) => {
@@ -2323,6 +2260,7 @@ fn run_repl_iocraft_dispatch(
                                         RESET
                                     )),
                                 }
+                                None
                             },
                         ));
                         true
@@ -2393,7 +2331,7 @@ fn run_repl_iocraft_dispatch(
             }
             repl_ui::InputEvent::QuestionAnswer(text) => {
                 if let Some(handler) = pending_slash_selection.take() {
-                    handler(&text, &cli_shared, &repl.output);
+                    pending_slash_selection = (handler.0)(&text, &cli_shared, &repl.output);
                 } else if !consume_pending_question_answer(&pending_question_answer, text) {
                     repl.output.println(&format!(
                         "{DIM}(no question is waiting for an answer){RESET}"

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1912,7 +1912,13 @@ fn cancel_pending_question_answer(pending: &PendingQuestionAnswer) {
 /// Returns `Option<SlashSelectionHandler>` to support chained interactions
 /// (tree navigation). A struct wrapper breaks the recursive type alias cycle.
 struct SlashSelectionHandler(
-    Box<dyn FnOnce(&str, &Arc<Mutex<LiveCli>>, &repl_ui::OutputSender) -> Option<SlashSelectionHandler>>,
+    Box<
+        dyn FnOnce(
+            &str,
+            &Arc<Mutex<LiveCli>>,
+            &repl_ui::OutputSender,
+        ) -> Option<SlashSelectionHandler>,
+    >,
 );
 
 /// Show an interactive selection question via iocraft's InputSlot and
@@ -1926,7 +1932,11 @@ fn show_slash_selection(
     ui: &repl_ui::UiCommandSender,
     question: repl_ui::QuestionPromptView,
     items: Vec<String>,
-    on_selected: impl FnOnce(String, &Arc<Mutex<LiveCli>>, &repl_ui::OutputSender) -> Option<SlashSelectionHandler>
+    on_selected: impl FnOnce(
+            String,
+            &Arc<Mutex<LiveCli>>,
+            &repl_ui::OutputSender,
+        ) -> Option<SlashSelectionHandler>
         + 'static,
 ) -> SlashSelectionHandler {
     ui.show_question(question);
@@ -2199,13 +2209,11 @@ fn run_repl_iocraft_dispatch(
                         let loader = runtime::ConfigLoader::default_for(&cwd);
                         let settings_path = loader.config_home().join("settings.json");
                         let sudocode_path = loader.config_home().join("sudocode.json");
-                        pending_slash_selection = Some(
-                            cli::config_ui::build_config_tree_handler(
-                                &repl.ui,
-                                settings_path,
-                                sudocode_path,
-                            ),
-                        );
+                        pending_slash_selection = Some(cli::config_ui::build_config_tree_handler(
+                            &repl.ui,
+                            settings_path,
+                            sudocode_path,
+                        ));
                         true
                     }
                     Ok(Some(SlashCommand::Model { model: None })) => {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1964,6 +1964,7 @@ impl IocraftQuestionPrompter {
                 .collect(),
             allow_custom_input: field.allow_custom_input,
             custom_input_hint: field.custom_input_hint.clone(),
+            force_fuzzy_select: false,
         });
     }
 
@@ -2186,6 +2187,90 @@ fn run_repl_iocraft_dispatch(
                 // Try slash command dispatch.
                 let trimmed = text.trim();
                 let is_slash = match SlashCommand::parse(trimmed) {
+                    Ok(Some(SlashCommand::Config { section: None })) => {
+                        // Interactive config picker via iocraft InputSlot.
+                        let cwd = env::current_dir().unwrap_or_default();
+                        let loader = runtime::ConfigLoader::default_for(&cwd);
+                        let user_settings_path = loader.config_home().join("settings.json");
+                        let config = match loader.load() {
+                            Ok(c) => c,
+                            Err(e) => {
+                                repl.output.println(&format!(
+                                    "{}{e}{}",
+                                    ansi_fg(theme().error),
+                                    RESET
+                                ));
+                                continue;
+                            }
+                        };
+                        let merged = config.merged();
+                        let keys: Vec<String> = merged.keys().cloned().collect();
+                        let options: Vec<repl_ui::QuestionOptionView> = keys
+                            .iter()
+                            .map(|k| {
+                                let val = merged.get(k).map_or("null".to_string(), |v| {
+                                    let s = v.render();
+                                    if s.len() > 40 {
+                                        format!("{}…", &s[..40])
+                                    } else {
+                                        s
+                                    }
+                                });
+                                repl_ui::QuestionOptionView {
+                                    label: format!("{k} = {val}"),
+                                    value: k.clone(),
+                                    description: None,
+                                    recommended: false,
+                                }
+                            })
+                            .collect();
+                        let settings_path = user_settings_path.clone();
+                        pending_slash_selection = Some(show_slash_selection(
+                            &repl.ui,
+                            repl_ui::QuestionPromptView {
+                                title: Some("Config".to_string()),
+                                description: Some(format!(
+                                    "Settings: {}",
+                                    user_settings_path.display()
+                                )),
+                                index: 0,
+                                total: 1,
+                                prompt: "Select setting to edit".to_string(),
+                                options,
+                                allow_custom_input: false,
+                                custom_input_hint: None,
+                                force_fuzzy_select: false,
+                            },
+                            keys,
+                            move |key, cli, out| {
+                                // Read current value, show it, and open editor for new value.
+                                let current = std::fs::read_to_string(&settings_path)
+                                    .unwrap_or_else(|_| "{}".to_string());
+                                let mut json: serde_json::Value =
+                                    serde_json::from_str(&current).unwrap_or(serde_json::json!({}));
+                                let current_val = json
+                                    .get(&key)
+                                    .map_or("null".to_string(), |v| {
+                                        serde_json::to_string_pretty(v)
+                                            .unwrap_or_else(|_| v.to_string())
+                                    });
+                                out.println(&format!(
+                                    "{DIM}Current {key} = {current_val}{RESET}\n\
+                                     {DIM}Type new value (JSON), or press Enter to keep current:{RESET}"
+                                ));
+                                // For now, print the current value. Interactive value
+                                // editing requires a second FuzzySelect/TextInput round
+                                // which is complex. The user can use `/config set <key> <value>`
+                                // or edit the file directly.
+                                out.println(&format!(
+                                    "{DIM}Edit: {}{RESET}",
+                                    settings_path.display()
+                                ));
+                                let _ = cli;
+                            },
+                        ));
+                        true
+                    }
                     Ok(Some(SlashCommand::Model { model: None })) => {
                         // Interactive model picker via iocraft InputSlot.
                         let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
@@ -2216,6 +2301,7 @@ fn run_repl_iocraft_dispatch(
                                 options,
                                 allow_custom_input: true,
                                 custom_input_hint: Some("or type a model name".to_string()),
+                                force_fuzzy_select: false,
                             },
                             models,
                             |model_name, cli, out| {
@@ -4532,7 +4618,8 @@ impl LiveCli {
                 resumed
             }
             SlashCommand::Config { section } => {
-                self.out_suspend(|| Self::print_config(section.as_deref()))?;
+                let report = render_config_report(section.as_deref())?;
+                self.out_println(report);
                 false
             }
             SlashCommand::ConfigSet { key, value } => {
@@ -6553,12 +6640,17 @@ fn resolve_model_switch_auth_mode(
     config: &api::SudoCodeConfig,
 ) -> Result<AuthMode, String> {
     let Some(entry) = api::resolve_model(config, model) else {
-        return explicit.ok_or_else(|| {
-            format!(
-                "model '{model}' not found in config. Run /model to configure it, \
-                 or pass --auth=<subscription|proxy|api-key> explicitly."
-            )
-        });
+        if let Some(mode) = explicit {
+            return Ok(mode);
+        }
+        // Proxy passthrough fallback — same logic as resolve_configured_auth_mode.
+        if config.auth_modes.contains_key("proxy") {
+            return AuthMode::parse("proxy");
+        }
+        return Err(format!(
+            "model '{model}' not found in config. Run /model to configure it, \
+             or pass --auth=<subscription|proxy|api-key> explicitly."
+        ));
     };
 
     if let Some(mode) = explicit {
@@ -6574,13 +6666,20 @@ fn resolve_configured_auth_mode(
     model: &str,
     config: &api::SudoCodeConfig,
 ) -> Result<AuthMode, String> {
-    let entry = api::resolve_model(config, model).ok_or_else(|| {
-        format!(
-            "model '{model}' not found in config. Run /model to configure it, \
-             or pass --auth=<subscription|proxy|api-key> explicitly."
-        )
-    })?;
-    resolve_configured_auth_mode_for_entry(model, entry)
+    if let Some(entry) = api::resolve_model(config, model) {
+        return resolve_configured_auth_mode_for_entry(model, entry);
+    }
+    // Model not in sudocode.json — if a proxy provider is configured,
+    // default to proxy auth mode and let proxy passthrough route it.
+    // This avoids requiring every model to be registered in sudocode.json
+    // when sudorouter already knows how to route it.
+    if config.auth_modes.contains_key("proxy") {
+        return AuthMode::parse("proxy");
+    }
+    Err(format!(
+        "model '{model}' not found in config. Run /model to configure it, \
+         or pass --auth=<subscription|proxy|api-key> explicitly."
+    ))
 }
 
 fn resolve_configured_auth_mode_for_entry(

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -398,7 +398,11 @@ impl SpinnerRef {
 
     pub fn set_retry(&self, attempt: u32, max_retries: u32, reason: String) {
         if let Some(ref phase) = self.phase {
-            *phase.lock().unwrap() = crate::repl_ui::TurnPhase::Retry { attempt, max_retries, reason };
+            *phase.lock().unwrap() = crate::repl_ui::TurnPhase::Retry {
+                attempt,
+                max_retries,
+                reason,
+            };
         }
     }
 

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write as FmtWrite;
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use crossterm::style::{Color, Stylize};
@@ -313,6 +313,7 @@ pub struct SpinnerRef {
     response_bytes: Arc<AtomicU32>,
     is_thinking: Arc<AtomicBool>,
     is_paused: Arc<AtomicBool>,
+    phase: Option<Arc<Mutex<crate::repl_ui::TurnPhase>>>,
     /// When true, a TurnRenderer manages the spinner display — pause/resume
     /// only set the atomic flag without writing to stdout.
     managed: bool,
@@ -332,6 +333,7 @@ impl SpinnerRef {
             response_bytes: Arc::clone(response_bytes),
             is_thinking: Arc::clone(is_thinking),
             is_paused: Arc::clone(is_paused),
+            phase: None,
             managed: true,
         }
     }
@@ -339,7 +341,14 @@ impl SpinnerRef {
     /// Create a `SpinnerRef` from a `SpinnerState`. Convenience wrapper
     /// around `from_state` for the iocraft REPL path.
     pub fn from_spinner_state(state: &crate::repl_ui::SpinnerState) -> Self {
-        Self::from_state(&state.response_bytes, &state.is_thinking, &state.is_paused)
+        Self {
+            pb: ProgressBar::hidden(),
+            response_bytes: Arc::clone(&state.response_bytes),
+            is_thinking: Arc::new(AtomicBool::new(false)),
+            is_paused: Arc::new(AtomicBool::new(false)),
+            phase: Some(state.phase_arc()),
+            managed: true,
+        }
     }
 
     /// Pause the spinner, run the closure, resume the spinner.
@@ -354,6 +363,9 @@ impl SpinnerRef {
     /// ticking while paused. When managed by a TurnRenderer, only the
     /// atomic flag is set — the render thread handles clearing.
     pub fn pause(&self) {
+        if let Some(ref phase) = self.phase {
+            *phase.lock().unwrap() = crate::repl_ui::TurnPhase::Paused;
+        }
         self.is_paused.store(true, Ordering::SeqCst);
         if self.managed {
             // TurnRenderer sees is_paused and clears the spinner line
@@ -367,11 +379,27 @@ impl SpinnerRef {
 
     /// Resume the spinner after a pause.
     pub fn resume(&self) {
+        if let Some(ref phase) = self.phase {
+            *phase.lock().unwrap() = crate::repl_ui::TurnPhase::Thinking;
+        }
         self.is_paused.store(false, Ordering::SeqCst);
     }
 
     pub fn set_thinking(&self, on: bool) {
+        if let Some(ref phase) = self.phase {
+            *phase.lock().unwrap() = if on {
+                crate::repl_ui::TurnPhase::Reasoning
+            } else {
+                crate::repl_ui::TurnPhase::Thinking
+            };
+        }
         self.is_thinking.store(on, Ordering::SeqCst);
+    }
+
+    pub fn set_retry(&self, attempt: u32, max_retries: u32, reason: String) {
+        if let Some(ref phase) = self.phase {
+            *phase.lock().unwrap() = crate::repl_ui::TurnPhase::Retry { attempt, max_retries, reason };
+        }
     }
 
     pub fn add_response_bytes(&self, n: u32) {
@@ -442,6 +470,7 @@ impl SpinnerHandle {
             response_bytes: Arc::clone(&self.response_bytes),
             is_thinking: Arc::clone(&self.is_thinking),
             is_paused: Arc::clone(&self.is_paused),
+            phase: None,
             managed: false,
         }
     }

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -36,8 +36,12 @@ use iocraft::prelude::*;
 mod stderr_redirect {
     pub struct StderrRedirect;
     impl StderrRedirect {
-        pub fn activate() -> Option<Self> { None }
-        pub fn drain(&self) -> Option<String> { None }
+        pub fn activate() -> Option<Self> {
+            None
+        }
+        pub fn drain(&self) -> Option<String> {
+            None
+        }
     }
 }
 
@@ -67,7 +71,8 @@ mod stderr_redirect {
             // `write_fd` is dropped here — fd 2 keeps the write end alive.
 
             // Make the read end non-blocking so drain() never stalls.
-            let flags = nix::fcntl::fcntl(read_fd.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).ok()?;
+            let flags =
+                nix::fcntl::fcntl(read_fd.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).ok()?;
             let mut oflags = nix::fcntl::OFlag::from_bits_truncate(flags);
             oflags.insert(nix::fcntl::OFlag::O_NONBLOCK);
             nix::fcntl::fcntl(read_fd.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(oflags)).ok()?;
@@ -89,7 +94,11 @@ mod stderr_redirect {
                     Err(_) => break,
                 }
             }
-            if collected.is_empty() { None } else { Some(collected) }
+            if collected.is_empty() {
+                None
+            } else {
+                Some(collected)
+            }
         }
     }
 }
@@ -101,7 +110,11 @@ mod stderr_redirect {
 pub enum TurnPhase {
     Thinking,
     Reasoning,
-    Retry { attempt: u32, max_retries: u32, reason: String },
+    Retry {
+        attempt: u32,
+        max_retries: u32,
+        reason: String,
+    },
     Paused,
 }
 
@@ -185,23 +198,35 @@ impl SpinnerState {
         let is_retry = matches!(current_phase, TurnPhase::Retry { .. });
 
         let (frame, current_label): (String, String) = if is_retry {
-            if let TurnPhase::Retry { attempt, max_retries, ref reason } = current_phase {
-                ("\u{27f3}".to_string(), format!("Retry {attempt}/{max_retries}: {reason}"))
+            if let TurnPhase::Retry {
+                attempt,
+                max_retries,
+                ref reason,
+            } = current_phase
+            {
+                (
+                    "\u{27f3}".to_string(),
+                    format!("Retry {attempt}/{max_retries}: {reason}"),
+                )
             } else {
                 unreachable!()
             }
         } else if is_reasoning {
             let reasoning_frames: &[&str] = &["\u{25d0}", "\u{25d3}", "\u{25d1}", "\u{25d2}"];
-            (reasoning_frames[frame_index % reasoning_frames.len()].to_string(),
-             "\u{1f9e0} Reasoning...".to_string())
+            (
+                reasoning_frames[frame_index % reasoning_frames.len()].to_string(),
+                "\u{1f9e0} Reasoning...".to_string(),
+            )
         } else {
             let thinking_frames: &[&str] = &[
                 "\u{280b}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283c}", "\u{2834}", "\u{2826}",
                 "\u{2827}", "\u{2807}", "\u{280f}",
             ];
             let label = self.label.lock().unwrap();
-            (thinking_frames[frame_index % thinking_frames.len()].to_string(),
-             label.clone())
+            (
+                thinking_frames[frame_index % thinking_frames.len()].to_string(),
+                label.clone(),
+            )
         };
 
         let elapsed = self.start_time.lock().unwrap().elapsed().as_secs_f64();
@@ -1177,9 +1202,10 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     // InputSlot rendering
     let (panel_text, prompt_label) = match &current_input_slot {
         InputSlot::Hint(_) | InputSlot::TextInput => (None, "\u{276f} "),
-        InputSlot::DialPad(q) => {
-            (Some(format_question_panel(q, dialpad_cursor.get())), "\u{2753} ")
-        }
+        InputSlot::DialPad(q) => (
+            Some(format_question_panel(q, dialpad_cursor.get())),
+            "\u{2753} ",
+        ),
         InputSlot::FuzzySelect(fs) => (Some(fs.format_panel()), "\u{1f50d} "),
     };
 

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -12,11 +12,11 @@
 //! + match makes the contract visible to any reader:
 //!
 //! ```text
-//! [StatusSlot]    ← spinner | turn_result (auto-dismiss) | tips (first-run) | empty
+//! [StatusSlot]    ← spinner | turn_result | tips | empty
 //! ──── separator ────
-//! [InputSlot]     ← text_input | question_panel   (Option<QuestionPromptView>)
+//! [InputSlot]     ← hint | text_input | question_panel
 //! ──── separator ────
-//! [FooterSlot]    ← full | minimal | turn_active
+//! [FooterSlot]    ← hint (3s) > turn_active > minimal > full
 //! ```
 
 use std::fmt::Write as FmtWrite;
@@ -29,16 +29,88 @@ use std::time::{Duration, Instant};
 use commands::suggest_slash_commands;
 use iocraft::prelude::*;
 
-// ── SpinnerState ───────────────────────────────────────────────────────
+// ── stderr redirect ───────────────────────────────────────────────────
+
+/// Windows stub — stderr redirect is a no-op on non-Unix platforms.
+#[cfg(not(unix))]
+mod stderr_redirect {
+    pub struct StderrRedirect;
+    impl StderrRedirect {
+        pub fn activate() -> Option<Self> { None }
+        pub fn drain(&self) -> Option<String> { None }
+    }
+}
+
+/// Unix pipe-based stderr redirect: replaces fd 2 with a pipe so that
+/// any library writing to stderr (e.g. tracing, nix, openssl) does not
+/// corrupt the iocraft canvas.  Captured bytes are drained each tick and
+/// routed through the iocraft stdout handle.
+///
+/// All syscalls go through `nix`'s safe wrappers — no `unsafe` blocks.
+#[cfg(unix)]
+mod stderr_redirect {
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, OwnedFd};
+
+    pub struct StderrRedirect {
+        read_file: std::fs::File,
+    }
+
+    impl StderrRedirect {
+        /// Replace fd 2 with the write end of a pipe.  Returns `Some` on
+        /// success.  The read end is kept for `drain()`.
+        pub fn activate() -> Option<Self> {
+            let (read_fd, write_fd): (OwnedFd, OwnedFd) = nix::unistd::pipe().ok()?;
+
+            // Point fd 2 at the write end of the pipe.
+            nix::unistd::dup2(write_fd.as_raw_fd(), 2).ok()?;
+            // `write_fd` is dropped here — fd 2 keeps the write end alive.
+
+            // Make the read end non-blocking so drain() never stalls.
+            let flags = nix::fcntl::fcntl(read_fd.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).ok()?;
+            let mut oflags = nix::fcntl::OFlag::from_bits_truncate(flags);
+            oflags.insert(nix::fcntl::OFlag::O_NONBLOCK);
+            nix::fcntl::fcntl(read_fd.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(oflags)).ok()?;
+
+            let read_file = std::fs::File::from(read_fd);
+            Some(Self { read_file })
+        }
+
+        /// Non-blocking drain: returns captured text or `None`.
+        pub fn drain(&self) -> Option<String> {
+            let mut buf = [0u8; 4096];
+            let mut collected = String::new();
+            let mut file = &self.read_file;
+            loop {
+                match file.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => collected.push_str(&String::from_utf8_lossy(&buf[..n])),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(_) => break,
+                }
+            }
+            if collected.is_empty() { None } else { Some(collected) }
+        }
+    }
+}
+
+// ── TurnPhase + SpinnerState ───────────────────────────────────────────
+
+/// Phase of the current agent turn — drives spinner icon/label selection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TurnPhase {
+    Thinking,
+    Reasoning,
+    Retry { attempt: u32, max_retries: u32, reason: String },
+    Paused,
+}
 
 /// Shared state for the spinner, read by the render thread and written
-/// by the runner thread. All fields are atomic for lock-free cross-thread
-/// access.
+/// by the runner thread.
 #[derive(Clone)]
 pub struct SpinnerState {
     pub response_bytes: Arc<AtomicU32>,
-    pub is_thinking: Arc<AtomicBool>,
-    pub is_paused: Arc<AtomicBool>,
+    phase: Arc<Mutex<TurnPhase>>,
     active: Arc<AtomicBool>,
     start_time: Arc<Mutex<Instant>>,
     label: Arc<Mutex<String>>,
@@ -52,8 +124,7 @@ impl SpinnerState {
     pub fn new_inactive() -> Self {
         Self {
             response_bytes: Arc::new(AtomicU32::new(0)),
-            is_thinking: Arc::new(AtomicBool::new(false)),
-            is_paused: Arc::new(AtomicBool::new(false)),
+            phase: Arc::new(Mutex::new(TurnPhase::Thinking)),
             active: Arc::new(AtomicBool::new(false)),
             start_time: Arc::new(Mutex::new(Instant::now())),
             label: Arc::new(Mutex::new(String::new())),
@@ -65,8 +136,7 @@ impl SpinnerState {
     /// Reset and activate for a new turn.
     pub fn start_turn(&self, label: &str, model: Option<&str>, token_budget: Option<u32>) {
         self.response_bytes.store(0, Ordering::SeqCst);
-        self.is_thinking.store(false, Ordering::SeqCst);
-        self.is_paused.store(false, Ordering::SeqCst);
+        *self.phase.lock().unwrap() = TurnPhase::Thinking;
         *self.start_time.lock().unwrap() = Instant::now();
         *self.label.lock().unwrap() = label.to_string();
         *self.model.lock().unwrap() = model.map(ToString::to_string);
@@ -79,33 +149,61 @@ impl SpinnerState {
         self.active.store(false, Ordering::SeqCst);
     }
 
+    /// Set the current turn phase.
+    pub fn set_phase(&self, phase: TurnPhase) {
+        *self.phase.lock().unwrap() = phase;
+    }
+
+    /// Read the current turn phase.
+    pub fn phase(&self) -> TurnPhase {
+        self.phase.lock().unwrap().clone()
+    }
+
+    /// Convenience: check whether the current phase is `Paused`.
+    pub fn is_paused(&self) -> bool {
+        *self.phase.lock().unwrap() == TurnPhase::Paused
+    }
+
+    /// Return a clone of the phase `Arc` for sharing with other threads.
+    pub fn phase_arc(&self) -> Arc<Mutex<TurnPhase>> {
+        Arc::clone(&self.phase)
+    }
+
     /// Render the current spinner frame as a colored ANSI string.
     /// Returns empty string when inactive or paused.
     pub fn render_frame(&self, frame_index: usize) -> String {
         if !self.active.load(Ordering::SeqCst) {
             return String::new();
         }
-        if self.is_paused.load(Ordering::SeqCst) {
+
+        let current_phase = self.phase.lock().unwrap().clone();
+        if current_phase == TurnPhase::Paused {
             return String::new();
         }
 
-        let thinking = self.is_thinking.load(Ordering::SeqCst);
-        let frames: &[&str] = if thinking {
-            &["\u{25d0}", "\u{25d3}", "\u{25d1}", "\u{25d2}"]
+        let is_reasoning = current_phase == TurnPhase::Reasoning;
+        let is_retry = matches!(current_phase, TurnPhase::Retry { .. });
+
+        let (frame, current_label): (String, String) = if is_retry {
+            if let TurnPhase::Retry { attempt, max_retries, ref reason } = current_phase {
+                ("\u{27f3}".to_string(), format!("Retry {attempt}/{max_retries}: {reason}"))
+            } else {
+                unreachable!()
+            }
+        } else if is_reasoning {
+            let reasoning_frames: &[&str] = &["\u{25d0}", "\u{25d3}", "\u{25d1}", "\u{25d2}"];
+            (reasoning_frames[frame_index % reasoning_frames.len()].to_string(),
+             "\u{1f9e0} Reasoning...".to_string())
         } else {
-            &[
+            let thinking_frames: &[&str] = &[
                 "\u{280b}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283c}", "\u{2834}", "\u{2826}",
                 "\u{2827}", "\u{2807}", "\u{280f}",
-            ]
-        };
-        let label = self.label.lock().unwrap();
-        let current_label = if thinking {
-            "\u{1f9e0} Reasoning..."
-        } else {
-            &label
+            ];
+            let label = self.label.lock().unwrap();
+            (thinking_frames[frame_index % thinking_frames.len()].to_string(),
+             label.clone())
         };
 
-        let frame = frames[frame_index % frames.len()];
         let elapsed = self.start_time.lock().unwrap().elapsed().as_secs_f64();
 
         let mut line = format!("{frame} {current_label}");
@@ -146,13 +244,17 @@ impl SpinnerState {
             }
         }
 
-        // Stall detection: yellow when no new bytes for 3+ seconds.
         let t = crate::render::theme();
-        let is_stalled = bytes > 0 && !thinking && elapsed > 3.0;
-        let color = if is_stalled {
+        let color = if is_retry {
             crate::render::ansi_fg(t.warning)
         } else {
-            crate::render::ansi_fg(t.info)
+            // Stall detection: yellow when no new bytes for 3+ seconds.
+            let is_stalled = bytes > 0 && !is_reasoning && elapsed > 3.0;
+            if is_stalled {
+                crate::render::ansi_fg(t.warning)
+            } else {
+                crate::render::ansi_fg(t.info)
+            }
         };
         format!("{color}{line}{}", crate::render::RESET)
     }
@@ -186,8 +288,12 @@ enum StatusSlot {
 }
 
 /// ChromeSlot: bottom hint line. Content varies by lifecycle phase.
+///
+/// Priority (highest first): Hint > TurnActive > Minimal > Full.
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum FooterSlot {
+    /// Transient hint — highest priority, auto-dismissed after 3 seconds.
+    Hint(String),
     /// Before first submit — full hints.
     Full,
     /// After first submit — just permission mode + essentials.
@@ -198,6 +304,7 @@ enum FooterSlot {
 
 fn format_footer_text(slot: &FooterSlot, perm: &str) -> String {
     match slot {
+        FooterSlot::Hint(msg) => format!("  {msg}"),
         FooterSlot::Full => format!(
             "  \u{23f5}\u{23f5} {perm} \u{00b7} /help for commands \u{00b7} /exit to quit \u{00b7} Tab for /commands"
         ),
@@ -237,12 +344,17 @@ pub struct QuestionPromptView {
     pub options: Vec<QuestionOptionView>,
     pub allow_custom_input: bool,
     pub custom_input_hint: Option<String>,
+    /// When true, always use FuzzySelect regardless of option count.
+    /// Used for config picker and other lists that benefit from search.
+    pub force_fuzzy_select: bool,
 }
 
 /// ChromeSlot: primary interaction area between the two separators.
 /// Exactly one variant renders at a time.
 #[derive(Clone, Debug)]
 enum InputSlot {
+    /// Transient hint — dismissed on any keypress.
+    Hint(String),
     /// Normal text input with ❯ prompt.
     TextInput,
     /// ≤9 options, digit-key shortcut per item (tool approval, init).
@@ -367,6 +479,7 @@ pub enum UiCommand {
     ShowQuestion(QuestionPromptView),
     ClearQuestion,
     SetTurnResult(String),
+    ShowInputHint(String),
 }
 
 #[derive(Clone)]
@@ -386,6 +499,21 @@ impl UiCommandSender {
     pub fn set_turn_result(&self, text: &str) {
         let _ = self.tx.send(UiCommand::SetTurnResult(text.to_string()));
     }
+
+    pub fn show_input_hint(&self, text: &str) {
+        let _ = self.tx.send(UiCommand::ShowInputHint(text.to_string()));
+    }
+}
+
+/// Submit the currently selected DialPad option. Shared by Enter key
+/// and digit-key shortcut paths (DRY).
+fn submit_dialpad_selection(
+    question: &QuestionPromptView,
+    selected_index: usize,
+    input_tx: &SyncSender<InputEvent>,
+) {
+    let answer = (selected_index + 1).to_string();
+    let _ = input_tx.send(InputEvent::QuestionAnswer(answer));
 }
 
 fn enter_key_event_for_value(
@@ -448,13 +576,19 @@ fn format_question_panel(question: &QuestionPromptView, selected_index: usize) -
             .filter(|description| !description.is_empty())
             .map_or(String::new(), |description| format!(" - {description}"));
         lines.push(format!(
-            "{selector} {}. {}{}{}",
+            "{selector} [{}] {}{}{}",
             index + 1,
             option.label,
             marker,
             description
         ));
     }
+    let max_digit = question.options.len().min(9);
+    lines.push(format!(
+        "{}  \u{2191}\u{2193} navigate \u{00b7} 1-{max_digit} quick select \u{00b7} Enter confirm{}",
+        crate::render::DIM,
+        crate::render::RESET,
+    ));
     lines.join("\n")
 }
 
@@ -626,6 +760,7 @@ struct ReplContext {
     spinner: SpinnerState,
     permission_mode: String,
     tips_line: String,
+    stderr_redir: Arc<Mutex<Option<stderr_redirect::StderrRedirect>>>,
 }
 
 #[component]
@@ -637,6 +772,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let spinner = ctx.spinner.clone();
     let permission_mode = ctx.permission_mode.clone();
     let tips_text = ctx.tips_line.clone();
+    let stderr_redir = Arc::clone(&ctx.stderr_redir);
     drop(ctx);
 
     // use_terminal_size must be called before use_future and use_terminal_events
@@ -658,17 +794,33 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut saved_input = hooks.use_state(String::new);
     let mut tab_candidates = hooks.use_state(Vec::<String>::new);
     let mut tab_index = hooks.use_state(|| 0usize);
+    let mut footer_hint = hooks.use_state(|| None::<(String, Instant)>);
+    let mut dialpad_cursor = hooks.use_state(|| 0usize);
 
     // Clone handles for the future (StdoutHandle is Clone).
     let stdout_for_future = stdout.clone();
     let spinner_for_future = spinner.clone();
     let output_rx_for_future = Arc::clone(&output_rx);
     let ui_rx_for_future = Arc::clone(&ui_rx);
+    let stderr_redir_for_future = Arc::clone(&stderr_redir);
 
     // 80ms tick loop: drain output/control channels, update spinner text.
     hooks.use_future(async move {
         loop {
             smol::Timer::after(Duration::from_millis(80)).await;
+
+            // Drain stderr redirect — route captured text through stdout
+            // so it appears in the iocraft scrollback instead of corrupting
+            // the canvas.
+            if let Ok(guard) = stderr_redir_for_future.lock() {
+                if let Some(ref redir) = *guard {
+                    if let Some(captured) = redir.drain() {
+                        for line in captured.lines() {
+                            stdout_for_future.println(line);
+                        }
+                    }
+                }
+            }
 
             // Drain output channel.
             if let Ok(rx) = output_rx_for_future.lock() {
@@ -689,9 +841,17 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 loop {
                     match rx.try_recv() {
                         Ok(UiCommand::ShowQuestion(question)) => {
-                            let slot = if question.options.len() > DIALPAD_MAX_OPTIONS {
+                            let slot = if question.force_fuzzy_select
+                                || question.options.len() > DIALPAD_MAX_OPTIONS
+                            {
                                 InputSlot::FuzzySelect(FuzzySelectState::new(question))
                             } else {
+                                let initial = question
+                                    .options
+                                    .iter()
+                                    .position(|o| o.recommended)
+                                    .unwrap_or(0);
+                                dialpad_cursor.set(initial);
                                 InputSlot::DialPad(question)
                             };
                             input_slot.set(slot);
@@ -704,10 +864,22 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         Ok(UiCommand::SetTurnResult(text)) => {
                             turn_result.set(Some(text));
                         }
+                        Ok(UiCommand::ShowInputHint(text)) => {
+                            input_slot.set(InputSlot::Hint(text));
+                        }
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => break,
                     }
                 }
+            }
+
+            // Auto-dismiss footer_hint after deadline.
+            let hint_expired = footer_hint
+                .read()
+                .as_ref()
+                .is_some_and(|(_, deadline)| Instant::now() >= *deadline);
+            if hint_expired {
+                footer_hint.set(None);
             }
 
             // Update spinner.  When a new turn starts (spinner becomes
@@ -736,25 +908,24 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 ..
             }) if kind != KeyEventKind::Release => {
                 let current_slot = input_slot.read().clone();
+                // Dismiss InputSlot::Hint on any keypress.
+                if matches!(current_slot, InputSlot::Hint(_)) {
+                    input_slot.set(InputSlot::TextInput);
+                    return;
+                }
                 match code {
                     // ── Enter ──────────────────────────────────────────
                     KeyCode::Enter if !modifiers.contains(KeyModifiers::SHIFT) => {
                         match &current_slot {
+                            InputSlot::Hint(_) => {
+                                input_slot.set(InputSlot::TextInput);
+                            }
                             InputSlot::DialPad(question) => {
-                                let val = input_value.read().clone();
-                                let selected_index = match &*input_slot.read() {
-                                    InputSlot::DialPad(q) => q.options.iter().position(|o| o.recommended).unwrap_or(0),
-                                    _ => 0,
-                                };
-                                if let Some(event) = enter_key_event_for_value(Some(question), selected_index, &val) {
-                                    if !*has_submitted.read() { has_submitted.set(true); }
-                                    let _ = input_tx_for_events.send(match event {
-                                        InputEvent::QuestionAnswer(_) => InputEvent::QuestionAnswer(val.clone()),
-                                        other => other,
-                                    });
-                                    input_value.set(String::new());
-                                    input_slot.set(InputSlot::TextInput);
-                                }
+                                let selected = dialpad_cursor.get();
+                                submit_dialpad_selection(question, selected, &input_tx_for_events);
+                                if !*has_submitted.read() { has_submitted.set(true); }
+                                input_value.set(String::new());
+                                input_slot.set(InputSlot::TextInput);
                             }
                             InputSlot::FuzzySelect(_) => {
                                 let answer = {
@@ -805,11 +976,17 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     }
                     // ── Up/Down — DialPad option selection ─────────────
                     KeyCode::Up if matches!(current_slot, InputSlot::DialPad(ref q) if !q.options.is_empty()) => {
-                        // DialPad doesn't track cursor separately — uses
-                        // the question's recommended field for initial highlight.
-                        // Up/Down not needed for ≤9 digit-key items.
+                        let cur = dialpad_cursor.get();
+                        dialpad_cursor.set(cur.saturating_sub(1));
                     }
-                    KeyCode::Down if matches!(current_slot, InputSlot::DialPad(ref q) if !q.options.is_empty()) => {}
+                    KeyCode::Down if matches!(current_slot, InputSlot::DialPad(ref q) if !q.options.is_empty()) => {
+                        let cur = dialpad_cursor.get();
+                        let max = match &current_slot {
+                            InputSlot::DialPad(q) => q.options.len().saturating_sub(1),
+                            _ => 0,
+                        };
+                        dialpad_cursor.set((cur + 1).min(max));
+                    }
                     // ── Up/Down — FuzzySelect cursor ───────────────────
                     KeyCode::Up if matches!(current_slot, InputSlot::FuzzySelect(_)) => {
                         let mut slot = input_slot.write();
@@ -866,9 +1043,13 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             _ => 0,
                         };
                         if digit >= 1 && digit <= option_count {
-                            let _ = input_tx_for_events
-                                .send(InputEvent::QuestionAnswer(digit.to_string()));
-                            input_value.set(String::new());
+                            dialpad_cursor.set(digit - 1);
+                            if let InputSlot::DialPad(ref question) = current_slot {
+                                submit_dialpad_selection(question, digit - 1, &input_tx_for_events);
+                                if !*has_submitted.read() { has_submitted.set(true); }
+                                input_value.set(String::new());
+                                input_slot.set(InputSlot::TextInput);
+                            }
                         }
                     }
                     // ── Typing in FuzzySelect updates filter ──────────
@@ -910,13 +1091,14 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         } else {
                             last_ctrlc.set(Some(now));
                             let _ = input_tx_for_events.send(InputEvent::Abort);
-                            stdout_for_events.println(format!("  {}Press Ctrl-C again to exit{}", crate::render::DIM, crate::render::RESET));
+                            let hint_msg = format!("{}Press Ctrl-C again to exit{}", crate::render::DIM, crate::render::RESET);
+                            footer_hint.set(Some((hint_msg, Instant::now() + Duration::from_secs(3))));
                             input_value.set(String::new());
                         }
                     }
                     KeyCode::Esc => {
-                        // In FuzzySelect/DialPad, ESC cancels the selection.
-                        if !matches!(current_slot, InputSlot::TextInput) {
+                        // In FuzzySelect/DialPad/Hint, ESC cancels.
+                        if !matches!(current_slot, InputSlot::TextInput | InputSlot::Hint(_)) {
                             input_slot.set(InputSlot::TextInput);
                             input_value.set(String::new());
                             let _ = input_tx_for_events.send(InputEvent::Abort);
@@ -981,8 +1163,10 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         StatusSlot::Empty
     };
 
-    // FooterSlot
-    let footer_slot = if matches!(status_slot, StatusSlot::Spinner(_)) {
+    // FooterSlot: Hint > TurnActive > Minimal > Full
+    let footer_slot = if let Some((ref msg, _)) = *footer_hint.read() {
+        FooterSlot::Hint(msg.clone())
+    } else if matches!(status_slot, StatusSlot::Spinner(_)) {
         FooterSlot::TurnActive
     } else if submitted {
         FooterSlot::Minimal
@@ -992,10 +1176,9 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
     // InputSlot rendering
     let (panel_text, prompt_label) = match &current_input_slot {
-        InputSlot::TextInput => (None, "\u{276f} "),
+        InputSlot::Hint(_) | InputSlot::TextInput => (None, "\u{276f} "),
         InputSlot::DialPad(q) => {
-            let selected = q.options.iter().position(|o| o.recommended).unwrap_or(0);
-            (Some(format_question_panel(q, selected)), "\u{2753} ")
+            (Some(format_question_panel(q, dialpad_cursor.get())), "\u{2753} ")
         }
         InputSlot::FuzzySelect(fs) => (Some(fs.format_panel()), "\u{1f50d} "),
     };
@@ -1020,7 +1203,19 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             #(panel_text.map(|panel| element! {
                 Text(content: panel, color: Color::Cyan)
             }))
-            #(if matches!(current_input_slot, InputSlot::FuzzySelect(_)) {
+            #(if let InputSlot::Hint(ref hint_text) = current_input_slot {
+                element! {
+                    View(flex_direction: FlexDirection::Row) {
+                        Text(content: hint_text.clone(), color: Color::DarkGrey)
+                    }
+                }
+            } else if matches!(current_input_slot, InputSlot::DialPad(_)) {
+                // DialPad: no input row — all interaction is via
+                // arrow keys and digit shortcuts shown in the panel.
+                element! {
+                    View(flex_direction: FlexDirection::Row) {}
+                }
+            } else if matches!(current_input_slot, InputSlot::FuzzySelect(_)) {
                 // FuzzySelect owns keyboard input — render filter as
                 // static text so TextInput's on_change doesn't compete.
                 let filter_display = match &current_input_slot {
@@ -1069,6 +1264,9 @@ pub fn spawn_repl_ui(permission_mode: &str, startup_banner: &str) -> ReplHandle 
     let (input_tx, input_rx) = mpsc::sync_channel::<InputEvent>(16);
     let spinner = SpinnerState::new_inactive();
 
+    let stderr_redir: Arc<Mutex<Option<stderr_redirect::StderrRedirect>>> =
+        Arc::new(Mutex::new(None));
+
     let ctx = ReplContext {
         output_rx: Arc::new(Mutex::new(output_rx)),
         ui_rx: Arc::new(Mutex::new(ui_rx)),
@@ -1076,6 +1274,7 @@ pub fn spawn_repl_ui(permission_mode: &str, startup_banner: &str) -> ReplHandle 
         spinner: spinner.clone(),
         permission_mode: permission_mode.to_string(),
         tips_line: "Type /help for commands \u{00b7} /status for live context \u{00b7} /resume latest jumps back to the newest session \u{00b7} /diff then /commit to ship \u{00b7} Tab for /command completions".to_string(),
+        stderr_redir: Arc::clone(&stderr_redir),
     };
 
     let banner = startup_banner.to_string();
@@ -1086,6 +1285,14 @@ pub fn spawn_repl_ui(permission_mode: &str, startup_banner: &str) -> ReplHandle 
             // session info in the scrollback. iocraft's render_loop enters
             // raw mode immediately, so we print first.
             println!("{banner}");
+
+            // Activate stderr redirect before entering raw mode so that
+            // any library writing to fd 2 is captured and routed through
+            // the iocraft stdout handle by the tick loop.
+            if let Ok(mut guard) = stderr_redir.lock() {
+                *guard = stderr_redirect::StderrRedirect::activate();
+            }
+
             smol::block_on(
                 element! {
                     ContextProvider(value: Context::owned(ctx)) {
@@ -1138,6 +1345,7 @@ mod tests {
             ],
             allow_custom_input: false,
             custom_input_hint: None,
+            force_fuzzy_select: false,
         }
     }
 
@@ -1152,6 +1360,7 @@ mod tests {
             options: vec![],
             allow_custom_input: true,
             custom_input_hint: None,
+            force_fuzzy_select: false,
         };
 
         assert_eq!(
@@ -1183,8 +1392,8 @@ mod tests {
         let panel = format_question_panel(&question_with_options(), 1);
 
         assert!(panel.contains("[Setup]"));
-        assert!(panel.contains("  1. Project recommended"));
-        assert!(panel.contains("> 2. User"));
+        assert!(panel.contains(" [1] Project recommended"));
+        assert!(panel.contains("> [2] User"));
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -94,6 +94,301 @@ fn iocraft_repl_auto_grow_exit_no_hang() {
     assert_eq!(exit, 0, "clean exit code");
 }
 
+/// Ctrl-C hint appears in the FooterSlot (not scrollback) and
+/// auto-dismisses. Pressing Ctrl-C once while idle should show
+/// "Press Ctrl-C again to exit" in the footer area, and a subsequent
+/// keypress should dismiss it. The hint must NOT appear in scrollback.
+#[test]
+#[cfg(unix)]
+fn iocraft_repl_ctrlc_hint_in_footer() {
+    let env = TestEnv::new("iocraft-ctrlc-hint");
+    let root = env.workspace_root().to_path_buf();
+    std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(10));
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt: {e}\nPTY:\n{screen}");
+    });
+
+    // Press Ctrl-C once — should show hint in footer area.
+    sess.send("\x03").expect("send Ctrl-C");
+
+    sess.expect("Press Ctrl-C again to exit").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("Ctrl-C hint should appear in footer: {e}\nPTY:\n{screen}");
+    });
+
+    // Clean exit.
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
+}
+
+/// TurnPhase::Thinking renders in the StatusSlot during a turn.
+/// Verifies the spinner shows the model name during streaming.
+/// This is the foundation test for the TurnPhase ChromeSlot — it
+/// confirms that phase-based rendering works end-to-end.
+///
+/// The retry sub-phase (TurnPhase::Retry) cannot be reliably triggered
+/// in automated tests — it requires a specific proxy error. Manual
+/// verification: use `/model claude-fable-5` (non-existent) and send a
+/// prompt to trigger retries, then verify retry text appears in the
+/// StatusSlot and Ctrl-C cancels cleanly.
+#[test]
+#[cfg(unix)]
+fn iocraft_repl_turn_phase_thinking_renders() {
+    let env = TestEnv::new("iocraft-turn-phase");
+
+    if env.is_mock() {
+        eprintln!(
+            "iocraft_repl_turn_phase_thinking_renders: \
+             skipped in mock mode (requires SCODE_TEST_BACKEND=live)"
+        );
+        return;
+    }
+
+    let root = env.workspace_root().to_path_buf();
+    std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(30));
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("What is 2+2? Answer only the number.\r")
+        .expect("send prompt");
+
+    // The spinner should show "Thinking" during the turn.
+    sess.expect("(?i)thinking").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("Thinking phase should render in StatusSlot: {e}\nPTY:\n{screen}");
+    });
+
+    // Wait for response and reprompt.
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should return to prompt: {e}\nPTY:\n{screen}");
+    });
+
+    // Clean exit.
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
+}
+
+/// SSOT endpoint routing: Claude models use anthropic-messages format
+/// (not openai-completions) when the model_capabilities SSOT has
+/// endpoint_types from sudorouter. Verifies that extended thinking
+/// content is visible (non-zero chars) — this only works with native
+/// Anthropic format, not OpenAI-compatible.
+///
+/// Live-only: requires real API with extended thinking model.
+#[test]
+#[cfg(unix)]
+fn iocraft_repl_anthropic_format_thinking_visible() {
+    let env = TestEnv::new("iocraft-anthropic-thinking");
+
+    if env.is_mock() {
+        eprintln!(
+            "iocraft_repl_anthropic_format_thinking_visible: \
+             skipped in mock mode (requires SCODE_TEST_BACKEND=live)"
+        );
+        return;
+    }
+
+    let root = env.workspace_root().to_path_buf();
+    std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(60));
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt: {e}\nPTY:\n{screen}");
+    });
+
+    // Use a model that supports extended thinking.
+    sess.send("/model claude-sonnet-4-6\r").expect("send /model");
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt after /model: {e}\nPTY:\n{screen}");
+    });
+
+    // Send a prompt that triggers thinking. The response should include
+    // a thinking summary with non-zero chars if anthropic format is used.
+    sess.send("What is 247 * 183? Think step by step.\r")
+        .expect("send prompt");
+
+    // Wait for response to complete.
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should return to prompt: {e}\nPTY:\n{screen}");
+    });
+
+    // Check the full screen for thinking summary. With anthropic format,
+    // we should see "Thinking (N chars hidden)" where N > 0.
+    // With openai format, N would be 0 (adaptive thinking, content empty).
+    let screen = sess.render(|s| s.contents());
+    let has_thinking = screen.contains("Thinking");
+    if has_thinking {
+        // If thinking summary is present, verify it's not "0 chars"
+        // which would indicate openai format (content lost).
+        assert!(
+            !screen.contains("0 chars hidden"),
+            "Thinking content should be non-empty with anthropic-messages format.\n\
+             If '0 chars hidden' appears, the model may be using openai-completions \
+             format instead of anthropic-messages.\nPTY:\n{screen}"
+        );
+    }
+    // Note: some models/prompts may not trigger thinking at all,
+    // so we don't assert thinking is always present.
+
+    // Clean exit.
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
+}
+
+/// SSOT endpoint routing: GPT models use openai-completions format.
+/// Verifies basic request/response works through proxy passthrough.
+///
+/// Live-only: requires real API.
+#[test]
+#[cfg(unix)]
+fn iocraft_repl_openai_format_gpt_works() {
+    let env = TestEnv::new("iocraft-openai-gpt");
+
+    if env.is_mock() {
+        eprintln!(
+            "iocraft_repl_openai_format_gpt_works: \
+             skipped in mock mode (requires SCODE_TEST_BACKEND=live)"
+        );
+        return;
+    }
+
+    let root = env.workspace_root().to_path_buf();
+    std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(30));
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("/model gpt-4.1-mini\r").expect("send /model");
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt after /model: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("Say exactly: GPT_ENDPOINT_OK\r")
+        .expect("send prompt");
+
+    sess.expect("GPT_ENDPOINT_OK").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("GPT should respond with marker: {e}\nPTY:\n{screen}");
+    });
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should return to prompt: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
+}
+
+/// SSOT endpoint routing: Gemini models use gemini format via proxy.
+/// Verifies basic request/response works through proxy passthrough.
+///
+/// Live-only: requires real API.
+#[test]
+#[cfg(unix)]
+fn iocraft_repl_gemini_format_works() {
+    let env = TestEnv::new("iocraft-gemini");
+
+    if env.is_mock() {
+        eprintln!(
+            "iocraft_repl_gemini_format_works: \
+             skipped in mock mode (requires SCODE_TEST_BACKEND=live)"
+        );
+        return;
+    }
+
+    let root = env.workspace_root().to_path_buf();
+    std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(30));
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("/model gemini-2.5-flash\r").expect("send /model");
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("prompt after /model: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("Say exactly: GEMINI_ENDPOINT_OK\r")
+        .expect("send prompt");
+
+    sess.expect("GEMINI_ENDPOINT_OK").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("Gemini should respond with marker: {e}\nPTY:\n{screen}");
+    });
+
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should return to prompt: {e}\nPTY:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send /exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
+}
+
 /// **P0 streaming regression guard**: markdown code blocks in model
 /// responses must render with intact box-drawing borders.
 ///

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -119,10 +119,11 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
     // Press Ctrl-C once — should show hint in footer area.
     sess.send("\x03").expect("send Ctrl-C");
 
-    sess.expect("Press Ctrl-C again to exit").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("Ctrl-C hint should appear in footer: {e}\nPTY:\n{screen}");
-    });
+    sess.expect("Press Ctrl-C again to exit")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("Ctrl-C hint should appear in footer: {e}\nPTY:\n{screen}");
+        });
 
     // Clean exit.
     sess.send("/exit\r").expect("send /exit");
@@ -229,7 +230,8 @@ fn iocraft_repl_anthropic_format_thinking_visible() {
     });
 
     // Use a model that supports extended thinking.
-    sess.send("/model claude-sonnet-4-6\r").expect("send /model");
+    sess.send("/model claude-sonnet-4-6\r")
+        .expect("send /model");
     sess.expect("❯").unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());
         panic!("prompt after /model: {e}\nPTY:\n{screen}");


### PR DESCRIPTION
## Summary

- **Spinner frame scrollback leak fix**: TurnPhase nested ChromeSlot (Thinking | Reasoning | Retry | Paused), RetryNotifier trait for API retries, stderr fd redirect, FooterSlot::Hint + InputSlot::Hint for transient messages
- **SSOT dynamic endpoint routing**: Proxy passthrough reads model_capabilities SSOT for preferred endpoint type (anthropic/openai/gemini). Claude models auto-route to native anthropic-messages format. Auth fallback to proxy when model not in sudocode.json
- **Config/DialPad UX**: /config display fixed for iocraft raw mode, DialPad supports Up/Down arrows + digit shortcuts, thinking summary ▼ arrow, interactive /config picker

## Test plan

- [x] `cargo test -p rusty-sudocode-cli --bin scode -- repl_ui` (10 pass)
- [x] `cargo test --test pty_iocraft_chrome` (5 pass)
- [x] `cargo test --test pty_repl_iocraft_features` (8 pass, 3 live-verified)
- [x] `cargo test --test pty_cancel` (2 pass)
- [x] Live: anthropic-messages thinking visible (claude-sonnet-4-6)
- [x] Live: openai-completions works (gpt-4.1-mini)
- [x] Live: gemini format works (gemini-2.5-flash)
- [ ] Manual: Ctrl-C hint in footer, retry in StatusSlot, /config picker