### PR TITLE
acp: resolve turn paths against a per-session workspace root, not the process cwd

### DIFF
--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -254,11 +254,11 @@ pub(crate) fn load_dotenv_file(
     Some(parse_dotenv(&content))
 }
 
-/// Look up `key` in a `.env` file located in the current working directory.
-/// Returns `None` when the file is missing, the key is absent, or the value
-/// is empty.
+/// Look up `key` in a `.env` file located in the current workspace root (the
+/// session's directory under ACP, the process cwd otherwise). Returns `None`
+/// when the file is missing, the key is absent, or the value is empty.
 pub(crate) fn dotenv_value(key: &str) -> Option<String> {
-    let cwd = std::env::current_dir().ok()?;
+    let cwd = runtime::current_workspace_root().ok()?;
     let values = load_dotenv_file(&cwd.join(".env"))?;
     values.get(key).filter(|value| !value.is_empty()).cloned()
 }

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -21,6 +21,7 @@ use crate::permissions::{
     QuestionPromptAnswer, QuestionPromptRequest, QuestionPrompter,
 };
 use crate::usage::UsageCostCurrency;
+use crate::workspace_root::WorkspaceRootScope;
 use agent_client_protocol::{
     on_receive_dispatch, on_receive_notification, on_receive_request, ConnectTo, ConnectionTo,
     Dispatch, Error, Handled, JsonRpcRequest, JsonRpcResponse, Responder,
@@ -32,9 +33,10 @@ use agent_client_protocol_schema::{
     LoadSessionRequest, LoadSessionResponse, McpServer, NewSessionRequest, NewSessionResponse,
     PermissionOption, PermissionOptionId, PermissionOptionKind, PromptCapabilities, PromptRequest,
     PromptResponse, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    SessionCapabilities, SessionCloseCapabilities, SessionInfo, SessionNotification, SessionUpdate,
-    SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, ToolCall,
-    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage,
+    SessionCapabilities, SessionCloseCapabilities, SessionInfo, SessionListCapabilities,
+    SessionNotification, SessionUpdate, SetSessionModelRequest, SetSessionModelResponse,
+    StopReason, TextContent, ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+    ToolKind, Usage,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map};
@@ -216,7 +218,12 @@ fn acp_mcp_servers_to_scoped(
 ///   an `AskUserQuestion` must not stall the others;
 /// * calls on the **same** session are already serialized by the server
 ///   (see [`SessionRegistry`]), so the delegate only needs per-session
-///   locking for memory safety, not for ordering.
+///   locking for memory safety, not for ordering;
+/// * every session-scoped call is made with the calling thread's
+///   [`crate::workspace_root`] scope set to that session's working
+///   directory, and the delegate must resolve paths through it (never through
+///   the process cwd) — that is what keeps concurrent turns of sessions in
+///   different directories from seeing each other's files.
 pub trait SdkAcpDelegate: Send + Sync + 'static {
     /// Create a new session for the given working directory, returning
     /// `(session_id, cwd, abort_signal)` on success.
@@ -669,8 +676,9 @@ pub fn new_session_registry() -> SharedSessionRegistry {
 ///   other sessions free to run. Two prompts on one session interleaving
 ///   their JSON-RPC traffic would corrupt the protocol, so this ordering is a
 ///   hard invariant, not a performance choice;
-/// * the working directory of each session, which feeds the
-///   [`WorkspaceCwdLease`] (see there for why that is needed).
+/// * the working directory of each session: every turn runs with it as the
+///   thread's [`crate::workspace_root`] scope, and the runtime-construction
+///   paths additionally take the [`WorkspaceCwdLease`] for it (see there).
 #[derive(Default)]
 pub struct SessionRegistry {
     sessions: Mutex<HashMap<String, SessionEntry>>,
@@ -751,23 +759,23 @@ impl SessionRegistry {
 
 /// Arbiter for the *process* working directory.
 ///
-/// The conversation runtime resolves relative paths, spawns `bash`, runs
-/// hooks and reads project config against `std::env::current_dir()`; a
-/// session's turn therefore has to run with the process cwd set to that
-/// session's cwd. That is a process-wide resource, so once turns of
-/// different sessions run concurrently something has to keep them from
-/// flipping the cwd under each other:
+/// Turns no longer touch the process cwd at all: everything a turn does —
+/// the tool loop, hooks, config, the session store — resolves paths against
+/// the session's [`crate::workspace_root`] scope, so turns of sessions in
+/// different directories run fully concurrently. What still resolves against
+/// the process cwd is *runtime construction*: `session/new`, `session/load`,
+/// `session/setModel` and the `/model` slash command rebuild a session's
+/// runtime, which spawns config-declared MCP servers and plugin processes
+/// that inherit the process cwd. Those paths are rare, short and never park
+/// on user input, so they simply run under this lease:
 ///
-/// * turns whose sessions share a cwd hold the lease **together** (it is
-///   reference-counted) and run fully concurrently;
-/// * a turn in a *different* cwd waits until the current holders are gone;
-/// * a turn that parks on user input (permission prompt / `AskUserQuestion`)
-///   **releases** the lease while it waits ([`CwdLeaseHandle::parked`]) and
-///   re-acquires it before continuing, so a parked session never keeps
-///   another cwd's session from running — the P0 this exists to fix.
+/// * holders whose sessions share a cwd hold the lease **together** (it is
+///   reference-counted) and run concurrently;
+/// * a holder for a *different* cwd waits until the current holders are gone.
 ///
 /// The lease only ever *sets* the cwd on acquisition; when the last holder
-/// leaves, the cwd is left as is (nothing outside a lease may depend on it).
+/// leaves, the cwd is left as is (nothing outside a lease may depend on it —
+/// in particular no turn does).
 #[derive(Default)]
 pub struct WorkspaceCwdLease {
     state: Mutex<CwdLeaseState>,
@@ -788,14 +796,10 @@ impl WorkspaceCwdLease {
     ///
     /// Returns the `set_current_dir` error if `cwd` cannot be entered; the
     /// lease is left untouched in that case.
-    pub fn acquire(self: &Arc<Self>, cwd: PathBuf) -> std::io::Result<CwdLeaseGuard> {
-        self.enter(&cwd)?;
+    pub fn acquire(self: &Arc<Self>, cwd: &std::path::Path) -> std::io::Result<CwdLeaseGuard> {
+        self.enter(cwd)?;
         Ok(CwdLeaseGuard {
-            handle: CwdLeaseHandle(Arc::new(CwdLeaseHandleInner {
-                lease: Arc::clone(self),
-                cwd,
-                held: std::sync::atomic::AtomicBool::new(true),
-            })),
+            lease: Arc::clone(self),
         })
     }
 
@@ -831,67 +835,14 @@ impl WorkspaceCwdLease {
     }
 }
 
-struct CwdLeaseHandleInner {
-    lease: Arc<WorkspaceCwdLease>,
-    cwd: PathBuf,
-    /// Whether this handle currently counts as a holder. Only the turn's
-    /// own thread flips it (acquire → park → unpark → drop), the atomic is
-    /// for `Sync`, not for contention.
-    held: std::sync::atomic::AtomicBool,
-}
-
-/// Cheap, cloneable reference to a held lease that lets the code parked
-/// deep inside a turn temporarily give the lease back.
-#[derive(Clone)]
-pub struct CwdLeaseHandle(Arc<CwdLeaseHandleInner>);
-
-impl CwdLeaseHandle {
-    /// Run `wait` with the lease released, then re-acquire the lease before
-    /// returning. If this handle is not currently holding the lease the
-    /// closure simply runs (a stale handle can never re-acquire on its own).
-    /// If the cwd cannot be re-entered afterwards, the failure is reported on
-    /// stderr and the turn continues without the lease — the directory has
-    /// vanished underneath the session, and its tools will report that
-    /// themselves.
-    pub fn parked<R>(&self, wait: impl FnOnce() -> R) -> R {
-        use std::sync::atomic::Ordering;
-        let released = self.0.held.swap(false, Ordering::AcqRel);
-        if released {
-            self.0.lease.leave();
-        }
-        let result = wait();
-        if released {
-            match self.0.lease.enter(&self.0.cwd) {
-                Ok(()) => self.0.held.store(true, Ordering::Release),
-                Err(error) => eprintln!(
-                    "[acp] failed to re-enter session cwd {} after user input: {error}",
-                    self.0.cwd.display()
-                ),
-            }
-        }
-        result
-    }
-}
-
 /// RAII holder of a [`WorkspaceCwdLease`] acquisition.
 pub struct CwdLeaseGuard {
-    handle: CwdLeaseHandle,
-}
-
-impl CwdLeaseGuard {
-    /// Handle to hand to code that may need to park while this guard lives.
-    #[must_use]
-    pub fn handle(&self) -> CwdLeaseHandle {
-        self.handle.clone()
-    }
+    lease: Arc<WorkspaceCwdLease>,
 }
 
 impl Drop for CwdLeaseGuard {
     fn drop(&mut self) {
-        use std::sync::atomic::Ordering;
-        if self.handle.0.held.swap(false, Ordering::AcqRel) {
-            self.handle.0.lease.leave();
-        }
+        self.lease.leave();
     }
 }
 
@@ -905,21 +856,6 @@ struct AcpPermissionBridge {
         PermissionRequest,
         tokio::sync::oneshot::Sender<PermissionPromptDecision>,
     )>,
-    /// Lease on the process cwd held by the turn this bridge serves; given
-    /// back while we wait on the user so other sessions can run.
-    cwd_lease: Option<CwdLeaseHandle>,
-}
-
-/// Block on `wait` with the turn's cwd lease (if any) parked for the
-/// duration: the turn is idle until the user answers, and nothing in it
-/// touches the process cwd meanwhile (tool calls run strictly one at a time),
-/// so holding the lease would only keep sessions in other directories from
-/// making progress.
-fn wait_parked<R>(cwd_lease: Option<&CwdLeaseHandle>, wait: impl FnOnce() -> R) -> R {
-    match cwd_lease {
-        Some(lease) => lease.parked(wait),
-        None => wait(),
-    }
 }
 
 impl PermissionPrompter for AcpPermissionBridge {
@@ -939,14 +875,17 @@ impl PermissionPrompter for AcpPermissionBridge {
         // tells the multi-thread scheduler this thread is about to block,
         // allowing the recv to complete safely (same pattern as
         // `AcpQuestionBridge::ask` below).
-        wait_parked(self.cwd_lease.as_ref(), || {
-            tokio::task::block_in_place(|| {
-                response_rx
-                    .blocking_recv()
-                    .unwrap_or(PermissionPromptDecision::Deny {
-                        reason: "permission response channel closed".to_string(),
-                    })
-            })
+        //
+        // While this thread is parked the turn holds nothing shared: its
+        // workspace root is a thread-scoped value (see
+        // `crate::workspace_root`), so a parked session cannot hold up any
+        // other session.
+        tokio::task::block_in_place(|| {
+            response_rx
+                .blocking_recv()
+                .unwrap_or(PermissionPromptDecision::Deny {
+                    reason: "permission response channel closed".to_string(),
+                })
         })
     }
 }
@@ -973,12 +912,10 @@ impl QuestionPrompter for AcpQuestionBridge {
         // the client as a generic "blocking task failed" / Internal error.
         // `block_in_place` informs the multi-thread scheduler that this worker
         // is about to block, allowing the recv to complete safely.
-        wait_parked(self.cwd_lease.as_ref(), || {
-            tokio::task::block_in_place(|| {
-                response_rx
-                    .blocking_recv()
-                    .unwrap_or_else(|_| Err("question response channel closed".to_string()))
-            })
+        tokio::task::block_in_place(|| {
+            response_rx
+                .blocking_recv()
+                .unwrap_or_else(|_| Err("question response channel closed".to_string()))
         })
     }
 }
@@ -989,8 +926,6 @@ struct AcpQuestionBridge {
         QuestionPromptRequest,
         tokio::sync::oneshot::Sender<Result<Vec<QuestionPromptAnswer>, String>>,
     )>,
-    /// See [`AcpPermissionBridge::cwd_lease`].
-    cwd_lease: Option<CwdLeaseHandle>,
 }
 
 const ACP_ASK_USER_QUESTION_METHOD: &str = "_scode/ask_user_question";
@@ -1150,7 +1085,11 @@ pub(crate) async fn run_acp_on_transport(
                                 .prompt_capabilities(PromptCapabilities::new().image(true))
                                 .session_capabilities(
                                     SessionCapabilities::new()
-                                        .close(SessionCloseCapabilities::new()),
+                                        .close(SessionCloseCapabilities::new())
+                                        // `session/list` is handled below; like
+                                        // `loadSession` it had simply never been
+                                        // advertised.
+                                        .list(SessionListCapabilities::new()),
                                 ),
                         )
                         .meta(initialize_meta());
@@ -1173,12 +1112,16 @@ pub(crate) async fn run_acp_on_transport(
                     cx.spawn(async move {
                         let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
-                            // Session construction resolves config / model /
-                            // permission mode against the process cwd, so it
-                            // runs under the cwd lease like a turn does.
+                            // Runtime construction: the delegate resolves
+                            // config / model / permission mode against the
+                            // workspace-root scope, but the MCP servers and
+                            // plugins it spawns inherit the process cwd, so
+                            // it also runs under the cwd lease.
+                            let cwd = session_lease_cwd(&req.cwd);
                             let _cwd = lease
-                                .acquire(session_lease_cwd(&req.cwd))
+                                .acquire(&cwd)
                                 .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
+                            let _scope = WorkspaceRootScope::enter(cwd);
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &req.cwd);
                             d.new_session(req.cwd, mcp_servers)
                         })
@@ -1243,6 +1186,7 @@ pub(crate) async fn run_acp_on_transport(
                         let _lane = registry.enter_lane(&sid).await;
                         let session_cwd = registry.cwd(&sid);
                         let cwd_lease = registry.cwd_lease();
+                        let is_slash_command = prompt_text.starts_with('/');
 
                         // Set up permission-prompt bridge channels.
                         let (bridge_tx, mut bridge_rx) = tokio::sync::mpsc::unbounded_channel::<(
@@ -1265,29 +1209,31 @@ pub(crate) async fn run_acp_on_transport(
                         let prompt_text_for_blocking = prompt_text.clone();
                         let trace_id_for_blocking = trace_id.clone();
                         let blocking_handle = tokio::task::spawn_blocking(move || {
-                            // Hold the process cwd for this session's directory
-                            // for the whole turn (shared with concurrent turns
-                            // in the same directory; parked while waiting on
-                            // the user — see `WorkspaceCwdLease`). Unknown
-                            // sessions have no cwd and fall through to the
-                            // delegate's `unknown sessionId` error.
-                            let cwd_guard = match session_cwd {
-                                Some(cwd) => Some(cwd_lease.acquire(cwd).map_err(|e| {
+                            // This thread works in the session's directory for
+                            // the whole turn through the workspace-root scope
+                            // (see `crate::workspace_root`): a thread-scoped
+                            // value, so turns of sessions in other directories
+                            // run at the same time on their own threads. The
+                            // process cwd is not touched. Unknown sessions have
+                            // no cwd and fall through to the delegate's
+                            // `unknown sessionId` error.
+                            let _scope = session_cwd.clone().map(WorkspaceRootScope::enter);
+                            // Slash commands are the exception: `/model`
+                            // rebuilds the session runtime, which is a
+                            // runtime-construction path (see
+                            // `WorkspaceCwdLease`), so they run under the
+                            // lease. They are short and never park on the
+                            // user.
+                            let _cwd_guard = match (is_slash_command, session_cwd) {
+                                (true, Some(cwd)) => Some(cwd_lease.acquire(&cwd).map_err(|e| {
                                     AcpError::internal(format!("failed to enter session cwd: {e}"))
                                 })?),
-                                None => None,
+                                _ => None,
                             };
-                            let lease_handle = cwd_guard.as_ref().map(CwdLeaseGuard::handle);
 
                             let mut observer = SdkSessionObserver::new(&sid_for_blocking, notif_tx);
-                            let mut bridge = AcpPermissionBridge {
-                                tx: bridge_tx,
-                                cwd_lease: lease_handle.clone(),
-                            };
-                            let question_bridge = AcpQuestionBridge {
-                                tx: question_tx,
-                                cwd_lease: lease_handle,
-                            };
+                            let mut bridge = AcpPermissionBridge { tx: bridge_tx };
+                            let question_bridge = AcpQuestionBridge { tx: question_tx };
                             let _ = d.set_question_prompter(
                                 &sid_for_blocking,
                                 Box::new(question_bridge),
@@ -1299,7 +1245,7 @@ pub(crate) async fn run_acp_on_transport(
                                 let _ = d.push_images(&sid_for_blocking, &images_for_blocking);
                             }
 
-                            let stop = if prompt_text_for_blocking.starts_with('/') {
+                            let stop = if is_slash_command {
                                 d.handle_slash_command(
                                     &sid_for_blocking,
                                     &prompt_text_for_blocking,
@@ -1315,7 +1261,6 @@ pub(crate) async fn run_acp_on_transport(
                                     trace_id_for_blocking.as_deref(),
                                 )
                             };
-                            drop(cwd_guard);
                             // Return the Result instead of unwrapping, so we can handle errors
                             stop
                         });
@@ -1567,10 +1512,11 @@ pub(crate) async fn run_acp_on_transport(
                         let session_cwd = registry.cwd(&sid);
                         let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
-                            // The model switch rebuilds the session runtime,
-                            // resolving config against the process cwd.
+                            // The model switch rebuilds the session runtime
+                            // (runtime construction — see `WorkspaceCwdLease`).
+                            let _scope = session_cwd.clone().map(WorkspaceRootScope::enter);
                             let _cwd = match session_cwd {
-                                Some(cwd) => Some(lease.acquire(cwd).map_err(|e| {
+                                Some(cwd) => Some(lease.acquire(&cwd).map_err(|e| {
                                     AcpError::internal(format!("failed to enter session cwd: {e}"))
                                 })?),
                                 None => None,
@@ -1613,9 +1559,12 @@ pub(crate) async fn run_acp_on_transport(
                         let _lane = registry.enter_lane(&sid).await;
                         let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
+                            // Runtime construction — see `session/new` above.
+                            let lease_cwd = session_lease_cwd(&cwd);
                             let _cwd = lease
-                                .acquire(session_lease_cwd(&cwd))
+                                .acquire(&lease_cwd)
                                 .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
+                            let _scope = WorkspaceRootScope::enter(lease_cwd);
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &cwd);
                             d.load_session(&sid, cwd, mcp_servers)
                         })

--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::env;
 use std::io;
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -15,6 +14,7 @@ use crate::sandbox::{
     build_linux_sandbox_command, resolve_sandbox_status_for_request, FilesystemIsolationMode,
     SandboxConfig, SandboxStatus,
 };
+use crate::workspace_root::current_workspace_root;
 use crate::ConfigLoader;
 
 /// Default foreground subprocess timeout for tool-backed command execution.
@@ -139,7 +139,10 @@ pub fn execute_bash_with_progress(
     abort_signal: Option<&HookAbortSignal>,
     on_progress: Option<BashProgressCallback>,
 ) -> io::Result<BashCommandOutput> {
-    let cwd = env::current_dir()?;
+    // The session's workspace root, not the process cwd: concurrent turns of
+    // sessions in different directories each spawn their shell in their own
+    // root (see `crate::workspace_root`).
+    let cwd = current_workspace_root()?;
     let sandbox_status = sandbox_status_for_input(&input, &cwd);
 
     if input.run_in_background.unwrap_or(false) {
@@ -230,7 +233,7 @@ impl AsyncRunner {
 }
 
 /// Detect git push to main and emit ship provenance event
-fn detect_and_emit_ship_prepared(command: &str) {
+fn detect_and_emit_ship_prepared(command: &str, cwd: &std::path::Path) {
     let trimmed = command.trim();
     // Simple detection: git push with main/master
     if trimmed.contains("git push") && (trimmed.contains("main") || trimmed.contains("master")) {
@@ -240,12 +243,12 @@ fn detect_and_emit_ship_prepared(command: &str) {
             .unwrap_or_default()
             .as_millis();
         let provenance = ShipProvenance {
-            source_branch: get_current_branch().unwrap_or_else(|| "unknown".to_string()),
-            base_commit: get_head_commit().unwrap_or_default(),
+            source_branch: get_current_branch(cwd).unwrap_or_else(|| "unknown".to_string()),
+            base_commit: get_head_commit(cwd).unwrap_or_default(),
             commit_count: 0, // Would need to calculate from range
             commit_range: "unknown..HEAD".to_string(),
             merge_method: ShipMergeMethod::DirectPush,
-            actor: get_git_actor().unwrap_or_else(|| "unknown".to_string()),
+            actor: get_git_actor(cwd).unwrap_or_else(|| "unknown".to_string()),
             pr_number: None,
         };
         let _event = LaneEvent::ship_prepared(format!("{now}"), &provenance);
@@ -257,9 +260,10 @@ fn detect_and_emit_ship_prepared(command: &str) {
     }
 }
 
-fn get_current_branch() -> Option<String> {
+fn get_current_branch(cwd: &std::path::Path) -> Option<String> {
     let output = Command::new("git")
         .args(["branch", "--show-current"])
+        .current_dir(cwd)
         .output()
         .ok()?;
     if output.status.success() {
@@ -269,9 +273,10 @@ fn get_current_branch() -> Option<String> {
     }
 }
 
-fn get_head_commit() -> Option<String> {
+fn get_head_commit(cwd: &std::path::Path) -> Option<String> {
     let output = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(cwd)
         .output()
         .ok()?;
     if output.status.success() {
@@ -281,9 +286,10 @@ fn get_head_commit() -> Option<String> {
     }
 }
 
-fn get_git_actor() -> Option<String> {
+fn get_git_actor(cwd: &std::path::Path) -> Option<String> {
     let name = Command::new("git")
         .args(["config", "user.name"])
+        .current_dir(cwd)
         .output()
         .ok()
         .filter(|o| o.status.success())
@@ -298,7 +304,7 @@ async fn execute_bash_async(
     abort_signal: Option<HookAbortSignal>,
 ) -> io::Result<BashCommandOutput> {
     // Detect and emit ship provenance for git push operations
-    detect_and_emit_ship_prepared(&input.command);
+    detect_and_emit_ship_prepared(&input.command, &cwd);
 
     let mut command = prepare_tokio_command(&input.command, &cwd, &sandbox_status, true);
     command.stdin(Stdio::null());
@@ -382,7 +388,7 @@ async fn execute_bash_streaming(
     abort_signal: Option<HookAbortSignal>,
     on_progress: Option<BashProgressCallback>,
 ) -> io::Result<BashCommandOutput> {
-    detect_and_emit_ship_prepared(&input.command);
+    detect_and_emit_ship_prepared(&input.command, &cwd);
 
     let mut command = prepare_tokio_command(&input.command, &cwd, &sandbox_status, true);
     command.stdout(Stdio::piped());
@@ -659,7 +665,7 @@ pub fn execute_bash_with_tracking(
 ) -> io::Result<BashWithTrackingResult> {
     let cwd = workspace_root
         .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| env::current_dir().unwrap_or_default());
+        .unwrap_or_else(|| current_workspace_root().unwrap_or_default());
 
     // Capture before snapshot
     let mut snapshot = FileChangeSnapshotWithMtime::capture_before(&cwd);

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -621,11 +621,11 @@ where
     /// fast-path) — zero disk I/O and zero allocation for the
     /// overwhelmingly common case.
     ///
-    /// Workspace root defaults to the process cwd, matching the
-    /// per-workspace `.sudocode-inbox/coordinator.jsonl` convention
-    /// that every emit site uses (also cwd-derived).
+    /// Workspace root is the turn's scoped root (the process cwd outside
+    /// ACP), matching the per-workspace `.sudocode-inbox/coordinator.jsonl`
+    /// convention that every emit site uses (same root).
     fn prepend_pending_task_notifications(&self, blocks: Vec<ContentBlock>) -> Vec<ContentBlock> {
-        let workspace_root = std::env::current_dir().unwrap_or_default();
+        let workspace_root = crate::workspace_root::current_workspace_root_or_default();
         let notifications =
             crate::coordinator_notification::drain(&workspace_root).unwrap_or_default();
         if notifications.is_empty() {

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -11,6 +11,7 @@
 use std::io;
 use std::sync::Arc;
 
+use crate::workspace_root::current_workspace_root;
 use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
 
@@ -285,15 +286,19 @@ impl FsBackend for StdFsBackend {
         std::fs::rename(&temp, path)
     }
 
+    /// The turn's workspace root (see [`crate::workspace_root`]), which is
+    /// the process cwd outside an ACP turn. Relative tool paths resolve
+    /// against it, so concurrent sessions in different directories never
+    /// see each other's files.
     fn working_root(&self) -> io::Result<String> {
-        Ok(std::env::current_dir()?.to_string_lossy().into_owned())
+        Ok(current_workspace_root()?.to_string_lossy().into_owned())
     }
 
     fn normalize(&self, path: &str) -> io::Result<String> {
         let candidate = if std::path::Path::new(path).is_absolute() {
             std::path::PathBuf::from(path)
         } else {
-            std::env::current_dir()?.join(path)
+            current_workspace_root()?.join(path)
         };
         Ok(candidate.canonicalize()?.to_string_lossy().into_owned())
     }
@@ -302,7 +307,7 @@ impl FsBackend for StdFsBackend {
         let candidate = if std::path::Path::new(path).is_absolute() {
             std::path::PathBuf::from(path)
         } else {
-            std::env::current_dir()?.join(path)
+            current_workspace_root()?.join(path)
         };
         if let Ok(canonical) = candidate.canonicalize() {
             return Ok(canonical.to_string_lossy().into_owned());

--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -881,20 +881,29 @@ fn format_hook_start_error(
 
 fn shell_command(command: &str) -> CommandWithStdin {
     #[cfg(windows)]
-    let command_builder = {
+    let mut command_builder = {
         let mut command_builder = Command::new("cmd");
         command_builder.arg("/C").arg(command);
-        CommandWithStdin::new(command_builder)
+        command_builder
     };
 
     #[cfg(not(windows))]
-    let command_builder = {
+    let mut command_builder = {
         let mut command_builder = Command::new("sh");
         command_builder.arg("-lc").arg(command);
-        CommandWithStdin::new(command_builder)
+        command_builder
     };
 
-    command_builder
+    // Hooks run in the session's workspace root, not the process cwd: under
+    // ACP several sessions in different directories run turns at once and
+    // the process cwd belongs to none of them (see `crate::workspace_root`).
+    // Outside a scope this is the process cwd, i.e. what `sh` inherited
+    // before.
+    if let Ok(root) = crate::workspace_root::current_workspace_root() {
+        command_builder.current_dir(root);
+    }
+
+    CommandWithStdin::new(command_builder)
 }
 
 struct CommandWithStdin {

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -76,6 +76,7 @@ mod time;
 mod trust_resolver;
 mod usage;
 pub mod worker_boot;
+pub mod workspace_root;
 
 pub use acp_sdk_server::AcpError;
 pub use bash::{
@@ -231,6 +232,10 @@ pub use usage::{
 pub use worker_boot::{
     Worker, WorkerEvent, WorkerEventKind, WorkerEventPayload, WorkerFailure, WorkerFailureKind,
     WorkerPromptTarget, WorkerReadySnapshot, WorkerRegistry, WorkerStatus, WorkerTrustResolution,
+};
+pub use workspace_root::{
+    current_workspace_root, current_workspace_root_or_default, scoped_workspace_root,
+    WorkspaceRootHandoff, WorkspaceRootScope,
 };
 
 #[cfg(test)]

--- a/rust/crates/runtime/src/memory/loader.rs
+++ b/rust/crates/runtime/src/memory/loader.rs
@@ -40,11 +40,12 @@ pub fn default_memory_dir_for(cwd: &Path) -> PathBuf {
         .join("memory")
 }
 
-/// Resolve the default memory directory using the process's current
-/// working directory. Convenience wrapper around [`default_memory_dir_for`].
+/// Resolve the default memory directory using the current workspace root
+/// (the turn's scoped root, else the process cwd). Convenience wrapper
+/// around [`default_memory_dir_for`].
 #[must_use]
 pub fn default_memory_dir() -> PathBuf {
-    default_memory_dir_for(&std::env::current_dir().unwrap_or_default())
+    default_memory_dir_for(&crate::workspace_root::current_workspace_root_or_default())
 }
 
 /// Resolve the per-agent-type memory directory for a given working

--- a/rust/crates/runtime/src/session_control.rs
+++ b/rust/crates/runtime/src/session_control.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use std::env;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -7,6 +6,7 @@ use std::time::UNIX_EPOCH;
 
 use crate::fs_backend::{FsBackend, StdFsBackend};
 use crate::session::{Session, SessionError};
+use crate::workspace_root::current_workspace_root;
 
 /// Per-worktree session store that namespaces on-disk session files by
 /// workspace fingerprint so that parallel `scode serve` instances never
@@ -403,7 +403,7 @@ impl From<SessionError> for SessionControlError {
 }
 
 pub fn sessions_dir() -> Result<PathBuf, SessionControlError> {
-    managed_sessions_dir_for(env::current_dir()?)
+    managed_sessions_dir_for(current_workspace_root()?)
 }
 
 pub fn managed_sessions_dir_for(
@@ -416,7 +416,7 @@ pub fn managed_sessions_dir_for(
 pub fn create_managed_session_handle(
     session_id: &str,
 ) -> Result<SessionHandle, SessionControlError> {
-    create_managed_session_handle_for(env::current_dir()?, session_id)
+    create_managed_session_handle_for(current_workspace_root()?, session_id)
 }
 
 pub fn create_managed_session_handle_for(
@@ -428,7 +428,7 @@ pub fn create_managed_session_handle_for(
 }
 
 pub fn resolve_session_reference(reference: &str) -> Result<SessionHandle, SessionControlError> {
-    resolve_session_reference_for(env::current_dir()?, reference)
+    resolve_session_reference_for(current_workspace_root()?, reference)
 }
 
 pub fn resolve_session_reference_for(
@@ -440,7 +440,7 @@ pub fn resolve_session_reference_for(
 }
 
 pub fn resolve_managed_session_path(session_id: &str) -> Result<PathBuf, SessionControlError> {
-    resolve_managed_session_path_for(env::current_dir()?, session_id)
+    resolve_managed_session_path_for(current_workspace_root()?, session_id)
 }
 
 pub fn resolve_managed_session_path_for(
@@ -461,7 +461,7 @@ pub fn is_managed_session_file(path: &Path) -> bool {
 }
 
 pub fn list_managed_sessions() -> Result<Vec<ManagedSessionSummary>, SessionControlError> {
-    list_managed_sessions_for(env::current_dir()?)
+    list_managed_sessions_for(current_workspace_root()?)
 }
 
 pub fn list_managed_sessions_for(
@@ -472,7 +472,7 @@ pub fn list_managed_sessions_for(
 }
 
 pub fn latest_managed_session() -> Result<ManagedSessionSummary, SessionControlError> {
-    latest_managed_session_for(env::current_dir()?)
+    latest_managed_session_for(current_workspace_root()?)
 }
 
 pub fn latest_managed_session_for(
@@ -483,7 +483,7 @@ pub fn latest_managed_session_for(
 }
 
 pub fn load_managed_session(reference: &str) -> Result<LoadedManagedSession, SessionControlError> {
-    load_managed_session_for(env::current_dir()?, reference)
+    load_managed_session_for(current_workspace_root()?, reference)
 }
 
 pub fn load_managed_session_for(
@@ -498,7 +498,7 @@ pub fn fork_managed_session(
     session: &Session,
     branch_name: Option<String>,
 ) -> Result<ForkedManagedSession, SessionControlError> {
-    fork_managed_session_for(env::current_dir()?, session, branch_name)
+    fork_managed_session_for(current_workspace_root()?, session, branch_name)
 }
 
 pub fn fork_managed_session_for(

--- a/rust/crates/runtime/src/stale_branch.rs
+++ b/rust/crates/runtime/src/stale_branch.rs
@@ -50,8 +50,12 @@ pub enum StaleBranchAction {
     MergeForward,
 }
 
+/// Check `branch` against `main_ref` in the current workspace root (the
+/// turn's scoped root, else the process cwd).
 pub fn check_freshness(branch: &str, main_ref: &str) -> BranchFreshness {
-    check_freshness_in(branch, main_ref, Path::new("."))
+    let root = crate::workspace_root::current_workspace_root()
+        .unwrap_or_else(|_| Path::new(".").to_path_buf());
+    check_freshness_in(branch, main_ref, &root)
 }
 
 pub fn apply_policy(freshness: &BranchFreshness, policy: StaleBranchPolicy) -> StaleBranchAction {

--- a/rust/crates/runtime/src/workspace_root.rs
+++ b/rust/crates/runtime/src/workspace_root.rs
@@ -1,0 +1,155 @@
+//! Per-turn workspace root — the directory a turn resolves relative paths,
+//! subprocess working directories, project config and project state
+//! (`.sudocode-*`, `.nexus/`, memory, session store) against.
+//!
+//! Historically every one of those sites read `std::env::current_dir()`,
+//! and the ACP server made that work by `set_current_dir`-ing to the
+//! session's directory before each turn. The process cwd is a single global,
+//! so two sessions in different directories could never run turns at the
+//! same time: one held the cwd for its whole turn (a 60 s `bash`, a long
+//! report) and every other session's turn queued behind it.
+//!
+//! This module replaces the process cwd with a *thread-scoped* root:
+//!
+//! * a turn (or any other unit of session work) wraps itself in a
+//!   [`WorkspaceRootScope`] naming the session's directory;
+//! * every site that used to read the process cwd calls
+//!   [`current_workspace_root`] instead, which returns the scoped root when
+//!   one is set on the calling thread and falls back to the process cwd
+//!   otherwise (the REPL and one-shot CLI paths, which never enter a scope,
+//!   behave exactly as before);
+//! * work that a turn hands to another thread carries the root across via
+//!   [`WorkspaceRootHandoff`].
+//!
+//! Why thread-local rather than task-local: the conversation runtime drives
+//! a turn with `Runtime::block_on`, which polls the turn future on the
+//! calling thread, and tool execution ([`crate::ToolExecutor::execute`]) is
+//! synchronous on that same thread. Nothing on the turn path is `tokio::spawn`ed
+//! (the runtime's spawned tasks are MCP transports and HTTP streams, none of
+//! which resolve paths). The only threads a turn creates are the sub-agent
+//! workers and the WebFetch/WebSearch helper threads; the former re-enter
+//! the scope from a handoff, the latter touch no paths.
+//!
+//! **Invariant:** outside test code, `runtime`, `tools`, `api` and `commands`
+//! contain no `std::env::current_dir()` — every path anchor goes through this
+//! module, so a turn can only ever see its own session's directory.
+
+use std::cell::RefCell;
+use std::io;
+use std::path::{Path, PathBuf};
+
+thread_local! {
+    static WORKSPACE_ROOT: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+/// The workspace root the calling thread currently works against.
+///
+/// Returns the innermost active [`WorkspaceRootScope`] on this thread, or the
+/// process working directory when no scope is active. This is the one
+/// function that replaces `std::env::current_dir()` on every path a turn can
+/// reach.
+///
+/// # Errors
+///
+/// Propagates the `current_dir` error when no scope is active and the
+/// process cwd cannot be read (deleted directory, permissions).
+pub fn current_workspace_root() -> io::Result<PathBuf> {
+    match scoped_workspace_root() {
+        Some(root) => Ok(root),
+        None => std::env::current_dir(),
+    }
+}
+
+/// Infallible variant of [`current_workspace_root`]: falls back to an empty
+/// path (which then behaves like a relative path against the process cwd),
+/// mirroring the `unwrap_or_default()` idiom the call sites used to apply to
+/// `current_dir()`.
+#[must_use]
+pub fn current_workspace_root_or_default() -> PathBuf {
+    current_workspace_root().unwrap_or_default()
+}
+
+/// The root of the innermost active [`WorkspaceRootScope`] on this thread,
+/// or `None` when the thread is not inside a scope. Prefer
+/// [`current_workspace_root`]; this exists for code that needs to know
+/// whether it is running under a scope at all.
+#[must_use]
+pub fn scoped_workspace_root() -> Option<PathBuf> {
+    WORKSPACE_ROOT.with(|cell| cell.borrow().clone())
+}
+
+/// RAII guard that makes `root` the workspace root of the current thread for
+/// as long as it lives. Scopes nest: dropping the guard restores whatever was
+/// active before it was entered.
+#[must_use = "the workspace root is only in effect while the scope is alive"]
+#[derive(Debug)]
+pub struct WorkspaceRootScope {
+    root: PathBuf,
+    previous: Option<PathBuf>,
+}
+
+impl WorkspaceRootScope {
+    /// Enter `root` as this thread's workspace root.
+    pub fn enter(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        let previous = WORKSPACE_ROOT.with(|cell| cell.borrow_mut().replace(root.clone()));
+        Self { root, previous }
+    }
+
+    /// The root this scope installed.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for WorkspaceRootScope {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        WORKSPACE_ROOT.with(|cell| {
+            *cell.borrow_mut() = previous;
+        });
+    }
+}
+
+/// Snapshot of the calling thread's workspace root, meant to be moved into a
+/// closure that runs on another thread (`std::thread::spawn`,
+/// `spawn_blocking`, …) and re-entered there. A handoff captured outside any
+/// scope re-enters nothing, so the receiving thread keeps falling back to
+/// the process cwd — same as before.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceRootHandoff {
+    root: Option<PathBuf>,
+}
+
+impl WorkspaceRootHandoff {
+    /// Capture the current thread's scoped root (if any).
+    #[must_use]
+    pub fn capture() -> Self {
+        Self {
+            root: scoped_workspace_root(),
+        }
+    }
+
+    /// A handoff that installs `root` explicitly, for jobs that already
+    /// carry their workspace directory.
+    #[must_use]
+    pub fn for_root(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: Some(root.into()),
+        }
+    }
+
+    /// The captured root, if any.
+    #[must_use]
+    pub fn root(&self) -> Option<&Path> {
+        self.root.as_deref()
+    }
+
+    /// Re-enter the captured root on the current thread. Returns `None` (and
+    /// installs nothing) when the handoff was captured outside a scope.
+    #[must_use]
+    pub fn enter(&self) -> Option<WorkspaceRootScope> {
+        self.root.clone().map(WorkspaceRootScope::enter)
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -559,7 +559,8 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                 output_format,
             }),
             Cmd::SystemPrompt { cwd, date } => {
-                let resolved_cwd = cwd.unwrap_or(env::current_dir().map_err(|e| e.to_string())?);
+                let resolved_cwd =
+                    cwd.unwrap_or(runtime::current_workspace_root().map_err(|e| e.to_string())?);
                 let resolved_date = date.unwrap_or_else(runtime::today_local);
                 Ok(CliAction::PrintSystemPrompt {
                     cwd: resolved_cwd,
@@ -1152,14 +1153,14 @@ fn config_alias_for_current_dir(alias: &str) -> Option<String> {
     if alias.is_empty() {
         return None;
     }
-    let cwd = env::current_dir().ok()?;
+    let cwd = runtime::current_workspace_root().ok()?;
     let loader = ConfigLoader::default_for(&cwd);
     let config = loader.load().ok()?;
     config.aliases().get(alias).cloned()
 }
 
 pub(crate) fn load_sudocode_config_for_current_dir() -> api::SudoCodeConfig {
-    let Ok(cwd) = env::current_dir() else {
+    let Ok(cwd) = runtime::current_workspace_root() else {
         return api::SudoCodeConfig::default();
     };
     load_sudocode_config_for_cwd(&cwd)
@@ -1187,7 +1188,7 @@ pub(crate) fn normalize_allowed_tools(values: &[String]) -> Result<Option<Allowe
 }
 
 fn current_tool_registry() -> Result<GlobalToolRegistry, String> {
-    let cwd = env::current_dir().map_err(|e| e.to_string())?;
+    let cwd = runtime::current_workspace_root().map_err(|e| e.to_string())?;
     let loader = ConfigLoader::default_for(&cwd);
     let runtime_config = loader.load().map_err(|e| e.to_string())?;
     let session_mcp: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig> =
@@ -1242,7 +1243,7 @@ pub(crate) fn default_permission_mode() -> PermissionMode {
 }
 
 fn config_permission_mode_for_current_dir() -> Option<PermissionMode> {
-    let cwd = env::current_dir().ok()?;
+    let cwd = runtime::current_workspace_root().ok()?;
     let loader = ConfigLoader::default_for(&cwd);
     loader
         .load()
@@ -1252,7 +1253,7 @@ fn config_permission_mode_for_current_dir() -> Option<PermissionMode> {
 }
 
 pub(crate) fn config_model_for_current_dir() -> Option<String> {
-    let cwd = env::current_dir().ok()?;
+    let cwd = runtime::current_workspace_root().ok()?;
     let loader = ConfigLoader::default_for(&cwd);
     loader.load().ok()?.model().map(ToOwned::to_owned)
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
@@ -175,7 +175,7 @@ pub(crate) fn render_diagnostic_check(check: &DiagnosticCheck) -> String {
 }
 
 pub(crate) fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let config_loader = ConfigLoader::default_for(&cwd);
     let config = config_loader.load();
     let discovered_config = config_loader.discover();

--- a/rust/crates/rusty-sudocode-cli/src/cli/git.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/git.rs
@@ -47,7 +47,7 @@ impl GitWorkspaceSummary {
 
 pub(crate) fn parse_git_status_metadata(status: Option<&str>) -> (Option<PathBuf>, Option<String>) {
     parse_git_status_metadata_for(
-        &env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        &runtime::current_workspace_root().unwrap_or_else(|_| PathBuf::from(".")),
         status,
     )
 }
@@ -162,7 +162,7 @@ pub(crate) fn parse_git_status_metadata_for(
 pub(crate) fn git_output(args: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
     let output = std::process::Command::new("git")
         .args(args)
-        .current_dir(env::current_dir()?)
+        .current_dir(runtime::current_workspace_root()?)
         .output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -174,7 +174,7 @@ pub(crate) fn git_output(args: &[&str]) -> Result<String, Box<dyn std::error::Er
 pub(crate) fn git_status_ok(args: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
     let output = std::process::Command::new("git")
         .args(args)
-        .current_dir(env::current_dir()?)
+        .current_dir(runtime::current_workspace_root()?)
         .output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -186,7 +186,7 @@ pub(crate) fn git_status_ok(args: &[&str]) -> Result<(), Box<dyn std::error::Err
 /// Detect if the current working directory is "broad" (home directory or
 /// filesystem root). Returns the cwd path if broad, None otherwise.
 pub(crate) fn detect_broad_cwd() -> Option<PathBuf> {
-    let Ok(cwd) = env::current_dir() else {
+    let Ok(cwd) = runtime::current_workspace_root() else {
         return None;
     };
     let is_home = env::var_os("HOME")

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
@@ -212,7 +211,7 @@ pub(crate) fn print_help_topic(
 pub(crate) fn render_config_report(
     section: Option<&str>,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let loader = ConfigLoader::default_for(&cwd);
     let discovered = loader.discover();
     let runtime_config = loader.load()?;
@@ -293,7 +292,7 @@ pub(crate) fn render_config_report(
 pub(crate) fn render_config_json(
     section: Option<&str>,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let loader = ConfigLoader::default_for(&cwd);
     let discovered = loader.discover();
     let runtime_config = loader.load()?;
@@ -373,7 +372,7 @@ pub(crate) fn render_config_json(
 }
 
 pub(crate) fn render_memory_report() -> Result<String, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let project_context = ProjectContext::discover(&cwd, runtime::today_local())?;
     let mut lines = vec![format!(
         "Memory
@@ -412,7 +411,7 @@ pub(crate) fn render_memory_report() -> Result<String, Box<dyn std::error::Error
 }
 
 pub(crate) fn render_memory_json() -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let project_context = ProjectContext::discover(&cwd, runtime::today_local())?;
     let files: Vec<_> = project_context
         .instruction_files
@@ -434,7 +433,7 @@ pub(crate) fn render_memory_json() -> Result<serde_json::Value, Box<dyn std::err
 }
 
 pub(crate) fn render_diff_report() -> Result<String, Box<dyn std::error::Error>> {
-    render_diff_report_for(&env::current_dir()?)
+    render_diff_report_for(&runtime::current_workspace_root()?)
 }
 
 pub(crate) fn render_diff_report_for(cwd: &Path) -> Result<String, Box<dyn std::error::Error>> {
@@ -563,7 +562,7 @@ pub(crate) fn run_git_diff_command_in(
 }
 
 pub(crate) fn render_teleport_report(target: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
 
     let file_list = Command::new("rg")
         .args(["--files"])

--- a/rust/crates/rusty-sudocode-cli/src/cli/session.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/session.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -34,12 +33,12 @@ pub(crate) fn sessions_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
 }
 
 pub(crate) fn current_session_store() -> Result<SessionStore, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     SessionStore::from_cwd(&cwd).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
 }
 
 pub(crate) fn new_cli_session() -> Result<Session, Box<dyn std::error::Error>> {
-    new_cli_session_for(&env::current_dir()?)
+    new_cli_session_for(&runtime::current_workspace_root()?)
 }
 
 pub(crate) fn new_cli_session_for(cwd: &Path) -> Result<Session, Box<dyn std::error::Error>> {
@@ -49,7 +48,7 @@ pub(crate) fn new_cli_session_for(cwd: &Path) -> Result<Session, Box<dyn std::er
 pub(crate) fn create_managed_session_handle(
     session_id: &str,
 ) -> Result<SessionHandle, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     create_managed_session_handle_for(&cwd, session_id)
 }
 

--- a/rust/crates/rusty-sudocode-cli/src/cli/status.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/status.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::{Path, PathBuf};
 
 use runtime::{self, resolve_sandbox_status, ConfigLoader, ProjectContext};
@@ -171,7 +170,7 @@ pub(crate) fn status_json_value(
 pub(crate) fn status_context(
     session_path: Option<&Path>,
 ) -> Result<StatusContext, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let loader = ConfigLoader::default_for(&cwd);
     let discovered_config_files = loader.discover().len();
     // #143: degrade gracefully on config parse failure rather than hard-fail.
@@ -315,7 +314,7 @@ pub(crate) fn format_status_report(
 pub(crate) fn print_sandbox_status_snapshot(
     output_format: CliOutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
+    let cwd = runtime::current_workspace_root()?;
     let loader = ConfigLoader::default_for(&cwd);
     let runtime_config = loader
         .load()

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2708,6 +2708,9 @@ impl AcpCliAgent {
         mcp_servers: &std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
     ) -> Result<AcpCliSession, AcpError> {
         let cwd = canonical_session_cwd(cwd)?;
+        // Config, plugin/MCP state and the API client's `.env` lookup all
+        // resolve against the workspace root (see `runtime::workspace_root`).
+        let _scope = runtime::WorkspaceRootScope::enter(&cwd);
         let model = self.resolve_model_for_cwd(&cwd)?;
         let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
         let system_prompt = build_system_prompt_for(&cwd, &model).map_err(|error| {
@@ -2779,8 +2782,9 @@ impl AcpCliAgent {
         if self.model_flag_raw.is_some() {
             return Ok(model);
         }
-        let _guard = ScopedCurrentDir::change_to(cwd)
-            .map_err(|error| AcpError::internal(format!("failed to enter cwd: {error}")))?;
+        // `resolve_repl_model` reads project config from the workspace root
+        // (see `runtime::workspace_root`), so scope it to this session's cwd.
+        let _scope = runtime::WorkspaceRootScope::enter(cwd);
         Ok(resolve_repl_model(model))
     }
 
@@ -2788,8 +2792,7 @@ impl AcpCliAgent {
         if let Some(mode) = self.permission_mode_override {
             return Ok(mode);
         }
-        let _guard = ScopedCurrentDir::change_to(cwd)
-            .map_err(|error| AcpError::internal(format!("failed to enter cwd: {error}")))?;
+        let _scope = runtime::WorkspaceRootScope::enter(cwd);
         Ok(default_permission_mode())
     }
 }
@@ -2802,6 +2805,10 @@ impl AcpCliAgent {
         session: &mut AcpCliSession,
         model: Option<String>,
     ) -> Result<String, AcpError> {
+        // Everything below (model report, alias lookup, config, plugin/MCP
+        // state, the API client's `.env` lookup) resolves against the
+        // workspace root.
+        let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
         let current = self.current_model();
 
         let Some(new_model) = model else {
@@ -2873,24 +2880,6 @@ impl AcpCliAgent {
             &resolved,
             message_count,
         ))
-    }
-}
-
-struct ScopedCurrentDir {
-    previous: PathBuf,
-}
-
-impl ScopedCurrentDir {
-    fn change_to(cwd: &Path) -> io::Result<Self> {
-        let previous = env::current_dir()?;
-        env::set_current_dir(cwd)?;
-        Ok(Self { previous })
-    }
-}
-
-impl Drop for ScopedCurrentDir {
-    fn drop(&mut self) {
-        let _ = env::set_current_dir(&self.previous);
     }
 }
 
@@ -3082,6 +3071,18 @@ impl AcpSdkDelegate {
         let handle = self.inner.session_handle(session_id)?;
         Ok(LockedAcpSession { handle })
     }
+
+    /// The working directory of a session, read from the registry slot so
+    /// it never waits on the session's own lock.
+    fn session_cwd(&self, session_id: &str) -> Result<PathBuf, runtime::AcpError> {
+        self.inner
+            .lock_sessions()
+            .get(session_id)
+            .map(|slot| slot.cwd.clone())
+            .ok_or_else(|| {
+                runtime::AcpError::invalid_params(format!("unknown sessionId: {session_id}"))
+            })
+    }
 }
 
 /// Owner of a session handle that hands out the locked session. Kept as a
@@ -3188,8 +3189,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             SlashCommand::Status => {
                 let locked = self.lock_session(session_id)?;
                 let session = locked.get();
-                let _guard = ScopedCurrentDir::change_to(&session.cwd)
-                    .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
+                let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
                 let tracker = UsageTracker::from_session(session.runtime.session());
                 format_status_report(
                     &self.inner.current_model(),
@@ -3219,19 +3219,25 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                     usage.cache_read_input_tokens,
                 )
             }
-            SlashCommand::Config { section } => render_config_report(section.as_deref())
-                .map_err(|e| runtime::AcpError::internal(e.to_string()))?,
+            SlashCommand::Config { section } => {
+                let _scope = runtime::WorkspaceRootScope::enter(self.session_cwd(session_id)?);
+                render_config_report(section.as_deref())
+                    .map_err(|e| runtime::AcpError::internal(e.to_string()))?
+            }
             SlashCommand::ConfigSet { .. } => {
                 "/config set is only available in interactive REPL mode".to_string()
             }
             SlashCommand::Diff => {
+                let cwd = self.session_cwd(session_id)?;
                 let output = std::process::Command::new("git")
                     .args(["diff", "--cached", "--no-color"])
+                    .current_dir(&cwd)
                     .output()
                     .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
                 let cached = String::from_utf8_lossy(&output.stdout);
                 let output2 = std::process::Command::new("git")
                     .args(["diff", "--no-color"])
+                    .current_dir(&cwd)
                     .output()
                     .map_err(|e| runtime::AcpError::internal(e.to_string()))?;
                 let unstaged = String::from_utf8_lossy(&output2.stdout);
@@ -3253,9 +3259,12 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                     )
                 }
             }
-            SlashCommand::Doctor => render_doctor_report()
-                .map(|report| report.render())
-                .map_err(|e| runtime::AcpError::internal(e.to_string()))?,
+            SlashCommand::Doctor => {
+                let _scope = runtime::WorkspaceRootScope::enter(self.session_cwd(session_id)?);
+                render_doctor_report()
+                    .map(|report| report.render())
+                    .map_err(|e| runtime::AcpError::internal(e.to_string()))?
+            }
             _ => format!(
                 "`{}` is not supported in ACP mode. Available: /model, /status, /cost, /config, /diff, /doctor, /help",
                 input.split_whitespace().next().unwrap_or(input)
@@ -3359,7 +3368,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         eprintln!(
             "[push_images] active_model={active_model:?} vision_capable={active_model_is_vision_capable}"
         );
-        let sudocode_config = load_sudocode_config_for_current_dir();
+        let sudocode_config = load_sudocode_config_for_cwd(&self.session_cwd(session_id)?);
         let sudorouter_creds = extract_sudorouter_credentials(&sudocode_config);
         eprintln!(
             "[push_images] sudorouter_creds_present={}",
@@ -3434,8 +3443,9 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
     ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
         let cwd = canonical_session_cwd(&cwd)?;
-        let _guard = ScopedCurrentDir::change_to(&cwd)
-            .map_err(|e| runtime::AcpError::internal(format!("failed to enter cwd: {e}")))?;
+        // The session store, config and system prompt all resolve against
+        // the workspace root; scope this thread to the requested cwd.
+        let _scope = runtime::WorkspaceRootScope::enter(&cwd);
 
         let (handle, session) = load_session_reference(session_id)
             .map_err(|e| runtime::AcpError::internal(format!("failed to load session: {e}")))?;
@@ -3513,9 +3523,14 @@ impl AcpSdkDelegate {
     > {
         // Reset abort signal for this new turn.
         session.abort_signal.reset();
-        let _guard = ScopedCurrentDir::change_to(&session.cwd).map_err(|e| {
-            runtime::AcpError::internal(format!("failed to enter session cwd: {e}"))
-        })?;
+        // The whole turn — tool loop, hooks, config, session store — resolves
+        // paths against this session's workspace root through
+        // `runtime::workspace_root`, never the process cwd. That is what lets
+        // turns of sessions in different directories run concurrently in
+        // one process (the ACP server also enters this scope around the
+        // blocking closure; nesting is harmless and keeps `run_prompt`
+        // correct for callers that do not).
+        let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
 
         // Set trace_id on the runtime if provided
         if let Some(tid) = trace_id {

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -1233,6 +1233,351 @@ async fn acp_stdio_paused_session_does_not_block_other_session_other_cwd() {
     scenario_paused_session_does_not_block_other_session("stdio-concurrency-other-cwd", true).await;
 }
 
+/// A session running a LONG TOOL (not parked on the user) must not starve a
+/// sibling session in a different cwd. This is the half of the P0 that the
+/// cwd lease does not cover: the process cwd is a shared resource, so an
+/// active turn in /a holds it for the whole turn — including a 30s bash —
+/// and a turn in /b waits. Reported symptom: one conversation writes a long
+/// report / installs deps, every other conversation of that user goes quiet.
+#[tokio::test]
+async fn acp_stdio_long_tool_does_not_block_other_cwd_session() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-long-tool-other-cwd");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    let cwd_b = workspace.root.join("project-b");
+    fs::create_dir_all(&cwd_b).expect("create sibling cwd");
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let session_a = scenario_session_new(&mut client, &workspace.root).await;
+
+    // `allow` so the bash tool executes instead of prompting — A must be BUSY,
+    // not parked (a parked turn yields the cwd lease, which is the half that
+    // is already fixed).
+    let (_, mode_resp) = client
+        .send_request(
+            "session/setPermissionMode",
+            json!({ "sessionId": session_a, "permissionMode": "allow" }),
+        )
+        .await;
+    assert!(
+        mode_resp.get("error").is_none(),
+        "session/setPermissionMode allow should succeed: {mode_resp}"
+    );
+
+    // A: a turn whose tool call runs `sleep 30` — busy, never parked.
+    let _prompt_a = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_a,
+                "prompt": [{
+                    "type": "text",
+                    "text": format!("{SCENARIO_PREFIX}bash_interrupt_long_running")
+                }]
+            }),
+        )
+        .await;
+
+    // Give A time to reach the tool call and take the cwd lease.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // B, in a different cwd, must still be served while A is busy.
+    let new_b = client
+        .send_request_no_wait(
+            "session/new",
+            json!({ "cwd": cwd_b.to_string_lossy().to_string(), "mcpServers": [] }),
+        )
+        .await;
+    let (_, new_b_resp) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, new_b))
+        .await
+        .unwrap_or_else(|seen| {
+            panic!(
+                "session/new got no response within 20s while session A was running a long \
+                 tool in another cwd (cwd lease held for the whole turn); seen: {seen:?}"
+            )
+        });
+    let session_b = new_b_resp["result"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("session/new should succeed: {new_b_resp}"))
+        .to_string();
+
+    let prompt_b = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_b,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}single_turn_text") }]
+            }),
+        )
+        .await;
+    client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, prompt_b))
+        .await
+        .unwrap_or_else(|seen| {
+            panic!(
+                "session B starved while session A ran a long tool in another cwd; seen: {seen:?}"
+            )
+        });
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// Set a session's permission mode, asserting success.
+async fn set_permission_mode(client: &mut AcpTestClient, session_id: &str, mode: &str) {
+    let (_, resp) = client
+        .send_request(
+            "session/setPermissionMode",
+            json!({ "sessionId": session_id, "permissionMode": mode }),
+        )
+        .await;
+    assert!(
+        resp.get("error").is_none(),
+        "session/setPermissionMode {mode} should succeed: {resp}"
+    );
+}
+
+/// Run `scenario` on `session_id`, wait up to `limit` for the turn to
+/// complete, and return the concatenated `agent_message_chunk` text the
+/// agent streamed for it plus every `tool_call_update` raw output (for
+/// diagnostics: the mock's final text does not distinguish a failed tool
+/// call from a successful one).
+async fn run_scenario_collect_text(
+    client: &mut AcpTestClient,
+    session_id: &str,
+    scenario: &str,
+    limit: Duration,
+    what: &str,
+) -> (String, Vec<Value>) {
+    let prompt_id = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}{scenario}") }]
+            }),
+        )
+        .await;
+    let (notifs, resp) = client
+        .recv_until(limit, |m| is_response_to(m, prompt_id))
+        .await
+        .unwrap_or_else(|seen| panic!("{what}: no response within {limit:?}; seen: {seen:?}"));
+    assert!(
+        resp["result"].get("stopReason").is_some(),
+        "{what}: turn should complete normally: {resp}"
+    );
+    let text = notifs
+        .iter()
+        .filter(|m| {
+            m["params"]["sessionId"].as_str() == Some(session_id)
+                && m["params"]["update"]["sessionUpdate"].as_str() == Some("agent_message_chunk")
+        })
+        .filter_map(|m| m["params"]["update"]["content"]["text"].as_str())
+        .collect::<String>();
+    let tool_outputs = notifs
+        .iter()
+        .filter(|m| {
+            m["params"]["sessionId"].as_str() == Some(session_id)
+                && m["params"]["update"]["sessionUpdate"].as_str() == Some("tool_call_update")
+        })
+        .map(|m| m["params"]["update"]["rawOutput"].clone())
+        .collect::<Vec<_>>();
+    (text, tool_outputs)
+}
+
+/// The invariant that makes concurrent cross-cwd turns safe: once the process
+/// cwd is no longer the single source of truth, a session's file operations
+/// must resolve against *its own* directory — never against the directory
+/// of whichever session happened to touch the process cwd last, and never
+/// against a sibling that is mid-turn.
+///
+/// Layout: session A in `project-a`, sessions in `project-b`, plus a decoy
+/// session created LAST in `decoy` (so the process cwd, which runtime
+/// construction still sets, points at the decoy). Each directory carries a
+/// differently worded `fixture.txt`; the scode process itself was started in
+/// the workspace root, which carries yet another one. While A is busy in a
+/// 30 s `bash`, sessions in `project-b` read and write relative paths and
+/// must see only `project-b`; then A is cancelled and sessions in
+/// `project-a` do the same there. (One session per file scenario: the mock
+/// model answers from the latest tool result in the history, so a second
+/// tool scenario on the same session would never issue its tool call.)
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn acp_stdio_concurrent_sessions_keep_file_ops_in_their_own_cwd() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-cwd-isolation");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    let cwd_a = workspace.root.join("project-a");
+    let cwd_b = workspace.root.join("project-b");
+    let cwd_decoy = workspace.root.join("decoy");
+    for (dir, marker) in [
+        (&workspace.root, "root-fixture"),
+        (&cwd_a, "alpha-fixture"),
+        (&cwd_b, "bravo-fixture"),
+        (&cwd_decoy, "decoy-fixture"),
+    ] {
+        fs::create_dir_all(dir).expect("create cwd");
+        fs::write(dir.join("fixture.txt"), format!("{marker}\n")).expect("write fixture");
+    }
+    let generated = |dir: &std::path::Path| dir.join("generated").join("output.txt");
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let session_a = scenario_session_new(&mut client, &cwd_a).await;
+    let reader_b = scenario_session_new(&mut client, &cwd_b).await;
+    let writer_b = scenario_session_new(&mut client, &cwd_b).await;
+    // Created last: whatever still keys off the process cwd now sees `decoy`.
+    let _session_decoy = scenario_session_new(&mut client, &cwd_decoy).await;
+    for sid in [&session_a, &reader_b, &writer_b] {
+        set_permission_mode(&mut client, sid, "allow").await;
+    }
+
+    // A: busy in `sleep 30` for the rest of the B phase.
+    let prompt_a = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_a,
+                "prompt": [{
+                    "type": "text",
+                    "text": format!("{SCENARIO_PREFIX}bash_interrupt_long_running")
+                }]
+            }),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // B reads a relative path while A is busy: must be B's own fixture.
+    let (text_b, tools_b) = run_scenario_collect_text(
+        &mut client,
+        &reader_b,
+        "read_file_roundtrip",
+        Duration::from_secs(20),
+        "project-b read_file while A busy in another cwd",
+    )
+    .await;
+    assert!(
+        text_b.contains("bravo-fixture"),
+        "project-b session must read its own fixture.txt (bravo-fixture); got: {text_b:?} \
+         (tool outputs: {tools_b:?})"
+    );
+    for leaked in ["alpha-fixture", "decoy-fixture", "root-fixture"] {
+        assert!(
+            !text_b.contains(leaked),
+            "project-b session read another directory's fixture ({leaked}); got: {text_b:?}"
+        );
+    }
+
+    // B writes a relative path while A is busy: must land in project-b only.
+    let (text_b, tools_b) = run_scenario_collect_text(
+        &mut client,
+        &writer_b,
+        "write_file_allowed",
+        Duration::from_secs(20),
+        "project-b write_file while A busy in another cwd",
+    )
+    .await;
+    assert!(
+        text_b.contains("write_file succeeded"),
+        "project-b write should succeed: {text_b:?} (tool outputs: {tools_b:?})"
+    );
+    assert!(
+        generated(&cwd_b).is_file(),
+        "project-b relative write must land in project-b (tool outputs: {tools_b:?})"
+    );
+    for (name, dir) in [
+        ("project-a", &cwd_a),
+        ("decoy", &cwd_decoy),
+        ("workspace root", &workspace.root),
+    ] {
+        assert!(
+            !generated(dir).exists(),
+            "project-b relative write leaked into {name}"
+        );
+    }
+    // A must still be busy — the project-b turns ran concurrently, not after A.
+    let a_done_early = client
+        .recv_until(Duration::from_millis(200), |m| is_response_to(m, prompt_a))
+        .await;
+    assert!(
+        a_done_early.is_err(),
+        "session A should still be running its long tool while project-b did file ops"
+    );
+
+    // Cancel A: the turn must end promptly (its `sleep 30` is interrupted).
+    client
+        .send_raw(&json!({
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": { "sessionId": session_a }
+        }))
+        .await;
+    let (_, resp_a) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, prompt_a))
+        .await
+        .unwrap_or_else(|seen| panic!("session A never finished after cancel; seen: {seen:?}"));
+    assert!(
+        resp_a.get("result").is_some() || resp_a.get("error").is_some(),
+        "session A's cancelled prompt should get a response: {resp_a}"
+    );
+
+    // Now project-a: its sessions must see project-a, even though project-b
+    // turns ran in between and the process cwd points at the decoy.
+    let reader_a = scenario_session_new(&mut client, &cwd_a).await;
+    let writer_a = scenario_session_new(&mut client, &cwd_a).await;
+    for sid in [&reader_a, &writer_a] {
+        set_permission_mode(&mut client, sid, "allow").await;
+    }
+    let (text_a, tools_a) = run_scenario_collect_text(
+        &mut client,
+        &reader_a,
+        "read_file_roundtrip",
+        Duration::from_secs(20),
+        "project-a read_file",
+    )
+    .await;
+    assert!(
+        text_a.contains("alpha-fixture"),
+        "project-a session must read its own fixture.txt (alpha-fixture); got: {text_a:?} \
+         (tool outputs: {tools_a:?})"
+    );
+    let (text_a, tools_a) = run_scenario_collect_text(
+        &mut client,
+        &writer_a,
+        "write_file_allowed",
+        Duration::from_secs(20),
+        "project-a write_file",
+    )
+    .await;
+    assert!(
+        text_a.contains("write_file succeeded"),
+        "project-a write should succeed: {text_a:?} (tool outputs: {tools_a:?})"
+    );
+    assert!(
+        generated(&cwd_a).is_file(),
+        "project-a relative write must land in project-a (tool outputs: {tools_a:?})"
+    );
+    assert!(
+        !generated(&cwd_decoy).exists() && !generated(&workspace.root).exists(),
+        "project-a relative write leaked outside project-a"
+    );
+
+    // The cancelled session and a project-b session must still be usable.
+    scenario_session_prompt_streaming(&mut client, &session_a).await;
+    scenario_session_prompt_streaming(&mut client, &reader_b).await;
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
 /// Same P0, other wait path: session A parked inside the `AskUserQuestion`
 /// tool (`_scode/ask_user_question` extension request to the client, left
 /// unanswered — "waiting for the user to answer a question" is exactly the

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -224,7 +224,8 @@ use runtime::{
     agent_mailbox::{self, kinds as mailbox_kinds, MailboxEnvelope},
     check_freshness,
     cron_registry::CronRegistry,
-    dedupe_superseded_commit_events, edit_file, execute_bash_with_abort, glob_search, grep_search,
+    current_workspace_root, dedupe_superseded_commit_events, edit_file, execute_bash_with_abort,
+    glob_search, grep_search,
     lsp_client::LspRegistry,
     mcp_tool_bridge::McpToolRegistry,
     permission_enforcer::{EnforcementResult, PermissionEnforcer},
@@ -237,7 +238,7 @@ use runtime::{
     LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass,
     McpDegradedReport, MessageRole, PermissionMode, PermissionPolicy, PromptCacheEvent,
     ProviderFallbackConfig, RuntimeError, Session, StdFsBackend, SystemPrompt, ToolDispatchContext,
-    ToolError, ToolExecutor, FORK_BOILERPLATE_TAG,
+    ToolError, ToolExecutor, WorkspaceRootHandoff, FORK_BOILERPLATE_TAG,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -2227,11 +2228,11 @@ fn run_cron_list(_input: Value) -> Result<String, String> {
 
 // ── SendMessage ────────────────────────────────────────────────────
 
-/// Resolve the workspace root that receives inbox files. The current
-/// working directory is the canonical anchor — matches the way plan-mode,
-/// todos, and agent manifests use `env::current_dir()`.
+/// Resolve the workspace root that receives inbox files. The turn's
+/// workspace root is the canonical anchor — matches the way plan-mode,
+/// todos, and agent manifests use [`current_workspace_root`].
 fn send_message_workspace() -> Result<PathBuf, String> {
-    std::env::current_dir().map_err(|e| format!("resolve workspace root: {e}"))
+    current_workspace_root().map_err(|e| format!("resolve workspace root: {e}"))
 }
 
 /// Best-effort sanitizer for a mailbox filename stem. Recipient
@@ -2733,7 +2734,7 @@ fn has_dangerous_paths(command: &str) -> bool {
             // Check if it's within CWD
             let path =
                 PathBuf::from(token.replace('~', &std::env::var("HOME").unwrap_or_default()));
-            if let Ok(cwd) = std::env::current_dir() {
+            if let Ok(cwd) = current_workspace_root() {
                 if !path.starts_with(&cwd) {
                     return true; // Path outside workspace
                 }
@@ -2834,15 +2835,24 @@ fn resolve_main_ref(branch: &str) -> Option<String> {
 }
 
 fn git_ref_exists(reference: &str) -> bool {
-    Command::new("git")
-        .args(["rev-parse", "--verify", "--quiet", reference])
+    let mut command = Command::new("git");
+    command.args(["rev-parse", "--verify", "--quiet", reference]);
+    if let Ok(root) = current_workspace_root() {
+        command.current_dir(root);
+    }
+    command
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
 }
 
 fn git_stdout(args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).output().ok()?;
+    let mut command = Command::new("git");
+    command.args(args);
+    if let Ok(root) = current_workspace_root() {
+        command.current_dir(root);
+    }
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -2986,10 +2996,15 @@ fn run_web_fetch(input: WebFetchInput) -> Result<String, String> {
     // Run on a dedicated OS thread: execute_web_fetch drives the request with
     // block_on on the shared HTTP runtime, which panics if called from within
     // an ambient tokio runtime (e.g. ACP mode). The spawned thread is outside
-    // any such runtime.
-    std::thread::spawn(move || to_pretty_json(execute_web_fetch(&input)?))
-        .join()
-        .unwrap_or_else(|_| Err("web fetch thread panicked".into()))
+    // any such runtime. The helper thread inherits the turn's workspace root
+    // so config lookups resolve against the session's directory.
+    let workspace = WorkspaceRootHandoff::capture();
+    std::thread::spawn(move || {
+        let _workspace = workspace.enter();
+        to_pretty_json(execute_web_fetch(&input)?)
+    })
+    .join()
+    .unwrap_or_else(|_| Err("web fetch thread panicked".into()))
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -2997,10 +3012,15 @@ fn run_web_search(input: WebSearchInput) -> Result<String, String> {
     // Run on a dedicated OS thread: execute_web_search drives the request with
     // block_on on the shared HTTP runtime, which panics if called from within
     // an ambient tokio runtime (e.g. ACP mode). The spawned thread is outside
-    // any such runtime.
-    std::thread::spawn(move || to_pretty_json(execute_web_search(&input)?))
-        .join()
-        .unwrap_or_else(|_| Err("web search thread panicked".into()))
+    // any such runtime. The helper thread inherits the turn's workspace root
+    // so `load_sudocode_config()` resolves against the session's directory.
+    let workspace = WorkspaceRootHandoff::capture();
+    std::thread::spawn(move || {
+        let _workspace = workspace.enter();
+        to_pretty_json(execute_web_search(&input)?)
+    })
+    .join()
+    .unwrap_or_else(|_| Err("web search thread panicked".into()))
 }
 
 fn run_todo_write(input: TodoWriteInput) -> Result<String, String> {
@@ -3112,9 +3132,9 @@ fn extract_powershell_path(command: &str) -> Option<String> {
 fn is_within_workspace(path: &str) -> bool {
     let path = PathBuf::from(path);
 
-    // If path is absolute, check if it starts with CWD
+    // If path is absolute, check if it starts with the workspace root
     if path.is_absolute() {
-        if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(cwd) = current_workspace_root() {
             return path.starts_with(&cwd);
         }
     }
@@ -3717,6 +3737,12 @@ struct AgentJob {
     /// `.abort()` for live delivery — mirrors CC-fork's
     /// `task.abortController.abort()`.
     abort_signal: HookAbortSignal,
+    /// The parent turn's workspace root, captured at spawn time. The worker
+    /// thread re-enters it before it does anything (see
+    /// [`runtime::WorkspaceRootHandoff`]) so a sub-agent of a session in
+    /// `/a` writes its manifests, inbox and files under `/a` even while a
+    /// sibling session's turn runs in `/b` on another thread.
+    workspace: WorkspaceRootHandoff,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -4488,12 +4514,12 @@ fn todo_store_path() -> Result<std::path::PathBuf, String> {
     if let Ok(path) = std::env::var("SUDOCODE_TODO_STORE") {
         return Ok(std::path::PathBuf::from(path));
     }
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     Ok(cwd.join(".sudocode-todos.json"))
 }
 
 fn resolve_skill_path(skill: &str) -> Result<std::path::PathBuf, String> {
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     let plugin_load_outcome = load_plugin_outcome_for_cwd(&cwd);
     commands::resolve_skill_path_with_plugins(&cwd, skill, plugin_load_outcome.as_ref())
         .map_err(|error| error.to_string())
@@ -4676,6 +4702,7 @@ fn prepare_agent_job(
         auth_mode,
         inherited_messages,
         abort_signal: HookAbortSignal::default(),
+        workspace: WorkspaceRootHandoff::capture(),
     };
     Ok(PreparedAgent { manifest, job })
 }
@@ -4807,7 +4834,10 @@ where
 
     let bg_manifest = manifest.clone();
     let bg_agent_id = agent_id.clone();
+    let workspace = job.workspace.clone();
     std::thread::spawn(move || {
+        // Worker threads carry the parent turn's workspace root with them.
+        let _workspace = workspace.enter();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| work_fn(job)));
         match result {
             Ok(Ok(final_text)) => {
@@ -4880,6 +4910,8 @@ fn spawn_agent_job(job: AgentJob) -> Result<(), String> {
 
 #[allow(clippy::needless_pass_by_value)] // ownership required for move into spawn_blocking
 fn run_spawned_agent_job(job: AgentJob) {
+    // Worker threads carry the parent turn's workspace root with them.
+    let _workspace = job.workspace.enter();
     let agent_id = job.manifest.agent_id.clone();
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         run_agent_job_returning_text(&job).and_then(|text| {
@@ -4949,7 +4981,7 @@ fn subagent_max_multi_turns() -> usize {
 fn run_agent_job_returning_text(job: &AgentJob) -> Result<String, String> {
     let mut conv_runtime =
         build_agent_runtime(job)?.with_max_iterations(DEFAULT_AGENT_MAX_ITERATIONS);
-    let workspace_root = std::env::current_dir().unwrap_or_default();
+    let workspace_root = current_workspace_root().unwrap_or_default();
     // Accumulate telemetry across every multi-turn iteration so a
     // long coordinator-driven conversation reports one aggregated
     // `<total_tokens>` / `<tool_uses>` count in the task-notification.
@@ -5373,7 +5405,7 @@ fn build_agent_runtime(
 }
 
 fn build_agent_system_prompt(subagent_type: &str, model: &str) -> Result<SystemPrompt, String> {
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     // Route sub-agents through the per-agent-type memory scope
     // (`<workspace>/agent-memory/<subagent_type>/`) so one agent's
     // remembered facts don't leak into another's memory index —
@@ -5694,7 +5726,7 @@ fn persist_agent_terminal_state_with_telemetry(
         // swallow. The `notified=true` flag persists regardless so
         // a retry doesn't double-emit.
         let xml = render_manifest_task_notification(&next_manifest);
-        let workspace_root = std::env::current_dir().unwrap_or_default();
+        let workspace_root = current_workspace_root().unwrap_or_default();
         if let Err(err) =
             runtime::coordinator_notification::emit(&workspace_root, &next_manifest.agent_id, &xml)
         {
@@ -6308,7 +6340,7 @@ fn derive_agent_state(
 fn maybe_commit_provenance(result: Option<&str>) -> Option<LaneCommitProvenance> {
     let commit = extract_commit_sha(result?)?;
     let branch = current_git_branch().unwrap_or_else(|| "unknown".to_string());
-    let worktree = std::env::current_dir()
+    let worktree = current_workspace_root()
         .ok()
         .map(|path| path.display().to_string());
     Some(LaneCommitProvenance {
@@ -6329,10 +6361,12 @@ fn extract_commit_sha(result: &str) -> Option<String> {
 }
 
 fn current_git_branch() -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .ok()?;
+    let mut command = Command::new("git");
+    command.args(["rev-parse", "--abbrev-ref", "HEAD"]);
+    if let Ok(root) = current_workspace_root() {
+        command.current_dir(root);
+    }
+    let output = command.output().ok()?;
     output
         .status
         .success()
@@ -6518,7 +6552,7 @@ fn build_provider_entry_with_config(
 }
 
 fn load_sudocode_config() -> SudoCodeConfig {
-    std::env::current_dir()
+    current_workspace_root()
         .ok()
         .and_then(|cwd| {
             runtime::config::ConfigLoader::default_for(cwd)
@@ -6529,7 +6563,7 @@ fn load_sudocode_config() -> SudoCodeConfig {
 }
 
 fn load_provider_fallback_config() -> ProviderFallbackConfig {
-    std::env::current_dir()
+    current_workspace_root()
         .ok()
         .and_then(|cwd| ConfigLoader::default_for(cwd).load().ok())
         .map_or_else(ProviderFallbackConfig::default, |config| {
@@ -7042,10 +7076,10 @@ fn agent_store_dir() -> Result<std::path::PathBuf, String> {
         if path.is_absolute() {
             return Ok(path);
         }
-        let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+        let cwd = current_workspace_root().map_err(|error| error.to_string())?;
         return Ok(cwd.join(path));
     }
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     Ok(cwd.join(".sudocode-agents"))
 }
 
@@ -7109,7 +7143,7 @@ fn lookup_custom_agent(
     if is_builtin_subagent(subagent_type) {
         return None;
     }
-    let cwd = std::env::current_dir().ok()?;
+    let cwd = current_workspace_root().ok()?;
     runtime::custom_agents::find_custom_agent(subagent_type, &cwd)
 }
 
@@ -7249,7 +7283,16 @@ fn iso8601_now() -> String {
 
 #[allow(clippy::too_many_lines)]
 fn execute_notebook_edit(input: NotebookEditInput) -> Result<NotebookEditOutput, String> {
-    let path = std::path::PathBuf::from(&input.notebook_path);
+    // Relative notebook paths resolve against the turn's workspace root,
+    // like every other file tool.
+    let requested = std::path::PathBuf::from(&input.notebook_path);
+    let path = if requested.is_absolute() {
+        requested
+    } else {
+        current_workspace_root()
+            .map_err(|error| error.to_string())?
+            .join(requested)
+    };
     if path.extension().and_then(|ext| ext.to_str()) != Some("ipynb") {
         return Err(String::from(
             "File must be a Jupyter notebook (.ipynb file).",
@@ -7471,7 +7514,16 @@ fn execute_brief(input: BriefInput) -> Result<BriefOutput, String> {
 }
 
 fn resolve_attachment(path: &str) -> Result<ResolvedAttachment, String> {
-    let resolved = std::fs::canonicalize(path).map_err(|error| error.to_string())?;
+    // Relative attachment paths resolve against the turn's workspace root.
+    let requested = std::path::Path::new(path);
+    let anchored = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        current_workspace_root()
+            .map_err(|error| error.to_string())?
+            .join(requested)
+    };
+    let resolved = std::fs::canonicalize(&anchored).map_err(|error| error.to_string())?;
     let metadata = std::fs::metadata(&resolved).map_err(|error| error.to_string())?;
     Ok(ResolvedAttachment {
         path: resolved.display().to_string(),
@@ -7707,6 +7759,9 @@ fn execute_repl(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+    if let Ok(root) = current_workspace_root() {
+        process.current_dir(root);
+    }
 
     let timeout_ms = input
         .timeout_ms
@@ -7939,7 +7994,7 @@ fn normalize_config_value(spec: ConfigSettingSpec, value: ConfigValue) -> Result
 }
 
 fn config_file_for_scope(scope: ConfigScope) -> Result<PathBuf, String> {
-    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     Ok(match scope {
         ConfigScope::Global => config_home_dir()?.join("settings.json"),
         ConfigScope::Settings => cwd
@@ -8162,6 +8217,9 @@ fn execute_shell_command(
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null());
+        if let Ok(root) = current_workspace_root() {
+            process.current_dir(root);
+        }
         let child = process.group_spawn()?;
         let pid = child.id();
         drop(child);
@@ -8190,6 +8248,9 @@ fn execute_shell_command(
         .arg("-NonInteractive")
         .arg("-Command")
         .arg(command);
+    if let Ok(root) = current_workspace_root() {
+        process.current_dir(root);
+    }
 
     let timeout_ms = timeout.unwrap_or(runtime::DEFAULT_TOOL_SUBPROCESS_TIMEOUT_MS);
     let result = run_in_process_group(&mut process, timeout_ms, abort_signal)?;


### PR DESCRIPTION
## 问题：#417 只修好了一半

#417 去掉了 ACP 的进程级 delegate 锁，**暂停中的会话不再阻塞别人**（真机 90s 超时 → 2s）。但活动中的 turn 之间仍按 cwd 互相等待：`run_prompt_impl` 每轮 `ScopedCurrentDir::change_to(session.cwd)`，而 bash 工具、fs backend、hooks、配置加载都读 `env::current_dir()` —— **进程 cwd 是单一全局资源**，所以 `WorkspaceCwdLease` 只能让不同 cwd 的 turn 排队。

上游 apeiron 每个会话一个 cwd，所以这条必然被踩到。真机实测：A 跑 `bash sleep 60` 时，B 的一句短消息等 **63 秒**。

用户视角：一个会话在写长报告 / 装依赖 / 跑测试，同一用户的其他会话全部没响应。

## 修法：线程作用域的 workspace root 取代进程 cwd

新增 `runtime/src/workspace_root.rs`：

- 一个 turn（或任何 session 绑定的工作单元）把自己包在 `WorkspaceRootScope` 里
- 所有原本读进程 cwd 的点改调 `current_workspace_root()` —— 有作用域用作用域，没有则回落进程 cwd（REPL 和一次性 CLI 路径行为不变）
- turn 交给别的线程的工作通过 `WorkspaceRootHandoff` 带着 root 过去

**为什么用 thread-local 而不是 task-local**：conversation runtime 用 `Runtime::block_on` 在调用线程上驱动 turn，工具执行（`ToolExecutor::execute`）是同一线程上的同步调用。turn 路径上没有任何 `tokio::spawn`（runtime spawn 的是 MCP 传输和 HTTP 流，都不解析路径）。turn 会创建的线程只有子 agent worker（通过 handoff 重新进入作用域）和 WebFetch/WebSearch 辅助线程（不碰路径）。

**不变量**：除测试代码外，`runtime` / `tools` / `api` / `commands` 里**没有任何 `std::env::current_dir()`** —— 每个路径锚点都走这个模块，一个 turn 只可能看到自己 session 的目录。

## `WorkspaceCwdLease` 的处置

**删掉**：`CwdLeaseHandle`、`parked()`、`held` 原子、bridge 上的 `cwd_lease` 字段。turn 不再持有租约，所以没有"parked 时归还、回答后重新获取"这回事 —— **#417 §8 里那个「重新获取失败后无租约继续跑」的隐患，是结构上消失了，不是修好了**。

**保留**：引用计数的租约本身，用于 `session/new` / `session/load` / `setModel` 和 slash 命令。这些路径会构造 runtime，而 runtime 会拉起配置声明的 MCP server / plugin 进程，那些子进程继承进程 cwd。常规 turn 完全不碰它。

**顺带**：`sessionCapabilities.list` 现在声明了（`session/list` 一直实现着，和 #417 修的 `loadSession` 是同类遗漏）。

## 测试

新增两个，其余全部保持绿：

| 测试 | 作用 |
|---|---|
| `acp_stdio_long_tool_does_not_block_other_cwd_session` | 本 PR 的红测试：A 跑 `sleep 30`（**`allow` 模式，确保是 busy 不是 parked**），B 在另一个 cwd 必须被服务 |
| `acp_stdio_concurrent_sessions_keep_file_ops_in_their_own_cwd` | **本 PR 最大的风险守卫**：cwd 不再是全局单一真相后，任何漏改的路径解析都会静默读到别的 session 的目录。用诱饵布局验证两个并发 session 的文件操作各自只看到自己的 |

反向守卫 `acp_stdio_same_session_prompts_stay_serial`（同 session 必须严格串行）继续绿。

```
cargo test --workspace                  1644 passed / 0 failed
acp_integration 连跑 5 轮                每轮 15 passed，稳定 4.0s
```

## 上游真机验证（apeiron on k3s + gVisor）

用本分支编译的 scode 换掉生产镜像，同一场景：

```
修复前   A 跑 bash sleep 60 → B 发短消息 → 63 秒
修复后   同样场景            → B 2 秒完成，A 的 sleep 还在跑
         A 随后正常跑完（回答 done，2 个工具完成）
```

文件隔离用 `kubectl exec` 直查（不采信 agent 自述）：B 写的 `marker.txt` 落在
`/home/user/session-2613f86c-681a/marker.txt`，即 B 自己的会话目录；B 的 `pwd` 也是自己的目录。

## 残留风险

- **构造 runtime 的路径仍按 cwd 串行**（`session/new` / `load` / `setModel` / slash 命令）。一个慢的 `session/new`（比如慢的 MCP server）会拖住另一个 cwd 的 `session/new`，**但不会拖住 turn**。彻底去掉租约需要 MCP/plugin 拉起时接受显式 cwd。
- **非 cwd 的进程级共享状态未变**：`AcpCliAgent.model`（一个 session 里 `/model` 会改别人的回落模型，既有行为）、`GLOBAL_AUTH_MODE`、内存里的 task/agent 注册表（`TaskList` 看得到所有 session 的任务）、`model_capabilities` 缓存。超出本任务范围。
- **grep 不变量抓不到裸相对路径**：它能抓 `current_dir()`，但抓不到新写的 `std::fs::read("foo.txt")` 这类隐式用进程 cwd 的调用。隔离测试的诱饵布局能在场景覆盖到时抓住，但不是全覆盖。

<details>
<summary><b>完整报告</b></summary>

# scode: turn paths no longer depend on the process cwd (P0#2, second half)

Branch `fix/acp-explicit-cwd`, one commit on top of `ad6abe6` (#417). Not pushed.

**Result:** turns of ACP sessions in different directories now run truly
concurrently in one process. Session B's short prompt while session A runs a
30 s `bash`: **63 s (baseline, lease held for the whole turn) → ~2 s**. The
red test provided with the task is green; a new cross-session file-isolation
test (mutation-checked) guards invariant 4; `acp_integration` 5/5 green;
`cargo test --workspace` 1644 passed / 0 failed; clippy warning count
identical before/after (902/902 lines, 817/817 distinct sites).

---

## 1. `env::current_dir()` call-site classification (109 at `ad6abe6`)

`git grep -n 'env::current_dir()' HEAD -- rust/crates` = 109 (matches the task).

| Bucket | Count | What |
|---|---|---|
| **A. On the turn / ACP-session path — had to change** | **32** | see A below |
| **A′. Turn-path cwd dependencies that were *not* `current_dir()` calls — also fixed** | 13 sites | `sh -lc` hooks inheriting the process cwd; git helpers in `bash.rs` (3) and `tools` (3) with no `current_dir`; REPL/PowerShell tool spawns (3); `check_freshness` running git in `Path::new(".")`; `NotebookEdit` and `Brief` attachment relative paths |
| **B. Not on the turn path, converted anyway (crate-wide rule / uniformity)** | **22** | `runtime::session_control` cwd wrappers (8), CLI helpers `cli/{args,session,status,help,git}.rs` (14) |
| **C. Not on the turn path, unchanged** | **32** | `main.rs` CLI startup / REPL / one-shot commands (30), `cli/export.rs`, `cli/cron.rs` |
| **D. Tests / doc comments** | **23** | `tools/tests` 4, `runtime/tests` 2, in-src `#[cfg(test)]` 15 (`tools` 12, `prompt.rs` 2, `git_context.rs` 1), doc comments 2 (`acp_sdk_server.rs:755`, `tools/lib.rs:2232`) |

32 + 22 + 32 + 23 = 109.

### A — turn / ACP-session path (32), all converted to `runtime::current_workspace_root()`

*runtime (7):* `bash.rs:142` (cwd handed to the spawned shell — the critical one), `bash.rs:662` (`execute_bash_with_tracking` fallback), `fs_backend.rs:289/296/305` (`StdFsBackend::working_root / normalize / normalize_allow_missing` — every relative path of `read_file/write_file/edit_file/glob/grep`), `conversation.rs:628` (coordinator inbox drain each turn), `memory/loader.rs:47` (`default_memory_dir`).

*tools (15):* `send_message_workspace` (SendMessage), `has_dangerous_paths` and `is_within_workspace` (bash permission classification), `todo_store_path` (TodoWrite), `resolve_skill_path` (Skill), `run_agent_job_returning_text`, `build_agent_system_prompt`, `persist_agent_terminal_state` inbox emit, `maybe_commit_provenance`, `load_sudocode_config`, `load_provider_fallback_config`, `agent_store_dir` ×2, `lookup_custom_agent` (Agent / TaskOutput family), `config_file_for_scope` (Config, Enter/ExitPlanMode).

*api (1):* `providers/mod.rs:261` `dotenv_value` — `.env` credential lookup; on the turn path through the Agent tool building child provider clients (and on runtime construction).

*CLI (9):* `main.rs` `ScopedCurrentDir::change_to` (the mechanism itself — deleted), `args.rs` `config_alias_for_current_dir` / `load_sudocode_config_for_current_dir` / `config_permission_mode_for_current_dir` / `config_model_for_current_dir` (reached from `push_images`, `get_model_info`, `/model`, `setModel`, `session/new|load` via `resolve_repl_model` / `default_permission_mode`), `session.rs` `current_session_store` (`session/load`), `status.rs` `status_context` (`/status`), `help.rs` `render_config_report` (`/config`), `doctor.rs` `render_doctor_report` (`/doctor`).

**Verifiable invariant after the change:** outside `#[cfg(test)]`, the crates
`runtime`, `tools`, `api`, `commands` contain **no** `env::current_dir()`
except the single fallback inside `runtime::workspace_root::current_workspace_root` itself.

## 2. Route chosen: A (thread-scoped workspace root), with explicit handoff to worker threads

`runtime::workspace_root` (new module, ~150 lines, no unit tests per repo rule):

* `WorkspaceRootScope::enter(root)` — RAII, thread-local, nests.
* `current_workspace_root()` — the scoped root, else `env::current_dir()`. So the
  REPL / one-shot CLI (which never enter a scope) behave exactly as before.
* `WorkspaceRootHandoff::capture() / enter()` — carries the root into a thread
  spawned from a turn.

The ACP server enters the scope for the session's cwd around every
session-bound `spawn_blocking` closure (prompt, new, load, setModel); the CLI
delegate does the same in `run_prompt_impl`, `build_session`, `load_session`,
`handle_acp_model_switch`, `handle_slash_command` (documented as the
`SdkAcpDelegate` contract). Nesting is harmless.

**Why not B (thread `workspace_root` through `ToolDispatchContext` into every tool):**
the 15 tools sites are deep helpers (`todo_store_path`, `agent_store_dir`,
`load_sudocode_config`, …) called from dozens of places, plus hooks, memory,
config, the API crate's `.env` lookup and the CLI slash-command helpers —
threading a parameter through all of them is a very large signature change
across four crates and still would not cover `api` (which cannot see
`ToolDispatchContext`) or the background sub-agent workers, which outlive the
tool call that spawned them. **Why not C:** once the accessor exists, making
bash / fs "explicit" on top of it adds no safety — they'd read the same value
from a parameter instead of the thread — and it splits the invariant into two
mechanisms to audit. One accessor + one grep-checkable invariant is easier to
keep honest.

**How I confirmed tool execution does not cross threads (the make-or-break for A):**

1. `run_prompt_impl` drives the turn with `self.inner.tokio_runtime.block_on(session.runtime.run_turn(..))`.
   `Runtime::block_on` polls the future on the *calling* thread (the
   `spawn_blocking` thread the ACP server started for this turn).
2. `ToolExecutor::execute_with_context(&mut self, ..)` is a synchronous
   method invoked inline from the tool loop; `conversation.rs` contains no
   `tokio::spawn` / `spawn_blocking` (grep). Hooks (`HookRunner`) run inline
   too; `hooks.rs` spawns no threads outside tests.
3. `bash`: `execute_bash_with_progress` reads the root **once, synchronously,
   on the turn thread** and passes it as an explicit `cwd` into
   `prepare_command` / `execute_bash_async`; the async body runs via
   `block_in_place(handle.block_on)` on the same thread anyway.
4. Threads a turn *does* create — full grep of `tokio::spawn|spawn_blocking|thread::spawn`
   over runtime/tools/api/commands/plugins/cli, non-test:
   * Agent tool sync auto-background thread and background `spawn_blocking`
     worker → `AgentJob.workspace: WorkspaceRootHandoff` captured at spawn,
     re-entered first thing on the worker (these outlive the tool call, so a
     capture-at-spawn is the only correct option);
   * WebFetch / WebSearch helper threads → handoff added (`execute_web_search`
     calls `load_sudocode_config()`, so this mattered);
   * `drain_group_child` pipe readers, VLM-describe thread, MCP transport
     tasks (`mcp_http/sse/ws`), stdin reader — touch no paths;
   * `runtime::mcp_stdio` spawns servers with an explicit `current_dir` when
     configured (session-injected servers always are); config-declared ones
     without it inherit the process cwd at spawn time, which happens under the
     lease during runtime construction — unchanged behaviour.
5. Mutation check: reintroducing `std::env::current_dir()` in one
   `StdFsBackend` method made the new isolation test fail with B's write
   landing in `decoy/` — the test observes exactly the failure mode A is
   accused of.

## 3. `WorkspaceCwdLease`: kept for runtime construction only, park/re-acquire machinery deleted

* **Deleted:** `CwdLeaseHandle`, `CwdLeaseHandleInner`, `parked()`, the
  `held` atomic, `CwdLeaseGuard::handle()`, `wait_parked`, and the
  `cwd_lease` fields on `AcpPermissionBridge` / `AcpQuestionBridge`. Turns
  hold no lease, so there is nothing to give back while parked — the "parked
  re-acquire failure continues without the lease" hazard from #417 §8 is gone
  by construction (there is no re-acquire).
* **Kept:** the ref-counted, cwd-keyed lease itself (`acquire(&Path) -> CwdLeaseGuard`),
  used by `session/new`, `session/load`, `session/setModel` and — the one
  exception in the prompt handler — **slash-command prompts** (`/model`
  rebuilds the session runtime; all slash commands are short and never park
  on the user). Rationale: runtime construction spawns config-declared MCP
  servers / plugin processes that inherit the process cwd. Regular turns
  never touch it.
* `session_lease_cwd` (canonical keying) kept.
* Also fixed: `sessionCapabilities.list` is now advertised (`session/list`
  was implemented but, like `loadSession` in #417, never declared).

## 4. The five invariants

1. **Same-session prompts stay serial** — unchanged mechanism: `SessionRegistry`
   lanes (`enter_lane`) around every session-scoped request; the workspace scope
   is per-thread and does not interact with ordering. Test: `acp_stdio_same_session_prompts_stay_serial` green (5/5 runs).
2. **Parked session does not block others** — the three tests
   `acp_stdio_paused_session_does_not_block_other_session_{same,other}_cwd`,
   `acp_stdio_session_parked_on_ask_user_question_does_not_block_other_session`
   green. Mechanically stronger than before: a parked turn now holds *nothing*
   process-wide (no lease at all), so there is no release/re-acquire window.
3. **Parked session finishes after the answer** — asserted at the end of the
   same three tests (A completes with the mock's "bash approved and executed"
   text and both sessions run another turn).
4. **File ops never cross into another session's cwd** — the risk of this
   change. Guarantees, layered:
   * every relative path of the file tools goes through `StdFsBackend::normalize*/working_root`, which read the scoped root; the shell gets an explicit `current_dir`; hooks get an explicit `current_dir`; workspace-anchored stores (`.sudocode-todos.json`, `.sudocode-agents`, `.sudocode-inbox`, memory dir, session store, `.env`, config) all read the scoped root;
   * worker threads inherit the root via handoff (Agent, WebFetch/WebSearch);
   * grep-checkable invariant: no `env::current_dir()` in runtime/tools/api/commands outside tests;
   * **new test `acp_stdio_concurrent_sessions_keep_file_ops_in_their_own_cwd`:** sessions in `project-a`, `project-b`, and a decoy session created *last* in `decoy` (so the process cwd — which runtime construction still sets — points at the decoy, and a leaked `current_dir()` would visibly land there rather than coincidentally in the right place). Each dir plus the workspace root has a differently-worded `fixture.txt`. While A runs `sleep 30`, `project-b` sessions `read_file fixture.txt` (must see `bravo-fixture`, none of the other three) and `write_file generated/output.txt` (must appear only under `project-b`), and A must still be running afterwards (proves concurrency, not sequencing). Then A is cancelled and `project-a` sessions do the same. Mutation-checked (see §2 item 5): red on the pre-fix tree by starvation, red on a single leaked `current_dir()` by misplacement.
5. **cancel / close / permission-mode paths** — `session/cancel` is exercised in the new isolation test (cancels the 30 s bash; the prompt gets its response and the session runs another turn afterwards). `session/close` and `session/setPermissionMode` are unchanged code (`setPermissionMode` runs in every new test); the full existing ACP suite (stdio + ws + MCP injection + resume) is green.

## 5. Red → green, and 5× stability

Both new tests against the pre-fix source (`git stash` of `crates/{api,runtime,tools,rusty-sudocode-cli/src}`, tests kept):

```
test acp_stdio_long_tool_does_not_block_other_cwd_session ... FAILED
test acp_stdio_concurrent_sessions_keep_file_ops_in_their_own_cwd ... FAILED
panicked at crates/rusty-sudocode-cli/tests/acp_integration.rs:1299:13:
session/new got no response within 20s while session A was running a long tool in
another cwd (cwd lease held for the whole turn); seen: [... "sessionUpdate":"tool_call" ... sleep 30 ...]
panicked at crates/rusty-sudocode-cli/tests/acp_integration.rs:1369:32:
project-b read_file while A busy in another cwd: no response within 20s; seen: [...]
test result: FAILED. 0 passed; 2 failed; ... finished in 23.32s
```

After the fix, `cargo test -p rusty-sudocode-cli --test acp_integration` ×5:

```
=== run 1  test result: ok. 15 passed; 0 failed; 0 ignored; finished in 4.02s
=== run 2  test result: ok. 15 passed; 0 failed; 0 ignored; finished in 4.01s
=== run 3  test result: ok. 15 passed; 0 failed; 0 ignored; finished in 4.03s
=== run 4  test result: ok. 15 passed; 0 failed; 0 ignored; finished in 4.02s
=== run 5  test result: ok. 15 passed; 0 failed; 0 ignored; finished in 4.03s
```

(15 = 13 pre-existing + 2 new; the two new ones take ~3.4 s and ~4 s.)
Mutation run (one `current_dir()` reintroduced in `StdFsBackend`): isolation test
FAILED with `filePath: .../decoy/generated/output.txt` — then reverted.

`cargo test --workspace`: **1644 passed, 0 failed, 6 ignored** (final run after
the last edit: see bottom of this file).

## 6. clippy before / after

`cargo clippy --workspace --all-targets -- -D warnings` fails on `main` and on
this branch identically: `error: could not compile telemetry (lib) due to 14 previous errors`
(the pre-existing pedantic lints; every `-->` in both logs points at
`crates/telemetry/src/lib.rs` — the after-run additionally got as far as the
`telemetry (lib test)` target, 14 + 2 test-only, before cargo aborted), so it
never reaches the other crates.
Comparable measurement, `cargo clippy --workspace --all-targets` (no `-D`),
same toolchain (rustc 1.92 clippy):

| | before (`ad6abe6`) | after |
|---|---|---|
| `^warning` lines, whole workspace | 902 | 902 |
| distinct (file, lint) warning sites | 817 | 817 |
| `runtime` (lib) | 163 | 163 |
| `tools` (lib) | 53 | 53 |
| `api` (lib) | 24 | 24 |
| `rusty-sudocode-cli` (bin `scode`) | 72 | 72 |
| `rusty-sudocode-cli` (test `acp_integration`) | 36 | 36 |

Only textual difference: `tools::prepare_agent_job` "too many lines (108/100)"
→ "(109/100)" (one added field initialiser). Three warnings my first draft
introduced (`needless_pass_by_value` on `acquire`, `similar_names` and
`too_many_lines` in the new test) were fixed before the count above.

## 7. Residual risks / not done

* **Runtime-construction paths still serialize per cwd** via the lease
  (`session/new`, `session/load`, `setModel`, slash commands). A slow
  `session/new` (e.g. a slow config-declared MCP server) can delay another
  cwd's `session/new` or `/status` — never a turn. Removing the lease entirely
  would need MCP/plugin spawns to take an explicit cwd; left as is (task said
  keep it there).
* **Process-global state that is *not* cwd** is unchanged and still shared
  across sessions: `AcpCliAgent.model` (process-wide current model — a
  `/model` in one session changes the fallback model for others, pre-existing),
  `GLOBAL_AUTH_MODE`, the in-memory task / agent registries (`TaskCreate` /
  `TaskList` see all sessions' tasks), `model_capabilities` cache. Out of scope.
* **`WorkspaceRootScope` fallback is the process cwd.** Outside ACP this is
  the desired behaviour; inside ACP every session-bound closure enters the
  scope, so a future call site that forgets to is covered as long as it runs
  on the turn thread or under a handoff. A future `thread::spawn` inside a
  tool that resolves paths without `WorkspaceRootHandoff` would regress to
  the process cwd (which is now "whichever runtime construction ran last").
  The isolation test's decoy layout is designed to catch exactly that if the
  path is exercised by a scenario; the grep invariant catches the
  `current_dir()` form. Not caught: a new relative-path `std::fs::*` call.
* Config-home fallback `.nexus/sudocode` when `HOME` is unset
  (`config.rs:756`) is relative to the process cwd — pre-existing edge, untouched.
* **Upstream apeiron end-to-end not run.** The deployed scode there is the
  #417 build; validating this change end-to-end needs the new binary deployed,
  which I cannot do from here. Local mock-based tests reproduce the 63 s
  symptom (20 s timeout in the red test) and its fix. The DeepSeek key was
  not used and appears nowhere in code, config, tests or this repo.
* `.claude/settings.json` shows as modified — that is hydra's hook wiring,
  not part of this change; left uncommitted. `task-scode-explicit-cwd.md`
  and this `REPORT.md` are untracked and not committed.

</details>
