### PR TITLE
docs(design): drop mis-signaling purple border

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -127,7 +127,7 @@
     <div class="el"><b>agent-name</b> — durable principal; the addressable identity. <span class="path">/agents/{name}/</span></div>
     <div class="el"><b>session-id</b> — durable UUID, the <code>--resume</code> key; spans N pids. <span class="path">/sessions/&lt;sid&gt;/</span></div>
     <div class="el"><b>pid</b> — ephemeral run handle, one boot; reaped on exit. <span class="path">/proc/{pid}/</span></div>
-    <div class="el" style="border-left-color:var(--q)"><b>session-id ≠ pid</b> (§2.3 name-collision fixed — nexus #4564)</div>
+    <div class="el"><b>session-id ≠ pid</b> (§2.3 name-collision fixed — nexus #4564)</div>
     <span class="b ok">given</span></td>
 </tr>
 <tr>


### PR DESCRIPTION
Purple = open-question in the legend; removed from a resolved-fact note.