### PR TITLE
fix(spawn_task): port co-host A2A mailbox loop onto main (survive transient inbox reads)

### DIFF
--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -177,26 +177,6 @@ where
     SpawnHandle { abort_signal, join }
 }
 
-/// Spawn the v1 echo-only loop (retained for backward compatibility
-/// and integration tests that don't need a full LLM provider).
-#[must_use]
-pub fn spawn_task_echo<K: KernelSyscall + Send + Sync + 'static>(
-    kernel: Arc<K>,
-    desc: AgentDescriptor,
-) -> SpawnHandle {
-    let abort_signal = HookAbortSignal::default();
-    let abort_for_thread = abort_signal.clone();
-
-    let join = thread::Builder::new()
-        .name(format!("managed-agent-echo-{}", desc.pid))
-        .spawn(move || {
-            run_echo_loop(&kernel, &desc, &abort_for_thread);
-        })
-        .expect("OS refused to spawn managed-agent thread");
-
-    SpawnHandle { abort_signal, join }
-}
-
 // ---------------------------------------------------------------------------
 // v2 loop — ConversationRuntime integration
 // ---------------------------------------------------------------------------
@@ -298,9 +278,19 @@ fn run_loop<K, C, T, F>(
 
                             if let Ok(bytes) = serde_json::to_vec(&response) {
                                 // Reply to the SENDER's inbox (A2A) or the
-                                // shared stream (LocalStream).
+                                // shared stream (LocalStream). The kernel's
+                                // byte-op path forwards a not-leader write to
+                                // the owning peer; if the write STILL fails
+                                // (sender inbox absent, peer unreachable) the
+                                // reply is lost, so surface it — a silent drop
+                                // reads as "the agent ignored me" across nodes.
                                 let reply_path = mailbox.reply_path(&sender);
-                                let _ = kernel.sys_write(&reply_path, &ctx, &bytes, 0);
+                                if let Err(e) = kernel.sys_write(&reply_path, &ctx, &bytes, 0) {
+                                    eprintln!(
+                                        "[managed-agent {self_id}] reply to {sender} \
+                                         ({reply_path}) failed: {e:?} — message dropped"
+                                    );
+                                }
                             }
 
                             // -- READY --
@@ -312,11 +302,21 @@ fn run_loop<K, C, T, F>(
                     next_offset = advanced as u64;
                 }
             }
-            Err(_) => {
-                // Path tear-down (procfs unregister) or transient kernel
-                // error — v2 treats every kernel error as terminal because
-                // the loop's lifetime is bounded by the pid's procfs subtree.
-                break;
+            Err(e) => {
+                // A read error is NOT terminal — `abort` (checked by the
+                // `while`) is the SOLE terminal signal. For the managed
+                // `/proc` stream, teardown fires `abort` via the service's
+                // on_terminate observer, so the loop still exits promptly.
+                // For the A2A inbox the stream is a durable, raft-replicated
+                // path: a cold-read-before-`resolve`, a momentary not-leader,
+                // or being read before the mint has planted it are all
+                // TRANSIENT — a `break` here would silently kill a co-hosted
+                // agent for the daemon's lifetime. Log, then fall through to
+                // `sys_watch` (which paces the retry at `WATCH_TIMEOUT_MS`)
+                // and re-check `abort`.
+                eprintln!(
+                    "[managed-agent {self_id}] inbox read error (transient, retrying): {e:?}"
+                );
             }
         }
         // Block until a FileWrite event fires on the inbox path, or
@@ -347,56 +347,6 @@ fn parse_inbound(bytes: &[u8], self_agent_id: &str) -> Option<(String, String)> 
         return None;
     }
     Some((from.to_string(), body))
