### PR TITLE
feat(cli): ←→ arrow keys for /config tree navigation

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
@@ -40,17 +40,20 @@ pub(crate) fn build_config_tree_handler(
                 value: "settings.json".to_string(),
                 description: None,
                 recommended: false,
+                is_navigable: true,
             },
             QuestionOptionView {
                 label: format!("sudocode.json  {DIM}{}{RESET}", sudocode_path.display()),
                 value: "sudocode.json".to_string(),
                 description: None,
                 recommended: false,
+                is_navigable: true,
             },
         ],
         allow_custom_input: false,
         custom_input_hint: None,
         force_fuzzy_select: false,
+        back_value: None,
     };
     ui.show_question(question);
 
@@ -118,23 +121,22 @@ fn show_schema_level(
         value: BACK_VALUE.to_string(),
         description: None,
         recommended: false,
+        is_navigable: false,
     }];
 
     for f in &visible {
         let val_summary = current_obj
             .and_then(|obj| obj.get(f.key))
             .map_or_else(|| "(not set)".to_string(), |v| truncate_json_value(v));
-        let hint = if f.children.is_some() && f.field_type == FieldType::Object {
-            " \u{25b8}"
-        } else {
-            ""
-        };
+        let is_object = f.children.is_some() && f.field_type == FieldType::Object;
+        let hint = if is_object { " \u{25b8}" } else { "" };
         keys.push(f.key.to_string());
         options.push(QuestionOptionView {
             label: format!("{}{hint}  {DIM}{val_summary}{RESET}", f.key),
             value: f.key.to_string(),
             description: Some(f.description.to_string()),
             recommended: false,
+            is_navigable: is_object,
         });
     }
 
@@ -155,6 +157,7 @@ fn show_schema_level(
         custom_input_hint: None,
         // +1 for the Back option.
         force_fuzzy_select: visible.len() + 1 > 9,
+        back_value: Some(BACK_VALUE.to_string()),
     };
     ui.show_question(question);
 
@@ -274,6 +277,7 @@ fn handle_leaf_edit(
                     value: o.clone(),
                     description: None,
                     recommended: o == current_str,
+                    is_navigable: false,
                 })
                 .collect();
             let question = QuestionPromptView {
@@ -290,6 +294,7 @@ fn handle_leaf_edit(
                 allow_custom_input: false,
                 custom_input_hint: None,
                 force_fuzzy_select: false,
+                back_value: None,
             };
             ui.show_question(question);
             let file_path = file_path.to_path_buf();
@@ -330,6 +335,7 @@ fn handle_leaf_edit(
                     value: m.clone(),
                     description: None,
                     recommended: m == current_str,
+                    is_navigable: false,
                 })
                 .collect();
             let question = QuestionPromptView {
@@ -346,6 +352,7 @@ fn handle_leaf_edit(
                 allow_custom_input: true,
                 custom_input_hint: Some("or type a model name".to_string()),
                 force_fuzzy_select: true,
+                back_value: None,
             };
             ui.show_question(question);
             let file_path = file_path.to_path_buf();

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1984,11 +1984,13 @@ impl IocraftQuestionPrompter {
                     value: option.value.clone(),
                     description: option.description.clone(),
                     recommended: option.recommended,
+                    is_navigable: false,
                 })
                 .collect(),
             allow_custom_input: field.allow_custom_input,
             custom_input_hint: field.custom_input_hint.clone(),
             force_fuzzy_select: false,
+            back_value: None,
         });
     }
 
