### PR TITLE
refactor(cli): remove ← Back option from /config DialPad

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/config_ui.rs
@@ -114,15 +114,8 @@ fn show_schema_level(
 
     let visible: Vec<&FieldSchema> = schema.iter().filter(|f| !f.is_deprecated).collect();
 
-    // Build options — prepend "← Back".
-    let mut keys: Vec<String> = vec![BACK_VALUE.to_string()];
-    let mut options: Vec<QuestionOptionView> = vec![QuestionOptionView {
-        label: "\u{2190} Back".to_string(),
-        value: BACK_VALUE.to_string(),
-        description: None,
-        recommended: false,
-        is_navigable: false,
-    }];
+    let mut keys: Vec<String> = Vec::new();
+    let mut options: Vec<QuestionOptionView> = Vec::new();
 
     for f in &visible {
         let val_summary = current_obj
@@ -155,8 +148,7 @@ fn show_schema_level(
         options,
         allow_custom_input: false,
         custom_input_hint: None,
-        // +1 for the Back option.
-        force_fuzzy_select: visible.len() + 1 > 9,
+        force_fuzzy_select: visible.len() > 9,
         back_value: Some(BACK_VALUE.to_string()),
     };
     ui.show_question(question);

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -543,13 +543,13 @@ fn config_tree_navigate_back_and_toggle() {
         panic!("sandbox should appear in filtered list: {e}\nPTY:\n{screen}");
     });
     sess.send("\r").expect("select sandbox");
-    sess.expect("Back").unwrap_or_else(|e| {
+    sess.expect("enabled").unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());
-        panic!("sandbox children with Back: {e}\nPTY:\n{screen}");
+        panic!("sandbox children: {e}\nPTY:\n{screen}");
     });
 
-    // 4. Select [1] ← Back → back to settings level.
-    sess.send("1").expect("select Back");
+    // 4. ← arrow → back to settings level.
+    sess.send("\x1b[D").expect("left arrow");
     sess.expect("Select field").unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());
         panic!("back to settings level: {e}\nPTY:\n{screen}");
@@ -568,9 +568,9 @@ fn config_tree_navigate_back_and_toggle() {
         panic!("sandbox children showing enabled: {e}\nPTY:\n{screen}");
     });
 
-    // 6. Select [2] enabled → instant bool toggle (BoolToggle).
-    // DialPad layout: [1] ← Back, [2] enabled, [3] namespaceRestrictions, ...
-    sess.send("2").expect("select enabled");
+    // 6. Select [1] enabled → instant bool toggle (BoolToggle).
+    // DialPad layout: [1] enabled, [2] namespaceRestrictions, ...
+    sess.send("1").expect("select enabled");
     sess.expect("enabled = true").unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());
         panic!("bool toggle output: {e}\nPTY:\n{screen}");
@@ -609,8 +609,8 @@ fn config_tree_navigate_back_and_toggle() {
         panic!("permissions children: {e}\nPTY:\n{screen}");
     });
 
-    // 9. Select [2] defaultMode → Enum DialPad (plan, read-only, ...).
-    sess.send("2").expect("select defaultMode");
+    // 9. Select [1] defaultMode → Enum DialPad (plan, read-only, ...).
+    sess.send("1").expect("select defaultMode");
     sess.expect("(?i)select value").unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());
         panic!("enum picker for defaultMode: {e}\nPTY:\n{screen}");


### PR DESCRIPTION
## Summary
← arrow key now handles back navigation, so the explicit `[1] ← Back` option is redundant. Field list is cleaner and digit shortcuts start from `[1]` for the first real field.

## Test plan
- [x] PTY test updated: uses `\x1b[D` for back nav, digit indices shifted
- [x] 3×3 stability-verified