### PR TITLE
test(pty): resolve sh via shared SSOT in pty_mcp_manage (fix Windows-local run)

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -430,7 +430,12 @@ fn spawn_with_workspace(
 /// against Git for Windows' bundled `sh.exe` first, then fall back to
 /// PATH scanning so contributors with a different sh installation
 /// (WSL, MSYS2, chocolatey) are still covered.
-fn resolve_sh() -> String {
+///
+/// Public so test files with their own bespoke spawn helpers (e.g.
+/// `pty_mcp_manage`) resolve `sh` through this one SSOT rather than
+/// handing a bare `"sh"` to `CreateProcessW` (which fails `os error 2`
+/// on Windows).
+pub fn resolve_sh() -> String {
     #[cfg(unix)]
     {
         String::from("sh")

--- a/rust/crates/rusty-sudocode-cli/tests/pty_mcp_manage.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_mcp_manage.rs
@@ -32,7 +32,11 @@ fn spawn_mcp_in_workspace(workspace: &HarnessWorkspace, args: &[&str]) -> pty_ex
     for arg in args {
         cmd.push_str(&format!(" '{arg}'"));
     }
-    let mut sess = pty_expect::PtySession::spawn("sh", &["-c", &cmd]).expect("spawn scode mcp");
+    // Resolve `sh` through the shared SSOT: on Windows a bare "sh" handed to
+    // CreateProcessW fails with `os error 2` (no PATH lookup); `resolve_sh`
+    // finds Git-for-Windows' `sh.exe`.
+    let sh = common::resolve_sh();
+    let mut sess = pty_expect::PtySession::spawn(&sh, &["-c", &cmd]).expect("spawn scode mcp");
     sess.set_default_timeout(DEFAULT_TIMEOUT);
     sess
 }


### PR DESCRIPTION
`pty_mcp_manage`'s own `spawn_mcp_in_workspace` helper handed a bare `"sh"` to `PtySession::spawn`. On Windows `CreateProcessW` does no PATH lookup, so all three tests failed instantly with `os error 2` (`系统找不到指定的文件`). Every other pty helper already resolves `sh` through `common::resolve_sh` (Git-for-Windows' `sh.exe`).

Make `resolve_sh` `pub` and reuse it here — DRY, one SSOT for shell resolution. Backend-agnostic tests (no model inference), so this only affects local Windows runs; Linux CI was already green because posix_spawn resolves `sh` from PATH.

Found while running the full live PTY suite locally on Windows. Verified: `pty_mcp_manage` 3/3 pass after the fix.