### PR TITLE
fix(cohost): kill A2A ping-pong — deliberate send_message reply, no auto-forward

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "a2a"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
+dependencies = [
+ "contracts",
+ "kernel",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,7 +867,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2295,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2357,9 +2368,10 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
 dependencies = [
  "ahash",
+ "arc-swap",
  "base64",
  "blake3",
  "contracts",
@@ -2382,6 +2394,8 @@ dependencies = [
  "thiserror 2.0.20",
  "time",
  "tokio",
+ "tokio-rustls",
+ "tokio-stream",
  "tonic 0.14.6",
  "tracing",
  "x509-parser",
@@ -2555,7 +2569,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
 
 [[package]]
 name = "nexus-vfs-client"
@@ -3715,6 +3729,7 @@ dependencies = [
 name = "runtime"
 version = "0.1.23"
 dependencies = [
+ "a2a",
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "agent-client-protocol-tokio",

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,7 +37,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2a62e6a5618d0008872c958d95db4e3ebaae6120", default-features = false }
+# The A2A messaging substrate: SSOT for the mailbox message schema
+# (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
+# nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
+# distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
+# use it without a direct a2a dependency.
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2a62e6a5618d0008872c958d95db4e3ebaae6120", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -12,7 +12,7 @@ use std::io;
 use std::sync::Arc;
 
 use crate::workspace_root::current_workspace_root;
-use kernel::kernel::syscall::KernelSyscall;
+use kernel::kernel::syscall::{KernelSyscall, ReaddirOpts};
 use kernel::kernel::OperationContext;
 
 // ---------------------------------------------------------------------------
@@ -438,7 +438,11 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
         // full paths like `/ws/a.rs`, not basenames. The `FsBackend`
         // contract (matching `StdFsBackend` / `NexusVfsFsBackend`) is the
         // basename, so strip the leading directory. DT_DIR == 1.
-        let entries = self.kernel.sys_readdir(path, zone, false);
+        // Single-level (default `ReaddirOpts`): the `FsBackend` contract is a
+        // basename listing of direct children, so no recursive descent here.
+        let entries = self
+            .kernel
+            .sys_readdir(path, zone, false, ReaddirOpts::default());
         Ok(entries
             .into_iter()
             .map(|(child, entry_type)| FsDirEntry {

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -177,26 +177,6 @@ where
     SpawnHandle { abort_signal, join }
 }
 
-/// Spawn the v1 echo-only loop (retained for backward compatibility
-/// and integration tests that don't need a full LLM provider).
-#[must_use]
-pub fn spawn_task_echo<K: KernelSyscall + Send + Sync + 'static>(
-    kernel: Arc<K>,
-    desc: AgentDescriptor,
-) -> SpawnHandle {
-    let abort_signal = HookAbortSignal::default();
-    let abort_for_thread = abort_signal.clone();
-
-    let join = thread::Builder::new()
-        .name(format!("managed-agent-echo-{}", desc.pid))
-        .spawn(move || {
-            run_echo_loop(&kernel, &desc, &abort_for_thread);
-        })
-        .expect("OS refused to spawn managed-agent thread");
-
-    SpawnHandle { abort_signal, join }
-}
-
 // ---------------------------------------------------------------------------
 // v2 loop — ConversationRuntime integration
 // ---------------------------------------------------------------------------
@@ -298,9 +278,19 @@ fn run_loop<K, C, T, F>(
 
                             if let Ok(bytes) = serde_json::to_vec(&response) {
                                 // Reply to the SENDER's inbox (A2A) or the
-                                // shared stream (LocalStream).
+                                // shared stream (LocalStream). The kernel's
+                                // byte-op path forwards a not-leader write to
+                                // the owning peer; if the write STILL fails
+                                // (sender inbox absent, peer unreachable) the
+                                // reply is lost, so surface it — a silent drop
+                                // reads as "the agent ignored me" across nodes.
                                 let reply_path = mailbox.reply_path(&sender);
-                                let _ = kernel.sys_write(&reply_path, &ctx, &bytes, 0);
+                                if let Err(e) = kernel.sys_write(&reply_path, &ctx, &bytes, 0) {
+                                    eprintln!(
+                                        "[managed-agent {self_id}] reply to {sender} \
+                                         ({reply_path}) failed: {e:?} — message dropped"
+                                    );
+                                }
                             }
 
                             // -- READY --
@@ -312,11 +302,21 @@ fn run_loop<K, C, T, F>(
                     next_offset = advanced as u64;
                 }
             }
-            Err(_) => {
-                // Path tear-down (procfs unregister) or transient kernel
-                // error — v2 treats every kernel error as terminal because
-                // the loop's lifetime is bounded by the pid's procfs subtree.
-                break;
+            Err(e) => {
+                // A read error is NOT terminal — `abort` (checked by the
+                // `while`) is the SOLE terminal signal. For the managed
+                // `/proc` stream, teardown fires `abort` via the service's
+                // on_terminate observer, so the loop still exits promptly.
+                // For the A2A inbox the stream is a durable, raft-replicated
+                // path: a cold-read-before-`resolve`, a momentary not-leader,
+                // or being read before the mint has planted it are all
+                // TRANSIENT — a `break` here would silently kill a co-hosted
+                // agent for the daemon's lifetime. Log, then fall through to
+                // `sys_watch` (which paces the retry at `WATCH_TIMEOUT_MS`)
+                // and re-check `abort`.
+                eprintln!(
+                    "[managed-agent {self_id}] inbox read error (transient, retrying): {e:?}"
+                );
             }
         }
         // Block until a FileWrite event fires on the inbox path, or
@@ -347,56 +347,6 @@ fn parse_inbound(bytes: &[u8], self_agent_id: &str) -> Option<(String, String)> 
         return None;
     }
     Some((from.to_string(), body))
-}
-
-// ---------------------------------------------------------------------------
-// v1 echo loop — retained for tests and backward compatibility
-// ---------------------------------------------------------------------------
-
-fn run_echo_loop<K: KernelSyscall>(
-    kernel: &Arc<K>,
-    desc: &AgentDescriptor,
-    abort: &HookAbortSignal,
-) {
-    let cwm_path = format!("/proc/{}/chat-with-me", desc.pid);
-    let agent_id = desc.name.as_str();
-    let ctx = OperationContext::new(&desc.owner_id, &desc.zone_id, false, Some(agent_id), true);
-
-    let mut next_offset: u64 = 0;
-    while !abort.is_aborted() {
-        match kernel.sys_read(&cwm_path, &ctx, READ_TIMEOUT_MS, next_offset) {
-            Ok(result) => {
-                if let Some(bytes) = result.data.as_ref() {
-                    if !bytes.is_empty() {
-                        if let Some(reply) = build_echo_reply(bytes, agent_id) {
-                            let _ = kernel.sys_write(&cwm_path, &ctx, &reply, 0);
-                        }
-                    }
-                }
-                if let Some(advanced) = result.stream_next_offset {
-                    next_offset = advanced as u64;
-                }
-            }
-            Err(_) => break,
-        }
-        kernel.sys_watch(&cwm_path, WATCH_TIMEOUT_MS);
-    }
-}
-
-fn build_echo_reply(inbound: &[u8], self_agent_id: &str) -> Option<Vec<u8>> {
-    let value: serde_json::Value = serde_json::from_slice(inbound).ok()?;
-    let obj = value.as_object()?;
-    let from = obj.get("from").and_then(|v| v.as_str())?;
-    if from == self_agent_id {
-        return None;
-    }
-    let body = obj.get("body").and_then(|v| v.as_str()).unwrap_or("");
-    let reply = serde_json::json!({
-        "to": from,
-        "from": self_agent_id,
-        "body": format!("echo: {body}"),
-    });
-    serde_json::to_vec(&reply).ok()
 }
 
 // Loop tests live under `runtime/tests/spawn_task.rs` as an integration

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -1,10 +1,12 @@
 //! Managed-agent loop spawn entry — v2 ConversationRuntime integration.
 //!
 //! Wires the per-pid agent loop into a full LLM turn-driver that waits
-//! on `/proc/{pid}/chat-with-me` for inbound JSON envelopes (via
-//! `sys_watch` condvar blocking), drives each prompt through a
-//! [`crate::ConversationRuntime`], and writes structured responses back
-//! through the same mailbox path.
+//! on the agent's mailbox (via `sys_watch` condvar blocking) for inbound
+//! [`MailboxEnvelope`]s and drives each one through a
+//! [`crate::ConversationRuntime`]. The loop does NOT auto-reply: the agent
+//! decides whether to respond by calling the `send_message` tool during the
+//! turn (routed through [`mailbox_sender`]). Not calling it = silence, so a
+//! two-agent conversation ends instead of ping-ponging every turn forever.
 //!
 //! ## State machine
 //!
@@ -44,6 +46,12 @@ use std::thread;
 pub use kernel::core::agents::registry::AgentDescriptor;
 pub use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
+
+// The A2A mailbox message contract is owned by the `a2a` substrate (it stamps
+// `from` + owns the path suffix). Re-export its SSOT types so this loop and the
+// downstream `tools` crate consume the one definition instead of hand-rolling
+// `{from,to,body}` JSON or the `chat-with-me` suffix.
+pub use a2a::{MailboxEnvelope, CHAT_WITH_ME_SUFFIX};
 
 use crate::conversation::{ApiClient, ConversationRuntime, ToolExecutor};
 use crate::hooks::HookAbortSignal;
@@ -92,7 +100,11 @@ impl Mailbox {
         match self {
             Mailbox::LocalStream { path, .. } => path.clone(),
             Mailbox::A2aInbox { base, self_name } => {
-                format!("{}/{}/chat-with-me", base.trim_end_matches('/'), self_name)
+                format!(
+                    "{}/{}{CHAT_WITH_ME_SUFFIX}",
+                    base.trim_end_matches('/'),
+                    self_name
+                )
             }
         }
     }
@@ -112,10 +124,47 @@ impl Mailbox {
         match self {
             Mailbox::LocalStream { path, .. } => path.clone(),
             Mailbox::A2aInbox { base, .. } => {
-                format!("{}/{}/chat-with-me", base.trim_end_matches('/'), sender)
+                format!(
+                    "{}/{}{CHAT_WITH_ME_SUFFIX}",
+                    base.trim_end_matches('/'),
+                    sender
+                )
             }
         }
     }
+}
+
+/// A type-erased "send a message to a peer's mailbox" capability handed to the
+/// co-hosted agent's `send_message` tool. This is the ONE place a co-hosted
+/// agent's reply is written: the poll loop no longer auto-forwards turn output,
+/// so a reply happens ONLY when the agent deliberately calls the tool. It writes
+/// a [`MailboxEnvelope`] (the a2a SSOT) to the recipient's inbox; the a2a stamp
+/// hook overwrites `from` with the authenticated caller when auth is armed.
+pub type MailboxSender = Arc<dyn Fn(&str, &str) -> Result<(), String> + Send + Sync>;
+
+/// Build the [`MailboxSender`] for a co-hosted agent (its kernel + mailbox +
+/// operation identity). Lives here, next to `Mailbox::reply_path`, so the
+/// envelope build + reply-path + `sys_write` stay in one place.
+#[must_use]
+pub fn mailbox_sender<K: KernelSyscall + Send + Sync + 'static>(
+    kernel: Arc<K>,
+    mailbox: Mailbox,
+    owner_id: String,
+    zone_id: String,
+) -> MailboxSender {
+    let self_name = mailbox.self_id().to_string();
+    Arc::new(move |to: &str, body: &str| {
+        let env = MailboxEnvelope {
+            from: self_name.clone(),
+            to: to.to_string(),
+            body: body.to_string(),
+        };
+        let ctx = OperationContext::new(&owner_id, &zone_id, false, Some(&self_name), true);
+        kernel
+            .sys_write(&mailbox.reply_path(to), &ctx, &env.to_bytes(), 0)
+            .map(|_| ())
+            .map_err(|e| format!("{e:?}"))
+    })
 }
 
 /// Handle returned by [`spawn_task`].
@@ -239,58 +288,21 @@ fn run_loop<K, C, T, F>(
             Ok(result) => {
                 if let Some(bytes) = result.data.as_ref() {
                     if !bytes.is_empty() {
-                        if let Some((sender, prompt)) = parse_inbound(bytes, &self_id) {
+                        if let Some((sender, body)) = parse_inbound(bytes, &self_id) {
                             // -- BUSY --
                             state_cb(AgentLoopState::Busy);
 
-                            let turn_result = rt.block_on(runtime.run_turn(&prompt, None, None));
-
-                            let response = match turn_result {
-                                Ok(summary) => {
-                                    let text = summary
-                                        .assistant_messages
-                                        .iter()
-                                        .filter_map(|m| {
-                                            m.blocks.iter().find_map(|b| match b {
-                                                crate::session::ContentBlock::Text { text } => {
-                                                    Some(text.as_str())
-                                                }
-                                                _ => None,
-                                            })
-                                        })
-                                        .collect::<Vec<_>>()
-                                        .join("\n");
-                                    serde_json::json!({
-                                        "to": sender,
-                                        "from": self_id,
-                                        "body": text,
-                                    })
-                                }
-                                Err(e) => {
-                                    serde_json::json!({
-                                        "to": sender,
-                                        "from": self_id,
-                                        "body": format!("error: {e}"),
-                                        "error": true,
-                                    })
-                                }
-                            };
-
-                            if let Ok(bytes) = serde_json::to_vec(&response) {
-                                // Reply to the SENDER's inbox (A2A) or the
-                                // shared stream (LocalStream). The kernel's
-                                // byte-op path forwards a not-leader write to
-                                // the owning peer; if the write STILL fails
-                                // (sender inbox absent, peer unreachable) the
-                                // reply is lost, so surface it — a silent drop
-                                // reads as "the agent ignored me" across nodes.
-                                let reply_path = mailbox.reply_path(&sender);
-                                if let Err(e) = kernel.sys_write(&reply_path, &ctx, &bytes, 0) {
-                                    eprintln!(
-                                        "[managed-agent {self_id}] reply to {sender} \
-                                         ({reply_path}) failed: {e:?} — message dropped"
-                                    );
-                                }
+                            // Drive ONE turn on the inbound message. The sender is
+                            // surfaced in the prompt so the agent can address a reply.
+                            // The agent decides whether to reply by calling the
+                            // `send_message` tool DURING the turn — the loop NO LONGER
+                            // harvests the turn's text and auto-forwards it. Not
+                            // calling `send_message` means silence, so the
+                            // conversation ends instead of two agents bouncing every
+                            // turn's output back to each other forever (the ping-pong).
+                            let turn_input = format!("[message from {sender}]\n\n{body}");
+                            if let Err(e) = rt.block_on(runtime.run_turn(&turn_input, None, None)) {
+                                eprintln!("[managed-agent {self_id}] turn error: {e:?}");
                             }
 
                             // -- READY --
@@ -332,21 +344,13 @@ fn run_loop<K, C, T, F>(
 /// Returns `Some((sender, body))` when the envelope is a JSON object
 /// with `from != self` and a non-empty `body` field.
 fn parse_inbound(bytes: &[u8], self_agent_id: &str) -> Option<(String, String)> {
-    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
-    let obj = value.as_object()?;
-    let from = obj.get("from").and_then(|v| v.as_str())?;
-    if from == self_agent_id {
+    let env = MailboxEnvelope::from_bytes(bytes)?;
+    // Skip anything without a real sender + body: our OWN writes (self-reply
+    // storm guard), an unstamped/senderless envelope, or an empty message.
+    if env.from.is_empty() || env.from == self_agent_id || env.body.is_empty() {
         return None;
     }
-    let body = obj
-        .get("body")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    if body.is_empty() {
-        return None;
-    }
-    Some((from.to_string(), body))
+    Some((env.from, env.body))
 }
 
 // Loop tests live under `runtime/tests/spawn_task.rs` as an integration

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -19,7 +19,9 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
 use kernel::kernel::{Kernel, OperationContext, ReadRequest, WriteRequest};
-use runtime::spawn_task::{spawn_task, Mailbox, SpawnHandle};
+use runtime::spawn_task::{
+    mailbox_sender, spawn_task, Mailbox, MailboxEnvelope, MailboxSender, SpawnHandle,
+};
 use runtime::{
     ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ModelFamilyIdentity,
     PermissionMode, PermissionPolicy, RuntimeError, SystemPromptBuilder, ToolError, ToolExecutor,
@@ -55,6 +57,61 @@ impl ToolExecutor for NoTools {
         Err(ToolError::new(format!(
             "unexpected tool call in test: {tool_name}"
         )))
+    }
+}
+
+/// [`ApiClient`] whose one turn calls the `send_message` tool addressed to
+/// `to` with `body` — the co-host's DELIBERATE reply path. Emits a single
+/// `ToolUse` + `MessageStop` so the loop drives the tool without network I/O.
+struct SendsReply {
+    to: String,
+    body: String,
+    /// Whether the one `send_message` call has been issued. The turn's tool
+    /// loop calls `stream` again after executing the tool; that follow-up round
+    /// must end the turn (no further tool) — otherwise the agent would send on
+    /// every round forever within a single turn.
+    sent: bool,
+}
+
+#[async_trait]
+impl ApiClient for SendsReply {
+    async fn stream(&mut self, _request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
+        if self.sent {
+            // Follow-up round after the tool result: end the turn, no more tools.
+            return Ok(Box::pin(futures::stream::iter(vec![Ok(
+                AssistantEvent::MessageStop,
+            )])));
+        }
+        self.sent = true;
+        let input = serde_json::json!({ "to": self.to, "body": self.body }).to_string();
+        Ok(Box::pin(futures::stream::iter(vec![
+            Ok(AssistantEvent::ToolUse {
+                id: "call-1".to_string(),
+                name: "send_message".to_string(),
+                input,
+                thought_signature: None,
+            }),
+            Ok(AssistantEvent::MessageStop),
+        ])))
+    }
+}
+
+/// Executor mirroring the production `ManagedToolExecutor` send path: routes
+/// `send_message` through the [`MailboxSender`] (the SSOT send-write), so a
+/// scripted `send_message` turn actually writes to the recipient's inbox.
+struct SendingTools {
+    send: MailboxSender,
+}
+
+impl ToolExecutor for SendingTools {
+    async fn execute(&self, tool_name: &str, input: &str) -> Result<String, ToolError> {
+        assert_eq!(tool_name, "send_message", "unexpected tool");
+        let v: serde_json::Value =
+            serde_json::from_str(input).map_err(|e| ToolError::new(e.to_string()))?;
+        let to = v.get("to").and_then(|x| x.as_str()).expect("to");
+        let body = v.get("body").and_then(|x| x.as_str()).expect("body");
+        (self.send)(to, body).map_err(ToolError::new)?;
+        Ok("delivered".to_string())
     }
 }
 
@@ -123,6 +180,41 @@ fn spawn_real(kernel: Arc<Kernel>, desc: AgentDescriptor, mailbox: Mailbox) -> S
     )
 }
 
+/// Spawn the REAL `run_loop` with a scripted `send_message` turn: on each
+/// inbound message the agent DELIBERATELY replies `reply_body` to `reply_to`
+/// via the mailbox sender (the production reply path).
+fn spawn_sending(
+    kernel: Arc<Kernel>,
+    desc: AgentDescriptor,
+    mailbox: Mailbox,
+    reply_to: &str,
+    reply_body: &str,
+) -> SpawnHandle {
+    let system_prompt = SystemPromptBuilder::new()
+        .with_model_family(ModelFamilyIdentity::Claude)
+        .build();
+    let send = mailbox_sender(
+        Arc::clone(&kernel),
+        mailbox.clone(),
+        desc.owner_id.clone(),
+        desc.zone_id.clone(),
+    );
+    spawn_task(
+        kernel,
+        desc,
+        mailbox,
+        SendsReply {
+            to: reply_to.to_string(),
+            body: reply_body.to_string(),
+            sent: false,
+        },
+        SendingTools { send },
+        system_prompt,
+        PermissionPolicy::new(PermissionMode::Allow),
+        |_state| {},
+    )
+}
+
 fn user_ctx() -> OperationContext {
     OperationContext::new("test-user", "root", false, Some("user-test"), true)
 }
@@ -135,10 +227,14 @@ fn write_envelope(
     to: &str,
     body: &str,
 ) {
-    let env = serde_json::json!({ "from": from, "to": to, "body": body });
+    let env = MailboxEnvelope {
+        from: from.to_string(),
+        to: to.to_string(),
+        body: body.to_string(),
+    };
     let reqs = [WriteRequest {
         path: path.to_string(),
-        content: serde_json::to_vec(&env).unwrap(),
+        content: env.to_bytes(),
         offset: 0,
     }];
     kernel
@@ -232,13 +328,15 @@ fn local_stream_round_trip_drives_real_run_loop() {
     mount(&kernel, "/proc");
     let path = "/proc/pid-ls/chat-with-me";
     plant_stream(&kernel, path);
-    let handle = spawn_real(
+    let handle = spawn_sending(
         Arc::clone(&kernel),
         make_desc("pid-ls", "scode"),
         Mailbox::LocalStream {
             path: path.to_string(),
             self_id: "scode".to_string(),
         },
+        "user-test",
+        REPLY_TEXT,
     );
 
     let ctx = user_ctx();
@@ -247,7 +345,7 @@ fn local_stream_round_trip_drives_real_run_loop() {
     handle.abort_signal.abort();
     let _ = handle.join.join();
 
-    let reply = reply.expect("real run_loop produced no reply on the shared stream");
+    let reply = reply.expect("agent's send_message produced no reply on the shared stream");
     assert_eq!(reply.get("body").and_then(|b| b.as_str()), Some(REPLY_TEXT));
     assert_eq!(reply.get("to").and_then(|t| t.as_str()), Some("user-test"));
 }
@@ -258,13 +356,15 @@ fn a2a_reads_own_inbox_and_replies_to_senders_inbox() {
     mount(&kernel, "/agents");
     plant_stream(&kernel, "/agents/win-ai/chat-with-me");
     plant_stream(&kernel, "/agents/user-test/chat-with-me");
-    let handle = spawn_real(
+    let handle = spawn_sending(
         Arc::clone(&kernel),
         make_desc("cohost-win-ai", "win-ai"),
         Mailbox::A2aInbox {
             base: "/agents".to_string(),
             self_name: "win-ai".to_string(),
         },
+        "user-test",
+        REPLY_TEXT,
     );
 
     let ctx = user_ctx();
@@ -341,13 +441,15 @@ fn skips_own_writes_no_reply_storm() {
     mount(&kernel, "/proc");
     let path = "/proc/pid-filter/chat-with-me";
     plant_stream(&kernel, path);
-    let handle = spawn_real(
+    let handle = spawn_sending(
         Arc::clone(&kernel),
         make_desc("pid-filter", "scode"),
         Mailbox::LocalStream {
             path: path.to_string(),
             self_id: "scode".to_string(),
         },
+        "user-test",
+        REPLY_TEXT,
     );
 
     let ctx = user_ctx();
@@ -377,13 +479,15 @@ fn a2a_inbox_survives_read_before_it_exists() {
     let kernel = Arc::new(Kernel::new());
     // Deliberately do NOT mount /agents yet → the loop's first reads all Err
     // (NotMounted). The old `Err(_) => break` would kill the loop here.
-    let handle = spawn_real(
+    let handle = spawn_sending(
         Arc::clone(&kernel),
         make_desc("cohost-win-ai", "win-ai"),
         Mailbox::A2aInbox {
             base: "/agents".to_string(),
             self_name: "win-ai".to_string(),
         },
+        "user-test",
+        REPLY_TEXT,
     );
     // Let the loop spin on the error path across several watch cycles.
     thread::sleep(Duration::from_millis(300));
@@ -414,5 +518,56 @@ fn a2a_inbox_survives_read_before_it_exists() {
     assert!(
         reply.is_some(),
         "loop died on the pre-mint read error (F1 regression) — no reply after the inbox appeared"
+    );
+}
+
+#[test]
+fn text_only_turn_writes_no_reply_the_ping_pong_fix() {
+    // THE ping-pong fix: a turn that produces TEXT but does NOT call
+    // `send_message` must write nothing back. The old loop harvested the turn's
+    // text and auto-forwarded it, so every message bounced a reply forever; now
+    // silence (no `send_message`) lets the exchange end.
+    let kernel = Arc::new(Kernel::new());
+    mount(&kernel, "/agents");
+    plant_stream(&kernel, "/agents/win-ai/chat-with-me");
+    plant_stream(&kernel, "/agents/user-test/chat-with-me");
+    // `spawn_real` = ScriptedReply (text only) + NoTools (send_message never called).
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+    );
+
+    let ctx = user_ctx();
+    write_envelope(
+        &kernel,
+        "/agents/win-ai/chat-with-me",
+        &ctx,
+        "user-test",
+        "win-ai",
+        "hi",
+    );
+    // Give the loop ample time to run the turn and (wrongly) auto-forward.
+    let leaked = wait_for_reply(
+        &kernel,
+        "/agents/user-test/chat-with-me",
+        &ctx,
+        "win-ai",
+        Duration::from_secs(2),
+    );
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+
+    assert!(
+        leaked.is_none(),
+        "a text-only turn auto-forwarded a reply — the ping-pong (auto-forward) is back"
+    );
+    assert_eq!(
+        count_from(&kernel, "/agents/win-ai/chat-with-me", &ctx, "win-ai"),
+        0,
+        "the agent wrote to its own inbox on a silent turn"
     );
 }

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -1,34 +1,75 @@
-//! Integration tests for `runtime::spawn_task`. Lives outside the
-//! lib's `#[cfg(test)] mod` so it compiles as its own test binary
-//! and stays decoupled from unrelated lib-test fixtures.
+//! Integration tests for `runtime::spawn_task` — drive the REAL v2
+//! `run_loop` (the exact production loop the co-host runs), NOT a scaffold.
+//!
+//! A scripted mock [`ApiClient`] returns one fixed text turn so the loop's
+//! mailbox mechanics are exercised deterministically with no network: inbound
+//! envelope parse, `from != self` self-filtering, reply routing for BOTH
+//! [`Mailbox`] variants, abort teardown, and the transient-read survival
+//! contract — a durable A2A inbox must NOT die on a read error / on being
+//! read before it exists (the regression guard for the co-host boot race,
+//! where the loop is spawned before the mint has planted the inbox).
+//!
+//! Lives outside the lib's `#[cfg(test)] mod` so it compiles as its own test
+//! binary; it uses the crate's normal deps (`async-trait`, `futures`).
 
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
 use kernel::kernel::{Kernel, OperationContext, ReadRequest, WriteRequest};
-use runtime::spawn_task::spawn_task_echo;
+use runtime::spawn_task::{spawn_task, Mailbox, SpawnHandle};
+use runtime::{
+    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ModelFamilyIdentity,
+    PermissionMode, PermissionPolicy, RuntimeError, SystemPromptBuilder, ToolError, ToolExecutor,
+};
 
 const DT_STREAM: i32 = 4;
 const STREAM_CAPACITY: usize = 65_536;
-const POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// Fixed text the scripted provider replies with — asserted end-to-end.
+const REPLY_TEXT: &str = "PONG";
 
-/// Add the `/proc` mount to the kernel's VFSRouter. Without this,
-/// `sys_read` / `sys_write` against `/proc/*` paths errors at
-/// `vfs_router.route()` before consulting the metastore. Mirrors
-/// `mount_proc` in the nexus-side managed_agent integration tests.
-fn mount_proc(kernel: &Kernel) {
-    kernel
-        .vfs_router_arc()
-        .add_mount("/proc", "root", None, false);
+// ── Mock provider: one fixed text turn, no tool calls ──────────────────
+
+/// [`ApiClient`] that streams a single `TextDelta` + `MessageStop`, so a
+/// turn resolves to the fixed [`REPLY_TEXT`] with zero network I/O.
+struct ScriptedReply;
+
+#[async_trait]
+impl ApiClient for ScriptedReply {
+    async fn stream(&mut self, _request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
+        Ok(Box::pin(futures::stream::iter(vec![
+            Ok(AssistantEvent::TextDelta(REPLY_TEXT.to_string())),
+            Ok(AssistantEvent::MessageStop),
+        ])))
+    }
 }
 
-fn plant_chat_stream(kernel: &Kernel, pid: &str) {
-    let path = format!("/proc/{pid}/chat-with-me");
+/// The scripted turn emits no `ToolUse`, so the executor is never invoked;
+/// a call would be a bug in the loop, so it fails loudly.
+struct NoTools;
+
+impl ToolExecutor for NoTools {
+    async fn execute(&self, tool_name: &str, _input: &str) -> Result<String, ToolError> {
+        Err(ToolError::new(format!(
+            "unexpected tool call in test: {tool_name}"
+        )))
+    }
+}
+
+// ── Kernel / mailbox helpers ───────────────────────────────────────────
+
+fn mount(kernel: &Kernel, mount_point: &str) {
+    kernel
+        .vfs_router_arc()
+        .add_mount(mount_point, "root", None, false);
+}
+
+fn plant_stream(kernel: &Kernel, path: &str) {
     kernel
         .sys_setattr(
-            &path,
+            path,
             DT_STREAM,
             /* backend_name */ "",
             /* backend */ None,
@@ -50,7 +91,7 @@ fn plant_chat_stream(kernel: &Kernel, pid: &str) {
             /* source */ None,
             /* remote_metastore */ None,
         )
-        .expect("plant /proc/{pid}/chat-with-me DT_STREAM");
+        .expect("plant DT_STREAM");
 }
 
 fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
@@ -64,24 +105,95 @@ fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
     }
 }
 
-fn user_ctx() -> OperationContext {
-    OperationContext::new(
-        "test-user",
-        "root",
-        /* is_admin */ false,
-        Some("user-test"),
-        /* is_system */ true,
+/// Spawn the REAL `run_loop` (via `spawn_task`) with the scripted mock —
+/// the exact loop the co-host runs, minus the network provider.
+fn spawn_real(kernel: Arc<Kernel>, desc: AgentDescriptor, mailbox: Mailbox) -> SpawnHandle {
+    let system_prompt = SystemPromptBuilder::new()
+        .with_model_family(ModelFamilyIdentity::Claude)
+        .build();
+    spawn_task(
+        kernel,
+        desc,
+        mailbox,
+        ScriptedReply,
+        NoTools,
+        system_prompt,
+        PermissionPolicy::new(PermissionMode::Allow),
+        |_state| {},
     )
 }
 
-fn read_envelopes(
+fn user_ctx() -> OperationContext {
+    OperationContext::new("test-user", "root", false, Some("user-test"), true)
+}
+
+fn write_envelope(
     kernel: &Kernel,
     path: &str,
     ctx: &OperationContext,
-    from_offset: u64,
-) -> (Vec<serde_json::Value>, u64) {
-    let mut offset = from_offset;
-    let mut out = Vec::new();
+    from: &str,
+    to: &str,
+    body: &str,
+) {
+    let env = serde_json::json!({ "from": from, "to": to, "body": body });
+    let reqs = [WriteRequest {
+        path: path.to_string(),
+        content: serde_json::to_vec(&env).unwrap(),
+        offset: 0,
+    }];
+    kernel
+        .sys_write(&reqs, ctx)
+        .pop()
+        .expect("sys_write returned empty vec")
+        .expect("write envelope");
+}
+
+/// Poll `path` until an envelope `from` the given author with a non-empty
+/// body arrives, or `timeout` elapses.
+fn wait_for_reply(
+    kernel: &Kernel,
+    path: &str,
+    ctx: &OperationContext,
+    from: &str,
+    timeout: Duration,
+) -> Option<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    let mut offset = 0u64;
+    while Instant::now() < deadline {
+        let reqs = [ReadRequest {
+            path: path.to_string(),
+            offset,
+            len: None,
+            timeout_ms: 0,
+        }];
+        if let Some(Ok(result)) = kernel.sys_read(&reqs, ctx).pop() {
+            if let Some(bytes) = result.data.as_ref() {
+                if !bytes.is_empty() {
+                    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+                        let is_from = v.get("from").and_then(|f| f.as_str()) == Some(from);
+                        let has_body = v
+                            .get("body")
+                            .and_then(|b| b.as_str())
+                            .is_some_and(|b| !b.is_empty());
+                        if is_from && has_body {
+                            return Some(v);
+                        }
+                    }
+                }
+            }
+            if let Some(next) = result.stream_next_offset {
+                offset = next as u64;
+            }
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+/// Count envelopes on `path` authored by `from`, walking the whole stream.
+fn count_from(kernel: &Kernel, path: &str, ctx: &OperationContext, from: &str) -> usize {
+    let mut offset = 0u64;
+    let mut count = 0;
     loop {
         let reqs = [ReadRequest {
             path: path.to_string(),
@@ -89,13 +201,14 @@ fn read_envelopes(
             len: None,
             timeout_ms: 0,
         }];
-        let mut results = kernel.sys_read(&reqs, ctx);
-        match results.pop() {
+        match kernel.sys_read(&reqs, ctx).pop() {
             Some(Ok(result)) => {
                 if let Some(bytes) = result.data.as_ref() {
                     if !bytes.is_empty() {
                         if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
-                            out.push(v);
+                            if v.get("from").and_then(|f| f.as_str()) == Some(from) {
+                                count += 1;
+                            }
                         }
                     }
                 }
@@ -108,150 +221,198 @@ fn read_envelopes(
             _ => break,
         }
     }
-    (out, offset)
+    count
 }
 
-fn wait_for_envelope_with_body(
-    kernel: &Kernel,
-    path: &str,
-    ctx: &OperationContext,
-    body_eq: &str,
-    timeout: Duration,
-) -> Option<serde_json::Value> {
-    let deadline = Instant::now() + timeout;
-    let mut offset = 0u64;
-    while Instant::now() < deadline {
-        let (envelopes, next) = read_envelopes(kernel, path, ctx, offset);
-        offset = next;
-        for env in envelopes {
-            if env.get("body").and_then(|v| v.as_str()) == Some(body_eq) {
-                return Some(env);
-            }
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
-    None
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn local_stream_round_trip_drives_real_run_loop() {
+    let kernel = Arc::new(Kernel::new());
+    mount(&kernel, "/proc");
+    let path = "/proc/pid-ls/chat-with-me";
+    plant_stream(&kernel, path);
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("pid-ls", "scode"),
+        Mailbox::LocalStream {
+            path: path.to_string(),
+            self_id: "scode".to_string(),
+        },
+    );
+
+    let ctx = user_ctx();
+    write_envelope(&kernel, path, &ctx, "user-test", "scode", "hello");
+    let reply = wait_for_reply(&kernel, path, &ctx, "scode", Duration::from_secs(5));
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+
+    let reply = reply.expect("real run_loop produced no reply on the shared stream");
+    assert_eq!(reply.get("body").and_then(|b| b.as_str()), Some(REPLY_TEXT));
+    assert_eq!(reply.get("to").and_then(|t| t.as_str()), Some("user-test"));
 }
 
 #[test]
-fn echo_round_trip_through_proc_pid_chat_with_me() {
+fn a2a_reads_own_inbox_and_replies_to_senders_inbox() {
     let kernel = Arc::new(Kernel::new());
-    mount_proc(&kernel);
-    plant_chat_stream(&kernel, "v0-echo-1");
-    let desc = make_desc("v0-echo-1", "agent-v0");
-    let handle = spawn_task_echo(Arc::clone(&kernel), desc);
+    mount(&kernel, "/agents");
+    plant_stream(&kernel, "/agents/win-ai/chat-with-me");
+    plant_stream(&kernel, "/agents/user-test/chat-with-me");
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+    );
 
     let ctx = user_ctx();
-    let cwm_path = "/proc/v0-echo-1/chat-with-me";
-    let prompt = serde_json::json!({
-        "from": "user-test",
-        "to": "agent-v0",
-        "body": "hello",
-    });
-    let write_reqs = [WriteRequest {
-        path: cwm_path.to_string(),
-        content: serde_json::to_vec(&prompt).unwrap(),
-        offset: 0,
-    }];
-    kernel
-        .sys_write(&write_reqs, &ctx)
-        .pop()
-        .expect("sys_write returned empty vec")
-        .expect("user write to chat-with-me");
-
-    let echo = wait_for_envelope_with_body(
+    // Sender writes to win-ai's OWN inbox …
+    write_envelope(
         &kernel,
-        cwm_path,
+        "/agents/win-ai/chat-with-me",
         &ctx,
-        "echo: hello",
-        Duration::from_secs(2),
+        "user-test",
+        "win-ai",
+        "hi",
+    );
+    // … and the reply must land in the SENDER's inbox, not win-ai's.
+    let reply = wait_for_reply(
+        &kernel,
+        "/agents/user-test/chat-with-me",
+        &ctx,
+        "win-ai",
+        Duration::from_secs(5),
     );
     handle.abort_signal.abort();
     let _ = handle.join.join();
-    let echo = echo.expect("agent echo response did not arrive within 2s");
 
-    assert_eq!(echo.get("from").and_then(|v| v.as_str()), Some("agent-v0"));
-    assert_eq!(echo.get("to").and_then(|v| v.as_str()), Some("user-test"));
+    let reply = reply.expect("A2A co-host produced no reply in the sender's inbox");
+    assert_eq!(reply.get("body").and_then(|b| b.as_str()), Some(REPLY_TEXT));
+    assert_eq!(reply.get("to").and_then(|t| t.as_str()), Some("user-test"));
+    // The reply went to the sender's box, so win-ai's own inbox holds only
+    // the inbound (no self-directed reply).
+    assert_eq!(
+        count_from(&kernel, "/agents/win-ai/chat-with-me", &ctx, "win-ai"),
+        0,
+        "reply must route to the sender's inbox, not the agent's own"
+    );
 }
 
 #[test]
 fn loop_exits_on_abort_signal() {
     let kernel = Arc::new(Kernel::new());
-    mount_proc(&kernel);
-    plant_chat_stream(&kernel, "v0-abort-1");
-    let desc = make_desc("v0-abort-1", "agent-abort");
-
-    let handle = spawn_task_echo(Arc::clone(&kernel), desc);
-    // No prompt sent — the loop is sitting in the poll sleep.
-    // abort() must wake it within one POLL_INTERVAL + a sys_read
-    // round trip.
+    mount(&kernel, "/proc");
+    let path = "/proc/pid-abort/chat-with-me";
+    plant_stream(&kernel, path);
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("pid-abort", "scode"),
+        Mailbox::LocalStream {
+            path: path.to_string(),
+            self_id: "scode".to_string(),
+        },
+    );
+    // No message sent — the loop is parked on `sys_watch`. abort() must let
+    // it exit on the next `while !abort` check (≤ one watch timeout).
     handle.abort_signal.abort();
 
     let watcher = thread::Builder::new()
         .spawn(move || handle.join.join())
         .expect("watcher thread");
-    let deadline = Instant::now() + Duration::from_secs(2);
+    let deadline = Instant::now() + Duration::from_secs(3);
     while !watcher.is_finished() {
-        if Instant::now() >= deadline {
-            panic!("spawn_task thread did not exit within 2s of abort()");
-        }
+        assert!(
+            Instant::now() < deadline,
+            "run_loop did not exit within 3s of abort()"
+        );
         thread::sleep(Duration::from_millis(20));
     }
     let _ = watcher.join();
 }
 
 #[test]
-fn skips_own_writes_to_avoid_echo_loop() {
-    // The agent's own echo writes carry from=self_agent_id; the
-    // loop must filter these out so the mailbox does not
-    // exponentially explode. Walks one round trip and asserts the
-    // stream contains exactly one agent echo (no echo-of-echo).
+fn skips_own_writes_no_reply_storm() {
+    // LocalStream reads AND replies on the same path, so the agent sees its
+    // own reply on the next poll; `from == self` filtering must stop it from
+    // replying to itself (which would explode the mailbox).
     let kernel = Arc::new(Kernel::new());
-    mount_proc(&kernel);
-    plant_chat_stream(&kernel, "v0-loop-1");
-    let desc = make_desc("v0-loop-1", "agent-loop");
-    let handle = spawn_task_echo(Arc::clone(&kernel), desc);
+    mount(&kernel, "/proc");
+    let path = "/proc/pid-filter/chat-with-me";
+    plant_stream(&kernel, path);
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("pid-filter", "scode"),
+        Mailbox::LocalStream {
+            path: path.to_string(),
+            self_id: "scode".to_string(),
+        },
+    );
 
     let ctx = user_ctx();
-    let cwm_path = "/proc/v0-loop-1/chat-with-me";
-    let prompt = serde_json::json!({
-        "from": "user-test",
-        "to": "agent-loop",
-        "body": "ping",
-    });
-    let write_reqs = [WriteRequest {
-        path: cwm_path.to_string(),
-        content: serde_json::to_vec(&prompt).unwrap(),
-        offset: 0,
-    }];
-    kernel
-        .sys_write(&write_reqs, &ctx)
-        .pop()
-        .expect("sys_write returned empty vec")
-        .unwrap();
-
-    let _ = wait_for_envelope_with_body(
-        &kernel,
-        cwm_path,
-        &ctx,
-        "echo: ping",
-        Duration::from_secs(2),
-    )
-    .expect("first echo did not arrive");
-    // Settle for several poll intervals so any bug-induced
-    // echo-of-echo would have written by now.
-    thread::sleep(POLL_INTERVAL * 4);
+    write_envelope(&kernel, path, &ctx, "user-test", "scode", "ping");
+    let _ = wait_for_reply(&kernel, path, &ctx, "scode", Duration::from_secs(5))
+        .expect("first agent reply did not arrive");
+    // Settle several watch cycles so any self-reply bug would have written by now.
+    thread::sleep(Duration::from_millis(600));
     handle.abort_signal.abort();
     let _ = handle.join.join();
 
-    let (envelopes, _) = read_envelopes(&kernel, cwm_path, &ctx, 0);
-    let agent_echoes = envelopes
-        .iter()
-        .filter(|v| v.get("from").and_then(|f| f.as_str()) == Some("agent-loop"))
-        .count();
     assert_eq!(
-        agent_echoes, 1,
-        "expected exactly one agent echo, got {agent_echoes} — \
-         loop is echoing its own writes"
+        count_from(&kernel, path, &ctx, "scode"),
+        1,
+        "agent replied to its own message — the from==self filter is broken"
+    );
+}
+
+#[test]
+fn a2a_inbox_survives_read_before_it_exists() {
+    // F1 regression: the co-host boot spawns the loop bound to
+    // `/agents/<self>/chat-with-me`, which the mint may not have planted yet
+    // (or which a fresh raft replica hasn't resolved). The OLD loop broke on
+    // the first `Err` and the agent silently died for the daemon's lifetime.
+    // The loop must SURVIVE the transient error and serve the message once
+    // the inbox appears.
+    let kernel = Arc::new(Kernel::new());
+    // Deliberately do NOT mount /agents yet → the loop's first reads all Err
+    // (NotMounted). The old `Err(_) => break` would kill the loop here.
+    let handle = spawn_real(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+    );
+    // Let the loop spin on the error path across several watch cycles.
+    thread::sleep(Duration::from_millis(300));
+
+    // Now the "mint" lands: mount + plant the inbox and the sender's box.
+    mount(&kernel, "/agents");
+    plant_stream(&kernel, "/agents/win-ai/chat-with-me");
+    plant_stream(&kernel, "/agents/user-test/chat-with-me");
+    let ctx = user_ctx();
+    write_envelope(
+        &kernel,
+        "/agents/win-ai/chat-with-me",
+        &ctx,
+        "user-test",
+        "win-ai",
+        "hi",
+    );
+
+    let reply = wait_for_reply(
+        &kernel,
+        "/agents/user-test/chat-with-me",
+        &ctx,
+        "win-ai",
+        Duration::from_secs(5),
+    );
+    handle.abort_signal.abort();
+    let _ = handle.join.join();
+    assert!(
+        reply.is_some(),
+        "loop died on the pre-mint read error (F1 regression) — no reply after the inbox appeared"
     );
 }

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2a62e6a5618d0008872c958d95db4e3ebaae6120", default-features = false }
 
 [lints]
 workspace = true

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -425,6 +425,20 @@ pub struct ToolSpec {
     pub required_permission: PermissionMode,
 }
 
+/// The single ToolSpec → wire `ToolDefinition` mapping. Both the CLI path
+/// (`GlobalToolRegistry::definitions`) and the co-host path
+/// (`ProviderRuntimeClient::stream` via `tool_specs_for_allowed_tools`) go
+/// through here, so the spec→definition shape has one SSOT.
+impl From<ToolSpec> for ToolDefinition {
+    fn from(spec: ToolSpec) -> Self {
+        ToolDefinition {
+            name: spec.name.to_string(),
+            description: Some(spec.description.to_string()),
+            input_schema: spec.input_schema,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GlobalToolRegistry {
     plugin_tools: Vec<PluginTool>,
@@ -581,11 +595,7 @@ impl GlobalToolRegistry {
             .into_iter()
             .filter(|spec| allowed_tools.is_none_or(|allowed| allowed.contains(spec.name)))
             .filter(|spec| coord_gate(spec.name))
-            .map(|spec| ToolDefinition {
-                name: spec.name.to_string(),
-                description: Some(spec.description.to_string()),
-                input_schema: spec.input_schema,
-            });
+            .map(ToolDefinition::from);
         let runtime = self
             .runtime_tools
             .iter()
@@ -1400,6 +1410,24 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::DangerFullAccess,
+        },
+        ToolSpec {
+            name: "send_message",
+            description: "Send a message to another agent's mailbox. Call this ONLY \
+                          when you decide to reply to a peer; if you have nothing to \
+                          say, do NOT call it — staying silent lets the conversation \
+                          end instead of bouncing forever. Only available to agents \
+                          that have a mailbox (A2A / co-hosted).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "to": { "type": "string", "description": "The recipient agent's id." },
+                    "body": { "type": "string", "description": "The message to send." }
+                },
+                "required": ["to", "body"],
+                "additionalProperties": false
+            }),
+            required_permission: PermissionMode::WorkspaceWrite,
         },
     ];
     if cron_tools_disabled() {
@@ -6587,11 +6615,7 @@ impl ApiClient for ProviderRuntimeClient {
     async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
         let tools = tool_specs_for_allowed_tools(Some(&self.allowed_tools))
             .into_iter()
-            .map(|spec| ToolDefinition {
-                name: spec.name.to_string(),
-                description: Some(spec.description.to_string()),
-                input_schema: spec.input_schema,
-            })
+            .map(ToolDefinition::from)
             .collect::<Vec<_>>();
         let messages = convert_messages(&request.messages);
         let system = (!request.system_prompt.is_empty()).then(|| request.system_prompt.render());

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -3,8 +3,7 @@
 //! Constructs the `ApiClient`, `ToolExecutor`, `SystemPrompt`, and
 //! `PermissionPolicy` dependencies from the `AgentDescriptor` metadata
 //! and calls `runtime::spawn_task::spawn_task` to launch the full LLM
-//! loop. The nexus cdylib's `SudoCodeSpawnAdapter` calls this instead
-//! of `spawn_task_echo`.
+//! loop. The nexus cdylib's `SudoCodeSpawnAdapter` calls this.
 //!
 //! Lives in the `tools` crate because it needs both the `api` crate
 //! (for `ProviderClient` / `resolve_provider_from_config`) and the
@@ -32,8 +31,7 @@ const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 
 /// Spawn a managed-agent loop with the full ConversationRuntime.
 ///
-/// This is the v2 upgrade of `spawn_task_echo`. The caller
-/// (nexus cdylib `SudoCodeSpawnAdapter`) invokes this after
+/// The caller (nexus cdylib `SudoCodeSpawnAdapter`) invokes this after
 /// `register_proc_entry` stamps the per-pid procfs subtree.
 ///
 /// # Arguments

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -14,7 +14,10 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use runtime::spawn_task::{AgentDescriptor, AgentLoopState, KernelSyscall, Mailbox, SpawnHandle};
+use runtime::spawn_task::{
+    mailbox_sender, AgentDescriptor, AgentLoopState, KernelSyscall, Mailbox, MailboxSender,
+    SpawnHandle,
+};
 use runtime::{
     FsBackend, KernelFsBackend, ModelFamilyIdentity, PermissionMode, PermissionPolicy,
     SystemPromptBuilder, ToolError, ToolExecutor,
@@ -61,7 +64,12 @@ where
         .unwrap_or_else(|| DEFAULT_MODEL.to_string());
 
     // -- ApiClient: provider chain from model id --
-    let api_client = ProviderRuntimeClient::new(model, BTreeSet::new())
+    // The co-hosted agent is A2A-capable, so its tool set includes
+    // `send_message` (its ONLY, deliberate reply path — see the ping-pong fix).
+    // The full tool set (file ops, etc.) is gated behind the agent-profile work;
+    // the duet needs only send_message.
+    let allowed_tools: BTreeSet<String> = std::iter::once("send_message".to_string()).collect();
+    let api_client = ProviderRuntimeClient::new(model, allowed_tools)
         .expect("failed to construct API client from model label");
 
     // -- FsBackend: in-process VFS, NOT host std::fs. The co-hosted
@@ -77,9 +85,19 @@ where
         workspace_root,
     ));
 
-    // -- ToolExecutor: dispatch through the global tool registry, bound
-    // to the VFS backend so every file tool is in-process. --
-    let tool_executor = ManagedToolExecutor { fs };
+    // -- Mailbox sender: the co-host's deliberate-reply capability, built from
+    // this agent's kernel + mailbox + operation identity. Clone the mailbox and
+    // identity here because `spawn_task` below moves the originals. --
+    let send = mailbox_sender(
+        Arc::clone(&kernel),
+        mailbox.clone(),
+        desc.owner_id.clone(),
+        desc.zone_id.clone(),
+    );
+
+    // -- ToolExecutor: file tools in-process via the VFS backend; `send_message`
+    // routes through the mailbox sender. --
+    let tool_executor = ManagedToolExecutor { fs, send };
 
     // -- SystemPrompt: minimal prompt for managed-agent context --
     let system_prompt = SystemPromptBuilder::new()
@@ -111,12 +129,34 @@ where
 /// in-process against the kernel trie.
 struct ManagedToolExecutor {
     fs: Arc<dyn FsBackend>,
+    /// The co-hosted agent's outbound-message capability. `send_message` is the
+    /// ONLY way this agent replies to a peer — the poll loop no longer
+    /// auto-forwards turn output (the ping-pong fix), so a reply happens ONLY
+    /// when the agent deliberately calls the tool.
+    send: MailboxSender,
 }
 
 impl ToolExecutor for ManagedToolExecutor {
     async fn execute(&self, tool_name: &str, input: &str) -> Result<String, ToolError> {
         let input_value: serde_json::Value =
             serde_json::from_str(input).map_err(|e| ToolError::new(e.to_string()))?;
+
+        // `send_message` is the co-host's deliberate-reply path — a quick
+        // in-process mailbox write bound to THIS agent's identity, not a file
+        // op, so it routes through the mailbox sender, not the fs backend.
+        if tool_name == "send_message" {
+            let to = input_value
+                .get("to")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolError::new("send_message requires a string 'to'"))?;
+            let body = input_value
+                .get("body")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolError::new("send_message requires a string 'body'"))?;
+            (self.send)(to, body).map_err(ToolError::new)?;
+            return Ok(format!("message delivered to {to}"));
+        }
+
         // Offload the blocking in-process syscall to the blocking pool so a
         // concurrency-safe batch of read-only tools overlaps (I/O
         // interleaving, not thread parallelism): only the `Arc<fs>` clone and


### PR DESCRIPTION
## Problem
The co-hosted A2A mailbox loop harvested every turn's assistant text and **unconditionally wrote it back** to the peer. Because an LLM turn always produces *some* text, there was no silence terminator — two co-hosted agents bounce messages forever (ping-pong).

## Fix (send-half)
- **Delete the auto-forward.** A turn no longer implies a reply.
- **Add a `send_message(to, body)` tool** as the agent's *only, deliberate* reply path. The agent replies by calling the tool inside its turn; **not calling it = silence = the conversation ends.**
- Read side is unchanged (inbound message is fed as the turn prompt). Read-agency is a separate follow-up.

## Message contract = the nexus-vfs `a2a` crate (SSOT/DRY)
The mailbox envelope (`from`/`to`/`body`, `from` anti-spoof stamp, `CHAT_WITH_ME_SUFFIX`) is owned by the kernel-tier `a2a` crate, not re-declared here. This needs the dep bump:
- kernel `c9ecc9da` → `2a62e6a5` and add `a2a` (default-features off).
- `send_message` is one `ToolSpec` in `mvp_tool_specs()` (the single tool-spec SSOT), so both the CLI registry and the co-host provider derive it from one place; `impl From<ToolSpec> for ToolDefinition` removes the prior duplicate map sites.

## Commits
1. `fix(spawn_task)`: survive transient A2A inbox reads + drop echo tombstone
2. `chore(deps)`: bump nexus-vfs kernel `c9ecc9da` → `2a62e6a5` + add `a2a` dep
3. `fix(cohost)`: kill A2A ping-pong — delete auto-forward, add `send_message` tool

## Tests
Local `cargo test -p runtime -p tools`: **861 passed, 0 failed** (runtime lib 634; `spawn_task` 6/6 incl the new `text_only_turn_writes_no_reply` ping-pong regression test; tools incl the tool-spec/permission parity test). `cargo fmt --check` clean. Rebased on current `main` (includes #443/#444/#445); `tools/src/lib.rs` auto-merge verified by the green tool-spec test.

Supersedes the closed #440 (that branch had only the transient-read fix; this is the full send-half on a clean base).