### PR TITLE
feat(runtime): offload oversized tool outputs with byte-identical resume

### DIFF
--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -103,10 +103,6 @@ pub struct BashCommandOutput {
     pub no_output_expected: Option<bool>,
     #[serde(rename = "structuredContent")]
     pub structured_content: Option<Vec<serde_json::Value>>,
-    #[serde(rename = "persistedOutputPath")]
-    pub persisted_output_path: Option<String>,
-    #[serde(rename = "persistedOutputSize")]
-    pub persisted_output_size: Option<u64>,
     #[serde(rename = "sandboxStatus")]
     pub sandbox_status: Option<SandboxStatus>,
 }
@@ -166,8 +162,6 @@ pub fn execute_bash_with_progress(
             return_code_interpretation: None,
             no_output_expected: Some(true),
             structured_content: None,
-            persisted_output_path: None,
-            persisted_output_size: None,
             sandbox_status: Some(sandbox_status),
         });
     }
@@ -345,8 +339,14 @@ async fn execute_bash_async(
         result = &mut output => result?,
     };
 
-    let stdout = truncate_output(&String::from_utf8_lossy(&output.stdout));
-    let stderr = truncate_output(&String::from_utf8_lossy(&output.stderr));
+    let stdout = truncate_output(
+        &String::from_utf8_lossy(&output.stdout),
+        MAX_OUTPUT_BYTES_SAFETY,
+    );
+    let stderr = truncate_output(
+        &String::from_utf8_lossy(&output.stderr),
+        MAX_OUTPUT_BYTES_SAFETY,
+    );
     let no_output_expected = Some(stdout.trim().is_empty() && stderr.trim().is_empty());
     let return_code_interpretation = output.status.code().and_then(|code| {
         if code == 0 {
@@ -369,8 +369,6 @@ async fn execute_bash_async(
         return_code_interpretation,
         no_output_expected,
         structured_content: None,
-        persisted_output_path: None,
-        persisted_output_size: None,
         sandbox_status: Some(sandbox_status),
     })
 }
@@ -506,8 +504,8 @@ async fn execute_bash_streaming(
     // Wait for the child to fully exit
     let status = child.wait().await?;
 
-    let stdout = truncate_output(&stdout_buf);
-    let stderr = truncate_output(&stderr_buf);
+    let stdout = truncate_output(&stdout_buf, MAX_OUTPUT_BYTES_SAFETY);
+    let stderr = truncate_output(&stderr_buf, MAX_OUTPUT_BYTES_SAFETY);
     let no_output_expected = Some(stdout.trim().is_empty() && stderr.trim().is_empty());
     let return_code_interpretation = status.code().and_then(|code| {
         if code == 0 {
@@ -530,8 +528,6 @@ async fn execute_bash_streaming(
         return_code_interpretation,
         no_output_expected,
         structured_content: None,
-        persisted_output_path: None,
-        persisted_output_size: None,
         sandbox_status: Some(sandbox_status),
     })
 }
@@ -555,8 +551,6 @@ fn interrupted_bash_output(
         return_code_interpretation: Some(return_code_interpretation.to_string()),
         no_output_expected: Some(true),
         structured_content: None,
-        persisted_output_path: None,
-        persisted_output_size: None,
         sandbox_status: Some(sandbox_status),
     }
 }
@@ -865,21 +859,28 @@ mod tests {
     }
 }
 
-/// Maximum output bytes before truncation (16 KiB, matching upstream).
-const MAX_OUTPUT_BYTES: usize = 16_384;
+/// Baseline output byte budget (16 KiB); the central offload threshold in the
+/// conversation loop matches it.
+pub(crate) const MAX_OUTPUT_BYTES: usize = 16_384;
 
-/// Truncate output to `MAX_OUTPUT_BYTES`, appending a marker when trimmed.
-fn truncate_output(s: &str) -> String {
-    if s.len() <= MAX_OUTPUT_BYTES {
+/// Hard safety cap for a single tool output buffered in memory before it
+/// reaches the central offload (`conversation.rs`). Far above the offload
+/// threshold, so normal oversized output flows through and gets offloaded to
+/// disk; this only guards against pathological unbounded output (e.g. `yes`).
+const MAX_OUTPUT_BYTES_SAFETY: usize = 10 * 1024 * 1024;
+
+/// Truncate output to `max` bytes, appending a marker when trimmed.
+pub(crate) fn truncate_output(s: &str, max: usize) -> String {
+    if s.len() <= max {
         return s.to_string();
     }
-    // Find the last valid UTF-8 boundary at or before MAX_OUTPUT_BYTES
-    let mut end = MAX_OUTPUT_BYTES;
+    // Find the last valid UTF-8 boundary at or before `max`
+    let mut end = max;
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;
     }
     let mut truncated = s[..end].to_string();
-    truncated.push_str("\n\n[output truncated — exceeded 16384 bytes]");
+    truncated.push_str(&format!("\n\n[output truncated — exceeded {max} bytes]"));
     truncated
 }
 
@@ -890,13 +891,13 @@ mod truncation_tests {
     #[test]
     fn short_output_unchanged() {
         let s = "hello world";
-        assert_eq!(truncate_output(s), s);
+        assert_eq!(truncate_output(s, MAX_OUTPUT_BYTES), s);
     }
 
     #[test]
     fn long_output_truncated() {
         let s = "x".repeat(20_000);
-        let result = truncate_output(&s);
+        let result = truncate_output(&s, MAX_OUTPUT_BYTES);
         assert!(result.len() < 20_000);
         assert!(result.ends_with("[output truncated — exceeded 16384 bytes]"));
     }
@@ -904,13 +905,13 @@ mod truncation_tests {
     #[test]
     fn exact_boundary_unchanged() {
         let s = "a".repeat(MAX_OUTPUT_BYTES);
-        assert_eq!(truncate_output(&s), s);
+        assert_eq!(truncate_output(&s, MAX_OUTPUT_BYTES), s);
     }
 
     #[test]
     fn one_over_boundary_truncated() {
         let s = "a".repeat(MAX_OUTPUT_BYTES + 1);
-        let result = truncate_output(&s);
+        let result = truncate_output(&s, MAX_OUTPUT_BYTES);
         assert!(result.contains("[output truncated"));
     }
 }

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -184,6 +184,12 @@ pub struct ToolDispatchContext {
     /// Populated by the runtime tool loop from `Session::messages`.
     /// Consumed by [`Self::is_inside_fork_child`].
     pub parent_session_messages: Vec<ConversationMessage>,
+    /// The current session's `tool-results/` directory — the sole handle
+    /// the `read_tool_output` tool needs to page an offloaded oversized
+    /// result back in. The runtime resolves it from `Session`; the model
+    /// only ever names the opaque tool_use id, so the physical path never
+    /// crosses the model boundary. `None` for in-memory sessions.
+    pub tool_results_dir: Option<std::path::PathBuf>,
 }
 
 impl ToolDispatchContext {
@@ -779,6 +785,50 @@ where
         Ok(())
     }
 
+    /// If a tool output exceeds the offload threshold, spill the full bytes to
+    /// `<session-dir>/tool-results/<tool_use_id>` (via the session `FsBackend`,
+    /// backend-agnostic) and replace it in-transcript with a head preview + a
+    /// deterministic `<persisted-output>` marker. Persisting the *replaced*
+    /// message is itself the content-replacement: resume replays it verbatim,
+    /// so the prompt-cache prefix stays byte-identical. The full bytes live only
+    /// in the offloaded file (the read-more side-channel); the transcript is the
+    /// prompt SSOT.
+    fn maybe_offload_tool_output(&self, tool_use_id: &str, output: String) -> String {
+        /// Outputs at or under this stay fully inline. Shares the bash output
+        /// budget so the "16 KiB" threshold lives in one place.
+        const OFFLOAD_THRESHOLD: usize = crate::bash::MAX_OUTPUT_BYTES;
+        /// Bytes of the head kept inline as a preview when offloading.
+        const PREVIEW_BYTES: usize = 12_288;
+        if output.len() <= OFFLOAD_THRESHOLD {
+            return output;
+        }
+        let head = |n: usize| {
+            let mut end = n.min(output.len());
+            while end > 0 && !output.is_char_boundary(end) {
+                end -= 1;
+            }
+            end
+        };
+        match self
+            .session
+            .offload_tool_result(tool_use_id, output.as_bytes())
+        {
+            Ok((_path, total)) => {
+                // The physical path never leaves the engine; the model only
+                // ever sees the opaque tool_use id. The full result is paged
+                // back in by line via `read_tool_output(id=..., offset, limit)`.
+                let end = head(PREVIEW_BYTES);
+                format!(
+                    "{}\n\n<persisted-output bytes={total} id=\"{tool_use_id}\">\n[Tool output was {total} bytes; the first {end} are shown above as a preview. The full result is preserved — read more by line with read_tool_output(id=\"{tool_use_id}\", offset=<line>, limit=<lines>).]\n</persisted-output>",
+                    &output[..end]
+                )
+            }
+            // Offload failed (e.g. no persistence path) — never send an
+            // unbounded prompt; fall back to a bounded truncation (shared with bash).
+            Err(_) => crate::bash::truncate_output(&output, OFFLOAD_THRESHOLD),
+        }
+    }
+
     fn push_interrupted_tool_results(
         &mut self,
         observer: &mut Option<&mut dyn RuntimeObserver>,
@@ -1129,6 +1179,7 @@ where
             let dispatch_context = ToolDispatchContext {
                 parent_assistant_message: Some(assistant_message),
                 parent_session_messages: self.session.messages.clone(),
+                tool_results_dir: self.session.tool_results_dir(),
             };
 
             let mut batch_start = 0usize;
@@ -1493,6 +1544,7 @@ where
                                 || post_hook_result.is_cancelled(),
                         );
 
+                        let output = self.maybe_offload_tool_output(&tool_use_id, output);
                         ConversationMessage::tool_result(tool_use_id, tool_name, output, is_error)
                     }
                     PermissionOutcome::Deny { reason } => ConversationMessage::tool_result(
@@ -2679,6 +2731,122 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn oversized_tool_output_is_offloaded_and_resume_is_byte_identical() {
+        // A tool whose output exceeds the offload threshold. A unique tail
+        // sentinel sits past the preview window so we can prove it is spilled
+        // to the offload file and never inlined into the transcript.
+        const SENTINEL: &str = "UNIQUE_TAIL_SENTINEL_ZZZ";
+        let big = format!("{}{SENTINEL}", "A".repeat(20_000));
+
+        struct OneToolThenStop;
+        #[async_trait]
+        impl ApiClient for OneToolThenStop {
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                if request.messages.iter().any(|m| m.role == MessageRole::Tool) {
+                    return Ok(events_to_stream(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]));
+                }
+                Ok(events_to_stream(vec![
+                    AssistantEvent::ToolUse {
+                        id: "big-1".to_string(),
+                        name: "big".to_string(),
+                        input: String::new(),
+                        thought_signature: None,
+                    },
+                    AssistantEvent::MessageStop,
+                ]))
+            }
+        }
+
+        struct AllowAll;
+        impl PermissionPrompter for AllowAll {
+            fn decide(&mut self, _request: &PermissionRequest) -> PermissionPromptDecision {
+                PermissionPromptDecision::Allow
+            }
+        }
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let session_file = std::env::temp_dir().join(format!("runtime-offload-e2e-{nanos}.jsonl"));
+
+        let tool_output = big.clone();
+        let mut runtime = ConversationRuntime::new(
+            Session::new().with_persistence_path(session_file.clone()),
+            OneToolThenStop,
+            StaticToolExecutor::new().register("big", move |_input| Ok(tool_output.clone())),
+            PermissionPolicy::new(PermissionMode::WorkspaceWrite),
+            SystemPrompt::default(),
+        );
+
+        runtime
+            .run_turn("please run big", Some(&mut AllowAll), None)
+            .await
+            .expect("conversation loop should succeed");
+
+        // 1. Full blob spilled to the session's tool-results/<id>, byte-exact.
+        let offloaded = runtime
+            .session()
+            .tool_results_dir()
+            .expect("tool-results dir")
+            .join("big-1");
+        let spilled = fs::read_to_string(&offloaded).expect("offloaded blob should exist");
+        assert_eq!(spilled, big);
+
+        // 2. In-transcript tool_result is the replaced preview+marker, NOT the
+        //    full blob: it carries the opaque-id marker, keeps only the head,
+        //    and drops the tail sentinel.
+        let tool_msg = runtime
+            .session()
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::Tool)
+            .expect("tool result message should exist");
+        let ContentBlock::ToolResult { output, .. } = &tool_msg.blocks[0] else {
+            panic!("expected a tool_result block");
+        };
+        assert!(output.contains("<persisted-output"));
+        assert!(output.contains("id=\"big-1\""));
+        assert!(!output.contains(SENTINEL), "tail must not be inlined");
+        assert!(output.len() < big.len());
+        let inline_output = output.clone();
+
+        // 3. Resume replays byte-identically: the persisted transcript never
+        //    held the tail, and reloads to the exact same tool_result content
+        //    (so the prompt-cache prefix stays warm across --resume).
+        let on_disk = fs::read_to_string(&session_file).expect("transcript should persist");
+        assert!(
+            !on_disk.contains(SENTINEL),
+            "transcript must not hold the tail"
+        );
+
+        let restored = Session::load_from_path(&session_file).expect("session should reload");
+        let restored_tool = restored
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::Tool)
+            .expect("reloaded tool result should exist");
+        let ContentBlock::ToolResult {
+            output: restored_output,
+            ..
+        } = &restored_tool.blocks[0]
+        else {
+            panic!("expected a reloaded tool_result block");
+        };
+        assert_eq!(*restored_output, inline_output);
+
+        let _ = fs::remove_file(&offloaded);
+        let _ = fs::remove_dir(offloaded.parent().unwrap());
+        let _ = fs::remove_file(&session_file);
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/coordinator_mode.rs
+++ b/rust/crates/runtime/src/coordinator_mode.rs
@@ -62,6 +62,7 @@ pub fn coordinator_allowed_tools() -> BTreeSet<&'static str> {
         "WebFetch",
         // Read-only code exploration
         "read_file",
