### PR TITLE
docs(design): matrix sub-block sweep + red-? for undecided migrations

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -48,6 +48,8 @@
   .was{color:var(--muted)}
   .to{color:#7dd3fc}
   .arw{color:var(--accent);font-weight:700;margin:0 3px}
+  /* red "?" — a migration point we have NOT decided yet (a gap to fill) */
+  .tbd{color:var(--miss);font-weight:800;border:1px solid var(--miss);border-radius:4px;padding:0 5px;font-size:11.5px;white-space:nowrap}
   /* hover tooltip for uncertain / notes */
   .tip{position:relative;border-bottom:1px dotted var(--q);cursor:help;color:var(--q)}
   .tip .tipbox{visibility:hidden;opacity:0;transition:.12s;position:absolute;left:0;top:1.6em;z-index:9;
@@ -81,7 +83,7 @@
 <br><br>
 <b>This table's job:</b> put CC's flat <code>~/.claude/projects/&lt;cwd&gt;/</code> model on each row, then read across — (1) does the Nexus end-state <i>cover</i> it? (2) how do sudocode &amp; sudowork store it today, and what's <span class="b dup">dup</span> to merge? CC is the <span class="b ref">reference</span> we map from; Nexus is the target all three converge to.
 <br><br>
-<b>This is a working doc (migration burndown), not a snapshot.</b> CC (reference) and the Nexus end-state (target) are fixed; the two <b>current</b> columns — sudocode &amp; sudowork — are live. As each migration lands, advance that cell + its badge (<span class="b miss">gap</span> → <span class="b partial">partial</span> → <span class="b ok">done</span>); a row is finished when its <i>current</i> = the Nexus <i>target</i>. Update the cell in the same edit that lands the code.
+<b>This is a working doc (migration burndown), not a snapshot.</b> CC (reference) and the Nexus end-state (target) are fixed; the two <b>current</b> columns — sudocode &amp; sudowork — are live, written as <span class="was">original</span> <span class="arw">→</span> <span class="to">what it maps to</span>. As each migration lands, advance that cell + its badge (<span class="b miss">gap</span> → <span class="b partial">partial</span> → <span class="b ok">done</span>); a row is finished when its <i>current</i> = the Nexus <i>target</i>. Where we have <b>not decided</b> how a point migrates, the target slot is a red <span class="tbd">?</span> — a gap to fill, not an answer.
 </div>
 
 <div class="legend">
@@ -92,6 +94,7 @@
   <span><span class="b dup">dup</span> duplicated, merge long-term</span>
   <span><span class="b q">open?</span> design question (hover)</span>
   <span><span class="b na">n/a</span> not applicable</span>
+  <span><span class="tbd">?</span> migration undecided — a gap to fill</span>
 </div>
 
 <h2>The matrix</h2>
@@ -100,8 +103,8 @@
   <th style="width:6%">mega-type</th>
   <th style="width:11%">item</th>
   <th style="width:21%">Claude Code <span class="h2">current — reference model</span></th>
-  <th style="width:21%">sudocode <span class="h2">current — standalone (StdFsBackend)</span></th>
-  <th style="width:18%">sudowork <span class="h2">current — SQLite</span></th>
+  <th style="width:21%">sudocode <span class="h2">current → maps to</span></th>
+  <th style="width:18%">sudowork <span class="h2">current → maps to</span></th>
   <th style="width:23%">Nexus end-state <span class="h2">target — all converge here</span></th>
 </tr></thead>
 <tbody>
@@ -110,7 +113,9 @@
 <tr>
   <td class="mega" rowspan="2">Identity</td>
   <td class="item">Primary key</td>
-  <td class="cc">Sanitized <b>cwd</b> → <span class="path">~/.claude/projects/&lt;C--Users-…&gt;/</span> (Win) / <span class="path">-Users-…</span> (POSIX). One implicit agent per project.</td>
+  <td class="cc">
+    <div class="el"><b>cwd</b> (sanitized) is the primary key. <span class="path">~/.claude/projects/&lt;C--Users-…&gt;/</span> (Win) / <span class="path">-Users-…</span> (POSIX)</div>
+    <div class="el">one implicit agent per project</div></td>
   <td>
     <div class="el"><span class="was">cwd <b>fingerprint</b> (FNV-16hex) <span class="path">.scode/sessions/&lt;fp&gt;/</span></span> <span class="arw">→</span> <span class="to">retires — the per-repo tie becomes a <b>session→repo DT_LINK</b></span></div>
     <div class="el"><span class="was">local <code>session-id</code></span> <span class="arw">→</span> <span class="to">flat <span class="path">/sessions/&lt;session-id&gt;/</span></span></div>
@@ -132,48 +137,81 @@
 </tr>
 <tr>
   <td class="item">Image vs runtime split</td>
-  <td class="cc">None — flat. (<code>bridge-pointer.json</code> is the only runtime pointer.)</td>
-  <td>No explicit split: sessions on disk under cwd; config in <span class="path">~/.scode/</span>; <code>AGENTS.md</code> in repo. <span class="b miss">gap</span></td>
-  <td>All in SQLite <code>conversations.extra</code> — mixes static + runtime. <span class="b dup">dup</span></td>
-  <td><b>image</b> <span class="path">/agents/{name}/</span> vs <b>runtime</b> <span class="path">/proc/{pid}/</span>. <span class="b ok">given</span></td>
+  <td class="cc">
+    <div class="el">none — flat</div>
+    <div class="el"><code>bridge-pointer.json</code> is the only runtime pointer</div></td>
+  <td>
+    <div class="el"><span class="was">no explicit split — sessions under cwd, config in <span class="path">~/.scode/</span>, <code>AGENTS.md</code> in repo</span> <span class="arw">→</span> <span class="to">fold into image <span class="path">/agents/{name}/</span> + runtime <span class="path">/proc/{pid}/</span></span></div>
+    <span class="b miss">gap</span></td>
+  <td>
+    <div class="el"><span class="was">all in SQLite <code>conversations.extra</code> (mixes static + runtime)</span> <span class="arw">→</span> <span class="to">split into image + runtime layers</span></div>
+    <span class="b dup">dup</span></td>
+  <td>
+    <div class="el"><b>image</b> <span class="path">/agents/{name}/</span></div>
+    <div class="el"><b>runtime</b> <span class="path">/proc/{pid}/</span></div>
+    <span class="b ok">given</span></td>
 </tr>
 
 <!-- SESSION -->
 <tr>
   <td class="mega" rowspan="2">Session</td>
   <td class="item">Transcript file</td>
-  <td class="cc"><span class="path">~/.claude/projects/&lt;key&gt;/&lt;uuid&gt;.jsonl</span> — JSONL, up to multi-GB, parentUuid DAG.</td>
-  <td><span class="path">&lt;cwd&gt;/.scode/sessions/&lt;fp16&gt;/&lt;session-id&gt;.jsonl</span>. Typed records in one file: <code>session_meta</code> / <code>compaction</code> / <code>prompt_history</code> / <code>message</code>; rotate 256 KiB × 3. <span class="b ok">done</span></td>
-  <td><code>messages</code> table = full UI copy of the conversation (assistant + tool calls/results), joined by <code>acpSessionId</code>. <span class="b dup">dup — primary</span></td>
-  <td><b>RESOLVED (nexus #4564):</b> <span class="path">/sessions/&lt;session-id&gt;/transcript.jsonl</span> — flat; session-id is the <b>sole structural key</b> (no workspace_hash, no agent-name nesting). An <code>owner</code> attribute records ownership; repos the session touched are DT_LINKs on it (0..N); <span class="path">/agents/{name}/sessions/&lt;sid&gt;</span> is a DT_LINK <b>enum index — not SSOT</b> (<code>list(prefix)</code>=readdir); pid→session <span class="path">/proc/{pid}/session</span> (reaped). Isolation = policy not path → cross-agent search always structurally possible. <span class="b ok">given</span></td>
+  <td class="cc"><div class="el"><span class="path">~/.claude/projects/&lt;key&gt;/&lt;uuid&gt;.jsonl</span> — JSONL, up to multi-GB, parentUuid DAG</div></td>
+  <td>
+    <div class="el"><span class="was"><span class="path">.scode/sessions/&lt;fp16&gt;/&lt;session-id&gt;.jsonl</span> — records <code>session_meta</code>/<code>compaction</code>/<code>prompt_history</code>/<code>message</code>; rotate 256 KiB × 3</span> <span class="arw">→</span> <span class="to"><span class="path">/sessions/&lt;session-id&gt;/transcript.jsonl</span> (KernelFsBackend; drop the fp dir)</span></div>
+    <span class="b ok">done (local)</span></td>
+  <td>
+    <div class="el"><span class="was"><code>messages</code> table = full UI copy (assistant + tool calls/results), joined by <code>acpSessionId</code></span> <span class="arw">→</span> <span class="to">a view over the engine <span class="path">/sessions/&lt;sid&gt;/transcript.jsonl</span></span></div>
+    <span class="b dup">dup — primary</span></td>
+  <td>
+    <div class="el"><b><span class="path">/sessions/&lt;session-id&gt;/transcript.jsonl</span></b> — flat; session-id is the <b>sole structural key</b> (no workspace_hash, no agent nesting)</div>
+    <div class="el"><code>owner</code> attribute records ownership</div>
+    <div class="el">repos the session touched = DT_LINKs on it (0..N)</div>
+    <div class="el"><span class="path">/agents/{name}/sessions/&lt;sid&gt;</span> = DT_LINK enum index — <b>not SSOT</b> (<code>list(prefix)</code>=readdir)</div>
+    <div class="el">pid→session <span class="path">/proc/{pid}/session</span> (reaped)</div>
+    <div class="el">isolation = policy not path → cross-agent search always structurally possible</div>
+    <span class="b ok">given</span></td>
 </tr>
 <tr>
   <td class="item">Cross-agent /<br>cross-session search
     <span class="tip">?<span class="tipbox">CC keeps every session flat under one <code>projects/&lt;cwd&gt;/</code>, so search across sessions is trivial. In the per-agent model each agent's sessions live under its own <code>/agents/{name}/sessions/</code>. Do we DT_LINK them into a shared <code>/agents/sessions/</code> (or <code>/sessions/</code>) index for cross-agent search while keeping per-agent SSOT? (needs the cross-node DT_LINK story — see Workspace row.)</span></span>
   </td>
-  <td class="cc">Implicit — all sessions flat under the project dir; easy cross-session listing.</td>
-  <td><code>SessionStore</code> per workspace-fp; <code>--resume latest</code> / <code>list</code> (computed by scanning + mtime sort). <span class="b partial">partial</span></td>
-  <td>Own SQLite index (<code>getUserConversations</code>, <code>ORDER BY updated_at</code>); never enumerates engine files. <span class="b dup">dup</span></td>
-  <td><b>RESOLVED (Q1):</b> all sessions flat under <span class="path">/sessions/</span>; cross-agent access = scan <span class="path">/sessions/</span> or hold a DT_LINK; <b>isolation is policy (owner-default), not path</b>; link-follow re-auths (§13) so a link ≠ a pass. <span class="b ok">given</span></td>
+  <td class="cc"><div class="el">implicit — all sessions flat under the project dir; easy cross-session listing</div></td>
+  <td>
+    <div class="el"><span class="was"><code>SessionStore</code> per workspace-fp; <code>--resume latest</code>/<code>list</code> (scan + mtime)</span> <span class="arw">→</span> <span class="to">scan flat <span class="path">/sessions/</span> (isolation by policy)</span></div>
+    <span class="b partial">partial</span></td>
+  <td>
+    <div class="el"><span class="was">own SQLite index (<code>getUserConversations</code>, <code>ORDER BY updated_at</code>); never enumerates engine files</span> <span class="arw">→</span> <span class="to">list over <span class="path">/sessions/</span> (or an agent DT_LINK index)</span></div>
+    <span class="b dup">dup</span></td>
+  <td>
+    <div class="el">all sessions flat under <span class="path">/sessions/</span></div>
+    <div class="el">cross-agent access = scan <span class="path">/sessions/</span> or hold a DT_LINK</div>
+    <div class="el"><b>isolation = policy (owner-default), not path</b>; link-follow re-auths (§13) → link ≠ pass</div>
+    <span class="b ok">given</span></td>
 </tr>
 
 <!-- SUBAGENT -->
 <tr>
   <td class="mega" rowspan="2">Subagent<br>/ fork</td>
   <td class="item">Subagent transcript + meta</td>
-  <td class="cc"><span class="path">&lt;uuid&gt;/subagents/agent-&lt;id&gt;.jsonl</span> + <span class="path">.meta.json</span> — full sidechain transcript (<code>agentType</code> / <code>worktreePath</code>).</td>
-  <td><span class="path">&lt;cwd&gt;/.sudocode-agents/agent-&lt;id&gt;.md</span> + <span class="path">.json</span> (+ optional <span class="path">.full.md</span>). Subagent <code>Session</code> is <b>in-memory only</b> — <b>no per-subagent jsonl transcript</b>. <span class="b partial">partial — differs</span></td>
-  <td>—<span class="b na"> n/a</span> (relies on engine)</td>
-  <td>Each subagent = its own <b>pid</b> sharing the profile; session under <span class="path">/agents/{name}/sessions/</span>. <span class="b ok">given</span></td>
+  <td class="cc"><div class="el"><span class="path">&lt;uuid&gt;/subagents/agent-&lt;id&gt;.jsonl</span> + <span class="path">.meta.json</span> — full sidechain transcript (<code>agentType</code>/<code>worktreePath</code>)</div></td>
+  <td>
+    <div class="el"><span class="was"><span class="path">.sudocode-agents/agent-&lt;id&gt;.md</span> + <span class="path">.json</span> (+ <span class="path">.full.md</span>); Session in-memory only — <b>no per-subagent jsonl</b></span> <span class="arw">→</span> <span class="tbd">? Q5 (persist jsonl?)</span></div>
+    <span class="b partial">partial — differs</span></td>
+  <td><div class="el">— relies on engine</div> <span class="b na">n/a</span></td>
+  <td><div class="el">each subagent = its own <b>pid</b> sharing the profile; session under <span class="path">/sessions/&lt;sid&gt;/</span> (agent index links it)</div> <span class="b ok">given</span></td>
 </tr>
 <tr>
   <td class="item">Fork inheritance + spawn
     <span class="tip">?<span class="tipbox">scode has <b>two</b> forks: (1) session <code>--fork</code> clones the FULL parent transcript (parity with CC); (2) the <code>Agent</code> tool's <code>subagent_type=fork</code> inherits only the last-assistant <b>cache-prefix</b> (2 messages, byte-identical across parallel forks for prompt-cache sharing). Open: do we also persist a per-subagent jsonl (CC parity), and do subagent forks become real nexus pids via <b>sudocode → <code>ManagedAgentService::start_session</code></b>?</span></span>
   </td>
-  <td class="cc">Fork inherits full parent transcript + rendered system-prompt bytes (<code>agentType:'fork'</code>).</td>
-  <td>Session <code>--fork</code> = <b>FULL</b> transcript (<code>messages.clone()</code>). Subagent fork = <b>last-assistant cache-prefix only</b>. Internal spawn (not MAS). <span class="b partial">partial</span></td>
-  <td>—<span class="b na"> n/a</span></td>
-  <td>Subagent = real pid via <b>sudocode → MAS::start_session</b>. <span class="b q">open? (direction)</span></td>
+  <td class="cc"><div class="el">fork inherits full parent transcript + rendered system-prompt bytes (<code>agentType:'fork'</code>)</div></td>
+  <td>
+    <div class="el"><span class="was">session <code>--fork</code> = <b>FULL</b> transcript (<code>messages.clone()</code>)</span></div>
+    <div class="el"><span class="was">subagent fork = last-assistant <b>cache-prefix only</b>; internal spawn (not MAS)</span> <span class="arw">→</span> <span class="tbd">? Q5 (full-transcript? MAS pid?)</span></div>
+    <span class="b partial">partial</span></td>
+  <td><div class="el">— n/a</div> <span class="b na">n/a</span></td>
+  <td><div class="el">subagent = real pid via <b>sudocode → MAS::start_session</b></div> <span class="b q">open? (direction)</span></td>
 </tr>
 
 <!-- TOOL OUTPUT -->
@@ -182,69 +220,87 @@
   <td class="item">Oversized offload + replacement
     <span class="tip">?<span class="tipbox">CC spills any tool result over ~50k chars to <code>tool-results/&lt;toolUseId&gt;.txt|.json</code> and injects a <code>&lt;persisted-output&gt;</code> replacement + a <code>content-replacement</code> transcript record, so resume rebuilds a byte-identical prompt-cache prefix. scode has the schema fields (<code>persistedOutputPath/Size</code>) but they are ALWAYS <code>None</code> — it hard-truncates at 16 KiB instead. Adopt CC's disk-offload? Where on VFS?</span></span>
   </td>
-  <td class="cc"><span class="path">&lt;uuid&gt;/tool-results/&lt;toolUseId&gt;.txt|.json</span> + <code>content-replacement</code> record → byte-identical resume.</td>
-  <td>Fields <code>persistedOutputPath/Size</code> exist but always <code>None</code>; 16 KiB hard-truncate, no offload, no replacement record. <span class="b miss">gap</span></td>
-  <td>—<span class="b na"> n/a</span> (tool results inline in <code>messages.content</code> = <span class="b dup">dup</span>)</td>
-  <td><span class="b q">open?</span> proposed <span class="path">/agents/{name}/sessions/&lt;hash&gt;/tool-results/</span></td>
+  <td class="cc"><div class="el"><span class="path">&lt;uuid&gt;/tool-results/&lt;toolUseId&gt;.txt|.json</span> + <code>content-replacement</code> record → byte-identical resume</div></td>
+  <td>
+    <div class="el"><span class="was">fields <code>persistedOutputPath/Size</code> exist but always <code>None</code>; 16 KiB hard-truncate, no offload/replacement</span> <span class="arw">→</span> <span class="tbd">? Q4 (adopt CC offload → <span class="path">/sessions/&lt;sid&gt;/tool-results/</span>?)</span></div>
+    <span class="b miss">gap</span></td>
+  <td><div class="el">— relies on engine; tool results inline in <code>messages.content</code> (<span class="b dup">dup</span>)</div> <span class="b na">n/a</span></td>
+  <td><div class="el">proposed <span class="path">/sessions/&lt;sid&gt;/tool-results/</span></div> <span class="b q">open?</span></td>
 </tr>
 
 <!-- MEMORY -->
 <tr>
   <td class="mega" rowspan="8">Memory</td>
   <td class="item">Auto-memory (4 types)</td>
-  <td class="cc"><span class="path">projects/&lt;git-root&gt;/memory/</span> — user/feedback/project/reference + <code>MEMORY.md</code> index (keyed by git root).</td>
-  <td><span class="path">~/.scode/projects/&lt;slug&gt;/memory/</span> + <code>MEMORY.md</code>, 4 types, prompt-driven Write, slug = git root. <span class="b ok">done</span></td>
-  <td><b>None</b> of its own. <span class="b na">n/a (relies on engine)</span></td>
-  <td><span class="path">/agents/{name}/memory/</span> (agent-keyed). <span class="b ok">design</span></td>
+  <td class="cc"><div class="el"><span class="path">projects/&lt;git-root&gt;/memory/</span> — user/feedback/project/reference + <code>MEMORY.md</code> (keyed by git root)</div></td>
+  <td>
+    <div class="el"><span class="was"><span class="path">~/.scode/projects/&lt;slug&gt;/memory/</span> + <code>MEMORY.md</code>, 4 types, prompt-driven Write</span> <span class="arw">→</span> <span class="to"><span class="path">/agents/{name}/memory/</span></span></div>
+    <span class="b ok">done</span></td>
+  <td><div class="el">none of its own — relies on engine</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><span class="path">/agents/{name}/memory/</span> (agent-keyed)</div> <span class="b ok">design</span></td>
 </tr>
 <tr>
   <td class="item">Agent memory (per agent-type)</td>
-  <td class="cc"><span class="path">agent-memory/&lt;type&gt;/</span> (user) · <span class="path">.claude/agent-memory[-local]/&lt;type&gt;/</span> + git-distributable snapshots.</td>
-  <td><span class="path">&lt;base&gt;/agent-memory/&lt;agent_type&gt;/</span>, routed per-subagent (no cross-leak). <span class="b ok">done</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td><span class="path">/agents/{name}/memory/</span> is already per-agent. <span class="b ok">design</span></td>
+  <td class="cc"><div class="el"><span class="path">agent-memory/&lt;type&gt;/</span> (user) · <span class="path">.claude/agent-memory[-local]/&lt;type&gt;/</span> + git-distributable snapshots</div></td>
+  <td>
+    <div class="el"><span class="was"><span class="path">&lt;base&gt;/agent-memory/&lt;agent_type&gt;/</span>, routed per-subagent (no cross-leak)</span> <span class="arw">→</span> <span class="to"><span class="path">/agents/{name}/memory/</span> (already per-agent)</span></div>
+    <span class="b ok">done</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><span class="path">/agents/{name}/memory/</span> is already per-agent</div> <span class="b ok">design</span></td>
 </tr>
 <tr>
   <td class="item">extractMemories (turn-end auto-writer)</td>
-  <td class="cc">Forked subagent at <code>handleStopHooks</code> writes durable memories; cursor + mutual-exclusion with main agent.</td>
-  <td><b>Missing</b> — memory is prompt-driven only, no auto-fork writer at turn end. <span class="b miss">gap</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td><span class="path">/proc/{pid}/</span> fork writing to <span class="path">/agents/{name}/memory/</span>. <span class="b q">open?</span></td>
+  <td class="cc"><div class="el">forked subagent at <code>handleStopHooks</code> writes durable memories; cursor + mutual-exclusion with main agent</div></td>
+  <td>
+    <div class="el"><span class="was"><b>missing</b> — prompt-driven only, no turn-end auto-fork writer</span> <span class="arw">→</span> <span class="tbd">? Q2 (build? mechanism?)</span></div>
+    <span class="b miss">gap</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><span class="path">/proc/{pid}/</span> fork → <span class="path">/agents/{name}/memory/</span></div> <span class="b q">open?</span></td>
 </tr>
 <tr>
   <td class="item">Session memory (running summary)</td>
-  <td class="cc"><code>getSessionMemoryDir()</code> markdown notes for <i>this</i> convo → feeds compaction; <code>/summary</code>.</td>
-  <td><b>Missing</b> (needs forked-agent infra). <span class="b miss">gap</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td><span class="path">/proc/{pid}/</span> or session sidecar under <span class="path">sessions/&lt;hash&gt;/</span>. <span class="b q">open?</span></td>
+  <td class="cc"><div class="el"><code>getSessionMemoryDir()</code> markdown notes for <i>this</i> convo → feeds compaction; <code>/summary</code></div></td>
+  <td>
+    <div class="el"><span class="was"><b>missing</b> (needs forked-agent infra)</span> <span class="arw">→</span> <span class="tbd">? Q2</span></div>
+    <span class="b miss">gap</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><span class="path">/proc/{pid}/</span> or a sidecar under <span class="path">/sessions/&lt;sid&gt;/</span></div> <span class="b q">open?</span></td>
 </tr>
 <tr>
   <td class="item">Team memory (org-shared)</td>
-  <td class="cc"><span class="path">&lt;mem&gt;/team/</span> + server <code>/api/…/team_memory</code>; repo-slug keyed; server-authoritative, ETag, secret-scan.</td>
-  <td><b>Missing</b> (enterprise). <span class="b miss">gap</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td><span class="path">/agents/{name}/memory/team/</span> via <b>zone raft / federation</b> (native — no API). <span class="b q">open?</span></td>
+  <td class="cc"><div class="el"><span class="path">&lt;mem&gt;/team/</span> + server <code>/api/…/team_memory</code>; repo-slug keyed; server-authoritative, ETag, secret-scan</div></td>
+  <td>
+    <div class="el"><span class="was"><b>missing</b> (enterprise)</span> <span class="arw">→</span> <span class="tbd">? Q2</span></div>
+    <span class="b miss">gap</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><span class="path">/agents/{name}/memory/team/</span> via <b>zone raft / federation</b> (native — no API)</div> <span class="b q">open?</span></td>
 </tr>
 <tr>
   <td class="item">Auto-dream (consolidation)</td>
-  <td class="cc">Nightly forked <code>/dream</code> rewrites memory topic files + <code>MEMORY.md</code>; gates ≥24h &amp; ≥5 sessions; <code>.consolidate-lock</code>.</td>
-  <td><b>Missing.</b> <span class="b miss">gap</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td>Background <span class="path">/proc/{pid}/</span> job over <span class="path">sessions/</span> → <span class="path">memory/</span>. <span class="b q">open?</span></td>
+  <td class="cc"><div class="el">nightly forked <code>/dream</code> rewrites memory topic files + <code>MEMORY.md</code>; gates ≥24h &amp; ≥5 sessions; <code>.consolidate-lock</code></div></td>
+  <td>
+    <div class="el"><span class="was"><b>missing</b></span> <span class="arw">→</span> <span class="tbd">? Q2</span></div>
+    <span class="b miss">gap</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el">background <span class="path">/proc/{pid}/</span> job over <span class="path">/sessions/</span> → <span class="path">memory/</span></div> <span class="b q">open?</span></td>
 </tr>
 <tr>
   <td class="item">Daily logs (KAIROS)</td>
-  <td class="cc"><span class="path">&lt;mem&gt;/logs/YYYY/MM/YYYY-MM-DD.md</span> append-only; nightly <code>/dream</code> distills.</td>
-  <td><b>Missing.</b> <span class="b miss">gap</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td><span class="path">/agents/{name}/memory/logs/YYYY/MM/…</span> (append-only DT_FILE/DT_STREAM). <span class="b q">open?</span></td>
+  <td class="cc"><div class="el"><span class="path">&lt;mem&gt;/logs/YYYY/MM/YYYY-MM-DD.md</span> append-only; nightly <code>/dream</code> distills</div></td>
+  <td>
+    <div class="el"><span class="was"><b>missing</b></span> <span class="arw">→</span> <span class="tbd">? Q2</span></div>
+    <span class="b miss">gap</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><span class="path">/agents/{name}/memory/logs/YYYY/MM/…</span> (append-only DT_FILE/DT_STREAM)</div> <span class="b q">open?</span></td>
 </tr>
 <tr>
   <td class="item">Manual layer (/remember, CLAUDE.md)</td>
-  <td class="cc"><code>CLAUDE.md</code> / <code>CLAUDE.local.md</code> static; <code>/remember</code> reviews + promotes across layers.</td>
-  <td><code>AGENTS.md</code> scan (repo cwd); <code>/remember</code>? <span class="b partial">partial</span></td>
-  <td>None. <span class="b na">n/a</span></td>
-  <td>Repo-mounted under <span class="path">/proc/{pid}/workspace/{repo}/</span>. <span class="b ok">design</span></td>
+  <td class="cc"><div class="el"><code>CLAUDE.md</code> / <code>CLAUDE.local.md</code> static; <code>/remember</code> reviews + promotes across layers</div></td>
+  <td>
+    <div class="el"><span class="was"><code>AGENTS.md</code> scan (repo cwd); <code>/remember</code>?</span> <span class="arw">→</span> <span class="to">repo-mounted under <span class="path">/proc/{pid}/workspace/{repo}/</span></span></div>
+    <span class="b partial">partial</span></td>
+  <td><div class="el">none</div> <span class="b na">n/a</span></td>
+  <td><div class="el">repo-mounted under <span class="path">/proc/{pid}/workspace/{repo}/</span></div> <span class="b ok">design</span></td>
 </tr>
 
 <!-- RESUME -->
@@ -253,20 +309,35 @@
   <td class="item">Live / persistent-assistant pointer
     <span class="tip">?<span class="tipbox">CC's Kairos <code>bridge-pointer.json {sessionId,environmentId,source}</code> answers "which session is the live persistent assistant" with an mtime-TTL heartbeat (4h) + cross-worktree "pick freshest" scan. Nexus's <code>AgentRegistry</code> (pid FSM) is the SSOT for "which pid is live". Do we adopt CC's file-pointer for the STANDALONE/offline scode case (no nexus)? scode currently has NO stored pointer — it recomputes "latest" by scanning + mtime.</span></span>
   </td>
-  <td class="cc"><span class="path">&lt;cwd&gt;/bridge-pointer.json</span> — <code>{sessionId,environmentId,source}</code>, mtime TTL 4h, cross-worktree freshest.</td>
-  <td><code>--resume &lt;id|latest|last|recent&gt;</code>; "latest" recomputed by scanning + mtime — <b>no stored file pointer</b>. <span class="b partial">partial</span></td>
-  <td><code>extra.acpSessionId</code> (acp) / <code>extra.mossSessionId</code> (remote) = the resume pointer. <span class="b dup">dup</span></td>
-  <td><b>Resume key = session-id</b> (durable UUID); <b>AgentRegistry</b> (pid FSM, kernel SSOT) = "which pid is live" (runtime); MAS registers pid keyed by session-id. <span class="path">/proc/{pid}/</span> = the live boot. <span class="b ok">given</span></td>
+  <td class="cc"><div class="el"><span class="path">&lt;cwd&gt;/bridge-pointer.json</span> — <code>{sessionId,environmentId,source}</code>, mtime TTL 4h, cross-worktree freshest</div></td>
+  <td>
+    <div class="el"><span class="was"><code>--resume &lt;id|latest|last|recent&gt;</code>; "latest" recomputed by scan + mtime — <b>no stored file pointer</b></span> <span class="arw">→</span> <span class="to"><b>AgentRegistry</b> pid FSM when nexus present</span></div>
+    <div class="el"><span class="was">standalone/offline: no pointer</span> <span class="arw">→</span> <span class="tbd">? Q7 (adopt CC bridge-pointer?)</span></div>
+    <span class="b partial">partial</span></td>
+  <td>
+    <div class="el"><span class="was"><code>extra.acpSessionId</code> (acp) / <code>extra.mossSessionId</code> (remote) = resume pointer</span> <span class="arw">→</span> <span class="to">the durable <b>session-id</b></span></div>
+    <span class="b dup">dup</span></td>
+  <td>
+    <div class="el"><b>resume key = session-id</b> (durable UUID)</div>
+    <div class="el"><b>AgentRegistry</b> pid FSM (kernel SSOT) = "which pid is live"; MAS registers pid keyed by session-id</div>
+    <div class="el"><span class="path">/proc/{pid}/</span> = the live boot</div>
+    <span class="b ok">given</span></td>
 </tr>
 
 <!-- A2A -->
 <tr>
   <td class="mega">A2A</td>
   <td class="item">Agent-to-agent messaging</td>
-  <td class="cc"><span class="b na">n/a</span> (single machine, no native A2A)</td>
-  <td><span class="path">&lt;ws&gt;/.sudocode-inbox/&lt;recipient&gt;.jsonl</span> (append-only, <code>MailboxEnvelope</code>) — standalone. <span class="b ok">done</span></td>
-  <td>IM channels (Telegram / Lark / DingTalk) — separate surface. <span class="b na">n/a</span></td>
-  <td><b>chat-with-me DT_STREAM</b> + kernel-tier <code>a2a</code> crate: <code>MailboxStampingHook</code> stamps unforgeable <code>from</code>, armed at boot, universal for all writers; raft cross-node (§3.3). <span class="b ok">substrate done</span></td>
+  <td class="cc"><div class="el"><span class="b na">n/a</span> — single machine, no native A2A</div></td>
+  <td>
+    <div class="el"><span class="was"><span class="path">&lt;ws&gt;/.sudocode-inbox/&lt;recipient&gt;.jsonl</span> (append-only, <code>MailboxEnvelope</code>) — standalone</span> <span class="arw">→</span> <span class="to">chat-with-me DT_STREAM (nexus a2a)</span></div>
+    <span class="b ok">done</span></td>
+  <td><div class="el">IM channels (Telegram / Lark / DingTalk) — separate surface</div> <span class="b na">n/a</span></td>
+  <td>
+    <div class="el"><b>chat-with-me DT_STREAM</b> + kernel <code>a2a</code> crate</div>
+    <div class="el"><code>MailboxStampingHook</code> stamps unforgeable <code>from</code>, armed at boot, universal for all writers</div>
+    <div class="el">raft cross-node (§3.3)</div>
+    <span class="b ok">substrate done</span></td>
 </tr>
 
 <!-- WORKSPACE -->
@@ -275,30 +346,47 @@
   <td class="item">Workspace &amp; multi-path
     <span class="tip">?<span class="tipbox">DT_LINK follow = full syscall re-entry on the target, so a link to a <b>federation-mounted</b> path resolves cross-node for free (inherits DT_FILE <code>try_remote_fetch</code> via <code>last_writer_address</code>). So <code>workspace/</code> linking repos across a distributed VFS works today for mounted targets; default-mount the launch path (project root) as <code>workspace[0]</code> is trivially local. Only a target on a node with NO local mount/zone needs genuinely-new owner-discovery ("who owns X", which no primitive provides) — see Q6.</span></span>
   </td>
-  <td class="cc">cwd IS the (single) workspace.</td>
-  <td>cwd = workspace (single); <code>workspace_fingerprint</code>. <span class="b partial">partial</span></td>
-  <td><code>extra.workspace</code> / <code>customWorkspace</code> / <code>mossWorkDir</code>. <span class="b dup">dup</span></td>
-  <td><b>Per-agent worktree, per-pid view</b> — <i>not</i> a mismatch. The repo worktree is persistent + <b>agent-name-owned</b> (<span class="path">/repos/{owner}/{repo}/</span>, rev4); <span class="path">/proc/{pid}/workspace/{alias}</span> is just an <b>ephemeral per-pid DT_LINK</b> into it (§2.2, reaped on exit). The pid path is a <i>view</i>, not the store. Multi-repo cross-node works for federation-mounted targets. <span class="b ok">given</span></td>
+  <td class="cc"><div class="el">cwd IS the (single) workspace</div></td>
+  <td>
+    <div class="el"><span class="was">cwd = workspace (single); <code>workspace_fingerprint</code></span> <span class="arw">→</span> <span class="to"><span class="path">/proc/{pid}/workspace/{alias}</span> DT_LINKs to repo zones</span></div>
+    <span class="b partial">partial</span></td>
+  <td>
+    <div class="el"><span class="was"><code>extra.workspace</code> / <code>customWorkspace</code> / <code>mossWorkDir</code></span> <span class="arw">→</span> <span class="to">repo DT_LINKs (<span class="path">/repos/</span> zones)</span></div>
+    <span class="b dup">dup</span></td>
+  <td>
+    <div class="el"><b>per-agent worktree, per-pid view</b> — not a mismatch</div>
+    <div class="el">repo worktree persistent + <b>agent-name-owned</b> (<span class="path">/repos/{owner}/{repo}/</span>)</div>
+    <div class="el"><span class="path">/proc/{pid}/workspace/{alias}</span> = ephemeral per-pid DT_LINK (§2.2, reaped) — a view, not the store</div>
+    <div class="el">multi-repo cross-node works for federation-mounted targets</div>
+    <span class="b ok">given</span></td>
 </tr>
 
 <!-- CROSS-MACHINE -->
 <tr>
   <td class="mega">Cross-<br>machine</td>
   <td class="item">Sync</td>
-  <td class="cc"><span class="b na">n/a</span> (single machine)</td>
-  <td>Inherits nexus VFS when embedded (<code>KernelFsBackend</code>); standalone = local FS only. <span class="b partial">partial</span></td>
-  <td>—<span class="b na"> n/a</span></td>
-  <td><b>Native</b> — distributed VFS: zone raft + federation mounts + FUSE over Tailscale (Mac↔Win byte-exact). <span class="b ok">done</span></td>
+  <td class="cc"><div class="el"><span class="b na">n/a</span> — single machine</div></td>
+  <td>
+    <div class="el"><span class="was">inherits nexus VFS when embedded (<code>KernelFsBackend</code>); standalone = local FS only</span> <span class="arw">→</span> <span class="to">native distributed VFS</span></div>
+    <span class="b partial">partial</span></td>
+  <td><div class="el">— n/a</div> <span class="b na">n/a</span></td>
+  <td><div class="el"><b>native</b> — distributed VFS: zone raft + federation mounts + FUSE over Tailscale (Mac↔Win byte-exact)</div> <span class="b ok">done</span></td>
 </tr>
 
 <!-- MIGRATION -->
 <tr>
   <td class="mega">Migration</td>
   <td class="item">Path to end-state</td>
-  <td class="cc"><span class="b ref">reference</span> — the model, not a migrator.</td>
-  <td>flat <span class="path">.scode/sessions/</span> (StdFsBackend) → <span class="path">/agents/{name}/sessions/&lt;hash&gt;/</span> (KernelFsBackend). Seam dormant (CLI defaults StdFs) → wire it, <b>cherry-pickable per surface</b>. <b>Caveat:</b> only <code>SessionStore</code>/<code>ConfigLoader</code>/<code>file_ops</code> route through <code>FsBackend</code>; <b>subagent store · mailbox · memory bypass it</b> (direct <code>std::fs</code>) → separate work to nexus-back those. <span class="b q">open? (priority)</span></td>
-  <td><code>messages</code> table → view over engine JSONL keyed by <code>acpSessionId</code>; keep only UI-unique fields (position/status/pin/cron/channel/user_id) — i.e. <b>sudowork becomes a thin UI over the engine transcript</b> (à la Claude Desktop). <span class="b dup">dup → merge</span></td>
-  <td><b>The superset</b> all others migrate toward.</td>
+  <td class="cc"><div class="el"><span class="b ref">reference</span> — the model, not a migrator</div></td>
+  <td>
+    <div class="el"><span class="was">flat <span class="path">.scode/sessions/</span> (StdFsBackend)</span> <span class="arw">→</span> <span class="to"><span class="path">/sessions/&lt;sid&gt;/</span> (KernelFsBackend); seam dormant → wire it, cherry-pickable per surface</span></div>
+    <div class="el"><b>caveat:</b> only <code>SessionStore</code>/<code>ConfigLoader</code>/<code>file_ops</code> route through <code>FsBackend</code>; <b>subagent · mailbox · memory bypass it</b> (direct <code>std::fs</code>) → separate work</div>
+    <span class="b q">open? (priority — Q8)</span></td>
+  <td>
+    <div class="el"><span class="was"><code>messages</code> table</span> <span class="arw">→</span> <span class="to">a view over the engine JSONL keyed by <code>acpSessionId</code>; keep only UI-unique fields (position/status/pin/cron/channel/user_id)</span></div>
+    <div class="el"><b>sudowork becomes a thin UI</b> over the engine transcript (à la Claude Desktop)</div>
+    <span class="b dup">dup → merge</span></td>
+  <td><div class="el"><b>the superset</b> all others migrate toward</div></td>
 </tr>
 
 </tbody>
@@ -323,17 +411,17 @@
 
 <h2>Open questions (for consensus)</h2>
 <div class="qbox"><span class="qn">Q1</span> <b>Session identity &amp; path — RESOLVED (nexus, 2026-08).</b> <u>Axis B (identity):</u> <b>session-id ≠ pid</b> — three IDs: agent-name (durable principal) · session-id (durable UUID, <code>--resume</code> key, spans N pids) · pid (ephemeral runtime handle). §2.3 had borrowed "session_id" to name the pid handle; fix = <code>start_session_v1</code> takes an optional session_id (resume) and returns {session_id, pid, workspace_path}; addressing fields renamed to pid. <u>Axis A (path):</u> <b>flat <span class="path">/sessions/&lt;session-id&gt;</span></b> is the byte SSOT (no workspace_hash, no agent-name nesting); an <code>owner</code> field drives default policy; all associations are DT_LINKs (agent→sessions, session→repo 0..N, pid→session). Isolation = <b>policy (soft), not path</b> — MetaStore has only get/list, so a DT_LINK dir-index reuses native <code>list(prefix)</code> = O(subset) vs building an attribute index. <small>Landed as <b>nexus #4564</b> (nexus-integration-architecture §2.1/§2.3, merged to develop); the two end-state cells above are updated to match.</small></div>
-<div class="qbox"><span class="qn">Q2</span> <b>Memory build-out.</b> Which of the 5 missing memory features (extractMemories · session-memory · team-memory · auto-dream · daily-logs) does scode build, and in what order? And where does <b>project-memory</b> live when a workspace DT_LINKs several repos — at the primary mount root (≈ launch path)?</div>
+<div class="qbox"><span class="qn">Q2</span> <b>Memory build-out.</b> Which of the 5 missing memory features (extractMemories · session-memory · team-memory · auto-dream · daily-logs) does scode build, and in what order? And where does <b>project-memory</b> live when a workspace DT_LINKs several repos — at the primary mount root (≈ launch path)? <small>(the 5 red <span class="tbd">?</span> in the Memory rows resolve here)</small></div>
 <div class="qbox"><span class="qn">Q3</span> <b>Cross-agent session search</b> via DT_LINK <code>/agents/{name}/sessions/</code> → shared <code>/agents/sessions/</code> index? <small>(depends on Q1 session-path + Q6; and on the nexus <b>search-plugin</b> — Rust glob/grep port committed, Python search service today)</small></div>
-<div class="qbox"><span class="qn">Q4</span> <b>Oversized tool-output offload</b> (CC's <code>tool-results/</code> + <code>content-replacement</code>) into scode — adopt? Path under <code>/agents/{name}/sessions/&lt;hash&gt;/tool-results/</code>?</div>
-<div class="qbox"><span class="qn">Q5</span> <b>Subagent parity.</b> (a) Persist a per-subagent jsonl transcript (CC's <code>agent-&lt;id&gt;.jsonl</code>+<code>.meta.json</code>) vs today's md/json artifacts? (b) Keep subagent-fork at cache-prefix, or make it full-transcript like session <code>--fork</code>? (c) Move subagents to nexus-managed pids (sudocode → <code>MAS::start_session</code>)?</div>
+<div class="qbox"><span class="qn">Q4</span> <b>Oversized tool-output offload</b> (CC's <code>tool-results/</code> + <code>content-replacement</code>) into scode — adopt? Path under <code>/sessions/&lt;sid&gt;/tool-results/</code>? <small>(the red <span class="tbd">?</span> in the Tool-output row resolves here)</small></div>
+<div class="qbox"><span class="qn">Q5</span> <b>Subagent parity.</b> (a) Persist a per-subagent jsonl transcript (CC's <code>agent-&lt;id&gt;.jsonl</code>+<code>.meta.json</code>) vs today's md/json artifacts? (b) Keep subagent-fork at cache-prefix, or make it full-transcript like session <code>--fork</code>? (c) Move subagents to nexus-managed pids (sudocode → <code>MAS::start_session</code>)? <small>(the 2 red <span class="tbd">?</span> in the Subagent rows resolve here)</small></div>
 <div class="qbox"><span class="qn">Q6</span> <b>Workspace &amp; DT_LINK — RESOLVED (nexus rev4).</b> Case A (link to a federation-mounted target resolves cross-node for free) verified. Case B (owner-discovery for a target on a node with no local mount) <b>declined</b> on structural grounds: <code>ZoneMetaStore.last_writer_address</code> is the owner SSOT; a separate path→owner registry = shadow SSOT + DRY violation + leaks federation topology into the kernel. <b>Decision: constrain workspace/link targets to federation-mounted paths</b> — ships today, zero new primitive. See the decisions callout above.</div>
-<div class="qbox"><span class="qn">Q7</span> <b>Standalone resume pointer.</b> Adopt CC's <code>bridge-pointer.json</code> (mtime-heartbeat + cross-worktree-freshest) for the offline scode case? (<code>AgentRegistry</code> is SSOT when nexus is present; standalone has no stored pointer today.)</div>
-<div class="qbox"><span class="qn">Q8</span> <b>Migration sequencing.</b> Order of: (a) wire scode's dormant <code>KernelFsBackend</code> seam (flat <code>.scode/sessions/</code> → layered <code>/agents/{name}/</code>); (b) collapse sudowork <code>messages</code> → a view over the engine JSONL keyed by <code>acpSessionId</code>; (c) build the missing memory features. Which first?</div>
+<div class="qbox"><span class="qn">Q7</span> <b>Standalone resume pointer.</b> Adopt CC's <code>bridge-pointer.json</code> (mtime-heartbeat + cross-worktree-freshest) for the offline scode case? (<code>AgentRegistry</code> is SSOT when nexus is present; standalone has no stored pointer today.) <small>(the red <span class="tbd">?</span> in the Resume row resolves here)</small></div>
+<div class="qbox"><span class="qn">Q8</span> <b>Migration sequencing.</b> Order of: (a) wire scode's dormant <code>KernelFsBackend</code> seam (flat <code>.scode/sessions/</code> → flat <code>/sessions/&lt;sid&gt;/</code>); (b) collapse sudowork <code>messages</code> → a view over the engine JSONL keyed by <code>acpSessionId</code>; (c) build the missing memory features. Which first?</div>
 <div class="qbox"><span class="qn">Q9</span> <b>sudowork adoption of the nexus workspace/identity model.</b> sudowork today has only conversation-id (SQLite) + <code>extra.workspace</code> — <b>no <code>agent-name</code> identity, no zones, no image/runtime split</b>. rev4 makes the workspace layout a <b>sudowork convention</b>, so this is ours to decide: (a) introduce the persistent <code>agent-name</code> layer — does a sudowork conversation map to a <code>session-id</code>, and what <i>is</i> <code>agent-name</code> (the CLI agent profile? the account/user?)? (b) adopt the content-type-first zones (<span class="path">/repos · /knowledge · /skills · /tools · /sessions · /scratch</span>) — which day 1? (c) reconcile zone-level <code>zone_perms</code> with sudowork's current per-<code>user_id</code> SQLite access (esp. multi-user WebUI + IM channels); (d) <code>on_terminate</code> GC policy — what does sudowork <code>sys_rmdir</code> on pid exit (<span class="path">/scratch</span> only, or more)? <small>(sudowork-side; (a)/(b) are product-direction calls — Ethan.)</small></div>
 
 <p class="note"><b>Repo SSOT:</b> <code>sudoprivacy/sudocode : docs/design/agent-context-storage-matrix.html</code> — this ShareOne view is remote-url-backed by that file, so comment here and the repo file is the source of record. Once consensus lands, this table gets tracked into <code>nexus-integration-architecture</code>.</p>
-<p class="note">Sources: Claude Code src/ (session/memory/bridge); sudocode origin/main v0.1.15 code-verified (session_control.rs / session.rs / tools / bash.rs / memory / agent_mailbox.rs); sudowork (database/schema.ts / storage.ts / AcpAgent.ts); <code>nexus-integration-architecture</code> §2–3. §3.3 verified current (a2a stamp hook in kernel <code>a2a</code> crate, armed at boot — no drift). Nexus <b>rev4 workspace reply</b> folded into Q1/Q6 + the decisions callout, verified against nexus-vfs. Draft 2026-07 — sudowork-win-pc-4.</p>
+<p class="note">Sources: Claude Code src/ (session/memory/bridge); sudocode origin/main v0.1.15 code-verified (session_control.rs / session.rs / tools / bash.rs / memory / agent_mailbox.rs); sudowork (database/schema.ts / storage.ts / AcpAgent.ts); <code>nexus-integration-architecture</code> §2–3. §3.3 verified current (a2a stamp hook in kernel <code>a2a</code> crate, armed at boot — no drift). Nexus <b>rev4 workspace reply</b> folded into Q1/Q6 + the decisions callout; session identity/path folded from <b>nexus #4564</b>. Draft 2026-08 — sudowork-win-pc-4.</p>
 
 </div>
 </body>


### PR DESCRIPTION
Whole-matrix presentational rewrite: per-element sub-blocks, current->maps-to, red-? gap markers for undecided migration points, stale paths aligned to /sessions/<sid>/. Same data, verified render (6 cols, no phantom).