-}
-
-// ---------------------------------------------------------------------------
-// v1 echo loop — retained for tests and backward compatibility
-// ---------------------------------------------------------------------------
-
-fn run_echo_loop<K: KernelSyscall>(
-    kernel: &Arc<K>,
-    desc: &AgentDescriptor,
-    abort: &HookAbortSignal,
-) {
-    let cwm_path = format!("/proc/{}/chat-with-me", desc.pid);
-    let agent_id = desc.name.as_str();
-    let ctx = OperationContext::new(&desc.owner_id, &desc.zone_id, false, Some(agent_id), true);
-
-    let mut next_offset: u64 = 0;
-    while !abort.is_aborted() {
-        match kernel.sys_read(&cwm_path, &ctx, READ_TIMEOUT_MS, next_offset) {
-            Ok(result) => {
-                if let Some(bytes) = result.data.as_ref() {
-                    if !bytes.is_empty() {
-                        if let Some(reply) = build_echo_reply(bytes, agent_id) {
-                            let _ = kernel.sys_write(&cwm_path, &ctx, &reply, 0);
-                        }
-                    }
-                }
-                if let Some(advanced) = result.stream_next_offset {
-                    next_offset = advanced as u64;
-                }
-            }
-            Err(_) => break,
-        }
-        kernel.sys_watch(&cwm_path, WATCH_TIMEOUT_MS);
-    }
-}
-
-fn build_echo_reply(inbound: &[u8], self_agent_id: &str) -> Option<Vec<u8>> {
-    let value: serde_json::Value = serde_json::from_slice(inbound).ok()?;
-    let obj = value.as_object()?;
-    let from = obj.get("from").and_then(|v| v.as_str())?;
-    if from == self_agent_id {
-        return None;
-    }
-    let body = obj.get("body").and_then(|v| v.as_str()).unwrap_or("");
-    let reply = serde_json::json!({
-        "to": from,
-        "from": self_agent_id,
-        "body": format!("echo: {body}"),
-    });
-    serde_json::to_vec(&reply).ok()
 }
 
 // Loop tests live under `runtime/tests/spawn_task.rs` as an integration

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -1,34 +1,75 @@
-//! Integration tests for `runtime::spawn_task`. Lives outside the
-//! lib's `#[cfg(test)] mod` so it compiles as its own test binary
-//! and stays decoupled from unrelated lib-test fixtures.
+//! Integration tests for `runtime::spawn_task` — drive the REAL v2
+//! `run_loop` (the exact production loop the co-host runs), NOT a scaffold.
+//!
+//! A scripted mock [`ApiClient`] returns one fixed text turn so the loop's
+//! mailbox mechanics are exercised deterministically with no network: inbound
+//! envelope parse, `from != self` self-filtering, reply routing for BOTH
+//! [`Mailbox`] variants, abort teardown, and the transient-read survival
+//! contract — a durable A2A inbox must NOT die on a read error / on being
+//! read before it exists (the regression guard for the co-host boot race,
+//! where the loop is spawned before the mint has planted the inbox).
+//!
+//! Lives outside the lib's `#[cfg(test)] mod` so it compiles as its own test
+//! binary; it uses the crate's normal deps (`async-trait`, `futures`).
 
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
 use kernel::kernel::{Kernel, OperationContext, ReadRequest, WriteRequest};
-use runtime::spawn_task::spawn_task_echo;
+use runtime::spawn_task::{spawn_task, Mailbox, SpawnHandle};
+use runtime::{
+    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ModelFamilyIdentity,
+    PermissionMode, PermissionPolicy, RuntimeError, SystemPromptBuilder, ToolError, ToolExecutor,
+};
 
 const DT_STREAM: i32 = 4;
 const STREAM_CAPACITY: usize = 65_536;
-const POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// Fixed text the scripted provider replies with — asserted end-to-end.
+const REPLY_TEXT: &str = "PONG";
 
