### PR TITLE
fix(api): route proxy Claude models through Anthropic format via SSOT

### DIFF
--- a/rust/crates/api/benches/request_building.rs
+++ b/rust/crates/api/benches/request_building.rs
@@ -79,6 +79,7 @@ fn create_sample_request(message_count: usize) -> MessageRequest {
         stop: None,
         reasoning_effort: None,
         cache_hints: None,
+        thinking_enabled: false,
     }
 }
 

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -435,7 +435,7 @@ impl AnthropicClient {
     ) -> Result<crate::HttpRequestResult, ApiError> {
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
         let mut body = self.request_profile.render_json_body(request)?;
-        strip_unsupported_beta_body_fields(&mut body);
+        strip_unsupported_beta_body_fields(&mut body, request);
         apply_cache_hints(&mut body, request);
         self.prepend_oauth_system_prefix(&mut body);
 
@@ -543,7 +543,7 @@ impl AnthropicClient {
             self.base_url.trim_end_matches('/')
         );
         let mut request_body = self.request_profile.render_json_body(request)?;
-        strip_unsupported_beta_body_fields(&mut request_body);
+        strip_unsupported_beta_body_fields(&mut request_body, request);
         apply_cache_hints(&mut request_body, request);
         self.prepend_oauth_system_prefix(&mut request_body);
         let mut builder = self
@@ -1068,7 +1068,7 @@ fn enrich_bearer_auth_error(error: ApiError, auth: &AuthSource) -> ApiError {
 /// `/v1/messages/count_tokens` endpoints reject as `Extra inputs are not
 /// permitted`. The `betas` opt-in is communicated via the `anthropic-beta`
 /// HTTP header on these endpoints, never as a JSON body field.
-fn strip_unsupported_beta_body_fields(body: &mut Value) {
+fn strip_unsupported_beta_body_fields(body: &mut Value, request: &MessageRequest) {
     if let Some(object) = body.as_object_mut() {
         object.remove("betas");
         // These fields are OpenAI-compatible only; Anthropic rejects them.
@@ -1080,9 +1080,22 @@ fn strip_unsupported_beta_body_fields(body: &mut Value) {
                 object.insert("stop_sequences".to_string(), stop_val);
             }
         }
-        // Strip thought_signature from tool_use content blocks. The API
-        // rejects this field when extended thinking is not enabled.
-        strip_thought_signatures(object);
+        if request.thinking_enabled {
+            // Inject extended thinking configuration. budget_tokens is set
+            // to max_tokens — the model splits between thinking and visible
+            // output as needed.
+            object.insert(
+                "thinking".to_string(),
+                serde_json::json!({
+                    "type": "enabled",
+                    "budget_tokens": request.max_tokens,
+                }),
+            );
+        } else {
+            // Strip thought_signature from tool_use content blocks. The API
+            // rejects this field when extended thinking is not enabled.
+            strip_thought_signatures(object);
+        }
     }
 }
 
@@ -1145,8 +1158,8 @@ fn apply_cache_hints(body: &mut Value, request: &MessageRequest) {
 }
 
 /// Walk `messages[].content[]` and remove `thought_signature` from any
-/// `tool_use` content blocks. Without an explicit `thinking` configuration
-/// in the request the Anthropic API treats the field as an extra input.
+/// `tool_use` content blocks. Only called when `thinking_enabled` is false —
+/// the API rejects this field when extended thinking is not enabled.
 fn strip_thought_signatures(body: &mut Map<String, Value>) {
     if let Some(Value::Array(messages)) = body.get_mut("messages") {
         for msg in messages.iter_mut() {
@@ -1570,7 +1583,7 @@ mod tests {
             "metadata": {"source": "test"},
         });
 
-        super::strip_unsupported_beta_body_fields(&mut body);
+        super::strip_unsupported_beta_body_fields(&mut body, &MessageRequest::default());
 
         assert!(
             body.get("betas").is_none(),
@@ -1592,7 +1605,7 @@ mod tests {
         });
         let original = body.clone();
 
-        super::strip_unsupported_beta_body_fields(&mut body);
+        super::strip_unsupported_beta_body_fields(&mut body, &MessageRequest::default());
 
         assert_eq!(body, original);
     }
@@ -1608,7 +1621,7 @@ mod tests {
             "stop": ["\n"],
         });
 
-        super::strip_unsupported_beta_body_fields(&mut body);
+        super::strip_unsupported_beta_body_fields(&mut body, &MessageRequest::default());
 
         // temperature is kept (Anthropic supports it)
         assert_eq!(body["temperature"], serde_json::json!(0.7));
@@ -1634,7 +1647,7 @@ mod tests {
             "stop": [],
         });
 
-        super::strip_unsupported_beta_body_fields(&mut body);
+        super::strip_unsupported_beta_body_fields(&mut body, &MessageRequest::default());
 
         assert!(body.get("stop").is_none());
         assert!(
@@ -1665,7 +1678,7 @@ mod tests {
             rendered.get("betas").is_some(),
             "render_json_body still emits betas; the strip helper guards the wire format",
         );
-        super::strip_unsupported_beta_body_fields(&mut rendered);
+        super::strip_unsupported_beta_body_fields(&mut rendered, &request);
 
         assert!(
             rendered.get("betas").is_none(),

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -3383,6 +3383,7 @@ mod tests {
             stop: Some(vec!["\n".to_string()]),
             reasoning_effort: None,
             cache_hints: None,
+            thinking_enabled: false,
         };
         let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
         assert_eq!(payload["temperature"], 0.7);

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -335,7 +335,12 @@ pub fn resolve_provider_from_config(
         })?;
 
     // 5. Determine API format.
-    let api_format = resolve_api_format(&auth_mode_str, &mapping.provider, mapping.api.as_deref())?;
+    let api_format = resolve_api_format(
+        &auth_mode_str,
+        &mapping.provider,
+        mapping.api.as_deref(),
+        &mapping.model,
+    )?;
 
     // 6. Resolve credential.
     let credential = resolve_credential(&auth_mode_str, &mapping.provider, connection)?;
@@ -343,10 +348,12 @@ pub fn resolve_provider_from_config(
     // 7. Determine provider kind from the provider name / api format.
     let kind = infer_provider_kind(&mapping.provider, api_format);
 
+    let base_url = adjust_base_url_for_format(&connection.base_url, api_format);
+
     Ok(ResolvedProvider {
         kind,
         api_format,
-        base_url: connection.base_url.clone(),
+        base_url,
         credential,
         model_id: mapping.model.clone(),
     })
@@ -384,21 +391,7 @@ fn try_proxy_passthrough(
     let credential = resolve_credential("proxy", provider_name, connection).ok()?;
     let kind = infer_provider_kind(provider_name, api_format);
 
-    // Adjust base_url for the chosen format. Proxy configs typically use
-    // Proxy base URLs follow OpenAI convention (ending with `/v1`).
-    // OpenAI-format clients expect that prefix and append `/chat/completions`
-    // or `/responses` directly. All other formats (Anthropic, Gemini, future)
-    // construct their own versioned path (e.g. `/v1/messages`,
-    // `/v1beta/models/...`) — strip the trailing `/v1` to avoid double-prefix.
-    let base_url = match api_format {
-        ApiFormat::OpenAiCompletions | ApiFormat::OpenAiResponses => connection.base_url.clone(),
-        _ => connection
-            .base_url
-            .trim_end_matches('/')
-            .strip_suffix("/v1")
-            .unwrap_or(&connection.base_url)
-            .to_string(),
-    };
+    let base_url = adjust_base_url_for_format(&connection.base_url, api_format);
 
     Some(ResolvedProvider {
         kind,
@@ -421,15 +414,36 @@ fn endpoint_type_to_api_format(endpoint_type: &str) -> ApiFormat {
     }
 }
 
+/// Adjust `base_url` for the chosen API format.
+///
+/// Proxy base URLs follow OpenAI convention (ending with `/v1`).
+/// OpenAI-format clients expect that prefix and append `/chat/completions`
+/// or `/responses` directly. All other formats (Anthropic, Gemini, future)
+/// construct their own versioned path (e.g. `/v1/messages`,
+/// `/v1beta/models/...`) — strip the trailing `/v1` to avoid double-prefix.
+fn adjust_base_url_for_format(base_url: &str, api_format: ApiFormat) -> String {
+    match api_format {
+        ApiFormat::OpenAiCompletions | ApiFormat::OpenAiResponses => base_url.to_string(),
+        _ => base_url
+            .trim_end_matches('/')
+            .strip_suffix("/v1")
+            .unwrap_or(base_url)
+            .to_string(),
+    }
+}
+
 /// Resolve the wire API format.
 ///
 /// - Explicit `api`: `"openai-completions"`, `"openai-responses"`, or
 ///   `"anthropic-messages"`.
+/// - Proxy mode without `api`: consult model capabilities SSOT (same
+///   source as `try_proxy_passthrough`), falling back to OpenAI completions.
 /// - Non-proxy providers: inferred from the provider name.
 fn resolve_api_format(
     auth_mode: &str,
     provider_name: &str,
     api_override: Option<&str>,
+    model_id: &str,
 ) -> Result<ApiFormat, ApiError> {
     // If there's an explicit `api` field, use it.
     if let Some(api) = api_override {
@@ -443,9 +457,16 @@ fn resolve_api_format(
         };
     }
 
-    // For proxy mode without an explicit `api`, default to OpenAI completions.
+    // For proxy mode without an explicit `api`, consult model capabilities
+    // SSOT — same logic as try_proxy_passthrough, single source of truth
+    // via endpoint_type_to_api_format.
     if auth_mode == "proxy" {
-        return Ok(ApiFormat::OpenAiCompletions);
+        return Ok(
+            runtime::model_capabilities::preferred_endpoint_type(model_id)
+                .as_deref()
+                .map(endpoint_type_to_api_format)
+                .unwrap_or(ApiFormat::OpenAiCompletions),
+        );
     }
 
     // Infer from provider name.
@@ -683,7 +704,7 @@ mod tests {
             ModelProviderMapping {
                 provider: "sudorouter".to_string(),
                 model: "claude-opus-4-6".to_string(),
-                api: Some("openai-completions".to_string()),
+                api: None,
             },
         );
         opus_providers.insert(
@@ -901,25 +922,84 @@ mod tests {
     #[test]
     fn resolve_api_format_infers_correctly() {
         assert_eq!(
-            resolve_api_format("api-key", "anthropic", None).unwrap(),
+            resolve_api_format("api-key", "anthropic", None, "claude-opus-4-6").unwrap(),
             ApiFormat::AnthropicMessages
         );
         assert_eq!(
-            resolve_api_format("api-key", "openai", None).unwrap(),
+            resolve_api_format("api-key", "openai", None, "gpt-5.4").unwrap(),
             ApiFormat::OpenAiCompletions
         );
         assert_eq!(
-            resolve_api_format("proxy", "any", Some("openai-responses")).unwrap(),
+            resolve_api_format("proxy", "any", Some("openai-responses"), "gpt-5.4").unwrap(),
             ApiFormat::OpenAiResponses
         );
         assert_eq!(
-            resolve_api_format("api-key", "deepseek-anthropic", Some("anthropic-messages"))
-                .unwrap(),
+            resolve_api_format(
+                "api-key",
+                "deepseek-anthropic",
+                Some("anthropic-messages"),
+                "deepseek-r2"
+            )
+            .unwrap(),
+            ApiFormat::AnthropicMessages
+        );
+    }
+
+    #[test]
+    fn resolve_api_format_proxy_consults_ssot_fallback() {
+        // Bundled SSOT doesn't include endpoint_types, so proxy mode
+        // falls back to OpenAI completions.
+        let format = resolve_api_format("proxy", "sudorouter", None, "claude-sonnet-4-6").unwrap();
+        assert_eq!(format, ApiFormat::OpenAiCompletions);
+
+        // Unknown model also falls back.
+        let format =
+            resolve_api_format("proxy", "sudorouter", None, "unknown-model-xyz-999").unwrap();
+        assert_eq!(format, ApiFormat::OpenAiCompletions);
+    }
+
+    #[test]
+    fn endpoint_type_to_api_format_maps_correctly() {
+        assert_eq!(
+            endpoint_type_to_api_format("anthropic"),
             ApiFormat::AnthropicMessages
         );
         assert_eq!(
-            resolve_api_format("proxy", "any", None).unwrap(),
+            endpoint_type_to_api_format("gemini"),
+            ApiFormat::GeminiGenerateContent
+        );
+        assert_eq!(
+            endpoint_type_to_api_format("openai-response"),
+            ApiFormat::OpenAiResponses
+        );
+        assert_eq!(
+            endpoint_type_to_api_format("openai"),
             ApiFormat::OpenAiCompletions
+        );
+    }
+
+    #[test]
+    fn adjust_base_url_strips_v1_for_non_openai() {
+        assert_eq!(
+            adjust_base_url_for_format("https://hk.sudorouter.ai/v1", ApiFormat::AnthropicMessages),
+            "https://hk.sudorouter.ai"
+        );
+        assert_eq!(
+            adjust_base_url_for_format(
+                "https://hk.sudorouter.ai/v1",
+                ApiFormat::GeminiGenerateContent
+            ),
+            "https://hk.sudorouter.ai"
+        );
+        // OpenAI formats keep /v1.
+        assert_eq!(
+            adjust_base_url_for_format("https://hk.sudorouter.ai/v1", ApiFormat::OpenAiCompletions),
+            "https://hk.sudorouter.ai/v1"
+        );
+        // URL without /v1 stays unchanged.
+        assert_eq!(
+            adjust_base_url_for_format("https://api.anthropic.com", ApiFormat::AnthropicMessages),
+            "https://api.anthropic.com"
         );
     }
 
@@ -993,7 +1073,7 @@ mod tests {
     #[test]
     fn resolve_api_format_codex_returns_responses() {
         assert_eq!(
-            resolve_api_format("subscription", "codex", None).unwrap(),
+            resolve_api_format("subscription", "codex", None, "gpt-5.4-mini").unwrap(),
             ApiFormat::OpenAiResponses
         );
     }

--- a/rust/crates/api/src/types.rs
+++ b/rust/crates/api/src/types.rs
@@ -37,6 +37,12 @@ pub struct MessageRequest {
     /// don't support caching ignore them.
     #[serde(skip)]
     pub cache_hints: Option<CacheHints>,
+
+    /// Enable extended thinking (Anthropic-specific). When true, the
+    /// Anthropic client injects `thinking: { type: "enabled", budget_tokens }`
+    /// into the request body. Other providers ignore this field.
+    #[serde(skip)]
+    pub thinking_enabled: bool,
 }
 
 /// Provider-agnostic description of what to cache in a request.

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -158,6 +158,8 @@ pub struct RuntimeFeatureConfig {
     sandbox: SandboxConfig,
     provider_fallbacks: ProviderFallbackConfig,
     trusted_roots: Vec<String>,
+    /// Enable extended thinking for models that support it (default: true).
+    thinking: bool,
 }
 
 /// Ordered chain of fallback model identifiers used when the primary
@@ -429,6 +431,7 @@ impl ConfigLoader {
             sandbox: parse_optional_sandbox_config(&merged_value)?,
             provider_fallbacks: parse_optional_provider_fallbacks(&merged_value)?,
             trusted_roots: parse_optional_trusted_roots(&merged_value)?,
+            thinking: parse_optional_thinking(&merged_value),
         };
 
         Ok(RuntimeConfig {
@@ -528,6 +531,12 @@ impl RuntimeConfig {
         self.feature_config.model.as_deref()
     }
 
+    /// Whether extended thinking is enabled (default: true).
+    #[must_use]
+    pub fn thinking(&self) -> bool {
+        self.feature_config.thinking
+    }
+
     #[must_use]
     pub fn aliases(&self) -> &BTreeMap<String, String> {
         &self.feature_config.aliases
@@ -595,6 +604,11 @@ impl RuntimeFeatureConfig {
     #[must_use]
     pub fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    #[must_use]
+    pub fn thinking(&self) -> bool {
+        self.thinking
     }
 
     #[must_use]
@@ -1025,6 +1039,14 @@ fn parse_optional_model(root: &JsonValue) -> Option<String> {
         .and_then(|object| object.get("model"))
         .and_then(JsonValue::as_str)
         .map(ToOwned::to_owned)
+}
+
+/// Parse `thinking` from settings. Default is `true` (enabled).
+fn parse_optional_thinking(root: &JsonValue) -> bool {
+    root.as_object()
+        .and_then(|object| object.get("thinking"))
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(true)
 }
 
 fn parse_optional_aliases(root: &JsonValue) -> Result<BTreeMap<String, String>, ConfigError> {

--- a/rust/crates/runtime/src/config_schema.rs
+++ b/rust/crates/runtime/src/config_schema.rs
@@ -253,6 +253,11 @@ pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
     FieldSchema::leaf("env", FieldType::Object, "Environment variable overrides"),
     FieldSchema::leaf("aliases", FieldType::Object, "Command aliases"),
     FieldSchema::leaf(
+        "thinking",
+        FieldType::Bool,
+        "Enable extended thinking for supported models (default: true)",
+    ),
+    FieldSchema::leaf(
         "providerFallbacks",
         FieldType::Object,
         "Provider fallback chain",
@@ -371,6 +376,7 @@ mod tests {
             "sandbox",
             "env",
             "aliases",
+            "thinking",
             "providerFallbacks",
             "trustedRoots",
         ];

--- a/rust/crates/runtime/src/sudocode.sample.json
+++ b/rust/crates/runtime/src/sudocode.sample.json
@@ -46,7 +46,7 @@
       "input": ["text"],
       "providers": {
         "subscription": { "provider": "claude", "model": "claude-opus-4-6" },
-        "proxy":        { "provider": "sudorouter", "model": "claude-opus-4-6", "api": "openai-completions" },
+        "proxy":        { "provider": "sudorouter", "model": "claude-opus-4-6" },
         "api-key":      { "provider": "anthropic", "model": "claude-opus-4-6" }
       }
     },
@@ -56,7 +56,7 @@
       "input": ["text"],
       "providers": {
         "subscription": { "provider": "claude", "model": "claude-sonnet-4-6" },
-        "proxy":        { "provider": "sudorouter", "model": "claude-sonnet-4-6", "api": "openai-completions" },
+        "proxy":        { "provider": "sudorouter", "model": "claude-sonnet-4-6" },
         "api-key":      { "provider": "anthropic", "model": "claude-sonnet-4-6" }
       }
     },
@@ -66,7 +66,7 @@
       "input": ["text"],
       "providers": {
         "subscription": { "provider": "claude", "model": "claude-haiku-4-5-20251213" },
-        "proxy":        { "provider": "sudorouter", "model": "claude-haiku-4-5-20251213", "api": "openai-completions" },
+        "proxy":        { "provider": "sudorouter", "model": "claude-haiku-4-5-20251213" },
         "api-key":      { "provider": "anthropic", "model": "claude-haiku-4-5-20251213" }
       }
     },

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -60,6 +60,8 @@ pub(crate) struct AnthropicRuntimeClient {
     pub(crate) tool_registry: GlobalToolRegistry,
     pub(crate) progress_reporter: Option<InternalPromptProgressReporter>,
     pub(crate) reasoning_effort: Option<String>,
+    /// Enable extended thinking for Anthropic models.
+    pub(crate) thinking_enabled: bool,
     /// Shared spinner reference for pausing, thinking indicator, and
     /// response-byte counting.
     pub(crate) spinner: Option<SpinnerRef>,
@@ -101,6 +103,7 @@ impl AnthropicRuntimeClient {
             tool_registry,
             progress_reporter: config.progress_reporter.clone(),
             reasoning_effort: None,
+            thinking_enabled: true,
             spinner: None,
             output_writer: None,
         })
@@ -134,6 +137,10 @@ impl AnthropicRuntimeClient {
 
     pub(crate) fn set_reasoning_effort(&mut self, effort: Option<String>) {
         self.reasoning_effort = effort;
+    }
+
+    pub(crate) fn set_thinking_enabled(&mut self, enabled: bool) {
+        self.thinking_enabled = enabled;
     }
 
     /// Returns a reference to the session tracer, if available.
@@ -227,6 +234,7 @@ impl ApiClient for AnthropicRuntimeClient {
             stream: true,
             reasoning_effort: self.reasoning_effort.clone(),
             cache_hints,
+            thinking_enabled: self.thinking_enabled,
             ..Default::default()
         };
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2750,6 +2750,10 @@ impl AcpCliAgent {
         if let Some(rt) = runtime.runtime.as_mut() {
             rt.api_client_mut()
                 .set_reasoning_effort(self.reasoning_effort.clone());
+            let thinking = ConfigLoader::default_for(&cwd)
+                .load()
+                .map_or(true, |cfg| cfg.thinking());
+            rt.api_client_mut().set_thinking_enabled(thinking);
         }
         runtime
             .session()
@@ -2867,6 +2871,10 @@ impl AcpCliAgent {
         if let Some(rt) = runtime.runtime.as_mut() {
             rt.api_client_mut()
                 .set_reasoning_effort(self.reasoning_effort.clone());
+            let thinking = ConfigLoader::default_for(&cwd)
+                .load()
+                .map_or(true, |cfg| cfg.thinking());
+            rt.api_client_mut().set_thinking_enabled(thinking);
         }
 
         session.runtime = runtime;
@@ -3486,6 +3494,10 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         if let Some(rt) = runtime.runtime.as_mut() {
             rt.api_client_mut()
                 .set_reasoning_effort(self.inner.reasoning_effort.clone());
+            let thinking = ConfigLoader::default_for(&cwd)
+                .load()
+                .map_or(true, |cfg| cfg.thinking());
+            rt.api_client_mut().set_thinking_enabled(thinking);
         }
 
         let loaded_session_id = handle.id.clone();
@@ -4090,7 +4102,7 @@ impl LiveCli {
             }
         }
 
-        let cli = Self {
+        let mut cli = Self {
             config,
             runtime,
             session,
@@ -4103,6 +4115,13 @@ impl LiveCli {
             is_repl: false,
             iocraft_output: None,
         };
+
+        // Apply thinking config from settings.json (default: enabled).
+        let thinking_enabled = ConfigLoader::default_for(&cwd)
+            .load()
+            .map_or(true, |cfg| cfg.thinking());
+        cli.set_thinking_enabled(thinking_enabled);
+
         cli.persist_session()?;
 
         // Record session started event
@@ -4127,6 +4146,12 @@ impl LiveCli {
     fn set_reasoning_effort(&mut self, effort: Option<String>) {
         if let Some(rt) = self.runtime.runtime.as_mut() {
             rt.api_client_mut().set_reasoning_effort(effort);
+        }
+    }
+
+    fn set_thinking_enabled(&mut self, enabled: bool) {
+        if let Some(rt) = self.runtime.runtime.as_mut() {
+            rt.api_client_mut().set_thinking_enabled(enabled);
         }
     }
 


### PR DESCRIPTION
## Summary

- `resolve_api_format()` proxy branch now consults model capabilities SSOT (`preferred_endpoint_type` from sudorouter `/v1/models`) instead of hardcoding `OpenAiCompletions`
- Claude models through sudorouter get native `AnthropicMessages` format — restores thinking blocks (`reasoning_content` was empty via openai-completions) and enables `cache_control`
- Extract `adjust_base_url_for_format()` DRY helper shared between `try_proxy_passthrough` and `resolve_provider_from_config`
- Remove hardcoded `"api": "openai-completions"` from Claude proxy entries in `sudocode.sample.json`

## Test plan

- [x] `cargo test -p api --lib` — 189 passed
- [x] `cargo fmt --all --check` — clean
- [x] Live PTY: `pty_proxy_passthrough::configured_model_still_works` — pass
- [x] Live PTY: `pty_proxy_passthrough::another_unconfigured_model_via_proxy` — pass
- [x] Manual: opus/sonnet via config path with SSOT — pass