### PR TITLE
acp: run sessions concurrently; advertise loadSession

### DIFF
--- a/docs/acp.md
+++ b/docs/acp.md
@@ -35,3 +35,46 @@ prompting.
 
 For local-only use, bind to `127.0.0.1`. For team access, expose the port
 behind your own auth proxy.
+
+## Sessions
+
+One `scode acp` process serves **many sessions**. Requests are ordered per
+session and independent across sessions:
+
+- Requests on the **same** session (`session/prompt`, `session/setModel`,
+  `session/setPermissionMode`, `session/close`) run strictly one at a time,
+  in arrival order. Two prompts sent to one session never interleave.
+- Requests on **different** sessions run concurrently. In particular, a
+  session that is waiting on the user — a pending `session/request_permission`
+  or `_scode/ask_user_question` — does not hold up `session/new` or prompts
+  on any other session.
+- `session/cancel` is never queued; it reaches a session mid-turn.
+- Sessions in the same working directory run fully in parallel. Because tool
+  execution is anchored to the *process* working directory, turns of sessions
+  in **different** directories share that directory cooperatively: a turn
+  waits for turns in another directory to finish or to pause on user input
+  before it starts, and a paused turn gives the directory back while it waits.
+
+### `session/load`
+
+`agentCapabilities.loadSession` is advertised. `session/load
+{sessionId, cwd, mcpServers}` re-opens a session persisted by an earlier
+process from `<cwd>/.scode/sessions/<workspace-fingerprint>/<sessionId>.jsonl`
+and the next `session/prompt` continues the conversation with the full prior
+transcript (user turns, assistant turns, thinking, tool calls and tool
+results) sent to the model.
+
+What is restored is the **transcript**: message history, the session's model,
+compaction state and fork lineage. What is not: in-memory turn state such as
+a permission mode set through `session/setPermissionMode` (the loaded session
+starts from the configured default again), per-turn "allow always" answers,
+running background commands, and MCP servers other than the ones passed in
+the `session/load` request.
+
+`cwd` must be the directory the session was created in — a session's store
+is keyed by its workspace and the persisted `workspace_root` is validated on
+load, so loading a session id from another directory is rejected. Continuing
+a conversation in a new directory is a fork, not a load. `session/load` does
+not currently replay the history to the client as `session/update`
+notifications; the client is expected to keep its own copy of the
+conversation.

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -160,6 +160,7 @@ enum Scenario {
     SleepOverMaxRoundtrip,
     ForkSubagentRecursionGuardRoundtrip,
     LlmCompactionRoundtrip,
+    AskUserQuestionRoundtrip,
 }
 
 impl Scenario {
@@ -197,6 +198,7 @@ impl Scenario {
                 Some(Self::ForkSubagentRecursionGuardRoundtrip)
             }
             "llm_compaction_roundtrip" => Some(Self::LlmCompactionRoundtrip),
+            "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             _ => None,
         }
     }
@@ -233,6 +235,7 @@ impl Scenario {
             Self::SleepOverMaxRoundtrip => "sleep_over_max_roundtrip",
             Self::ForkSubagentRecursionGuardRoundtrip => "fork_subagent_recursion_guard_roundtrip",
             Self::LlmCompactionRoundtrip => "llm_compaction_roundtrip",
+            Self::AskUserQuestionRoundtrip => "ask_user_question_roundtrip",
         }
     }
 }