-/// Add the `/proc` mount to the kernel's VFSRouter. Without this,
-/// `sys_read` / `sys_write` against `/proc/*` paths errors at
-/// `vfs_router.route()` before consulting the metastore. Mirrors
-/// `mount_proc` in the nexus-side managed_agent integration tests.
-fn mount_proc(kernel: &Kernel) {
-    kernel
-        .vfs_router_arc()
-        .add_mount("/proc", "root", None, false);
+// ── Mock provider: one fixed text turn, no tool calls ──────────────────
+
+/// [`ApiClient`] that streams a single `TextDelta` + `MessageStop`, so a
+/// turn resolves to the fixed [`REPLY_TEXT`] with zero network I/O.
+struct ScriptedReply;
+
+#[async_trait]
+impl ApiClient for ScriptedReply {
+    async fn stream(&mut self, _request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
+        Ok(Box::pin(futures::stream::iter(vec![
+            Ok(AssistantEvent::TextDelta(REPLY_TEXT.to_string())),
+            Ok(AssistantEvent::MessageStop),
+        ])))
+    }
 }
 
-fn plant_chat_stream(kernel: &Kernel, pid: &str) {
-    let path = format!("/proc/{pid}/chat-with-me");
+/// The scripted turn emits no `ToolUse`, so the executor is never invoked;
+/// a call would be a bug in the loop, so it fails loudly.
+struct NoTools;
+
+impl ToolExecutor for NoTools {
+    async fn execute(&self, tool_name: &str, _input: &str) -> Result<String, ToolError> {
+        Err(ToolError::new(format!(
+            "unexpected tool call in test: {tool_name}"
+        )))
+    }
+}
+
+// ── Kernel / mailbox helpers ───────────────────────────────────────────
+
+fn mount(kernel: &Kernel, mount_point: &str) {
+    kernel
+        .vfs_router_arc()
+        .add_mount(mount_point, "root", None, false);
+}
+
+fn plant_stream(kernel: &Kernel, path: &str) {
     kernel
         .sys_setattr(
-            &path,
+            path,
             DT_STREAM,
             /* backend_name */ "",
             /* backend */ None,
@@ -50,7 +91,7 @@ fn plant_chat_stream(kernel: &Kernel, pid: &str) {
             /* source */ None,
             /* remote_metastore */ None,
         )
-        .expect("plant /proc/{pid}/chat-with-me DT_STREAM");
+        .expect("plant DT_STREAM");
 }
 
 fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
@@ -64,24 +105,95 @@ fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
     }
 }
 
-fn user_ctx() -> OperationContext {
-    OperationContext::new(
-        "test-user",
-        "root",
-        /* is_admin */ false,
-        Some("user-test"),
-        /* is_system */ true,
+/// Spawn the REAL `run_loop` (via `spawn_task`) with the scripted mock —
+/// the exact loop the co-host runs, minus the network provider.
+fn spawn_real(kernel: Arc<Kernel>, desc: AgentDescriptor, mailbox: Mailbox) -> SpawnHandle {
+    let system_prompt = SystemPromptBuilder::new()
+        .with_model_family(ModelFamilyIdentity::Claude)
+        .build();
+    spawn_task(
+        kernel,
+        desc,
+        mailbox,
+        ScriptedReply,
+        NoTools,
+        system_prompt,
+        PermissionPolicy::new(PermissionMode::Allow),
+        |_state| {},
     )
 }
 
-fn read_envelopes(
+fn user_ctx() -> OperationContext {
+    OperationContext::new("test-user", "root", false, Some("user-test"), true)
+}
+
+fn write_envelope(
     kernel: &Kernel,
     path: &str,
     ctx: &OperationContext,
-    from_offset: u64,
-) -> (Vec<serde_json::Value>, u64) {
-    let mut offset = from_offset;
-    let mut out = Vec::new();
+    from: &str,
+    to: &str,
+    body: &str,
+) {
+    let env = serde_json::json!({ "from": from, "to": to, "body": body });
+    let reqs = [WriteRequest {
+        path: path.to_string(),
+        content: serde_json::to_vec(&env).unwrap(),
+        offset: 0,
+    }];
+    kernel
+        .sys_write(&reqs, ctx)
+        .pop()
+        .expect("sys_write returned empty vec")
+        .expect("write envelope");
+}
+
+/// Poll `path` until an envelope `from` the given author with a non-empty
+/// body arrives, or `timeout` elapses.
+fn wait_for_reply(
+    kernel: &Kernel,
+    path: &str,
+    ctx: &OperationContext,
+    from: &str,
+    timeout: Duration,
+) -> Option<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    let mut offset = 0u64;
+    while Instant::now() < deadline {
+        let reqs = [ReadRequest {
+            path: path.to_string(),
+            offset,
+            len: None,
+            timeout_ms: 0,
+        }];
+        if let Some(Ok(result)) = kernel.sys_read(&reqs, ctx).pop() {
+            if let Some(bytes) = result.data.as_ref() {
+                if !bytes.is_empty() {
+                    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+                        let is_from = v.get("from").and_then(|f| f.as_str()) == Some(from);
+                        let has_body = v
+                            .get("body")
+                            .and_then(|b| b.as_str())
+                            .is_some_and(|b| !b.is_empty());
+                        if is_from && has_body {
+                            return Some(v);
+                        }
+                    }
+                }
+            }
+            if let Some(next) = result.stream_next_offset {
+                offset = next as u64;
+            }
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+/// Count envelopes on `path` authored by `from`, walking the whole stream.
+fn count_from(kernel: &Kernel, path: &str, ctx: &OperationContext, from: &str) -> usize {
+    let mut offset = 0u64;
+    let mut count = 0;
     loop {
         let reqs = [ReadRequest {
             path: path.to_string(),
@@ -89,13 +201,14 @@ fn read_envelopes(
             len: None,
             timeout_ms: 0,
         }];
-        let mut results = kernel.sys_read(&reqs, ctx);
-        match results.pop() {
+        match kernel.sys_read(&reqs, ctx).pop() {
             Some(Ok(result)) => {
                 if let Some(bytes) = result.data.as_ref() {
                     if !bytes.is_empty() {
                         if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
-                            out.push(v);
+                            if v.get("from").and_then(|f| f.as_str()) == Some(from) {
+                                count += 1;
+                            }
                         }
                     }
                 }
@@ -108,150 +221,198 @@ fn read_envelopes(
             _ => break,
         }
     }
-    (out, offset)
+    count
 }
 
-fn wait_for_envelope_with_body(
-    kernel: &Kernel,
-    path: &str,
-    ctx: &OperationContext,
-    body_eq: &str,
-    timeout: Duration,
-) -> Option<serde_json::Value> {
-    let deadline = Instant::now() + timeout;
-    let mut offset = 0u64;
-    while Instant::now() < deadline {
-        let (envelopes, next) = read_envelopes(kernel, path, ctx, offset);
-        offset = next;
-        for env in envelopes {
-            if env.get("body").and_then(|v| v.as_str()) == Some(body_eq) {
-                return Some(env);
-            }
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
-    None
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn local_stream_round_trip_drives_real_run_loop() {
+    let kernel = Arc::new(Kernel::new());
+    mount(&kernel, "/proc");
+    let path = "/proc/pid-ls/chat-with-me";
+    plant_stream(&kernel, path);
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("pid-ls", "scode"),
+        Mailbox::LocalStream {
+            path: path.to_string(),
+            self_id: "scode".to_string(),
+        },
+    );
+
+    let ctx = user_ctx();
+    write_envelope(&kernel, path, &ctx, "user-test", "scode", "hello");
+    let reply = wait_for_reply(&kernel, path, &ctx, "scode", Duration::from_secs(5));
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+
+    let reply = reply.expect("real run_loop produced no reply on the shared stream");
+    assert_eq!(reply.get("body").and_then(|b| b.as_str()), Some(REPLY_TEXT));
+    assert_eq!(reply.get("to").and_then(|t| t.as_str()), Some("user-test"));
 }
 
 #[test]
-fn echo_round_trip_through_proc_pid_chat_with_me() {
+fn a2a_reads_own_inbox_and_replies_to_senders_inbox() {
     let kernel = Arc::new(Kernel::new());
-    mount_proc(&kernel);
-    plant_chat_stream(&kernel, "v0-echo-1");
-    let desc = make_desc("v0-echo-1", "agent-v0");
-    let handle = spawn_task_echo(Arc::clone(&kernel), desc);
+    mount(&kernel, "/agents");
+    plant_stream(&kernel, "/agents/win-ai/chat-with-me");
+    plant_stream(&kernel, "/agents/user-test/chat-with-me");
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+    );
 
     let ctx = user_ctx();
-    let cwm_path = "/proc/v0-echo-1/chat-with-me";
-    let prompt = serde_json::json!({
-        "from": "user-test",
-        "to": "agent-v0",
-        "body": "hello",
-    });
-    let write_reqs = [WriteRequest {
-        path: cwm_path.to_string(),
-        content: serde_json::to_vec(&prompt).unwrap(),
-        offset: 0,
-    }];
-    kernel
-        .sys_write(&write_reqs, &ctx)
-        .pop()
-        .expect("sys_write returned empty vec")
-        .expect("user write to chat-with-me");
-
-    let echo = wait_for_envelope_with_body(
+    // Sender writes to win-ai's OWN inbox …
+    write_envelope(
         &kernel,
-        cwm_path,
+        "/agents/win-ai/chat-with-me",
         &ctx,
-        "echo: hello",
-        Duration::from_secs(2),
+        "user-test",
+        "win-ai",
+        "hi",
+    );
+    // … and the reply must land in the SENDER's inbox, not win-ai's.
+    let reply = wait_for_reply(
+        &kernel,
+        "/agents/user-test/chat-with-me",
+        &ctx,
+        "win-ai",
+        Duration::from_secs(5),
     );
     handle.abort_signal.abort();
     let _ = handle.join.join();
-    let echo = echo.expect("agent echo response did not arrive within 2s");
 
-    assert_eq!(echo.get("from").and_then(|v| v.as_str()), Some("agent-v0"));
-    assert_eq!(echo.get("to").and_then(|v| v.as_str()), Some("user-test"));
+    let reply = reply.expect("A2A co-host produced no reply in the sender's inbox");
+    assert_eq!(reply.get("body").and_then(|b| b.as_str()), Some(REPLY_TEXT));
+    assert_eq!(reply.get("to").and_then(|t| t.as_str()), Some("user-test"));
+    // The reply went to the sender's box, so win-ai's own inbox holds only
+    // the inbound (no self-directed reply).
+    assert_eq!(
+        count_from(&kernel, "/agents/win-ai/chat-with-me", &ctx, "win-ai"),
+        0,
+        "reply must route to the sender's inbox, not the agent's own"
+    );
 }
 
 #[test]
 fn loop_exits_on_abort_signal() {
     let kernel = Arc::new(Kernel::new());
-    mount_proc(&kernel);
-    plant_chat_stream(&kernel, "v0-abort-1");
-    let desc = make_desc("v0-abort-1", "agent-abort");
-
-    let handle = spawn_task_echo(Arc::clone(&kernel), desc);
-    // No prompt sent — the loop is sitting in the poll sleep.
-    // abort() must wake it within one POLL_INTERVAL + a sys_read
-    // round trip.
+    mount(&kernel, "/proc");
+    let path = "/proc/pid-abort/chat-with-me";
+    plant_stream(&kernel, path);
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("pid-abort", "scode"),
+        Mailbox::LocalStream {
+            path: path.to_string(),
+            self_id: "scode".to_string(),
+        },
+    );
+    // No message sent — the loop is parked on `sys_watch`. abort() must let
+    // it exit on the next `while !abort` check (≤ one watch timeout).
     handle.abort_signal.abort();
 
     let watcher = thread::Builder::new()
         .spawn(move || handle.join.join())
         .expect("watcher thread");
-    let deadline = Instant::now() + Duration::from_secs(2);
+    let deadline = Instant::now() + Duration::from_secs(3);
     while !watcher.is_finished() {
-        if Instant::now() >= deadline {
-            panic!("spawn_task thread did not exit within 2s of abort()");
-        }
+        assert!(
+            Instant::now() < deadline,
+            "run_loop did not exit within 3s of abort()"
+        );
         thread::sleep(Duration::from_millis(20));
     }
     let _ = watcher.join();
 }
 
 #[test]
-fn skips_own_writes_to_avoid_echo_loop() {
-    // The agent's own echo writes carry from=self_agent_id; the
-    // loop must filter these out so the mailbox does not
-    // exponentially explode. Walks one round trip and asserts the
-    // stream contains exactly one agent echo (no echo-of-echo).
+fn skips_own_writes_no_reply_storm() {
+    // LocalStream reads AND replies on the same path, so the agent sees its
+    // own reply on the next poll; `from == self` filtering must stop it from
+    // replying to itself (which would explode the mailbox).
     let kernel = Arc::new(Kernel::new());
-    mount_proc(&kernel);
-    plant_chat_stream(&kernel, "v0-loop-1");
-    let desc = make_desc("v0-loop-1", "agent-loop");
-    let handle = spawn_task_echo(Arc::clone(&kernel), desc);
+    mount(&kernel, "/proc");
+    let path = "/proc/pid-filter/chat-with-me";
+    plant_stream(&kernel, path);
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("pid-filter", "scode"),
+        Mailbox::LocalStream {
+            path: path.to_string(),
+            self_id: "scode".to_string(),
+        },
+    );
 
     let ctx = user_ctx();
-    let cwm_path = "/proc/v0-loop-1/chat-with-me";
-    let prompt = serde_json::json!({
-        "from": "user-test",
-        "to": "agent-loop",
-        "body": "ping",
-    });
-    let write_reqs = [WriteRequest {
-        path: cwm_path.to_string(),
-        content: serde_json::to_vec(&prompt).unwrap(),
-        offset: 0,
-    }];
-    kernel
-        .sys_write(&write_reqs, &ctx)
-        .pop()
-        .expect("sys_write returned empty vec")
-        .unwrap();
-
-    let _ = wait_for_envelope_with_body(
-        &kernel,
-        cwm_path,
-        &ctx,
-        "echo: ping",
-        Duration::from_secs(2),
-    )
-    .expect("first echo did not arrive");
-    // Settle for several poll intervals so any bug-induced
-    // echo-of-echo would have written by now.
-    thread::sleep(POLL_INTERVAL * 4);
+    write_envelope(&kernel, path, &ctx, "user-test", "scode", "ping");
+    let _ = wait_for_reply(&kernel, path, &ctx, "scode", Duration::from_secs(5))
+        .expect("first agent reply did not arrive");
+    // Settle several watch cycles so any self-reply bug would have written by now.
+    thread::sleep(Duration::from_millis(600));
     handle.abort_signal.abort();
     let _ = handle.join.join();
 
-    let (envelopes, _) = read_envelopes(&kernel, cwm_path, &ctx, 0);
-    let agent_echoes = envelopes
-        .iter()
-        .filter(|v| v.get("from").and_then(|f| f.as_str()) == Some("agent-loop"))
-        .count();
     assert_eq!(
-        agent_echoes, 1,
-        "expected exactly one agent echo, got {agent_echoes} — \
-         loop is echoing its own writes"
+        count_from(&kernel, path, &ctx, "scode"),
+        1,
+        "agent replied to its own message — the from==self filter is broken"
+    );
+}
+
+#[test]
+fn a2a_inbox_survives_read_before_it_exists() {
+    // F1 regression: the co-host boot spawns the loop bound to
+    // `/agents/<self>/chat-with-me`, which the mint may not have planted yet
+    // (or which a fresh raft replica hasn't resolved). The OLD loop broke on
+    // the first `Err` and the agent silently died for the daemon's lifetime.
+    // The loop must SURVIVE the transient error and serve the message once
+    // the inbox appears.
+    let kernel = Arc::new(Kernel::new());
+    // Deliberately do NOT mount /agents yet → the loop's first reads all Err
+    // (NotMounted). The old `Err(_) => break` would kill the loop here.
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+    );
+    // Let the loop spin on the error path across several watch cycles.
+    thread::sleep(Duration::from_millis(300));
+
+    // Now the "mint" lands: mount + plant the inbox and the sender's box.
+    mount(&kernel, "/agents");
+    plant_stream(&kernel, "/agents/win-ai/chat-with-me");
+    plant_stream(&kernel, "/agents/user-test/chat-with-me");
+    let ctx = user_ctx();
+    write_envelope(
+        &kernel,
+        "/agents/win-ai/chat-with-me",
+        &ctx,
+        "user-test",
+        "win-ai",
+        "hi",
+    );
+
+    let reply = wait_for_reply(
+        &kernel,
+        "/agents/user-test/chat-with-me",
+        &ctx,
+        "win-ai",
+        Duration::from_secs(5),
+    );
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+    assert!(
+        reply.is_some(),
+        "loop died on the pre-mint read error (F1 regression) — no reply after the inbox appeared"
     );
 }

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -3,8 +3,7 @@
 //! Constructs the `ApiClient`, `ToolExecutor`, `SystemPrompt`, and
 //! `PermissionPolicy` dependencies from the `AgentDescriptor` metadata
 //! and calls `runtime::spawn_task::spawn_task` to launch the full LLM
-//! loop. The nexus cdylib's `SudoCodeSpawnAdapter` calls this instead
-//! of `spawn_task_echo`.
+//! loop. The nexus cdylib's `SudoCodeSpawnAdapter` calls this.
 //!
 //! Lives in the `tools` crate because it needs both the `api` crate
 //! (for `ProviderClient` / `resolve_provider_from_config`) and the
@@ -32,8 +31,7 @@ const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 
 /// Spawn a managed-agent loop with the full ConversationRuntime.
 ///
-/// This is the v2 upgrade of `spawn_task_echo`. The caller
-/// (nexus cdylib `SudoCodeSpawnAdapter`) invokes this after
+/// The caller (nexus cdylib `SudoCodeSpawnAdapter`) invokes this after
 /// `register_proc_entry` stamps the per-pid procfs subtree.
 ///
 /// # Arguments


### PR DESCRIPTION
Ports the co-host managed-agent mailbox loop (originally `b1d3e887` on the stale `feat/cohost-a2a-mailbox` branch that nexus pins) onto current main, which now carries the async ToolExecutor re-arch (#437). Removes the stale-branch hazard and gives the loop a current base for the ping-pong + seek-to-tail follow-ups.

- `abort` is the sole terminal signal; a kernel read error logs + falls through to `sys_watch` instead of killing the agent. The durable raft-replicated A2A inbox `/agents/<self>/chat-with-me` can be cold-read before `StreamManager.resolve`, during a momentary not-leader, or before the mint has planted it — all transient; the old `Err(_) => break` silently killed a co-hosted agent for good (the cross-machine boot race).
- Reply-write failures are surfaced, not swallowed.
- Deletes the retired v1 echo scaffold (only ever used by tests).
- `runtime/tests/spawn_task.rs` rewritten against the REAL `run_loop`; `NoTools` mock matches main's async `ToolExecutor`.

Tests: `cargo test -p runtime --test spawn_task` 5/5; `cargo check --workspace --all-targets` clean.