### PR TITLE
docs(design): sudowork delegates identity to sudocode (Q9 a/b)

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -99,7 +99,7 @@
   <span><span class="tbd">?</span> migration undecided — a gap to fill</span>
 </div>
 <p class="note"><b>Badges compare each system to the target, per row.</b> <b>gap</b> — this system lacks a capability CC has / the end-state needs; on the burndown it advances <span class="b miss">gap</span> → <span class="b partial">partial</span> → <span class="b ok">done</span> (what's missing is the <span class="was">left</span> side of that cell). <b>dup</b> — it keeps its <i>own</i> copy of data the <b>engine</b> (scode's session jsonl, ultimately the nexus <code>/sessions/</code> SSOT) already owns; <b>"merge long-term"</b> = that copy collapses into a <i>view</i> over the one SSOT — one store, not two. Example: sudowork's <code>messages</code> table is a full duplicate of the engine transcript → becomes a view (see the Migration row).</p>
-<p class="note"><b>The sudowork column reads in 3 buckets.</b> <b>stays (SQLite)</b> = UI-unique, kept · <b>→ sudocode</b> = delegate to the engine (read its store — the dedup) · <b>→ nexus (direct)</b> = what sudowork adopts <i>itself</i> on nexus (agent-name / zones, Q9) — <i>not</i> the transitive <code>engine→nexus</code>, which is the sudocode column's job. Chain: sudowork → sudocode → nexus, so each hop is written once.</p>
+<p class="note"><b>The sudowork column reads in 3 buckets.</b> <b>stays (SQLite)</b> = UI-unique, kept · <b>→ sudocode</b> = delegate to the engine — read its store; this is where the <i>agent</i> identity lives (<code>session-id</code> · <code>agent-name</code> · zones), since sudowork is a UI and sudocode is the agent · <b>→ nexus (direct)</b> = only what sudowork does <i>without</i> the engine (rare for a UI — e.g. multi-user ACL, Q9c). Chain: <code>sudowork → sudocode → nexus</code>, each hop written once. <b>Consistency check (read a row left-to-right):</b> whatever sudowork delegates <code>→ sudocode</code> must appear in the sudocode cell, and be provided by the Nexus end-state.</p>
 
 <h2>The matrix</h2>
 <table>
@@ -127,9 +127,8 @@
     <div class="el"><span class="was">no explicit pid</span> <span class="arw">→</span> <span class="to">ephemeral run handle</span></div>
     <span class="b partial">partial</span></td>
   <td>
-    <div class="el"><b>stays (SQLite):</b> conversation-list index · position/status/pin/cron/channel/user_id — UI-unique, sudowork's own</div>
-    <div class="el"><b>→ sudocode:</b> session identity + transcript copy (<code>conversation-id</code> / <code>messages</code> / <code>acpSessionId</code>) — key by the engine's durable <code>session-id</code>, read its store <span class="b dup">dup</span></div>
-    <div class="el"><b>→ nexus (direct):</b> <code>agent-name</code> / zones — sudowork itself as a first-class principal <span class="tbd">? Q9</span></div>
+    <div class="el"><b>stays (SQLite):</b> conversation-list index · position/status/pin/cron/channel/user_id — UI-unique</div>
+    <div class="el"><b>→ sudocode</b> (sudowork is a UI; the <i>agent</i> is sudocode): read the whole identity from the engine — durable <code>session-id</code> + <code>agent-name</code>; its <code>messages</code>/<code>acpSessionId</code> copy collapses to a view <span class="b dup">dup</span></div>
     <span class="b partial">partial</span></td>
   <td>
     <div class="el"><b>agent-name</b> — durable principal; the addressable identity. <span class="path">/agents/{name}/</span></div>


### PR DESCRIPTION
sudowork=UI → agent-name/zones are sudocode's (→sudocode, not →nexus direct); +consistency check.