@@ -738,6 +741,16 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             }
             None => tool_use_sse("toolu_sleep_short", "Sleep", &[r#"{"duration_ms":600}"#]),
         },
+        Scenario::AskUserQuestionRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => {
+                final_text_sse(&format!("ask_user_question answered: {tool_output}"))
+            }
+            None => tool_use_sse(
+                "toolu_ask_user_question",
+                "AskUserQuestion",
+                &[r#"{"question":"Which colour?","options":["red","blue"]}"#],
+            ),
+        },
         Scenario::SleepOverMaxRoundtrip => match latest_tool_result(request) {
             Some((tool_output, is_error)) => final_text_sse(&format!(
                 "sleep over-max roundtrip complete (is_error={is_error}): {tool_output}"
@@ -1140,6 +1153,18 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 json!({"duration_ms": 600}),
             ),
         },
+        Scenario::AskUserQuestionRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => text_message_response(
+                "msg_ask_user_question_final",
+                &format!("ask_user_question answered: {tool_output}"),
+            ),
+            None => tool_message_response(
+                "msg_ask_user_question_tool",
+                "toolu_ask_user_question",
+                "AskUserQuestion",
+                json!({"question": "Which colour?", "options": ["red", "blue"]}),
+            ),
+        },
         Scenario::SleepOverMaxRoundtrip => match latest_tool_result(request) {
             Some((tool_output, is_error)) => text_message_response(
                 "msg_sleep_over_max_final",
@@ -1210,6 +1235,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
             "req_fork_subagent_recursion_guard_roundtrip"
         }
         Scenario::LlmCompactionRoundtrip => "req_llm_compaction_roundtrip",
+        Scenario::AskUserQuestionRoundtrip => "req_ask_user_question_roundtrip",
     }
 }
 

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -1141,6 +1141,12 @@ pub(crate) async fn run_acp_on_transport(
                         .agent_info(Implementation::new("scode", &version))
                         .agent_capabilities(
                             AgentCapabilities::new()
+                                // `session/load` re-opens a persisted session
+                                // (same cwd) in a fresh process; the handler
+                                // below has always existed, the flag had just
+                                // never been advertised, so spec-conformant
+                                // clients never tried it.
+                                .load_session(true)
                                 .prompt_capabilities(PromptCapabilities::new().image(true))
                                 .session_capabilities(
                                     SessionCapabilities::new()

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -206,11 +206,22 @@ fn acp_mcp_servers_to_scoped(
 /// Callback trait that the CLI crate implements to provide session
 /// construction and prompt execution, keeping runtime/provider deps out of
 /// this crate.
-pub trait SdkAcpDelegate: Send + 'static {
+///
+/// Every method takes `&self`: the delegate is shared across all in-flight
+/// ACP requests (see [`SharedDelegate`]) and is responsible for its own
+/// interior locking. The contract the ACP server relies on is
+///
+/// * calls on **different** sessions may run concurrently and must not
+///   block each other — a session that is parked on a permission prompt or
+///   an `AskUserQuestion` must not stall the others;
+/// * calls on the **same** session are already serialized by the server
+///   (see [`SessionRegistry`]), so the delegate only needs per-session
+///   locking for memory safety, not for ordering.
+pub trait SdkAcpDelegate: Send + Sync + 'static {
     /// Create a new session for the given working directory, returning
     /// `(session_id, cwd, abort_signal)` on success.
     fn new_session(
-        &mut self,
+        &self,
         cwd: PathBuf,
         mcp_servers: BTreeMap<String, ScopedMcpServerConfig>,
     ) -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
@@ -218,7 +229,7 @@ pub trait SdkAcpDelegate: Send + 'static {
     /// Run a prompt turn. The implementation should call observer methods
     /// to stream session updates.
     fn run_prompt(
-        &mut self,
+        &self,
         session_id: &str,
         prompt: String,
         observer: &mut SdkSessionObserver,
@@ -227,7 +238,7 @@ pub trait SdkAcpDelegate: Send + 'static {
 
     /// Run a prompt with permission prompting bridged to the ACP client.
     fn run_prompt_with_prompter(
-        &mut self,
+        &self,
         session_id: &str,
         prompt: String,
         observer: &mut SdkSessionObserver,
@@ -237,14 +248,14 @@ pub trait SdkAcpDelegate: Send + 'static {
 
     /// Install a question prompter for AskUserQuestion tool execution within a session.
     fn set_question_prompter(
-        &mut self,
+        &self,
         session_id: &str,
         prompter: Box<dyn QuestionPrompter>,
     ) -> Result<(), AcpError>;
 
     /// Handle a slash command, returning text output.
     fn handle_slash_command(
-        &mut self,
+        &self,
         session_id: &str,
         input: &str,
         observer: &mut SdkSessionObserver,
@@ -254,32 +265,24 @@ pub trait SdkAcpDelegate: Send + 'static {
     fn list_sessions(&self) -> Vec<(String, PathBuf)>;
 
     /// Close (drop) a session by ID. Returns true if it existed.
-    fn close_session(&mut self, session_id: &str) -> bool;
+    fn close_session(&self, session_id: &str) -> bool;
 
     /// Switch the model for a session. Returns a human-readable report.
-    fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, AcpError>;
+    fn set_model(&self, session_id: &str, model_id: &str) -> Result<String, AcpError>;
 
     /// Return the current model ID and available models.
     fn get_model_info(&self) -> (String, Vec<String>);
 
     /// Change the permission mode for a session.
-    fn set_permission_mode(
-        &mut self,
-        session_id: &str,
-        mode: PermissionMode,
-    ) -> Result<(), AcpError>;
+    fn set_permission_mode(&self, session_id: &str, mode: PermissionMode) -> Result<(), AcpError>;
 
     /// Push image content blocks into a session before running a prompt.
-    fn push_images(
-        &mut self,
-        session_id: &str,
-        images: &[(String, String)],
-    ) -> Result<(), AcpError>;
+    fn push_images(&self, session_id: &str, images: &[(String, String)]) -> Result<(), AcpError>;
 
     /// Load an existing persisted session by its ID and working directory,
     /// returning `(session_id, cwd, abort_signal)` on success.
     fn load_session(
-        &mut self,
+        &self,
         session_id: &str,
         cwd: PathBuf,
         mcp_servers: BTreeMap<String, ScopedMcpServerConfig>,
@@ -634,18 +637,262 @@ mod tests {
 }
 
 /// Thread-safe handle to a delegate, shared across async handlers.
-pub type SharedDelegate = Arc<Mutex<Box<dyn SdkAcpDelegate>>>;
+///
+/// There is deliberately **no** server-side mutex around the delegate: a
+/// process-wide lock held for the duration of `session/prompt` is exactly
+/// what made one parked session block every other session. Cross-session
+/// concurrency is the delegate's responsibility ([`SdkAcpDelegate`]);
+/// same-session ordering is the server's ([`SessionRegistry`] lanes).
+pub type SharedDelegate = Arc<dyn SdkAcpDelegate>;
 
-/// Separate registry of abort signals so that `session/cancel` can fire
-/// without contending on the main delegate mutex.
-pub type AbortRegistry = Arc<Mutex<HashMap<String, HookAbortSignal>>>;
+/// Shared handle to the [`SessionRegistry`].
+pub type SharedSessionRegistry = Arc<SessionRegistry>;
 
-/// Create a new empty abort registry. Share this across connections so that
-/// cancel notifications on a reconnected transport can still reach sessions
-/// created on a previous connection.
+/// Create a new empty session registry. Share this across connections so
+/// that cancel notifications on a reconnected transport can still reach
+/// sessions created on a previous connection, and so that per-session
+/// ordering holds across connections too.
 #[must_use]
-pub fn new_abort_registry() -> AbortRegistry {
-    Arc::new(Mutex::new(HashMap::new()))
+pub fn new_session_registry() -> SharedSessionRegistry {
+    Arc::new(SessionRegistry::default())
+}
+
+/// Per-process registry of live ACP sessions.
+///
+/// It carries three things the server needs *outside* the delegate:
+///
+/// * the [`HookAbortSignal`] so `session/cancel` fires without touching any
+///   session lock (a running turn must be cancellable);
+/// * a per-session **lane** (an async mutex) that serializes every
+///   session-scoped request — `session/prompt`, `session/setPermissionMode`,
+///   `session/setModel`, `session/close` — for that session while leaving
+///   other sessions free to run. Two prompts on one session interleaving
+///   their JSON-RPC traffic would corrupt the protocol, so this ordering is a
+///   hard invariant, not a performance choice;
+/// * the working directory of each session, which feeds the
+///   [`WorkspaceCwdLease`] (see there for why that is needed).
+#[derive(Default)]
+pub struct SessionRegistry {
+    sessions: Mutex<HashMap<String, SessionEntry>>,
+    cwd_lease: Arc<WorkspaceCwdLease>,
+}
+
+struct SessionEntry {
+    abort: HookAbortSignal,
+    lane: Arc<tokio::sync::Mutex<()>>,
+    cwd: PathBuf,
+}
+
+/// Async guard for a session lane; drop it to let the next request on the
+/// same session proceed.
+pub type SessionLaneGuard = tokio::sync::OwnedMutexGuard<()>;
+
+impl SessionRegistry {
+    fn lock_sessions(&self) -> std::sync::MutexGuard<'_, HashMap<String, SessionEntry>> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Register (or re-register) a session after `session/new` / `session/load`.
+    pub fn register(&self, session_id: String, abort: HookAbortSignal, cwd: PathBuf) {
+        let mut sessions = self.lock_sessions();
+        // A reload of a session that is already live keeps its lane so that
+        // requests already queued behind it stay ordered.
+        let lane = sessions.get(&session_id).map_or_else(
+            || Arc::new(tokio::sync::Mutex::new(())),
+            |e| Arc::clone(&e.lane),
+        );
+        sessions.insert(session_id, SessionEntry { abort, lane, cwd });
+    }
+
+    /// Forget a session after `session/close`.
+    pub fn remove(&self, session_id: &str) {
+        self.lock_sessions().remove(session_id);
+    }
+
+    /// Abort signal for `session/cancel`; `None` for unknown sessions.
+    #[must_use]
+    pub fn abort_signal(&self, session_id: &str) -> Option<HookAbortSignal> {
+        self.lock_sessions()
+            .get(session_id)
+            .map(|e| e.abort.clone())
+    }
+
+    /// Working directory a session was created / loaded with.
+    #[must_use]
+    pub fn cwd(&self, session_id: &str) -> Option<PathBuf> {
+        self.lock_sessions().get(session_id).map(|e| e.cwd.clone())
+    }
+
+    /// Wait for the session's lane. Requests on the same session are served
+    /// in arrival order (tokio's mutex is FIFO-fair); requests on other
+    /// sessions are unaffected. Unknown sessions get no lane — the delegate
+    /// will reject them with `unknown sessionId` — so the caller does not
+    /// have to special-case them.
+    pub async fn enter_lane(&self, session_id: &str) -> Option<SessionLaneGuard> {
+        let lane = self
+            .lock_sessions()
+            .get(session_id)
+            .map(|e| Arc::clone(&e.lane))?;
+        Some(lane.lock_owned().await)
+    }
+
+    /// The process-wide working-directory lease.
+    #[must_use]
+    pub fn cwd_lease(&self) -> Arc<WorkspaceCwdLease> {
+        Arc::clone(&self.cwd_lease)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process working-directory lease
+// ---------------------------------------------------------------------------
+
+/// Arbiter for the *process* working directory.
+///
+/// The conversation runtime resolves relative paths, spawns `bash`, runs
+/// hooks and reads project config against `std::env::current_dir()`; a
+/// session's turn therefore has to run with the process cwd set to that
+/// session's cwd. That is a process-wide resource, so once turns of
+/// different sessions run concurrently something has to keep them from
+/// flipping the cwd under each other:
+///
+/// * turns whose sessions share a cwd hold the lease **together** (it is
+///   reference-counted) and run fully concurrently;
+/// * a turn in a *different* cwd waits until the current holders are gone;
+/// * a turn that parks on user input (permission prompt / `AskUserQuestion`)
+///   **releases** the lease while it waits ([`CwdLeaseHandle::parked`]) and
+///   re-acquires it before continuing, so a parked session never keeps
+///   another cwd's session from running — the P0 this exists to fix.
+///
+/// The lease only ever *sets* the cwd on acquisition; when the last holder
+/// leaves, the cwd is left as is (nothing outside a lease may depend on it).
+#[derive(Default)]
+pub struct WorkspaceCwdLease {
+    state: Mutex<CwdLeaseState>,
+    released: std::sync::Condvar,
+}
+
+#[derive(Default)]
+struct CwdLeaseState {
+    holder: Option<PathBuf>,
+    holders: usize,
+}
+
+impl WorkspaceCwdLease {
+    /// Block until the process cwd can be `cwd`, set it, and return a guard
+    /// that gives the lease back on drop.
+    ///
+    /// # Errors
+    ///
+    /// Returns the `set_current_dir` error if `cwd` cannot be entered; the
+    /// lease is left untouched in that case.
+    pub fn acquire(self: &Arc<Self>, cwd: PathBuf) -> std::io::Result<CwdLeaseGuard> {
+        self.enter(&cwd)?;
+        Ok(CwdLeaseGuard {
+            handle: CwdLeaseHandle(Arc::new(CwdLeaseHandleInner {
+                lease: Arc::clone(self),
+                cwd,
+                held: std::sync::atomic::AtomicBool::new(true),
+            })),
+        })
+    }
+
+    fn enter(&self, cwd: &std::path::Path) -> std::io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while state.holder.as_deref().is_some_and(|held| held != cwd) {
+            state = self
+                .released
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        if state.holder.is_none() {
+            std::env::set_current_dir(cwd)?;
+            state.holder = Some(cwd.to_path_buf());
+        }
+        state.holders += 1;
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.holders = state.holders.saturating_sub(1);
+        if state.holders == 0 {
+            state.holder = None;
+            self.released.notify_all();
+        }
+    }
+}
+
+struct CwdLeaseHandleInner {
+    lease: Arc<WorkspaceCwdLease>,
+    cwd: PathBuf,
+    /// Whether this handle currently counts as a holder. Only the turn's
+    /// own thread flips it (acquire → park → unpark → drop), the atomic is
+    /// for `Sync`, not for contention.
+    held: std::sync::atomic::AtomicBool,
+}
+
+/// Cheap, cloneable reference to a held lease that lets the code parked
+/// deep inside a turn temporarily give the lease back.
+#[derive(Clone)]
+pub struct CwdLeaseHandle(Arc<CwdLeaseHandleInner>);
+
+impl CwdLeaseHandle {
+    /// Run `wait` with the lease released, then re-acquire the lease before
+    /// returning. If this handle is not currently holding the lease the
+    /// closure simply runs (a stale handle can never re-acquire on its own).
+    /// If the cwd cannot be re-entered afterwards, the failure is reported on
+    /// stderr and the turn continues without the lease — the directory has
+    /// vanished underneath the session, and its tools will report that
+    /// themselves.
+    pub fn parked<R>(&self, wait: impl FnOnce() -> R) -> R {
+        use std::sync::atomic::Ordering;
+        let released = self.0.held.swap(false, Ordering::AcqRel);
+        if released {
+            self.0.lease.leave();
+        }
+        let result = wait();
+        if released {
+            match self.0.lease.enter(&self.0.cwd) {
+                Ok(()) => self.0.held.store(true, Ordering::Release),
+                Err(error) => eprintln!(
+                    "[acp] failed to re-enter session cwd {} after user input: {error}",
+                    self.0.cwd.display()
+                ),
+            }
+        }
+        result
+    }
+}
+
+/// RAII holder of a [`WorkspaceCwdLease`] acquisition.
+pub struct CwdLeaseGuard {
+    handle: CwdLeaseHandle,
+}
+
+impl CwdLeaseGuard {
+    /// Handle to hand to code that may need to park while this guard lives.
+    #[must_use]
+    pub fn handle(&self) -> CwdLeaseHandle {
+        self.handle.clone()
+    }
+}
+
+impl Drop for CwdLeaseGuard {
+    fn drop(&mut self) {
+        use std::sync::atomic::Ordering;
+        if self.handle.0.held.swap(false, Ordering::AcqRel) {
+            self.handle.0.lease.leave();
+        }
+    }
 }
 
 /// A permission prompter that bridges to the ACP client over channels.
@@ -658,6 +905,21 @@ struct AcpPermissionBridge {
         PermissionRequest,
         tokio::sync::oneshot::Sender<PermissionPromptDecision>,
     )>,
+    /// Lease on the process cwd held by the turn this bridge serves; given
+    /// back while we wait on the user so other sessions can run.
+    cwd_lease: Option<CwdLeaseHandle>,
+}
+
+/// Block on `wait` with the turn's cwd lease (if any) parked for the
+/// duration: the turn is idle until the user answers, and nothing in it
+/// touches the process cwd meanwhile (tool calls run strictly one at a time),
+/// so holding the lease would only keep sessions in other directories from
+/// making progress.
+fn wait_parked<R>(cwd_lease: Option<&CwdLeaseHandle>, wait: impl FnOnce() -> R) -> R {
+    match cwd_lease {
+        Some(lease) => lease.parked(wait),
+        None => wait(),
+    }
 }
 
 impl PermissionPrompter for AcpPermissionBridge {
@@ -677,12 +939,14 @@ impl PermissionPrompter for AcpPermissionBridge {
         // tells the multi-thread scheduler this thread is about to block,
         // allowing the recv to complete safely (same pattern as
         // `AcpQuestionBridge::ask` below).
-        tokio::task::block_in_place(|| {
-            response_rx
-                .blocking_recv()
-                .unwrap_or(PermissionPromptDecision::Deny {
-                    reason: "permission response channel closed".to_string(),
-                })
+        wait_parked(self.cwd_lease.as_ref(), || {
+            tokio::task::block_in_place(|| {
+                response_rx
+                    .blocking_recv()
+                    .unwrap_or(PermissionPromptDecision::Deny {
+                        reason: "permission response channel closed".to_string(),
+                    })
+            })
         })
     }
 }
@@ -709,10 +973,12 @@ impl QuestionPrompter for AcpQuestionBridge {
         // the client as a generic "blocking task failed" / Internal error.
         // `block_in_place` informs the multi-thread scheduler that this worker
         // is about to block, allowing the recv to complete safely.
-        tokio::task::block_in_place(|| {
-            response_rx
-                .blocking_recv()
-                .unwrap_or_else(|_| Err("question response channel closed".to_string()))
+        wait_parked(self.cwd_lease.as_ref(), || {
+            tokio::task::block_in_place(|| {
+                response_rx
+                    .blocking_recv()
+                    .unwrap_or_else(|_| Err("question response channel closed".to_string()))
+            })
         })
     }
 }
@@ -723,6 +989,8 @@ struct AcpQuestionBridge {
         QuestionPromptRequest,
         tokio::sync::oneshot::Sender<Result<Vec<QuestionPromptAnswer>, String>>,
     )>,
+    /// See [`AcpPermissionBridge::cwd_lease`].
+    cwd_lease: Option<CwdLeaseHandle>,
 }
 
 const ACP_ASK_USER_QUESTION_METHOD: &str = "_scode/ask_user_question";
@@ -854,7 +1122,7 @@ fn uuid_v4() -> String {
 pub(crate) async fn run_acp_on_transport(
     config: &SdkAcpConfig,
     delegate: SharedDelegate,
-    abort_registry: AbortRegistry,
+    registry: SharedSessionRegistry,
     transport: impl ConnectTo<Agent>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let agent_version = config.agent_version.clone();
@@ -890,28 +1158,30 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
-                let abort_registry = Arc::clone(&abort_registry);
+                let registry = Arc::clone(&registry);
                 async move |req: NewSessionRequest,
                             responder: Responder<NewSessionResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
-                    let registry = Arc::clone(&abort_registry);
+                    let registry = Arc::clone(&registry);
                     cx.spawn(async move {
+                        let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
+                            // Session construction resolves config / model /
+                            // permission mode against the process cwd, so it
+                            // runs under the cwd lease like a turn does.
+                            let _cwd = lease
+                                .acquire(session_lease_cwd(&req.cwd))
+                                .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &req.cwd);
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .new_session(req.cwd, mcp_servers)
+                            d.new_session(req.cwd, mcp_servers)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
 
                         match result {
-                            Ok((session_id, _cwd, signal)) => {
-                                registry
-                                    .lock()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                    .insert(session_id.clone(), signal);
+                            Ok((session_id, cwd, signal)) => {
+                                registry.register(session_id.clone(), signal, cwd);
                                 responder.respond(NewSessionResponse::new(session_id))?;
                             }
                             Err(e) => {
@@ -929,6 +1199,7 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
+                let registry = Arc::clone(&registry);
                 async move |req: PromptRequest,
                             responder: Responder<PromptResponse>,
                             cx: ConnectionTo<Client>| {
@@ -955,10 +1226,18 @@ pub(crate) async fn run_acp_on_transport(
                     });
 
                     let d = Arc::clone(&delegate);
+                    let registry = Arc::clone(&registry);
                     let sid = req.session_id.to_string();
                     let cx_inner = cx.clone();
                     let cx_perm = cx.clone();
                     cx.spawn(async move {
+                        // Same-session ordering: wait (asynchronously — no
+                        // thread is tied up) for this session's lane. Other
+                        // sessions have their own lanes and are unaffected.
+                        let _lane = registry.enter_lane(&sid).await;
+                        let session_cwd = registry.cwd(&sid);
+                        let cwd_lease = registry.cwd_lease();
+
                         // Set up permission-prompt bridge channels.
                         let (bridge_tx, mut bridge_rx) = tokio::sync::mpsc::unbounded_channel::<(
                             PermissionRequest,
@@ -980,12 +1259,30 @@ pub(crate) async fn run_acp_on_transport(
                         let prompt_text_for_blocking = prompt_text.clone();
                         let trace_id_for_blocking = trace_id.clone();
                         let blocking_handle = tokio::task::spawn_blocking(move || {
+                            // Hold the process cwd for this session's directory
+                            // for the whole turn (shared with concurrent turns
+                            // in the same directory; parked while waiting on
+                            // the user — see `WorkspaceCwdLease`). Unknown
+                            // sessions have no cwd and fall through to the
+                            // delegate's `unknown sessionId` error.
+                            let cwd_guard = match session_cwd {
+                                Some(cwd) => Some(cwd_lease.acquire(cwd).map_err(|e| {
+                                    AcpError::internal(format!("failed to enter session cwd: {e}"))
+                                })?),
+                                None => None,
+                            };
+                            let lease_handle = cwd_guard.as_ref().map(CwdLeaseGuard::handle);
+
                             let mut observer = SdkSessionObserver::new(&sid_for_blocking, notif_tx);
-                            let mut bridge = AcpPermissionBridge { tx: bridge_tx };
-                            let question_bridge = AcpQuestionBridge { tx: question_tx };
-                            let mut delegate =
-                                d.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                            let _ = delegate.set_question_prompter(
+                            let mut bridge = AcpPermissionBridge {
+                                tx: bridge_tx,
+                                cwd_lease: lease_handle.clone(),
+                            };
+                            let question_bridge = AcpQuestionBridge {
+                                tx: question_tx,
+                                cwd_lease: lease_handle,
+                            };
+                            let _ = d.set_question_prompter(
                                 &sid_for_blocking,
                                 Box::new(question_bridge),
                             );
@@ -993,19 +1290,18 @@ pub(crate) async fn run_acp_on_transport(
                             // Push image content blocks into the session before
                             // running the prompt so the API client includes them.
                             if !images_for_blocking.is_empty() {
-                                let _ = delegate.push_images(&sid_for_blocking, &images_for_blocking);
+                                let _ = d.push_images(&sid_for_blocking, &images_for_blocking);
                             }
 
                             let stop = if prompt_text_for_blocking.starts_with('/') {
-                                delegate
-                                    .handle_slash_command(
-                                        &sid_for_blocking,
-                                        &prompt_text_for_blocking,
-                                        &mut observer,
-                                    )
-                                    .map(|()| (StopReason::EndTurn, None))
+                                d.handle_slash_command(
+                                    &sid_for_blocking,
+                                    &prompt_text_for_blocking,
+                                    &mut observer,
+                                )
+                                .map(|()| (StopReason::EndTurn, None))
                             } else {
-                                delegate.run_prompt_with_prompter(
+                                d.run_prompt_with_prompter(
                                     &sid_for_blocking,
                                     prompt_text_for_blocking,
                                     &mut observer,
@@ -1013,6 +1309,7 @@ pub(crate) async fn run_acp_on_transport(
                                     trace_id_for_blocking.as_deref(),
                                 )
                             };
+                            drop(cwd_guard);
                             // Return the Result instead of unwrapping, so we can handle errors
                             stop
                         });
@@ -1178,15 +1475,12 @@ pub(crate) async fn run_acp_on_transport(
         // --- session/cancel (notification) ---
         .on_receive_notification(
             {
-                let abort_registry = Arc::clone(&abort_registry);
+                let registry = Arc::clone(&registry);
                 async move |notif: CancelNotification, _cx: ConnectionTo<Client>| {
-                    let sid = notif.session_id.to_string();
-                    let signal = abort_registry
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .get(&sid)
-                        .cloned();
-                    if let Some(signal) = signal {
+                    // Deliberately lock-free w.r.t. sessions: cancel must reach
+                    // a session whose lane is busy running the very turn being
+                    // cancelled.
+                    if let Some(signal) = registry.abort_signal(&notif.session_id.to_string()) {
                         signal.abort();
                     }
                     Ok(())
@@ -1198,26 +1492,24 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
-                let abort_registry = Arc::clone(&abort_registry);
+                let registry = Arc::clone(&registry);
                 async move |req: CloseSessionRequest,
                             responder: Responder<CloseSessionResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
-                    let registry = Arc::clone(&abort_registry);
+                    let registry = Arc::clone(&registry);
                     let sid = req.session_id.to_string();
                     cx.spawn(async move {
+                        // Queue behind any in-flight turn on this session (as
+                        // before: close waits for the turn to finish).
+                        let _lane = registry.enter_lane(&sid).await;
                         let sid_clone = sid.clone();
                         tokio::task::spawn_blocking(move || {
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .close_session(&sid_clone);
+                            d.close_session(&sid_clone);
                         })
                         .await
                         .ok();
-                        registry
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner)
-                            .remove(&sid);
+                        registry.remove(&sid);
                         responder.respond(CloseSessionResponse::new())?;
                         Ok(())
                     })?;
@@ -1236,9 +1528,7 @@ pub(crate) async fn run_acp_on_transport(
                     let d = Arc::clone(&delegate);
                     cx.spawn(async move {
                         let infos = tokio::task::spawn_blocking(move || {
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .list_sessions()
+                            d.list_sessions()
                                 .into_iter()
                                 .map(|(id, cwd)| SessionInfo::new(id, cwd))
                                 .collect::<Vec<_>>()
@@ -1258,17 +1548,28 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
+                let registry = Arc::clone(&registry);
                 async move |req: SetSessionModelRequest,
                             responder: Responder<SetSessionModelResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
+                    let registry = Arc::clone(&registry);
                     let sid = req.session_id.to_string();
                     let model_id: String = req.model_id.0.to_string();
                     cx.spawn(async move {
+                        let _lane = registry.enter_lane(&sid).await;
+                        let session_cwd = registry.cwd(&sid);
+                        let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .set_model(&sid, &model_id)
+                            // The model switch rebuilds the session runtime,
+                            // resolving config against the process cwd.
+                            let _cwd = match session_cwd {
+                                Some(cwd) => Some(lease.acquire(cwd).map_err(|e| {
+                                    AcpError::internal(format!("failed to enter session cwd: {e}"))
+                                })?),
+                                None => None,
+                            };
+                            d.set_model(&sid, &model_id)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
@@ -1292,30 +1593,32 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
-                let abort_registry = Arc::clone(&abort_registry);
+                let registry = Arc::clone(&registry);
                 async move |req: LoadSessionRequest,
                             responder: Responder<LoadSessionResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
-                    let registry = Arc::clone(&abort_registry);
+                    let registry = Arc::clone(&registry);
                     let sid = req.session_id.to_string();
                     let cwd = req.cwd;
                     cx.spawn(async move {
+                        // If the session is already live in this process, a
+                        // reload must not race a turn on it.
+                        let _lane = registry.enter_lane(&sid).await;
+                        let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
+                            let _cwd = lease
+                                .acquire(session_lease_cwd(&cwd))
+                                .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &cwd);
-                            d.lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .load_session(&sid, cwd, mcp_servers)
+                            d.load_session(&sid, cwd, mcp_servers)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
 
                         match result {
-                            Ok((session_id, _cwd, signal)) => {
-                                registry
-                                    .lock()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                    .insert(session_id, signal);
+                            Ok((session_id, cwd, signal)) => {
+                                registry.register(session_id, signal, cwd);
                                 responder.respond(LoadSessionResponse::new())?;
                             }
                             Err(e) => {
@@ -1333,11 +1636,14 @@ pub(crate) async fn run_acp_on_transport(
         .on_receive_request(
             {
                 let delegate = Arc::clone(&delegate);
+                let registry = Arc::clone(&registry);
                 async move |req: SetPermissionModeRequest,
                             responder: Responder<SetPermissionModeResponse>,
                             cx: ConnectionTo<Client>| {
                     let d = Arc::clone(&delegate);
+                    let registry = Arc::clone(&registry);
                     cx.spawn(async move {
+                        let _lane = registry.enter_lane(&req.session_id).await;
                         let result = tokio::task::spawn_blocking(move || {
                             let mode = match req.permission_mode.as_str() {
                                 "read-only" => Ok(PermissionMode::ReadOnly),
@@ -1350,10 +1656,7 @@ pub(crate) async fn run_acp_on_transport(
                                 ))),
                             };
                             match mode {
-                                Ok(m) => d
-                                    .lock()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                    .set_permission_mode(&req.session_id, m),
+                                Ok(m) => d.set_permission_mode(&req.session_id, m),
                                 Err(e) => Err(e),
                             }
                         })
@@ -1400,6 +1703,15 @@ pub(crate) async fn run_acp_on_transport(
         .await?;
 
     Ok(())
+}
+
+/// Key the cwd lease by the canonical directory so that two sessions
+/// naming the same directory differently (`./x` vs `/abs/x`, symlinks) share
+/// one lease instead of serializing against each other. Falls back to the
+/// path as given when it cannot be canonicalized (the delegate then rejects
+/// the request with a proper `params.cwd` error).
+fn session_lease_cwd(cwd: &std::path::Path) -> PathBuf {
+    std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf())
 }
 
 /// Map our `AcpError` to the SDK's `Error` type.

--- a/rust/crates/runtime/src/acp_stdio_server.rs
+++ b/rust/crates/runtime/src/acp_stdio_server.rs
@@ -2,12 +2,12 @@
 //!
 //! Thin wrapper that runs the shared ACP handler chain over stdin/stdout.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use agent_client_protocol_tokio::Stdio;
 
 use crate::acp_sdk_server::{
-    new_abort_registry, run_acp_on_transport, SdkAcpConfig, SdkAcpDelegate, SharedDelegate,
+    new_session_registry, run_acp_on_transport, SdkAcpConfig, SdkAcpDelegate, SharedDelegate,
 };
 
 /// Run the ACP server on stdin/stdout.
@@ -30,8 +30,8 @@ pub async fn run_acp_stdio_server(
     spawn_stdin_eof_watchdog();
     spawn_parent_exit_watchdog();
 
-    let delegate: SharedDelegate = Arc::new(Mutex::new(delegate));
-    run_acp_on_transport(&config, delegate, new_abort_registry(), Stdio::new()).await
+    let delegate: SharedDelegate = Arc::from(delegate);
+    run_acp_on_transport(&config, delegate, new_session_registry(), Stdio::new()).await
 }
 
 /// Watch for stdin's writer end closing and exit when it does.

--- a/rust/crates/runtime/src/acp_ws_server.rs
+++ b/rust/crates/runtime/src/acp_ws_server.rs
@@ -4,7 +4,7 @@
 //! handler chain used for stdio serves WebSocket connections. This gives WS
 //! full feature parity (including elicitation/permission prompting) for free.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{State, WebSocketUpgrade};
@@ -15,8 +15,8 @@ use futures::{SinkExt, StreamExt};
 use tokio::net::TcpListener;
 
 use crate::acp_sdk_server::{
-    new_abort_registry, run_acp_on_transport, AbortRegistry, SdkAcpConfig, SdkAcpDelegate,
-    SharedDelegate,
+    new_session_registry, run_acp_on_transport, SdkAcpConfig, SdkAcpDelegate, SharedDelegate,
+    SharedSessionRegistry,
 };
 
 static WEB_UI_HTML: &str = include_str!("acp_web_ui.html");
@@ -25,7 +25,7 @@ static WEB_UI_HTML: &str = include_str!("acp_web_ui.html");
 struct AppState {
     config: SdkAcpConfig,
     delegate: SharedDelegate,
-    abort_registry: AbortRegistry,
+    registry: SharedSessionRegistry,
 }
 
 /// Run an ACP server over WebSocket + serve the embedded web UI.
@@ -40,8 +40,8 @@ pub async fn run_acp_ws_server(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let state = AppState {
         config,
-        delegate: Arc::new(Mutex::new(delegate)),
-        abort_registry: new_abort_registry(),
+        delegate: Arc::from(delegate),
+        registry: new_session_registry(),
     };
     let app = Router::new()
         .route("/", get(serve_html))
@@ -91,7 +91,7 @@ async fn handle_ws(socket: WebSocket, state: AppState) {
     if let Err(e) = run_acp_on_transport(
         &state.config,
         Arc::clone(&state.delegate),
-        Arc::clone(&state.abort_registry),
+        Arc::clone(&state.registry),
         transport,
     )
     .await

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2616,14 +2616,36 @@ struct AcpCliSession {
     session_mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
 }
 
+/// One live ACP session as held by [`AcpCliAgent`].
+///
+/// The session proper sits behind its **own** mutex so that turns of
+/// different sessions run concurrently; the ACP server additionally
+/// serializes requests within one session, so this lock is uncontended in
+/// practice and exists for memory safety. `cwd` is duplicated here so
+/// `session/list` can answer without touching a session that is mid-turn.
+struct AcpCliSessionSlot {
+    cwd: PathBuf,
+    session: Arc<Mutex<AcpCliSession>>,
+}
+
+/// Locked view of a session; deref gives `&mut AcpCliSession`.
+type AcpCliSessionGuard<'a> = std::sync::MutexGuard<'a, AcpCliSession>;
+
 struct AcpCliAgent {
-    model: String,
+    /// Process-wide "current model" (`/model`, `session/setModel` move it).
+    /// Read at the start of every turn as the fallback for sessions that
+    /// carry no model of their own, hence its own short-held lock rather
+    /// than living under any session's lock.
+    model: Mutex<String>,
     model_flag_raw: Option<String>,
     allowed_tools: Option<AllowedToolSet>,
     permission_mode_override: Option<PermissionMode>,
     reasoning_effort: Option<String>,
     auth_mode: Option<AuthMode>,
-    sessions: HashMap<String, AcpCliSession>,
+    /// Session registry. Only ever locked briefly to look a slot up or to
+    /// insert / remove one — never while a session lock is held, and never
+    /// across a turn.
+    sessions: Mutex<HashMap<String, AcpCliSessionSlot>>,
     tokio_runtime: tokio::runtime::Runtime,
 }
 
@@ -2637,16 +2659,47 @@ impl AcpCliAgent {
         auth_mode: Option<AuthMode>,
     ) -> Self {
         Self {
-            model,
+            model: Mutex::new(model),
             model_flag_raw,
             allowed_tools,
             permission_mode_override,
             reasoning_effort,
             auth_mode,
-            sessions: HashMap::new(),
+            sessions: Mutex::new(HashMap::new()),
             tokio_runtime: tokio::runtime::Runtime::new()
                 .expect("failed to create tokio runtime for ACP agent"),
         }
+    }
+
+    /// Snapshot of the process-wide current model.
+    fn current_model(&self) -> String {
+        self.model
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn lock_sessions(&self) -> std::sync::MutexGuard<'_, HashMap<String, AcpCliSessionSlot>> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Fetch the shared handle of a session (the registry lock is released
+    /// before the caller locks the session itself).
+    fn session_handle(&self, session_id: &str) -> Result<Arc<Mutex<AcpCliSession>>, AcpError> {
+        self.lock_sessions()
+            .get(session_id)
+            .map(|slot| Arc::clone(&slot.session))
+            .ok_or_else(|| AcpError::invalid_params(format!("unknown sessionId: {session_id}")))
+    }
+
+    fn insert_session(&self, session_id: String, session: AcpCliSession) {
+        let slot = AcpCliSessionSlot {
+            cwd: session.cwd.clone(),
+            session: Arc::new(Mutex::new(session)),
+        };
+        self.lock_sessions().insert(session_id, slot);
     }
 
     fn build_session(
@@ -2722,12 +2775,13 @@ impl AcpCliAgent {
     }
 
     fn resolve_model_for_cwd(&self, cwd: &Path) -> Result<String, AcpError> {
+        let model = self.current_model();
         if self.model_flag_raw.is_some() {
-            return Ok(self.model.clone());
+            return Ok(model);
         }
         let _guard = ScopedCurrentDir::change_to(cwd)
             .map_err(|error| AcpError::internal(format!("failed to enter cwd: {error}")))?;
-        Ok(resolve_repl_model(self.model.clone()))
+        Ok(resolve_repl_model(model))
     }
 
     fn resolve_permission_mode_for_cwd(&self, cwd: &Path) -> Result<PermissionMode, AcpError> {
@@ -2741,36 +2795,33 @@ impl AcpCliAgent {
 }
 
 impl AcpCliAgent {
+    /// Switch the process-wide model and rebuild `session`'s runtime for it.
+    /// The caller holds the session lock (`session` is the locked session).
     fn handle_acp_model_switch(
-        &mut self,
-        session_id: &str,
+        &self,
+        session: &mut AcpCliSession,
         model: Option<String>,
     ) -> Result<String, AcpError> {
-        let session = self
-            .sessions
-            .get(session_id)
-            .ok_or_else(|| AcpError::invalid_params(format!("unknown sessionId: {session_id}")))?;
+        let current = self.current_model();
 
         let Some(new_model) = model else {
             return Ok(format_model_report(
-                &self.model,
+                &current,
                 session.runtime.session().messages.len(),
                 UsageTracker::from_session(session.runtime.session()).turns(),
             ));
         };
 
         let resolved = resolve_model_alias_with_config(&new_model);
-        if resolved == self.model {
-            let session = self.sessions.get(session_id).unwrap();
+        if resolved == current {
             return Ok(format_model_report(
-                &self.model,
+                &current,
                 session.runtime.session().messages.len(),
                 UsageTracker::from_session(session.runtime.session()).turns(),
             ));
         }
 
-        let previous = self.model.clone();
-        let session = self.sessions.get(session_id).unwrap();
+        let previous = current;
         let message_count = session.runtime.session().messages.len();
         let mut cloned_session = session.runtime.session().clone();
         // Keep the session's own model in sync with the switch. `build_runtime_with_plugin_state`
@@ -2811,9 +2862,11 @@ impl AcpCliAgent {
                 .set_reasoning_effort(self.reasoning_effort.clone());
         }
 
-        let session = self.sessions.get_mut(session_id).unwrap();
         session.runtime = runtime;
-        self.model.clone_from(&resolved);
+        self.model
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone_from(&resolved);
 
         Ok(format_model_switch_report(
             &previous,
@@ -3020,9 +3073,34 @@ impl AcpSdkDelegate {
     }
 }
 
+impl AcpSdkDelegate {
+    /// Lock one session for the duration of a delegate call. Different
+    /// sessions lock independently, so a session parked on user input never
+    /// holds up another one; the ACP server serializes calls on the same
+    /// session, so this normally never waits.
+    fn lock_session(&self, session_id: &str) -> Result<LockedAcpSession, runtime::AcpError> {
+        let handle = self.inner.session_handle(session_id)?;
+        Ok(LockedAcpSession { handle })
+    }
+}
+
+/// Owner of a session handle that hands out the locked session. Kept as a
+/// separate value so the `Arc` outlives the guard borrowed from it.
+struct LockedAcpSession {
+    handle: Arc<Mutex<AcpCliSession>>,
+}
+
+impl LockedAcpSession {
+    fn get(&self) -> AcpCliSessionGuard<'_> {
+        self.handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
 impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
     fn new_session(
-        &mut self,
+        &self,
         cwd: PathBuf,
         mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
     ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
@@ -3030,12 +3108,12 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         let session_id = session.handle.id.clone();
         let session_cwd = session.cwd.clone();
         let abort_signal = session.abort_signal.clone();
-        self.inner.sessions.insert(session_id.clone(), session);
+        self.inner.insert_session(session_id.clone(), session);
         Ok((session_id, session_cwd, abort_signal))
     }
 
     fn run_prompt(
-        &mut self,
+        &self,
         session_id: &str,
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
@@ -3047,11 +3125,13 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         ),
         runtime::AcpError,
     > {
-        self.run_prompt_impl(session_id, prompt, observer, None, trace_id)
+        let locked = self.lock_session(session_id)?;
+        let mut session = locked.get();
+        self.run_prompt_impl(&mut session, prompt, observer, None, trace_id)
     }
 
     fn run_prompt_with_prompter(
-        &mut self,
+        &self,
         session_id: &str,
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
@@ -3064,18 +3144,19 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         ),
         runtime::AcpError,
     > {
-        self.run_prompt_impl(session_id, prompt, observer, Some(prompter), trace_id)
+        let locked = self.lock_session(session_id)?;
+        let mut session = locked.get();
+        self.run_prompt_impl(&mut session, prompt, observer, Some(prompter), trace_id)
     }
 
     fn set_question_prompter(
-        &mut self,
+        &self,
         session_id: &str,
         prompter: Box<dyn runtime::QuestionPrompter>,
     ) -> Result<(), runtime::AcpError> {
-        let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
-            runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
-        })?;
-        session
+        let locked = self.lock_session(session_id)?;
+        locked
+            .get()
             .runtime
             .tool_executor_mut()
             .set_question_prompter(prompter);
@@ -3083,7 +3164,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
     }
 
     fn handle_slash_command(
-        &mut self,
+        &self,
         session_id: &str,
         input: &str,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
@@ -3098,20 +3179,20 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
         let response = match &command {
             SlashCommand::Model { model } => {
-                self.inner.handle_acp_model_switch(session_id, model.clone())?
+                let locked = self.lock_session(session_id)?;
+                let mut session = locked.get();
+                self.inner
+                    .handle_acp_model_switch(&mut session, model.clone())?
             }
             SlashCommand::Help => render_repl_help(),
             SlashCommand::Status => {
-                let session = self.inner.sessions.get(session_id).ok_or_else(|| {
-                    runtime::AcpError::invalid_params(format!(
-                        "unknown sessionId: {session_id}"
-                    ))
-                })?;
+                let locked = self.lock_session(session_id)?;
+                let session = locked.get();
                 let _guard = ScopedCurrentDir::change_to(&session.cwd)
                     .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
                 let tracker = UsageTracker::from_session(session.runtime.session());
                 format_status_report(
-                    &self.inner.model,
+                    &self.inner.current_model(),
                     StatusUsage {
                         message_count: session.runtime.session().messages.len(),
                         turns: tracker.turns(),
@@ -3126,11 +3207,8 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 )
             }
             SlashCommand::Cost => {
-                let session = self.inner.sessions.get(session_id).ok_or_else(|| {
-                    runtime::AcpError::invalid_params(format!(
-                        "unknown sessionId: {session_id}"
-                    ))
-                })?;
+                let locked = self.lock_session(session_id)?;
+                let session = locked.get();
                 let usage = UsageTracker::from_session(session.runtime.session())
                     .cumulative_usage();
                 format!(
@@ -3190,14 +3268,24 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
     fn list_sessions(&self) -> Vec<(String, PathBuf)> {
         self.inner
-            .sessions
+            .lock_sessions()
             .iter()
-            .map(|(id, s)| (id.clone(), s.cwd.clone()))
+            .map(|(id, slot)| (id.clone(), slot.cwd.clone()))
             .collect()
     }
 
-    fn close_session(&mut self, session_id: &str) -> bool {
-        if let Some(session) = self.inner.sessions.remove(session_id) {
+    fn close_session(&self, session_id: &str) -> bool {
+        // Unregister first (new requests see `unknown sessionId` right away),
+        // then wait for the session itself: a turn still running on it keeps
+        // the session alive through its `Arc` until it returns.
+        let Some(slot) = self.inner.lock_sessions().remove(session_id) else {
+            return false;
+        };
+        {
+            let session = slot
+                .session
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             // Record token usage and session ended event
             let duration_ms = session.started_at.elapsed().as_millis() as u64;
             let usage = session.runtime.usage().cumulative_usage();
@@ -3217,39 +3305,37 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                     duration_ms,
                 );
             }
-            true
-        } else {
-            false
         }
+        drop(slot);
+        true
     }
 
-    fn set_model(&mut self, session_id: &str, model_id: &str) -> Result<String, runtime::AcpError> {
+    fn set_model(&self, session_id: &str, model_id: &str) -> Result<String, runtime::AcpError> {
+        let locked = self.lock_session(session_id)?;
+        let mut session = locked.get();
         self.inner
-            .handle_acp_model_switch(session_id, Some(model_id.to_string()))
+            .handle_acp_model_switch(&mut session, Some(model_id.to_string()))
     }
 
     fn get_model_info(&self) -> (String, Vec<String>) {
+        let current = self.inner.current_model();
         let config = load_sudocode_config_for_current_dir();
         let config_keys: Vec<String> = config.models.keys().cloned().collect();
         let mut models = runtime::model_capabilities::merge_discovery_ids(&config_keys);
         // Ensure the current model is always present.
-        if !models
-            .iter()
-            .any(|m| m.eq_ignore_ascii_case(&self.inner.model))
-        {
-            models.insert(0, self.inner.model.clone());
+        if !models.iter().any(|m| m.eq_ignore_ascii_case(&current)) {
+            models.insert(0, current.clone());
         }
-        (self.inner.model.clone(), models)
+        (current, models)
     }
 
     fn set_permission_mode(
-        &mut self,
+        &self,
         session_id: &str,
         mode: PermissionMode,
     ) -> Result<(), runtime::AcpError> {
-        let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
-            runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
-        })?;
+        let locked = self.lock_session(session_id)?;
+        let mut session = locked.get();
         if let Some(rt) = session.runtime.runtime.as_mut() {
             rt.permission_policy_mut().set_active_mode(mode);
         }
@@ -3257,7 +3343,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
     }
 
     fn push_images(
-        &mut self,
+        &self,
         session_id: &str,
         images: &[(String, String)],
     ) -> Result<(), runtime::AcpError> {
@@ -3266,8 +3352,8 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             images.len()
         );
         // Resolve everything that needs runtime-level state BEFORE taking the
-        // mutable session borrow: the active model + sudorouter creds.
-        let active_model = self.inner.model.clone();
+        // session lock: the active model + sudorouter creds.
+        let active_model = self.inner.current_model();
         let active_model_is_vision_capable =
             runtime::model_capabilities::vision_capable(&active_model);
         eprintln!(
@@ -3322,10 +3408,9 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             blocks.push(block);
         }
 
-        // Single critical section: take the session mut and push all messages.
-        let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
-            runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
-        })?;
+        // Single critical section: lock the session and push all messages.
+        let locked = self.lock_session(session_id)?;
+        let mut session = locked.get();
         for block in blocks {
             let msg = runtime::ConversationMessage {
                 role: runtime::MessageRole::User,
@@ -3343,7 +3428,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
     }
 
     fn load_session(
-        &mut self,
+        &self,
         session_id: &str,
         cwd: PathBuf,
         mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
@@ -3395,7 +3480,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
         let loaded_session_id = handle.id.clone();
         let signal = abort_signal.clone();
-        self.inner.sessions.insert(
+        self.inner.insert_session(
             loaded_session_id.clone(),
             AcpCliSession {
                 cwd: cwd.clone(),
@@ -3411,9 +3496,10 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 }
 
 impl AcpSdkDelegate {
+    /// Run one turn on an already-locked session.
     fn run_prompt_impl(
-        &mut self,
-        session_id: &str,
+        &self,
+        session: &mut AcpCliSession,
         prompt: String,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
         prompter: Option<&mut dyn runtime::PermissionPrompter>,
@@ -3425,9 +3511,6 @@ impl AcpSdkDelegate {
         ),
         runtime::AcpError,
     > {
-        let session = self.inner.sessions.get_mut(session_id).ok_or_else(|| {
-            runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
-        })?;
         // Reset abort signal for this new turn.
         session.abort_signal.reset();
         let _guard = ScopedCurrentDir::change_to(&session.cwd).map_err(|e| {
@@ -3440,12 +3523,13 @@ impl AcpSdkDelegate {
         }
 
         // Pre-send token estimation and auto-compact logic
+        let fallback_model = self.inner.current_model();
         let model = session
             .runtime
             .session()
             .model
             .as_ref()
-            .unwrap_or(&self.inner.model);
+            .unwrap_or(&fallback_model);
         // Context window comes from the model-capabilities SSOT file (per-model
         // entry, else the file's `default`). No hardcoded fallback here.
         let context_limit = runtime::model_capabilities::context_window_or_default(model) as usize;

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -188,6 +188,50 @@ impl AcpTestClient {
         }
     }
 
+    /// Send a JSON-RPC request WITHOUT waiting for its response. Returns the
+    /// request id so the caller can pick the response out of the stream later
+    /// with [`AcpTestClient::recv_until`]. Used by the cross-session
+    /// concurrency scenarios where one request is deliberately left pending.
+    async fn send_request_no_wait(&mut self, method: &str, params: Value) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        });
+        self.send_raw(&request).await;
+        id
+    }
+
+    /// Read messages until `pred` matches one, returning it together with
+    /// every message that arrived before it. Returns `Err(seen)` if `limit`
+    /// elapses first (the messages seen so far are returned for diagnostics).
+    async fn recv_until(
+        &mut self,
+        limit: Duration,
+        pred: impl Fn(&Value) -> bool,
+    ) -> Result<(Vec<Value>, Value), Vec<Value>> {
+        let mut seen = Vec::new();
+        let deadline = tokio::time::Instant::now() + limit;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(seen);
+            }
+            match timeout(remaining, self.recv_inner()).await {
+                Ok(msg) => {
+                    if pred(&msg) {
+                        return Ok((seen, msg));
+                    }
+                    seen.push(msg);
+                }
+                Err(_) => return Err(seen),
+            }
+        }
+    }
+
     async fn send_raw(&mut self, value: &Value) {
         match &mut self.transport {
             Transport::Stdio { stdin, .. } => {
@@ -937,6 +981,362 @@ async fn acp_stdio_resume_restores_history_across_reconnect() {
          a fresh/empty session would omit it. body: {}",
         last.raw_body
     );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+// ---------------------------------------------------------------------------
+// Cross-session concurrency
+// ---------------------------------------------------------------------------
+
+/// True when `msg` is the JSON-RPC *response* to client request `id` (a
+/// server-originated request such as `session/request_permission` also
+/// carries an `id`, so the absence of `method` is what distinguishes them).
+fn is_response_to(msg: &Value, id: u64) -> bool {
+    msg.get("id").and_then(Value::as_u64) == Some(id) && msg.get("method").is_none()
+}
+
+fn is_server_request(msg: &Value, method: &str) -> bool {
+    msg.get("method").and_then(Value::as_str) == Some(method) && msg.get("id").is_some()
+}
+
+/// Send a `session/prompt` on `session_id` that makes the mock model call
+/// `bash`, and — because the session runs in `workspace-write` — parks the
+/// turn on a `session/request_permission` round-trip that we deliberately do
+/// NOT answer. Returns `(prompt request id, permission request id)`.
+async fn park_session_on_permission_prompt(
+    client: &mut AcpTestClient,
+    session_id: &str,
+) -> (u64, Value) {
+    let (_, resp) = client
+        .send_request(
+            "session/setPermissionMode",
+            json!({ "sessionId": session_id, "permissionMode": "workspace-write" }),
+        )
+        .await;
+    assert!(
+        resp.get("error").is_none(),
+        "session/setPermissionMode should succeed: {resp}"
+    );
+
+    let prompt_id = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{
+                    "type": "text",
+                    "text": format!("{SCENARIO_PREFIX}bash_permission_prompt_approved")
+                }]
+            }),
+        )
+        .await;
+
+    let (_, perm_req) = client
+        .recv_until(Duration::from_secs(30), |m| {
+            is_server_request(m, "session/request_permission")
+        })
+        .await
+        .unwrap_or_else(|seen| {
+            panic!("expected session/request_permission from the agent; saw: {seen:?}")
+        });
+    assert_eq!(
+        perm_req["params"]["sessionId"].as_str(),
+        Some(session_id),
+        "permission request must be attributed to the parked session"
+    );
+    (prompt_id, perm_req["id"].clone())
+}
+
+/// Answer a pending `session/request_permission` with `allow_once`.
+async fn allow_permission(client: &mut AcpTestClient, perm_req_id: &Value) {
+    client
+        .send_raw(&json!({
+            "jsonrpc": "2.0",
+            "id": perm_req_id,
+            "result": { "outcome": { "outcome": "selected", "optionId": "allow_once" } }
+        }))
+        .await;
+}
+
+/// Regression guard for the multi-session P0: while session A is parked on
+/// a permission prompt (waiting for the user), a `session/prompt` on an
+/// unrelated session B must still be answered. Before the fix every prompt
+/// took one process-wide delegate mutex for the whole turn, so A's pause
+/// blocked B (and every other session) indefinitely.
+///
+/// `other_cwd` picks whether B lives in the same working directory as A or
+/// in a sibling directory; both must work.
+async fn scenario_paused_session_does_not_block_other_session(label: &str, other_cwd: bool) {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new(label);
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    let cwd_b = if other_cwd {
+        let dir = workspace.root.join("project-b");
+        fs::create_dir_all(&dir).expect("create sibling cwd");
+        dir
+    } else {
+        workspace.root.clone()
+    };
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let session_a = scenario_session_new(&mut client, &workspace.root).await;
+
+    let (prompt_a, perm_req_id) = park_session_on_permission_prompt(&mut client, &session_a).await;
+
+    // Mirrors the reported flow: the user opens a NEW conversation while the
+    // first one is waiting on them. session/new itself must not block either.
+    let new_b = client
+        .send_request_no_wait(
+            "session/new",
+            json!({ "cwd": cwd_b.to_string_lossy().to_string(), "mcpServers": [] }),
+        )
+        .await;
+    let (_, new_b_resp) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, new_b))
+        .await
+        .unwrap_or_else(|seen| {
+            panic!(
+                "session/new got no response within 20s while session A was parked on a \
+                 permission prompt (cross-session blocking); messages seen: {seen:?}"
+            )
+        });
+    let session_b = new_b_resp["result"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("session/new should succeed: {new_b_resp}"))
+        .to_string();
+
+    // Session B must make progress while A is parked.
+    let prompt_b = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_b,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text") }]
+            }),
+        )
+        .await;
+    let (before_b, resp_b) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, prompt_b))
+        .await
+        .unwrap_or_else(|seen| {
+            panic!(
+                "session B's prompt got no response within 20s while session A was parked on a \
+                 permission prompt (cross-session blocking); messages seen: {seen:?}"
+            )
+        });
+    assert!(
+        resp_b["result"].get("stopReason").is_some(),
+        "session B's turn should complete normally: {resp_b}"
+    );
+    assert!(
+        !before_b.iter().any(|m| is_response_to(m, prompt_a)),
+        "session A must still be parked (its prompt must not have completed yet)"
+    );
+    // B's streamed updates must be attributed to B only.
+    for m in &before_b {
+        if m.get("method").and_then(Value::as_str) == Some("session/update") {
+            assert_eq!(
+                m["params"]["sessionId"].as_str(),
+                Some(session_b.as_str()),
+                "unexpected session/update for another session while B ran: {m}"
+            );
+        }
+    }
+
+    // Now release A: it must finish its turn normally (the parked session is
+    // not lost or corrupted by B having run in the meantime).
+    allow_permission(&mut client, &perm_req_id).await;
+    let (notifs_a, resp_a) = client
+        .recv_until(Duration::from_secs(30), |m| is_response_to(m, prompt_a))
+        .await
+        .unwrap_or_else(|seen| panic!("session A never completed after approval; saw: {seen:?}"));
+    assert!(
+        resp_a["result"].get("stopReason").is_some(),
+        "session A's turn should complete after the permission is granted: {resp_a}"
+    );
+    let blob = serde_json::to_string(&notifs_a).unwrap_or_default();
+    assert!(
+        blob.contains("bash approved and executed"),
+        "session A should have run the approved bash call and streamed the mock's final text; \
+         got: {blob}"
+    );
+
+    // Both sessions must still be usable afterwards.
+    scenario_session_prompt_streaming(&mut client, &session_a).await;
+    scenario_session_prompt_streaming(&mut client, &session_b).await;
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+#[tokio::test]
+async fn acp_stdio_paused_session_does_not_block_other_session_same_cwd() {
+    scenario_paused_session_does_not_block_other_session("stdio-concurrency-same-cwd", false).await;
+}
+
+#[tokio::test]
+async fn acp_stdio_paused_session_does_not_block_other_session_other_cwd() {
+    scenario_paused_session_does_not_block_other_session("stdio-concurrency-other-cwd", true).await;
+}
+
+/// Same P0, other wait path: session A parked inside the `AskUserQuestion`
+/// tool (`_scode/ask_user_question` extension request to the client, left
+/// unanswered — "waiting for the user to answer a question" is exactly the
+/// reported symptom), session B must still be served.
+#[tokio::test]
+async fn acp_stdio_session_parked_on_ask_user_question_does_not_block_other_session() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-concurrency-ask-user");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let session_a = scenario_session_new(&mut client, &workspace.root).await;
+
+    let prompt_a = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_a,
+                "prompt": [{
+                    "type": "text",
+                    "text": format!("{SCENARIO_PREFIX}ask_user_question_roundtrip")
+                }]
+            }),
+        )
+        .await;
+    let (_, question_req) = client
+        .recv_until(Duration::from_secs(30), |m| {
+            is_server_request(m, "_scode/ask_user_question")
+        })
+        .await
+        .unwrap_or_else(|seen| {
+            panic!("expected _scode/ask_user_question from the agent; saw: {seen:?}")
+        });
+    assert_eq!(
+        question_req["params"]["sessionId"].as_str(),
+        Some(session_a.as_str())
+    );
+
+    // New conversation while A waits on the user: must be served.
+    let new_b = client
+        .send_request_no_wait(
+            "session/new",
+            json!({ "cwd": workspace.root.to_string_lossy().to_string(), "mcpServers": [] }),
+        )
+        .await;
+    let (_, new_b_resp) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, new_b))
+        .await
+        .unwrap_or_else(|seen| {
+            panic!("session/new blocked behind an unanswered AskUserQuestion; saw: {seen:?}")
+        });
+    let session_b = new_b_resp["result"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("session/new should succeed: {new_b_resp}"))
+        .to_string();
+    let prompt_b = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_b,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text") }]
+            }),
+        )
+        .await;
+    let (_, resp_b) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, prompt_b))
+        .await
+        .unwrap_or_else(|seen| {
+            panic!("session B blocked behind an unanswered AskUserQuestion; saw: {seen:?}")
+        });
+    assert!(resp_b["result"].get("stopReason").is_some(), "{resp_b}");
+
+    // Answer A's question; A must complete with the answer visible to the model.
+    client
+        .send_raw(&json!({
+            "jsonrpc": "2.0",
+            "id": question_req["id"],
+            "result": { "answers": [{ "id": "q1", "value": "blue", "label": "blue" }] }
+        }))
+        .await;
+    let (notifs_a, resp_a) = client
+        .recv_until(Duration::from_secs(30), |m| is_response_to(m, prompt_a))
+        .await
+        .unwrap_or_else(|seen| panic!("session A never completed after the answer; saw: {seen:?}"));
+    assert!(resp_a["result"].get("stopReason").is_some(), "{resp_a}");
+    let blob = serde_json::to_string(&notifs_a).unwrap_or_default();
+    assert!(
+        blob.contains("ask_user_question answered") && blob.contains("blue"),
+        "session A should have resumed with the user's answer; got: {blob}"
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// The flip side of cross-session concurrency: prompts on the SAME session
+/// must stay strictly serial. A second `session/prompt` sent while the first
+/// is parked on a permission prompt must not start (no response, no
+/// `session/update`) until the first turn has finished.
+#[tokio::test]
+async fn acp_stdio_same_session_prompts_stay_serial() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-same-session-serial");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let session_a = scenario_session_new(&mut client, &workspace.root).await;
+
+    let (prompt_1, perm_req_id) = park_session_on_permission_prompt(&mut client, &session_a).await;
+
+    let prompt_2 = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_a,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text") }]
+            }),
+        )
+        .await;
+
+    // While turn 1 is parked, turn 2 must produce nothing at all.
+    let leaked = client
+        .recv_until(Duration::from_secs(3), |m| {
+            is_response_to(m, prompt_2)
+                || m.get("method").and_then(Value::as_str) == Some("session/update")
+        })
+        .await;
+    assert!(
+        leaked.is_err(),
+        "second prompt on the same session must not run while the first is parked; got: {:?}",
+        leaked.ok().map(|(_, m)| m)
+    );
+
+    allow_permission(&mut client, &perm_req_id).await;
+    let (_, resp_1) = client
+        .recv_until(Duration::from_secs(30), |m| is_response_to(m, prompt_1))
+        .await
+        .unwrap_or_else(|seen| panic!("first turn never completed; saw: {seen:?}"));
+    assert!(resp_1["result"].get("stopReason").is_some(), "{resp_1}");
+    let (_, resp_2) = client
+        .recv_until(Duration::from_secs(30), |m| is_response_to(m, prompt_2))
+        .await
+        .unwrap_or_else(|seen| panic!("second turn never completed; saw: {seen:?}"));
+    assert!(resp_2["result"].get("stopReason").is_some(), "{resp_2}");
 
     client.shutdown().await;
     workspace.cleanup();

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -441,9 +441,16 @@ async fn scenario_initialize(client: &mut AcpTestClient) {
         agent_info.get("version").is_some(),
         "agentInfo should include version"
     );
-    assert!(
-        result.get("agentCapabilities").is_some(),
-        "response should include agentCapabilities"
+    let caps = result
+        .get("agentCapabilities")
+        .expect("response should include agentCapabilities");
+    // `session/load` is implemented (see the resume-across-processes test
+    // below); clients such as sudowork / apeiron gate reconnect-after-restart
+    // on this flag, so it must be advertised.
+    assert_eq!(
+        caps["loadSession"].as_bool(),
+        Some(true),
+        "agentCapabilities.loadSession must be advertised: {caps}"
     );
 
     // Image-handling SSOT: assert the `_meta.sudocode.imageCapability` extension
@@ -589,7 +596,9 @@ async fn scenario_session_list(client: &mut AcpTestClient, expected_session_id: 
     );
 }
 
-async fn scenario_session_load_not_supported(client: &mut AcpTestClient) {
+/// `session/load` of an id that was never persisted must fail cleanly (it
+/// must not mint a fresh session under that id).
+async fn scenario_session_load_unknown_session_errors(client: &mut AcpTestClient) {
     let (notifs, resp) = client
         .send_request("session/load", json!({ "sessionId": "nonexistent" }))
         .await;
@@ -815,7 +824,7 @@ async fn run_all_scenarios(client: &mut AcpTestClient, workspace: &TestWorkspace
     scenario_session_prompt_streaming(client, &session_id).await;
     scenario_session_prompt_with_image_attachment(client, &session_id).await;
     scenario_session_list(client, &session_id).await;
-    scenario_session_load_not_supported(client).await;
+    scenario_session_load_unknown_session_errors(client).await;
     scenario_unknown_method(client).await;
     scenario_slash_command_model(client, &session_id).await;
     // Run per-turn usage test last with a fresh session
@@ -981,9 +990,48 @@ async fn acp_stdio_resume_restores_history_across_reconnect() {
          a fresh/empty session would omit it. body: {}",
         last.raw_body
     );
+    // The full transcript is restored, not just the last user turn: the
+    // assistant reply from process A must be in the request as well.
+    assert!(
+        last.raw_body.contains("\"role\":\"assistant\""),
+        "resumed model request must carry process A's assistant turn; body: {}",
+        last.raw_body
+    );
+
+    // The loaded session is a first-class live session again.
+    scenario_session_list(&mut client, &session_id).await;
+    scenario_session_load_rejects_other_cwd(&mut client, &workspace, &session_id).await;
 
     client.shutdown().await;
     workspace.cleanup();
+}
+
+/// Boundary of `session/load`: sessions are stored per workspace
+/// (`<cwd>/.scode/sessions/<fingerprint(cwd)>/<id>.jsonl`) and a load
+/// validates the persisted `workspace_root`, so loading the same id from a
+/// *different* cwd is rejected rather than silently re-homed. Cross-cwd
+/// continuation is a fork, not a load.
+async fn scenario_session_load_rejects_other_cwd(
+    client: &mut AcpTestClient,
+    workspace: &TestWorkspace,
+    session_id: &str,
+) {
+    let other_cwd = workspace.root.join("elsewhere");
+    fs::create_dir_all(&other_cwd).expect("create other cwd");
+    let (_, cross_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": session_id,
+                "cwd": other_cwd.to_string_lossy().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        cross_resp.get("error").is_some(),
+        "session/load from another cwd must be rejected, got: {cross_resp}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**P0:** one `scode acp` process serves many sessions, but every handler took a single process-wide delegate mutex and `session/prompt` held it for the whole turn. A session parked on `session/request_permission` or `_scode/ask_user_question` therefore blocked `session/new` and prompts on **every other session** until the user answered ("new conversation gets no response while another one waits for input").

- **Reproduced first:** new integration tests park session A on a permission prompt / AskUserQuestion, then `session/new` + prompt on session B — on `main` B gets *nothing* (not even the `session/new` response) for 20s.
- **Fix:** no server-side delegate lock (`SdkAcpDelegate` methods take `&self`, `SharedDelegate = Arc<dyn …>`); the CLI delegate locks **per session** (`Arc<Mutex<AcpCliSession>>`, short map/model locks). The server keeps a `SessionRegistry` with a FIFO **lane per session** so same-session requests stay strictly serial (JSON-RPC traffic never interleaves) while sessions run concurrently; `session/cancel` stays lock-free. A `WorkspaceCwdLease` arbitrates the process cwd the runtime depends on: same-cwd turns run fully in parallel, and a turn parked on user input **releases the lease** while it waits, so a paused session never blocks anyone.
- **`session/load`:** implemented since the initial commit and what sudowork already uses to resume, but `AgentCapabilities.loadSession` was never advertised, so spec-conformant clients (apeiron) concluded reconnect-after-restart is impossible. Now advertised; the cross-process resume test also pins that the whole transcript reaches the model and that loading from another cwd is rejected. Docs updated.

Full write-up (root cause evidence, why this design over the alternatives, correctness argument per invariant, what `session/load` restores and where its boundary is, residual risks, `session/fork` recommendation) is in `REPORT.md`.

## Testing

- `cargo test -p rusty-sudocode-cli --test acp_integration` — 13 passed (4 new concurrency tests, red on `main`).
- `cargo test --workspace` × 3 — 1642 passed / 0 failed each; concurrency tests 10/10 in a loop.
- `cargo clippy --workspace --all-targets` (warn mode, all crates): 902 → 902 warnings, zero new. `-D warnings` fails on the pre-existing `crates/telemetry` pedantic lints on `main` too.
- `cargo fmt --all --check` clean.

## Residual / not done

- *Active* turns in different cwds still wait for each other (root: process-cwd-based tool executor; long-term fix is a cwd-explicit runtime).
- `session/load` does not replay history as `session/update` (spec deviation, ~1 day; needs a check with sudowork to avoid duplicate rendering) — left as a decision, documented in `docs/acp.md`.
- `sessionCapabilities.list` is likewise implemented but undeclared — untouched here.


---

<details>
<summary><b>完整报告</b>（复现细节、正确性论证、clippy 对比、残留风险）</summary>

# scode ACP：会话间并发阻塞 + `session/load` 能力核查 — 报告






## 1. 复现

测试在 `rust/crates/rusty-sudocode-cli/tests/acp_integration.rs`：

- `acp_stdio_paused_session_does_not_block_other_session_same_cwd` /
  `..._other_cwd`（`scenario_paused_session_does_not_block_other_session`）：
  session A 切到 `workspace-write`，发 `bash_permission_prompt_approved` 场景 →
  agent 发出 `session/request_permission`，**测试不回答**；然后 `session/new`
  开 session B（同 cwd / 不同 cwd 两个变体）并对 B 发 `streaming_text` prompt，
  要求 20s 内拿到响应；再回答 A 的权限请求，要求 A 正常跑完（响应里带
  `bash approved and executed`）；最后 A、B 各再跑一轮确认都还能用。
- `acp_stdio_session_parked_on_ask_user_question_does_not_block_other_session`：
  同上，但 A 卡在 `_scode/ask_user_question`（对应「等待用户回答问题」这条原始症状）。
- `acp_stdio_same_session_prompts_stay_serial`：反向守卫，同一 session 第二个
  prompt 在第一个 turn 挂起期间**不得**产生任何响应/更新，回答后两个 turn 按序完成。

修改前（红）：

```
running 3 tests
test acp_stdio_same_session_prompts_stay_serial ... ok
test acp_stdio_paused_session_does_not_block_other_session_other_cwd ... FAILED
test acp_stdio_paused_session_does_not_block_other_session_same_cwd ... FAILED

---- acp_stdio_paused_session_does_not_block_other_session_same_cwd stdout ----
panicked at crates/rusty-sudocode-cli/tests/acp_integration.rs:1101:13:
session/new got no response within 20s while session A was parked on a permission prompt
(cross-session blocking); messages seen: []
```

```
test acp_stdio_session_parked_on_ask_user_question_does_not_block_other_session ... FAILED
panicked at crates/rusty-sudocode-cli/tests/acp_integration.rs:1240:13:
session/new blocked behind an unanswered AskUserQuestion; saw: []
```

`messages seen: []`：A 挂起后连 `session/new` 都收不到响应——和前端报的
「新开会话发消息无响应」以及另一位同事在 0.1.18 上抓到的
`B BLOCKED for 60000ms … (B updates: 0)` 完全一致。

修改后四个测试全绿（见 §7）。

## 2. 根因

**是那把全局锁**，且它是唯一的串行点：

- `SharedDelegate = Arc<Mutex<Box<dyn SdkAcpDelegate>>>`；每个 handler 都是
  `spawn_blocking(|| d.lock().method(..))`。`session/prompt` 的 blocking 闭包拿锁后
  调 `run_prompt_with_prompter`（整轮对话），权限确认 / AskUserQuestion 在闭包里
  `blocking_recv()` 等客户端回答——锁一直不放；此时任何 handler
  （`session/new`、别的 session 的 prompt、`session/list`……）都排在这把锁后面。
- 证据 1：红测试里 B 一条消息都没有（连 `session/new` 都无响应）——阻塞点在进模型
  之前，是 handler 层面。
- 证据 2：修复**只**去掉了这把锁（SDK 分发层 `Agent.builder().on_receive_request` +
  `cx.spawn` 一字未动），同一测试即绿。若上层派发是串行的，去锁不会有效果。
  SDK 层的确不是串行的：每个 handler 立刻 `cx.spawn` 后返回。
- `session/cancel` 之所以一直能用，是因为它走独立的 `AbortRegistry`，不碰这把锁——
  这也印证锁是唯一瓶颈。

## 3. 修法与取舍

**先看 delegate 内部是否本来就按 session 分隔**：是。`AcpCliAgent` 的状态是
`sessions: HashMap<id, AcpCliSession>`（每个 session 自带 `BuiltRuntime`、abort
signal、cwd、MCP 状态），加三样跨 session 的东西：

1. `model: String`（进程级"当前模型"，`/model`、`session/setModel` 会改；每轮开始读一次做 fallback）
2. `tokio_runtime`（`Runtime::block_on(&self)` 允许多线程并发调用，无需处理）
3. **进程 cwd**：`run_prompt_impl` 每轮 `ScopedCurrentDir::change_to(session.cwd)`，
   而 bash 工具、fs backend、hooks、配置加载都读 `env::current_dir()`
   （`bash.rs:142`、`fs_backend.rs:289-305`、`conversation.rs:628` 等）。
   这是并发化真正的障碍——不是锁的问题，是运行时按进程 cwd 工作。

### 选择：delegate 自管细粒度锁 + server 侧 per-session lane + cwd 租约

- **`SdkAcpDelegate` 全部方法 `&self`，`SharedDelegate = Arc<dyn SdkAcpDelegate>`**
  （`acp_sdk_server.rs:646`）。server 侧不再有任何 delegate 级锁。
- **CLI delegate**（`main.rs:2626` 起）：`sessions: Mutex<HashMap<id, Slot{cwd, Arc<Mutex<AcpCliSession>>}>>`
  只在查表/增删时短暂持有；每个 session 自己一把 `Mutex`，一轮 turn 只锁自己；
  `model: Mutex<String>` 短锁。`handle_acp_model_switch` 改为接收已锁定的
  `&mut AcpCliSession`（调用方先锁 session，避免嵌套锁）。
- **server 侧 `SessionRegistry`**（`acp_sdk_server.rs:675`）：原 `AbortRegistry`
  扩展为每 session 一条 **lane**（`tokio::sync::Mutex<()>`，FIFO），
  `session/prompt` / `setPermissionMode` / `setModel` / `close` / `load` 在
  spawn 的 task 里 `enter_lane(sid).await`（异步等待，不占线程），保证同 session 串行；
  `session/cancel` 仍不排队。
- **`WorkspaceCwdLease`**（`acp_sdk_server.rs:772`）：进程 cwd 的引用计数租约。
  同 cwd 的 turn 共享租约、完全并发；不同 cwd 的 turn 等当前持有者退出；
  **turn 在等用户回答时（`AcpPermissionBridge::decide` / `AcpQuestionBridge::ask`）
  通过 `CwdLeaseHandle::parked` 让出租约、回答后重新拿回**。所以「暂停中的 session」
  永远不会挡住任何 cwd 的其他 session（`..._other_cwd` 测试覆盖）。
  `session/new` / `session/load` / `session/setModel` 也在租约内执行（它们内部会
  `ScopedCurrentDir::change_to`）。

### 为什么不选其它几条

- **换 `RwLock`**：`run_prompt_with_prompter` 需要 `&mut`，写锁 = 互斥，问题不变。
- **保留 `&mut self` trait、server 侧"按 session 拆锁"**：`Arc<Mutex<Box<dyn>>>` 下
  任何方法调用都必须持 delegate 锁；要让 turn 不持锁只能把 session "check-out"
  出来。但 check-out 期间该 session 在 `list/close/setPermissionMode` 里不可见或
  需要在持 delegate 锁的同时去等 session 锁——后者又把「暂停的 session 拖住全局」
  带回来。改成 `&self` 让 delegate 自己决定锁粒度，最直接。
- **把 session 状态从 delegate 提到 runtime crate**：session 状态是 CLI crate 类型
  （`BuiltRuntime`、plugin/MCP 状态），提取意味着一个大得多的 trait 面；收益只是
  把锁挪个地方，没有解决 cwd 问题。
- **把运行时改成显式 cwd（不依赖进程 cwd）**：这是长期正确的做法，但横跨
  bash / fs_backend / hooks / memory / prompt / session_control 十几处
  `env::current_dir()`，超出本任务；租约是过渡桥梁，且把"暂停不阻塞"这条 P0
  在所有 cwd 组合下都补齐了。

## 4. 正确性论证（逐条）

- **同一 session 仍串行**：两层保证。server 侧 lane（FIFO `tokio::sync::Mutex`）
  在整个 prompt task 生命周期内持有（包括通知转发和最终响应）；delegate 侧
  `Arc<Mutex<AcpCliSession>>` 在 `run_prompt_impl` 期间持有。前者保证 JSON-RPC
  报文不交错，后者保证内存安全。`acp_stdio_same_session_prompts_stay_serial` 验证。
  同 session 的 `set_question_prompter → push_images → run_prompt` 序列也在同一条 lane
  内，不会被同 session 的另一个 prompt 插队（旧代码靠 delegate 锁的原子性，
  现在靠 lane）。
- **暂停的 session 不丢、continue 后跑完**：挂起只是 turn 线程 `blocking_recv`，
  session 锁、lane 都保持；`parked` 只让出 cwd 租约。回答到达 → 重新 `enter(cwd)`
  （若别的 cwd 正在跑则等待其结束/暂停）→ 继续 tool 循环 → 正常结束、
  `save_to_path`、响应。三个并发测试都在 B 跑完后回答 A，并断言 A 的最终文本与
  后续再跑一轮。
- **无死锁/活锁**：锁序固定。lane（异步）→ spawn_blocking → cwd 租约 → session 锁 →
  model 锁（短）；sessions map 锁从不在持 session 锁时获取（先取 `Arc` 再释放 map 锁）；
  持租约或 session 锁时从不等待 lane。租约等待者只持自己的 lane 与一个 blocking
  线程；持有者要么在跑（有界）、要么暂停（已让出）——无环。`parked` 若 handle 已
  非持有者则不会重进（stale bridge 无副作用）。
- **`spawn_blocking` 里持锁生命周期**：`cwd_guard` 在闭包末尾显式 `drop`；panic 时
  unwinding 也会 drop（租约归还）；lane guard 随 task 结束释放。
- **`session/cancel`**：只查 registry 的 abort signal，不排 lane、不碰 session 锁
  （`acp_sdk_server.rs` cancel handler），行为不变。
- **`session/close`**：排 lane（等待进行中的 turn，与旧行为一致：旧代码等 delegate 锁），
  delegate 里先从 map 摘除再锁 session 记录 telemetry。对*另一个*空闲 session
  的 close 不再被暂停的 session 拖住（改进）。
- **权限模式切换 / setModel**：排 lane + （setModel）租约；`/model` 走 prompt 的
  lane 与租约。语义与旧代码一致（在同 session turn 结束后生效）。
- **`PoisonError::into_inner`**：所有新增锁（sessions map、每 session 锁、model 锁、
  registry map、租约状态）都用同一写法；turn panic 只毒化该 session 的锁，其它
  session 不受影响，该 session 下次 lock 仍可 `into_inner` 继续。
- **不同 cwd 的 tool 正确性**：租约保证任一时刻进程 cwd 只属于一个目录的活动 turn；
  暂停期间该 turn 不执行任何工具（tool 循环严格顺序，`conversation.rs:1120` 起），
  让出是安全的。

## 5. `session/load` 核查

**结论：实现可用，纯粹漏了能力声明。已补声明。**

- 实测：`acp_stdio_resume_restores_history_across_reconnect`（进程 A 建 session +
  一轮带 marker → 退出 → 进程 B `session/load` → 再一轮，断言发给模型的请求含
  A 的用户消息**和 assistant 回复**）通过；同一测试新增：load 后 `session/list`
  可见；**换 cwd load 同一 id 被拒绝**（`scenario_session_load_rejects_other_cwd`）。
  `initialize` 现在断言 `agentCapabilities.loadSession == true`。
- 为什么没声明：`load_session` handler 从 Initial commit（2f640d7）就在，
  `AgentCapabilities` 从来没加过 `.load_session(true)`；git 历史、docs、roadmap 里
  没有任何"有意不声明"的记录。唯一线索是老测试名
  `scenario_session_load_not_supported`（实际只测不存在的 id 报错），已改名为
  `scenario_session_load_unknown_session_errors`。sudowork 早已在用 `session/load`
  做 resume（6dc7e2a 的测试注释），只是不看 capability。判定：遗漏。
- 恢复到什么程度（`Session` 结构 + `load_session()`）：
  - **恢复**：完整 transcript（user/assistant 消息、thinking 块、tool_use、tool_result、
    图片块）、`session.model`、compaction 状态、fork 血缘、prompt_history、
    `workspace_root`。下一轮把整段历史发给模型（测试断言 assistant role 在请求体里）。
  - **不恢复**：`session/setPermissionMode` 设过的模式（load 后回到 cwd 配置的默认 /
    CLI override）；权限授予——ACP 的 `allow_always` 在 `map_permission_response` 里
    与 `allow_once` 同样映射为一次 Allow，本来就不持久（连进程内都不记）；后台命令；
    MCP 只用 load 请求里传的；trace_id。
  - **边界**：store 在 `<cwd>/.scode/sessions/<fingerprint(cwd)>/<id>.jsonl`，
    `validate_loaded_session` 校验持久化的 `workspace_root` → 换 cwd 直接 load 报错
    （同事看到的 Internal error 就是 `WorkspaceMismatch`）。
  - **规范偏差（未做，需决策）**：ACP 规范要求 `session/load` 在响应前把整段历史以
    `session/update` 回放给客户端；scode 直接返回 `{}`。apeiron / sudowork 自己存对话
    所以不需要，但通用客户端（Zed）会看到空线程。实现约 100 行（`Session.messages`
    → `UserMessageChunk/AgentMessageChunk/AgentThoughtChunk/ToolCall/ToolCallUpdate`）
    + 一个测试，半天到一天；**风险**是 sudowork 已在用 load 且不期待回放，可能重复
    渲染，要先和 sudowork 对一下再做，所以这次没做，只在 `docs/acp.md` 写明。
- **关于跨 cwd fork 的判断**：同事"复制 transcript + 改 header 再 load"的做法可行，
  但把 store 布局（fingerprint 目录、`session_meta` 首行）暴露给上层，任何格式变动
  都会打断。scode 已有 `Session::fork()` + `SessionStore::fork_session()`（新 id、
  `fork.parent_session_id` 血缘、`with_workspace_root(new cwd)`），SDK schema 也已有
  unstable 的 `session/fork {sessionId, cwd}`（feature `unstable_session_fork`）。
  建议在 scode 侧做正式 `session/fork`：从源 cwd 的 store 读 parent → `fork_session`
  写到目标 cwd 的 store → 注册为 live session 返回新 id；需要一个源 cwd 参数
  （SDK 的 fork 请求没有，可放 `_meta.sudocode.sourceCwd`，同 cwd 时省略）。
  估计 1–2 天含测试。**不建议**让 `session/load` 接受跨 cwd：load 的语义是"同一个
  session 回来"，跨目录继续本质是新 session，应保留血缘而不是改写 `workspace_root`。

## 6. clippy 对比

`cargo clippy --workspace --all-targets -- -D warnings`：修改前后都在
`crates/telemetry/src/lib.rs` 的 14 个既有 pedantic lint 上失败（`-D` 让 clippy 在
telemetry 处中止，后面的 crate 根本没被 lint，所以这个数字不能用来比较）。

用 warn 模式（所有 crate 都 lint）做前后集合对比（按「消息 + 文件」计数）：

| | warning 行数 |
|---|---|
| 修改前（stash 后 origin/main 状态） | 902 |
| 修改后 | 902 |
| 新增 / 消失 | 0 / 0 |

（中途出现过 2 个新 warning——`assigning_clones` 与测试函数 101 行——已修掉。）
`cargo fmt --all --check` 通过。

## 7. `cargo test --workspace` 多次运行

见下方（3 次全量运行，含 PTY 测试）。并发相关的 4 个测试另外单独跑了多次
（每次 <4s，无偶发）。

| 运行 | 测试二进制数 | passed | failed | exit |
|---|---|---|---|---|
| 1 | 104 | 1642 | 0 | 0 |
| 2 | 104 | 1642 | 0 | 0 |
| 3 | 104 | 1642 | 0 | 0 |

并发相关 5 个测试（4 个并发 + resume）单独连续 10 次：10/10 通过，每次 ~3.3s（含同 session 串行测试里的 3s 静默窗口）。

## 8. 残留风险 / 没做的部分

- **不同 cwd 的活动 turn 之间仍互相等待**（不是暂停中的）：session A 在 /a 正在跑
  长工具，session B 在 /b 的 turn 或 `session/new` 要等 A 结束或暂停。根因是运行时
  依赖进程 cwd；彻底解法是给 tool executor / fs backend / bash / hooks 显式 cwd，
  规模是独立任务。apeiron 一用户一 Pod、同工作区的情况不受影响。
- 租约在最后一个持有者退出后**不恢复**启动目录（保持最后一次的 cwd）。所有 delegate
  路径都在租约内执行，`push_images` 现在在 session cwd 下读 sudocode 配置（旧代码在
  启动目录下读）——更合理，但属语义变化，记录一下。
- 对**已暂停** session 的 `session/close` / `setPermissionMode` 仍会等到该 session 被
  回答（旧行为亦然，只是以前顺带拖住全局）。若前端会在权限弹窗未处理时关闭会话，
  建议 close 先 abort + 让 pending 权限请求以 `cancelled` 结束——未做，属语义变更。
- `session/cancel` 对暂停中的 turn 依赖客户端按规范以 `cancelled` 回应 pending 的
  `request_permission`（旧行为，未改）。
- `session/list` 已实现但同样未声明 `sessionCapabilities.list`——与本任务同类的遗漏，
  未顺手改（保持 diff 聚焦），建议一并补。
- `session/load` 的历史回放（§5）与 `session/fork`（§5）未做，留决策。
- `.claude/settings.json`（hydra hook）与 `task-scode-acp-concurrency.md` 未提交。

</details>