+        "read_tool_output",
         "glob_search",
         "grep_search",
         // Coordinator's own bookkeeping

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -264,6 +264,70 @@ impl Session {
             .unwrap_or(&DEFAULT)
     }
 
+    /// The offload dir for a given session file + id:
+    /// `<sessions-dir>/tool-results/<session-id>/`. The single SSOT for the
+    /// offloaded-tool-results location — shared by the writer
+    /// ([`Self::tool_results_dir`]) and session-deletion GC so both always
+    /// agree on the subtree to create/read/remove.
+    #[must_use]
+    pub fn tool_results_dir_for(session_file: &Path, session_id: &str) -> Option<PathBuf> {
+        let parent = session_file.parent()?;
+        Some(
+            parent
+                .join("tool-results")
+                .join(Self::sanitize_offload_id(session_id)),
+        )
+    }
+
+    /// This session's `tool-results/<session-id>/` dir (a grandchild of the
+    /// shared sessions dir). `None` for an in-memory session. Namespacing by
+    /// session-id is required, not cosmetic: managed session files live flat
+    /// in one sessions dir (`<sessions>/<session-id>.jsonl`), so a plain
+    /// sibling dir would let one session's tool_use ids collide with another's
+    /// and leave nothing to GC per session.
+    #[must_use]
+    pub fn tool_results_dir(&self) -> Option<PathBuf> {
+        Self::tool_results_dir_for(self.persistence_path()?, &self.session_id)
+    }
+
+    /// Offload a full tool-result blob to `<session-dir>/tool-results/<id>` via
+    /// the session's `FsBackend` — backend-agnostic: it lands on the local FS
+    /// under `StdFsBackend` and on the nexus VFS under `KernelFsBackend`, no
+    /// caller change. `id` is the (unique) tool_use id; it is sanitized to a
+    /// safe filename. Written once. Returns the stored path and byte length.
+    /// Map an arbitrary tool_use id to a filesystem-safe filename: every
+    /// char outside `[A-Za-z0-9_-]` becomes `_`. Applied symmetrically by the
+    /// offload write ([`Self::offload_tool_result`]) and the read-more path
+    /// (`read_tool_output`) so both resolve the same file — and a hostile id
+    /// can neither escape the tool-results dir nor reintroduce a separator.
+    #[must_use]
+    pub fn sanitize_offload_id(id: &str) -> String {
+        id.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect()
+    }
+
+    pub fn offload_tool_result(&self, id: &str, full: &[u8]) -> std::io::Result<(String, u64)> {
+        let dir = self.tool_results_dir().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "session has no persistence path")
+        })?;
+        let dir_str = dir.to_string_lossy().into_owned();
+        let backend = self.backend();
+        backend.create_dir_all(&dir_str)?;
+        let path_str = dir
+            .join(Self::sanitize_offload_id(id))
+            .to_string_lossy()
+            .into_owned();
+        backend.write_atomic(&path_str, full)?;
+        Ok((path_str, full.len() as u64))
+    }
+
     pub fn save_to_path(&self, path: impl AsRef<Path>) -> Result<(), SessionError> {
         let path = path.as_ref();
         let snapshot = self.render_jsonl_snapshot()?;
@@ -1392,6 +1456,60 @@ mod tests {
 
         assert!(first < second);
         assert!(second < third);
+    }
+
+    #[test]
+    fn offload_tool_result_writes_full_blob_and_returns_path_and_size() {
+        let session_file = temp_session_path("offload");
+        let session = Session::new().with_persistence_path(session_file.clone());
+
+        let id = "tool_use_ABC-123";
+        let payload = "x".repeat(50_000);
+        let (path, size) = session
+            .offload_tool_result(id, payload.as_bytes())
+            .expect("offload should write");
+
+        assert_eq!(size, payload.len() as u64);
+
+        // The blob lands under the session's own tool-results/<session-id>/ dir;
+        // the id here is already filesystem-safe so it round-trips unchanged.
+        let dir = session.tool_results_dir().expect("tool-results dir");
+        assert_eq!(PathBuf::from(&path), dir.join(id));
+
+        let written = fs::read(&path).expect("offloaded file should exist");
+        assert_eq!(written, payload.as_bytes());
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+        let _ = fs::remove_file(&session_file);
+    }
+
+    #[test]
+    fn offload_tool_result_sanitizes_ids_to_stay_in_dir() {
+        let session_file = temp_session_path("offload-sanitize");
+        let session = Session::new().with_persistence_path(session_file.clone());
+
+        let (path, _size) = session
+            .offload_tool_result("../../etc/passwd", b"data")
+            .expect("offload should write");
+
+        // Every char outside [A-Za-z0-9_-] becomes '_', so a hostile id can
+        // neither escape the tool-results dir nor reintroduce separators.
+        let dir = session.tool_results_dir().expect("tool-results dir");
+        let written = PathBuf::from(&path);
+        assert!(
+            written.starts_with(&dir),
+            "offloaded path must stay under tool-results"
+        );
+        let name = written.file_name().unwrap().to_string_lossy();
+        assert!(
+            !name.contains('/') && !name.contains('\\') && !name.contains(".."),
+            "sanitized id must not contain path separators or .."
+        );
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+        let _ = fs::remove_file(&session_file);
     }
 
     #[test]

--- a/rust/crates/runtime/tests/fork_dispatch_context.rs
+++ b/rust/crates/runtime/tests/fork_dispatch_context.rs
@@ -83,6 +83,7 @@ fn assistant_only_history_is_not_inside_fork_child() {
     // user-role message inside a fork child's session.
     let ctx = ToolDispatchContext {
         parent_assistant_message: None,
+        tool_results_dir: None,
         parent_session_messages: vec![
             assistant_text("hi"),
             assistant_text(&format!("<{FORK_BOILERPLATE_TAG}> ignore me")),
@@ -95,6 +96,7 @@ fn assistant_only_history_is_not_inside_fork_child() {
 fn user_without_boilerplate_is_not_inside_fork_child() {
     let ctx = ToolDispatchContext {
         parent_assistant_message: None,
+        tool_results_dir: None,
         parent_session_messages: vec![
             user_text("please spawn a fork subagent"),
             assistant_text("Sure."),
@@ -110,6 +112,7 @@ fn user_with_boilerplate_tag_is_inside_fork_child() {
     );
     let ctx = ToolDispatchContext {
         parent_assistant_message: None,
+        tool_results_dir: None,
         parent_session_messages: vec![user_text(&seeded_directive)],
     };
     assert!(ctx.is_inside_fork_child());
@@ -124,6 +127,7 @@ fn boilerplate_in_any_prior_user_message_is_detected() {
     let boilerplate_message = user_text(&format!("<{FORK_BOILERPLATE_TAG}> stub"));
     let ctx = ToolDispatchContext {
         parent_assistant_message: None,
+        tool_results_dir: None,
         parent_session_messages: vec![
             boilerplate_message,
             assistant_text("did stuff"),
@@ -146,6 +150,7 @@ fn parent_assistant_message_is_preserved_verbatim() {
     let parent = assistant_tool_use("tu_abc", "Agent", r#"{"description":"child"}"#);
     let ctx = ToolDispatchContext {
         parent_assistant_message: Some(parent.clone()),
+        tool_results_dir: None,
         parent_session_messages: vec![],
     };
     assert_eq!(ctx.parent_assistant_message.as_ref(), Some(&parent));

--- a/rust/crates/rusty-sudocode-cli/src/cli/session.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/session.rs
@@ -145,6 +145,15 @@ pub(crate) fn delete_managed_session(path: &Path) -> Result<(), Box<dyn std::err
         return Err(format!("session file does not exist: {}", path.display()).into());
     }
     fs::remove_file(path)?;
+    // GC the session's offloaded tool-results subtree (write-once blobs spilled
+    // from oversized tool outputs). The managed file is `<session-id>.jsonl`, so
+    // its stem is the session-id that namespaces the offload dir. Best-effort:
+    // an absent dir (session never offloaded anything) is not an error.
+    if let Some(session_id) = path.file_stem().and_then(|stem| stem.to_str()) {
+        if let Some(dir) = Session::tool_results_dir_for(path, session_id) {
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
     Ok(())
 }
 
@@ -270,4 +279,38 @@ pub(crate) fn session_clear_backup_path(session_path: &Path) -> PathBuf {
         .and_then(|value| value.to_str())
         .unwrap_or("session.jsonl");
     session_path.with_file_name(format!("{file_name}.before-clear-{timestamp}.bak"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn delete_managed_session_gcs_offloaded_tool_results() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let sessions_dir = std::env::temp_dir().join(format!("scode-del-gc-{nanos}"));
+        fs::create_dir_all(&sessions_dir).expect("sessions dir");
+        let session_id = "sess-abc-123";
+        let session_file = sessions_dir.join(format!("{session_id}.jsonl"));
+        fs::write(&session_file, b"{}\n").expect("write session file");
+
+        // An offloaded blob under the session's namespaced tool-results dir.
+        let offload_dir =
+            Session::tool_results_dir_for(&session_file, session_id).expect("offload dir");
+        fs::create_dir_all(&offload_dir).expect("offload dir");
+        fs::write(offload_dir.join("tool-1"), b"big output").expect("write blob");
+        assert!(offload_dir.exists());
+
+        delete_managed_session(&session_file).expect("delete should succeed");
+
+        // Both the transcript and the offloaded subtree are gone.
+        assert!(!session_file.exists());
+        assert!(!offload_dir.exists());
+
+        let _ = fs::remove_dir_all(&sessions_dir);
+    }
 }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -803,6 +803,21 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             required_permission: PermissionMode::ReadOnly,
         },
         ToolSpec {
+            name: "read_tool_output",
+            description: "Page an oversized earlier tool result back into context by line. When a tool's output was too large to inline, the transcript shows a <persisted-output id=\"...\"> marker with a head preview; pass that id here to read the full result in bounded slices (offset = start line, limit = line count).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "The tool_use id from the <persisted-output> marker." },
+                    "offset": { "type": "integer", "minimum": 0, "description": "0-based start line (default 0)." },
+                    "limit": { "type": "integer", "minimum": 1, "description": "Maximum lines to return." }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+            }),
+            required_permission: PermissionMode::ReadOnly,
+        },
+        ToolSpec {
             name: "write_file",
             description: "Write a text file in the workspace.",
             input_schema: json!({
@@ -1569,6 +1584,11 @@ fn execute_tool_with_enforcer(
         "read_file" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
             from_value::<ReadFileInput>(input).and_then(|input| run_read_file(input, fs))
+        }
+        "read_tool_output" => {
+            maybe_enforce_permission_check(enforcer, name, input)?;
+            from_value::<ReadToolOutputInput>(input)
+                .and_then(|input| run_read_tool_output(input, ctx, fs))
         }
         "write_file" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
@@ -2951,8 +2971,6 @@ fn branch_divergence_output(
             })),
         )
         .expect("lane event should serialize")]),
-        persisted_output_path: None,
-        persisted_output_size: None,
         sandbox_status: None,
     }
 }
@@ -2960,6 +2978,34 @@ fn branch_divergence_output(
 #[allow(clippy::needless_pass_by_value)]
 fn run_read_file(input: ReadFileInput, fs: &dyn FsBackend) -> Result<String, String> {
     to_pretty_json(read_file(fs, &input.path, input.offset, input.limit).map_err(io_to_string)?)
+}
+
+/// Page an offloaded oversized tool result back into context. The model
+/// supplies only the opaque tool_use `id` from the `<persisted-output>`
+/// marker; the physical file (`<session-dir>/tool-results/<id>`) is resolved
+/// here from the trusted dispatch context and never crosses the model
+/// boundary. Reading reuses `read_file`'s bounded, line-addressed reader
+/// (offset = start line, limit = line count), and the resolved `file_path`
+/// is dropped from the response so the path stays engine-internal.
+#[allow(clippy::needless_pass_by_value)]
+fn run_read_tool_output(
+    input: ReadToolOutputInput,
+    ctx: Option<&ToolDispatchContext>,
+    fs: &dyn FsBackend,
+) -> Result<String, String> {
+    let dir = ctx
+        .and_then(|c| c.tool_results_dir.as_ref())
+        .ok_or_else(|| "no offloaded tool output is available in this session".to_string())?;
+    let resolved = dir.join(Session::sanitize_offload_id(&input.id));
+    let out = read_file(fs, &resolved.to_string_lossy(), input.offset, input.limit)
+        .map_err(io_to_string)?;
+    to_pretty_json(json!({
+        "id": input.id,
+        "content": out.file.content,
+        "startLine": out.file.start_line,
+        "numLines": out.file.num_lines,
+        "totalLines": out.file.total_lines,
+    }))
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -3213,6 +3259,13 @@ fn io_to_string(error: std::io::Error) -> String {
 #[derive(Debug, Deserialize)]
 struct ReadFileInput {
     path: String,
+    offset: Option<usize>,
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReadToolOutputInput {
+    id: String,
     offset: Option<usize>,
     limit: Option<usize>,
 }
@@ -8271,8 +8324,6 @@ fn execute_shell_command(
             return_code_interpretation: None,
             no_output_expected: Some(true),
             structured_content: None,
-            persisted_output_path: None,
-            persisted_output_size: None,
             sandbox_status: None,
         });
     }
@@ -8376,8 +8427,6 @@ fn shell_run_to_bash_output(result: ShellRunResult, timeout_ms: u64) -> runtime:
                 .map(|code| format!("exit_code:{code}")),
             no_output_expected: Some(stdio_empty),
             structured_content: None,
-            persisted_output_path: None,
-            persisted_output_size: None,
             sandbox_status: None,
         },
         ShellOutcome::Interrupted => runtime::BashCommandOutput {
@@ -8393,8 +8442,6 @@ fn shell_run_to_bash_output(result: ShellRunResult, timeout_ms: u64) -> runtime:
             return_code_interpretation: Some(String::from("interrupted")),
             no_output_expected: Some(false),
             structured_content: None,
-            persisted_output_path: None,
-            persisted_output_size: None,
             sandbox_status: None,
         },
         ShellOutcome::TimedOut => runtime::BashCommandOutput {
@@ -8413,8 +8460,6 @@ fn shell_run_to_bash_output(result: ShellRunResult, timeout_ms: u64) -> runtime:
             return_code_interpretation: Some(String::from("timeout")),
             no_output_expected: Some(false),
             structured_content: None,
-            persisted_output_path: None,
-            persisted_output_size: None,
             sandbox_status: None,
         },
     }
@@ -8734,6 +8779,74 @@ mod tests {
             .expect("time")
             .as_nanos();
         std::env::temp_dir().join(format!("sudocode-tools-{unique}-{name}"))
+    }
+
+    #[test]
+    fn read_tool_output_pages_offloaded_result_without_leaking_path() {
+        // Offload a multi-line blob via the real Session writer, then page it
+        // back through read_tool_output: proves the write and the read agree
+        // on the file (shared id sanitizer) and that no filesystem path leaks
+        // into the model-facing payload. Each session gets its own dir, so
+        // `tool-results/` (a sibling of the transcript) stays isolated.
+        let session_dir = temp_path("readmore");
+        fs::create_dir_all(&session_dir).expect("session dir");
+        let session_file = session_dir.join("session.jsonl");
+        let session = Session::new().with_persistence_path(session_file.clone());
+
+        let id = "tu_readmore_1";
+        let body = (0..100)
+            .map(|i| format!("line-{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        session
+            .offload_tool_result(id, body.as_bytes())
+            .expect("offload should write");
+
+        let ctx = runtime::ToolDispatchContext {
+            tool_results_dir: session.tool_results_dir(),
+            ..Default::default()
+        };
+
+        // offset = start line (0-based), limit = line count → lines 10..13.
+        let out = super::run_read_tool_output(
+            super::ReadToolOutputInput {
+                id: id.to_string(),
+                offset: Some(10),
+                limit: Some(3),
+            },
+            Some(&ctx),
+            &runtime::StdFsBackend,
+        )
+        .expect("read-more should succeed");
+
+        assert!(out.contains("line-10"));
+        assert!(out.contains("line-12"));
+        assert!(!out.contains("line-13"), "limit must bound the slice");
+        assert!(out.contains("\"totalLines\": 100"));
+
+        // No physical path — not the tool-results dir, not the session dir —
+        // crosses into the payload the model sees.
+        assert!(!out.contains("tool-results"));
+        assert!(!out.contains(&*session_dir.to_string_lossy()));
+
+        let _ = fs::remove_dir_all(&session_dir);
+    }
+
+    #[test]
+    fn read_tool_output_without_dispatch_context_is_a_clean_error() {
+        // No offload dir (in-memory session / missing context) must fail with
+        // a message — never panic, never read an arbitrary path.
+        let err = super::run_read_tool_output(
+            super::ReadToolOutputInput {
+                id: "whatever".to_string(),
+                offset: None,
+                limit: None,
+            },
+            None,
+            &runtime::StdFsBackend,
+        )
+        .expect_err("must error without an offload dir");
+        assert!(err.contains("no offloaded tool output"));
     }
 
     fn run_git(cwd: &Path, args: &[&str]) {


### PR DESCRIPTION
Implements Q4 (oversized tool-output offload) from the agent-context storage matrix. Closes #430.

## What
When a tool result exceeds the inline budget, spill the full bytes to a **write-once** file and replace the in-transcript message with a head preview + a `<persisted-output id="...">` marker carrying **only the opaque tool_use id**. Persisting the *replaced* message is itself the content-replacement (Approach A), so `--resume` replays **byte-identically** and the prompt-cache prefix stays warm.

## Design
- **session** — `offload_tool_result` writes `<sessions>/tool-results/<session-id>/<id>` via the session `FsBackend` (backend-agnostic: local `StdFsBackend` today, nexus VFS later, no caller change). Per-session namespacing is required, not cosmetic: managed session files live **flat** in one sessions dir, so a plain sibling dir would let one session's tool_use ids collide with another's and leave nothing to GC. `sanitize_offload_id` + `tool_results_dir_for` are the shared SSOT for the path (writer + deleter).
- **conversation** — one central offload point covers every tool (DRY). The marker names `read_tool_output`; offload failure falls back to the bounded truncation shared with bash (never an unbounded prompt).
- **tools** — `read_tool_output` pages an offloaded result back in **by line** via the opaque id. The physical path is resolved from the trusted dispatch context and **never crosses the model boundary** (reuses `read_file`'s bounded reader; redacts `file_path`).
- **cli** — `delete_managed_session` GCs the session's `tool-results` subtree.

## Boundary / isolation
The model only ever names the opaque `tool_use` id — the filesystem path is engine-internal on both the write (marker) and read (`read_tool_output`) sides. A hostile id is sanitized to a safe filename and cannot escape the session's dir.

## Tests
- offload write + id sanitization (path-escape rejected)
- **end-to-end offload + byte-identical resume** through the runtime (`run_turn`): full blob spilled, transcript holds preview+marker not the blob, reload round-trips the replaced content exactly
- `read_tool_output` paging + no-path-leak + clean error when no offload dir
- deletion GCs the offload subtree
- Full `runtime` (635) + `tools` (109) lib suites green

Live-PTY `cache_read>0` confirmation with a real provider key to follow as the final gate.