@@ -2241,6 +2243,7 @@ fn run_repl_iocraft_dispatch(
                                 value: m.clone(),
                                 description: None,
                                 recommended: *m == current,
+                                is_navigable: false,
                             })
                             .collect();
                         pending_slash_selection = Some(show_slash_selection(
@@ -2255,6 +2258,7 @@ fn run_repl_iocraft_dispatch(
                                 allow_custom_input: true,
                                 custom_input_hint: Some("or type a model name".to_string()),
                                 force_fuzzy_select: false,
+                                back_value: None,
                             },
                             models,
                             |model_name, cli, out| {

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -357,6 +357,8 @@ pub struct QuestionOptionView {
     pub value: String,
     pub description: Option<String>,
     pub recommended: bool,
+    /// When true, Right arrow drills into this option (tree navigation).
+    pub is_navigable: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -372,6 +374,9 @@ pub struct QuestionPromptView {
     /// When true, always use FuzzySelect regardless of option count.
     /// Used for config picker and other lists that benefit from search.
     pub force_fuzzy_select: bool,
+    /// When set, Left arrow submits this value as the answer (← Back).
+    /// Right arrow always submits the current selection (same as Enter).
+    pub back_value: Option<String>,
 }
 
 /// ChromeSlot: primary interaction area between the two separators.
@@ -452,6 +457,12 @@ impl FuzzySelectState {
 
     fn selected_value(&self) -> Option<String> {
         self.filtered.get(self.cursor).map(|&i| (i + 1).to_string())
+    }
+
+    fn selected_option(&self) -> Option<&QuestionOptionView> {
+        self.filtered
+            .get(self.cursor)
+            .and_then(|&i| self.question.options.get(i))
     }
 
     fn format_panel(&self) -> String {
@@ -609,8 +620,13 @@ fn format_question_panel(question: &QuestionPromptView, selected_index: usize) -
         ));
     }
     let max_digit = question.options.len().min(9);
+    let arrow_hint = if question.back_value.is_some() {
+        "\u{2190}\u{2192} back/open \u{00b7} "
+    } else {
+        ""
+    };
     lines.push(format!(
-        "{}  \u{2191}\u{2193} navigate \u{00b7} 1-{max_digit} quick select \u{00b7} Enter confirm{}",
+        "{}  {arrow_hint}\u{2191}\u{2193} navigate \u{00b7} 1-{max_digit} quick select \u{00b7} Enter confirm{}",
         crate::render::DIM,
         crate::render::RESET,
     ));
@@ -1025,6 +1041,53 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             fs.move_down();
                         }
                     }
+                    // ── Left — submit back_value (tree navigation) ────
+                    KeyCode::Left if matches!(current_slot, InputSlot::DialPad(_) | InputSlot::FuzzySelect(_)) => {
+                        let back = match &current_slot {
+                            InputSlot::DialPad(q) | InputSlot::FuzzySelect(FuzzySelectState { question: q, .. }) => {
+                                q.back_value.clone()
+                            }
+                            _ => None,
+                        };
+                        if let Some(val) = back {
+                            let _ = input_tx_for_events.send(InputEvent::QuestionAnswer(val));
+                            input_slot.set(InputSlot::TextInput);
+                            input_value.set(String::new());
+                        }
+                    }
+                    // ── Right — drill into navigable option ───────────
+                    KeyCode::Right if matches!(current_slot, InputSlot::DialPad(_)) => {
+                        if let InputSlot::DialPad(ref q) = current_slot {
+                            let selected = dialpad_cursor.get();
+                            if q.options.get(selected).is_some_and(|o| o.is_navigable) {
+                                submit_dialpad_selection(q, selected, &input_tx_for_events);
+                                input_slot.set(InputSlot::TextInput);
+                                input_value.set(String::new());
+                            }
+                        }
+                    }
+                    KeyCode::Right if matches!(current_slot, InputSlot::FuzzySelect(_)) => {
+                        let should_submit = {
+                            let slot = input_slot.read();
+                            if let InputSlot::FuzzySelect(ref fs) = *slot {
+                                fs.selected_option().is_some_and(|o| o.is_navigable)
+                            } else {
+                                false
+                            }
+                        };
+                        if should_submit {
+                            let slot = input_slot.read();
+                            if let InputSlot::FuzzySelect(ref fs) = *slot {
+                                if let Some(option) = fs.selected_option() {
+                                    let _ = input_tx_for_events
+                                        .send(InputEvent::QuestionAnswer(option.value.clone()));
+                                }
+                            }
+                            drop(slot);
+                            input_slot.set(InputSlot::TextInput);
+                            input_value.set(String::new());
+                        }
+                    }
                     // ── Up/Down — TextInput history ────────────────────
                     KeyCode::Up if matches!(current_slot, InputSlot::TextInput) => {
                         let h = history.read();
@@ -1361,17 +1424,20 @@ mod tests {
                     value: "project".to_string(),
                     description: None,
                     recommended: true,
+                    is_navigable: false,
                 },
                 QuestionOptionView {
                     label: "User".to_string(),
                     value: "user".to_string(),
                     description: None,
                     recommended: false,
+                    is_navigable: false,
                 },
             ],
             allow_custom_input: false,
             custom_input_hint: None,
             force_fuzzy_select: false,
+            back_value: None,
         }
     }
 
@@ -1387,6 +1453,7 @@ mod tests {
             allow_custom_input: true,
             custom_input_hint: None,
             force_fuzzy_select: false,
+            back_value: None,
         };
 
         assert_eq!(


### PR DESCRIPTION
## Summary
- **← Left**: returns to parent level (submits `back_value`)
- **→ Right**: drills into navigable Object fields only (ignores leaf fields)
- **Enter**: unchanged — confirms any selection (drill + edit)
- Hint line shows `←→ back/open · ↑↓ navigate · 1-N quick select · Enter confirm`

New fields: `QuestionPromptView.back_value`, `QuestionOptionView.is_navigable`

## Test plan
- [x] PTY test `config_tree_navigate_back_and_toggle` still passes
- [x] All 25 config_ui + repl_ui unit tests pass
- [x] `cargo fmt` + `cargo check` clean