### PR TITLE
feat(cli): sudoprivacy VI color theme + dynamic model identity

### DIFF
--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -40,14 +40,22 @@ impl From<ConfigError> for PromptBuildError {
 pub const SYSTEM_PROMPT_DYNAMIC_BOUNDARY: &str = "__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__";
 /// Human-readable label used for the "Model family" environment bullet
 /// when the provider is Anthropic.
-pub const FRONTIER_MODEL_NAME: &str = "Claude Opus 4.6";
+/// Fallback label when no model-specific display name is available.
+pub const FRONTIER_MODEL_NAME: &str = "Claude";
 
 const MAX_INSTRUCTION_FILE_CHARS: usize = 4_000;
 const MAX_TOTAL_INSTRUCTION_CHARS: usize = 12_000;
 
-/// Neutral identity for the model family line in generated prompts.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Identity for the "Model family" line in the system prompt environment section.
+///
+/// `Named(display_name)` is preferred — it carries the human-readable name
+/// from `sudocode.json` (e.g. "Claude Opus 4.8", "GPT 5.4").
+/// The legacy `Claude` / `Generic` variants are fallbacks when the caller
+/// cannot resolve a display name.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum ModelFamilyIdentity {
+    /// Model with a known display name (from sudocode.json SSOT).
+    Named(String),
     #[default]
     Claude,
     Generic,
@@ -55,8 +63,9 @@ pub enum ModelFamilyIdentity {
 
 impl ModelFamilyIdentity {
     #[must_use]
-    pub const fn family_label(self) -> &'static str {
+    pub fn family_label(&self) -> &str {
         match self {
+            Self::Named(name) => name.as_str(),
             Self::Claude => FRONTIER_MODEL_NAME,
             Self::Generic => "an AI assistant",
         }
@@ -270,7 +279,7 @@ impl SystemPromptBuilder {
             || "unknown".to_string(),
             |context| context.cwd.display().to_string(),
         );
-        let identity = self.model_family.unwrap_or_default();
+        let identity = self.model_family.as_ref().cloned().unwrap_or_default();
         let mut lines = vec!["# Environment context".to_string()];
         lines.extend(prepend_bullets(vec![
             format!("Model family: {}", identity.family_label()),

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -862,7 +862,7 @@ fn print_system_prompt(
         date,
         env::consts::OS,
         "unknown",
-        model_family_identity_for(model),
+        resolve_model_identity(model),
     )?;
     // Mirror what build_runtime_with_plugin_state does for live sessions:
     // append active SudoCode plugin capabilities so system-prompt output
@@ -5750,7 +5750,7 @@ fn build_system_prompt_for(
         runtime::today_local(),
         env::consts::OS,
         "unknown",
-        model_family_identity_for(model),
+        resolve_model_identity(model),
     )?;
     // Coordinator mode: when the SUDOCODE_COORDINATOR_MODE env var is
     // set, prepend the ported CC-fork coordinator role prompt so it
@@ -5758,6 +5758,27 @@ fn build_system_prompt_for(
     // runtime::coordinator_mode for the full port.
     runtime::coordinator_mode::apply_coordinator_prompt_if_enabled(&mut prompt);
     Ok(prompt)
+}
+
+/// Resolve model identity for the system prompt from sudocode.json SSOT.
+///
+/// Looks up `models.<id>.name` in the loaded config; falls back to the
+/// provider-based enum identity if no entry exists.
+fn resolve_model_identity(model: &str) -> runtime::ModelFamilyIdentity {
+    let config = load_sudocode_config_for_current_dir();
+    // Try exact match by alias key.
+    if let Some(entry) = config.models.get(model) {
+        return runtime::ModelFamilyIdentity::Named(entry.name.clone());
+    }
+    // Case-insensitive alias search.
+    let lower = model.to_ascii_lowercase();
+    for entry in config.models.values() {
+        if entry.alias.eq_ignore_ascii_case(model) || entry.name.to_ascii_lowercase() == lower {
+            return runtime::ModelFamilyIdentity::Named(entry.name.clone());
+        }
+    }
+    // Fallback: use model ID as display name (better than a generic label).
+    runtime::ModelFamilyIdentity::Named(model.to_string())
 }
 
 fn build_runtime_plugin_state() -> Result<RuntimePluginState, Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-sudocode-cli/src/render.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render.rs
@@ -156,31 +156,45 @@ pub struct ColorTheme {
 }
 
 impl ColorTheme {
+    // ── Sudoprivacy VI palette ─────────────────────────────────────
+    //
+    // Brand colors (from sudowork.sudoprivacy.com):
+    //   amber  #F59E0B  → ANSI 214  primary brand touch-point
+    //   teal   #0D9488  → ANSI 36   secondary brand touch-point
+    //
+    // Semantic colors (industry standard, not brand-specific):
+    //   success = green, error = red, diff = green/red
+    //
+    // Derived:
+    //   warning  = teal-bright #2DD4BF → ANSI 79  (avoids amber clash with primary)
+    //   muted    = VI grey #6b7280     → ANSI 243
+    //   border   = VI border #E5E7EB   → ANSI 248
+
     /// Dark terminal background (default).
     #[must_use]
     pub fn dark() -> Self {
         Self {
-            primary: Color::Cyan,
-            success: Color::Green,
-            error: Color::Red,
-            warning: Color::Yellow,
-            info: Color::Blue,
-            muted: Color::DarkGrey,
-            emphasis: Color::Magenta,
-            strong: Color::Yellow,
-            link: Color::Blue,
-            code: Color::Green,
-            code_bg: 236,
-            border: Color::AnsiValue(245),
-            diff_added: Color::AnsiValue(70),
-            diff_removed: Color::AnsiValue(203),
-            hook_feedback: Color::AnsiValue(214),
-            logo: Color::AnsiValue(117),
-            logo_accent: Color::AnsiValue(208),
-            quote: Color::DarkGrey,
+            primary: Color::AnsiValue(214),       // amber #F59E0B
+            success: Color::Green,                // semantic
+            error: Color::Red,                    // semantic
+            warning: Color::AnsiValue(79),        // teal-bright #2DD4BF
+            info: Color::AnsiValue(36),           // teal #0D9488
+            muted: Color::AnsiValue(243),         // grey #767676
+            emphasis: Color::AnsiValue(214),      // amber (italic text)
+            strong: Color::White,                 // bold text
+            link: Color::AnsiValue(36),           // teal
+            code: Color::AnsiValue(79),           // teal-bright
+            code_bg: 236,                         // dark grey bg
+            border: Color::AnsiValue(248),        // light grey
+            diff_added: Color::AnsiValue(70),     // semantic green
+            diff_removed: Color::AnsiValue(203),  // semantic red
+            hook_feedback: Color::AnsiValue(214), // amber
+            logo: Color::AnsiValue(214),          // amber
+            logo_accent: Color::AnsiValue(36),    // teal
+            quote: Color::AnsiValue(243),         // grey
             heading_h2: Color::White,
-            heading_h3: Color::Blue,
-            heading_h4: Color::Grey,
+            heading_h3: Color::AnsiValue(36),  // teal
+            heading_h4: Color::AnsiValue(243), // grey
         }
     }
 
@@ -188,27 +202,27 @@ impl ColorTheme {
     #[must_use]
     pub fn light() -> Self {
         Self {
-            primary: Color::DarkCyan,
-            success: Color::DarkGreen,
-            error: Color::DarkRed,
-            warning: Color::AnsiValue(130), // dark orange
-            info: Color::DarkBlue,
-            muted: Color::Grey,
-            emphasis: Color::DarkMagenta,
-            strong: Color::AnsiValue(130),
-            link: Color::DarkBlue,
-            code: Color::DarkGreen,
-            code_bg: 253, // light grey bg
-            border: Color::AnsiValue(240),
-            diff_added: Color::AnsiValue(22),    // dark green
-            diff_removed: Color::AnsiValue(124), // dark red
-            hook_feedback: Color::AnsiValue(130),
-            logo: Color::AnsiValue(25),         // dark blue
-            logo_accent: Color::AnsiValue(166), // dark orange
-            quote: Color::Grey,
+            primary: Color::AnsiValue(172),       // darker amber #D97706
+            success: Color::DarkGreen,            // semantic
+            error: Color::DarkRed,                // semantic
+            warning: Color::AnsiValue(30),        // dark teal #008787
+            info: Color::AnsiValue(30),           // dark teal
+            muted: Color::AnsiValue(245),         // medium grey
+            emphasis: Color::AnsiValue(172),      // darker amber
+            strong: Color::Black,                 // bold text
+            link: Color::AnsiValue(30),           // dark teal
+            code: Color::AnsiValue(30),           // dark teal
+            code_bg: 253,                         // light grey bg
+            border: Color::AnsiValue(250),        // light grey
+            diff_added: Color::AnsiValue(22),     // semantic dark green
+            diff_removed: Color::AnsiValue(124),  // semantic dark red
+            hook_feedback: Color::AnsiValue(172), // darker amber
+            logo: Color::AnsiValue(172),          // darker amber
+            logo_accent: Color::AnsiValue(30),    // dark teal
+            quote: Color::AnsiValue(245),         // grey
             heading_h2: Color::Black,
-            heading_h3: Color::DarkBlue,
-            heading_h4: Color::DarkGrey,
+            heading_h3: Color::AnsiValue(30),  // dark teal
+            heading_h4: Color::AnsiValue(245), // grey
         }
     }
 


### PR DESCRIPTION
## Summary
- **Color theme**: Replace generic cyan/blue/yellow palette with Sudoprivacy VI — amber primary, teal info, teal-bright warning/code. Semantic colors (success/error/diff) unchanged.
- **Model identity fix**: System prompt now shows actual model name from sudocode.json SSOT instead of hardcoded "Claude Opus 4.6" for all models. `ModelFamilyIdentity::Named(String)` variant resolves display name dynamically.

## Test plan
- [x] 40 prompt tests pass
- [x] 146 CLI unit tests pass
- [x] `cargo fmt` + `cargo check` clean
- [x] Manual verification: `/model claude-opus-4-8` → model self-identifies correctly