### PR TITLE
docs(roadmap): retire 4 analysis tables; ref per-tier alignment worksheets

### DIFF
--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -1095,191 +1095,60 @@ injection, 3 PTY tests). The following gaps remain for full CC parity:</p>
   </tbody>
 </table>
 
-<h3 id="system-prompt-alignment">System prompt — CC alignment (per-model bloat audit)</h3>
+<h3 id="system-prompt-alignment">System prompt — per-model tiering (decided)</h3>
 
-<p>The scode system prompt is assembled by <code>SystemPromptBuilder</code>
-(Rust, <code>runtime/src/prompt.rs</code> <code>build()</code>). Sections were
-originally written to mirror CC's <em>verbose</em> prompt. CC has since split
-its prompt <strong>per model</strong>: its top-end opus reasoning models get a
-lean ~5.9&nbsp;KB prompt, while every sonnet + haiku + older model keeps the
-full ~27&nbsp;KB verbose prompt. scode currently serves the full verbose
-variant to <em>all</em> models — <code>build()</code> pushes all seven sections
-unconditionally; <code>model_family</code> flows in but only feeds the identity
-line, never gates section inclusion. This section captures what CC actually
-serves each model (the SSOT to mirror) and the scode sections that are
-over-written against it.</p>
+<p><strong>Decision.</strong> scode's system prompt becomes <em>model-dependent</em>,
+split into three tiers — <strong>Lean / Mid / Full</strong> — gated in
+<code>runtime/src/prompt.rs</code> <code>build()</code> (today it serves the full
+verbose prompt to every model). <strong>Claude models</strong> get the tier CC
+serves them; <strong>non-Claude models</strong> get <strong>Full</strong>
+(conservative v1 — CC never runs them, so full scaffolding is the safe start;
+capable ones can graduate later with eval evidence). Structure first; the per-tier
+<em>content</em> decision — <strong>去糟粕取精华</strong> against CC (keep the
+essence, drop the dross; <em>not</em> mirror) — is in progress in the worksheets
+below.</p>
 
-<p><strong>Capture method (corrected):</strong> <code>claude-trace</code> does
-<em>not</em> instrument the native CC 2.x binary (logs 0 request pairs). The
-working runtime-observation method is a tiny logging HTTP proxy on
-<code>ANTHROPIC_BASE_URL</code> that dumps the first request body and returns a
-<code>400</code>; run <code>claude --model &lt;id&gt; -p hi</code> (with the
-<code>CLAUDE_CODE_*</code> child-session env cleared) and read the
-<code>system</code> field CC assembled client-side for that model. All figures
-below were captured first-hand against <strong>CC&nbsp;2.1.207</strong>. This is
-automated in <a href="https://github.com/sudoprivacy/sudocode/blob/main/scripts/capture_cc_system_prompt.py"><code>scripts/capture_cc_system_prompt.py</code></a>
-— re-run it after upgrading the local CC binary to refresh Table&nbsp;A.
-Verbatim CC prompt text is kept local (not committed), treated like the private
-CC snapshot in <a href="#reference-sources">Reference sources</a>.</p>
-
-<p class="table-title"><strong>Table A — what CC serves each model</strong> (SSOT reference, captured CC&nbsp;2.1.233, 2026-08-17).</p>
+<p class="table-title"><strong>Table — scode tier assignment</strong> (Claude tiers captured from CC&nbsp;2.1.233, 2026-08-17).</p>
 
 <table>
-  <thead><tr><th>Model</th><th>CC variant</th><th>System-prompt size</th><th>Memory block</th><th>Distinctive sections</th></tr></thead>
+  <thead><tr><th>Model</th><th>scode tier</th><th>Basis</th></tr></thead>
   <tbody>
-    <tr><td><code>opus-4-8</code></td><td data-status="covered"><strong>Lean</strong></td><td>~6.3 KB</td><td><code># Memory</code> (2,092)</td><td><code># Harness</code> + 4 core sections only — no Doing&nbsp;tasks / Actions / Using&nbsp;tools / Tone / Text&nbsp;output. The <em>only</em> true-Lean model.</td></tr>
-    <tr><td><code>opus-5</code></td><td data-status="gap-l2"><strong>Mid</strong></td><td>~9.6 KB</td><td><code># Memory</code> (2,092)</td><td>Lean's 5 sections <em>plus</em> <code># Delivering work</code> (2,002) + <code># Corrections</code> (1,355). <strong>Moved Lean→Mid since 2.1.207.</strong></td></tr>
-    <tr><td><code>fable-5</code></td><td data-status="gap-l2"><strong>Mid</strong></td><td>~10.7 KB</td><td><code># Memory</code> (2,092)</td><td>Short <code># Harness</code> (661) + <code># Communicating with the user</code> (4,105) — a <em>different</em> Mid from opus-5.</td></tr>
-    <tr><td><code>opus-4-6</code> — <strong>current default</strong> (<code>config.rs</code> primary)</td><td data-status="gap"><strong>Full</strong></td><td>~27.8 KB</td><td><code># auto memory</code> (12,833)</td><td>Captured CC&nbsp;2.1.233 → <strong>Full</strong>, byte-identical to opus-4-5. <strong>Default stays Full — no silent cut for default users.</strong> Do <em>not</em> extrapolate "frontier → Lean": 4-6 is newer than 4-5 yet both are Full.</td></tr>
-    <tr><td><code>opus-4-5</code>, <code>sonnet-5</code>, <code>sonnet-4-5</code>, <code>haiku-4-5</code>, older</td><td data-status="gap"><strong>Full</strong></td><td>~27.8 KB</td><td><code># auto memory</code> (12,833)</td><td>All 10 verbose sections — newest sonnet/haiku still get the full prompt</td></tr>
-    <tr><td><strong>non-Anthropic</strong> — GPT / qwen / DeepSeek / local (via sudorouter + openai-compat)</td><td data-status="gap-l2"><strong>scode's own</strong></td><td>n/a</td><td>n/a</td><td>CC does not run these, so there is <em>no CC prompt to mirror</em>. scode decides the tier itself — <strong>Lean by default</strong> (no CC baggage to shed). Roughly half the models scode runs in production.</td></tr>
+    <tr><td><code>opus-4-8</code></td><td data-status="covered"><strong>Lean</strong> (~6.3&nbsp;KB)</td><td>= CC</td></tr>
+    <tr><td><code>opus-5</code></td><td data-status="gap-l2"><strong>Mid</strong> (~9.7&nbsp;KB)</td><td>= CC (Lean + <code># Delivering work</code> + <code># Corrections</code>)</td></tr>
+    <tr><td><code>fable-5</code></td><td data-status="gap-l2"><strong>Mid</strong> (~10.8&nbsp;KB)</td><td>= CC (Lean + <code># Communicating</code>)</td></tr>
+    <tr><td><code>opus-4-6</code> (default), <code>opus-4-5</code>, <code>sonnet-*</code>, <code>haiku-*</code></td><td data-status="gap"><strong>Full</strong> (~27.8&nbsp;KB)</td><td>= CC — the default stays Full, so zero-risk for default users</td></tr>
+    <tr><td><strong>non-Claude</strong> — GPT / qwen / DeepSeek / local</td><td data-status="gap"><strong>Full</strong></td><td>conservative v1 default (no CC to mirror)</td></tr>
   </tbody>
 </table>
 
-<p class="table-caption"><strong>As of CC 2.1.233 there are FOUR variants, not
-three</strong> (re-validated 2026-08-17 on an isolated 2.1.233 install — mapping
-+ sections unchanged since 2.1.229, only <code># Context management</code> grew
-~+51 chars; 2.1.207 had three): true Lean is <code>opus-4-8</code> only;
-<code>opus-5</code> and
-<code>fable-5</code> each get a <em>different</em> Mid; everything else is Full.
-The boundary is <em>model-specific, not generational</em> — sonnet-5 and
-haiku-4-5 are new but still Full. The production default <code>opus-4-6</code> is
-Full, so default users are unaffected by the trim. scode must support all
-models: CC maps only its own, so it's a reference for the Anthropic rows only —
-non-Anthropic (last row) has nothing to mirror. CC's Lean+Mid variants share the
-collapsed <code># Memory</code> (2,092); Full keeps <code># auto memory</code>
-(12,833). CC's Lean cut vs Full: delete <code># Doing tasks</code> /
-<code># Executing actions</code> / <code># Using your tools</code> /
-<code># Tone and style</code> / <code># Text output</code>, collapse
-<code># auto memory</code> → <code># Memory</code>. Net 27,819 → 6,324 chars
-(−77%). (<code>opus-4-1</code>/<code>opus-4</code> requests are remapped to
-opus-4-8 by CC → Lean; that remap is CC's, not scode's concern.)</p>
-
-<p class="table-title"><strong>Table B — scode section-by-section, exhaustive.</strong></p>
+<p><strong>Detailed CC ↔ scode block-by-block alignment</strong> — the per-tier
+worksheets (each = CC's verbatim prompt on the left, scode's current prompt
+block-aligned on the right, with a per-block keep/drop decision) live in the
+private repo <a href="https://github.com/sudoprivacy/scode-prompt-alignment"><code>sudoprivacy/scode-prompt-alignment</code></a>.
+That repo is <strong>access-controlled</strong> because it holds CC's verbatim
+prompts (kept off this public repo). Each worksheet is independently verified
+<strong>100% coverage on both sides</strong> against CC&nbsp;2.1.233 (CC
+re-captured byte-identical). This replaces the earlier four analysis tables,
+which were an exploration artifact and have been retired. The worksheets are also
+published (password-protected, comment-enabled) for review:</p>
 
 <table>
-  <thead><tr><th>scode section (file)</th><th>Now</th><th>CC-full</th><th>CC-mid (opus-5 / fable-5)</th><th>CC-lean (opus-4-8)</th><th>Action</th></tr></thead>
+  <thead><tr><th>Tier</th><th>Worksheet</th><th>Models</th></tr></thead>
   <tbody>
-    <tr><td><code>get_simple_intro_section</code> — identity + safety (<code>prompt.rs:621</code>)</td><td>910</td><td>preamble</td><td>→ <code># Harness</code></td><td>→ <code># Harness</code></td><td data-status="covered">Keep — core identity/safety</td></tr>
-    <tr><td><code>get_simple_system_section</code> — <code># System</code> (<code>:637</code>)</td><td>1,239</td><td><code># System</code> 1,619</td><td><code># Harness</code> 661–1,638</td><td><code># Harness</code> 1,692</td><td data-status="gap-l2">Slim + reframe to <code># Harness</code></td></tr>
-    <tr><td><code>get_simple_doing_tasks_section</code> — <code># Doing tasks</code> (<code>:648</code>)</td><td>2,196</td><td>3,308</td><td>removed</td><td>removed</td><td data-status="gap">Drop for lean + mid</td></tr>
-    <tr><td><code>get_actions_section</code> — <code># Executing actions with care</code> (<code>:664</code>)</td><td>1,575</td><td>3,556</td><td>removed</td><td>removed</td><td data-status="gap">Drop (incl. the <code>Examples:</code> block — examples hurt newest models)</td></tr>
-    <tr><td><code>get_using_tools_section</code> — <code># Using your tools</code> + git-commit + PR procedure (<code>:676</code>)</td><td><strong>3,657</strong></td><td>746 (scode is 5× larger)</td><td>removed</td><td>removed</td><td data-status="gap">Drop procedure; keep one "prefer dedicated tools / batch independent calls" line in Harness; move git/PR steps to a <code>/commit</code> skill / dynamic injection</td></tr>
-    <tr><td><code>get_tone_style_section</code> — <code># Tone and style</code> (<code>:715</code>)</td><td>564</td><td>541</td><td>≈ <code># Communicating</code> ✦</td><td>removed</td><td data-status="gap">Drop for lean; <strong>mid keeps a comms block</strong> — scode's tone/output already fill that role, so a Mid-tier scode model should retain them</td></tr>
-    <tr><td><code>get_output_efficiency_section</code> — <code># Output efficiency</code> (<code>:724</code>)</td><td>749</td><td>≈ <code># Text output</code> 1,657</td><td>≈ <code># Communicating</code> ✦</td><td>removed</td><td data-status="gap">Drop for lean; keep for mid (see above)</td></tr>
-    <tr><td>memory instructions (<code>memory/mod.rs</code>) — was one 12,525 <code># auto memory</code></td><td><strong>2,984</strong> compact / 12,489 full</td><td><code># auto memory</code> 12,833</td><td><code># Memory</code> 2,092</td><td><code># Memory</code> 2,092</td><td data-status="covered"><strong>Done by #406</strong> — split into a 2,984 compact digest (main loop + built-in sub-agents) + 12,489 full (custom <code>memory:</code> agents). <em>Per-agent-type, not per-tier</em> — see the 3-way table below.</td></tr>
-    <tr><td><code># Environment context</code> (dynamic, <code>:278</code>)</td><td>dynamic</td><td><code># Environment</code></td><td><code># Environment</code></td><td><code># Environment</code></td><td data-status="covered">Keep — aligned with CC, not bloat</td></tr>
-    <tr><td><code># Project context</code> — AGENTS.md injection (dynamic, <code>:387</code>)</td><td>dynamic</td><td>CC: CLAUDE.md injection</td><td>same</td><td>same</td><td data-status="covered">Keep — scode-specific, same concept as CC, not bloat</td></tr>
-    <tr><td><code># Project instructions</code> (dynamic, <code>:408</code>)</td><td>dynamic</td><td>—</td><td>—</td><td>—</td><td data-status="covered">Keep — runtime-injected, not a static-mirror surface</td></tr>
-    <tr><td><code># Runtime config</code> (dynamic, <code>:603</code>)</td><td>dynamic</td><td>—</td><td>—</td><td>—</td><td data-status="covered">Keep — scode-specific runtime state, not bloat</td></tr>
-    <tr><td>coordinator prompt (<code>coordinator_mode.rs:125</code>)</td><td>10,996</td><td colspan="2">no CC-public equivalent (CC-old style: turn-by-turn <code>## Example</code> + code samples)</td><td>—</td><td data-status="gap-l2">Trim examples for lean/mid; <strong>fix <code>"You are Claude Code"</code> → <code>"Sudo Code"</code></strong> (naming bug, all models)</td></tr>
-    <tr><td>summarizer (<code>lib.rs:5308</code>) + subagent role hints (<code>:5551</code>)</td><td>~600 / 1 line</td><td colspan="3">n/a — already lean</td><td data-status="covered">Keep as-is</td></tr>
-    <tr><td>built-in tool descriptions — <code>mvp_tool_specs()</code> (<code>lib.rs:744</code>), 36 tools</td><td>~3,019 (avg 83/tool)</td><td colspan="3">CC's per-tool descriptions run far larger</td><td data-status="covered">Keep — terse one-liners, <strong>not a bloat surface</strong> (separate from the system prompt; a per-tool API contract loaded only when the tool is available)</td></tr>
+    <tr><td><strong>Full</strong></td><td><a href="https://s.shareone.vip/s/scode-align-full">scode-align-full</a></td><td><code>opus-4-6</code> (default) / <code>opus-4-5</code> / <code>sonnet-*</code> / <code>haiku-*</code> / all non-Claude</td></tr>
+    <tr><td><strong>Lean</strong></td><td><a href="https://s.shareone.vip/s/scode-align-lean">scode-align-lean</a></td><td><code>opus-4-8</code></td></tr>
+    <tr><td><strong>Mid</strong></td><td><a href="https://s.shareone.vip/s/scode-align-mid-opus5">scode-align-mid-opus5</a></td><td><code>opus-5</code> (+ <code># Delivering work</code> + <code># Corrections</code>)</td></tr>
+    <tr><td><strong>Mid</strong></td><td><a href="https://s.shareone.vip/s/scode-align-mid-fable5">scode-align-mid-fable5</a></td><td><code>fable-5</code> (+ <code># Communicating</code>)</td></tr>
   </tbody>
 </table>
+<p class="table-caption">Access is password-controlled (the worksheets carry CC
+verbatim prompts); the password lives in the team vault, not here.</p>
 
-<p class="table-caption">Every section <code>build()</code> can emit is listed
-(static + dynamic), with the size of each Rust prompt literal and what each CC
-variant does with it. <code>CC-mid</code> spans <em>two distinct variants</em>
-(opus-5 / fable-5). Rows marked <em>keep</em> are aligned or scode-specific — not
-bloat.<br>
-✦ The two Mid variants differ in what they <em>add</em> on top of Lean's five
-sections: <code>fable-5</code> adds <code># Communicating with the user</code>
-(4,105); <code>opus-5</code> instead adds <code># Delivering work</code> (2,002)
-+ <code># Corrections</code> (1,355). Both drop the same five sections as Lean
-and share the collapsed <code># Memory</code>. scode's <code># Tone and style</code>
-+ <code># Output efficiency</code> overlap the comms role, so a Mid-tier scode
-model retains them rather than cutting them — and see Table&nbsp;C ① for the new
-CC sections worth adopting outright.</p>
-
-<p><strong>Net for lean models:</strong> memory is <em>already</em> compact
-(2,984) for all main-loop via #406, so the remaining tiering work is the main
-prompt: 10,890 → ~2,120 (−80.5%) for lean models. Combined with #406's memory, a
-lean model's root prompt lands near CC's lean ~6,324 (2.1.233). Because every
-sub-agent reuses <code>build()</code> via <code>load_system_prompt_for_agent</code>,
-the saving multiplies across each spawn.</p>
-
-<p class="table-title"><strong>Table C — lean-CC ↔ scode content-level two-way diff.</strong></p>
-
-<table>
-  <thead><tr><th>Direction</th><th>Content</th><th>Other side</th><th>Action</th></tr></thead>
-  <tbody>
-    <tr><td rowspan="8" data-status="gap-l2"><strong>① In CC,<br>NOT in scode</strong><br>(adopt candidates)</td><td>"Report outcomes <strong>faithfully</strong> — if tests fail say so with output; if a step was skipped say that; state done plainly <strong>without hedging</strong>" (<code># Harness</code>)</td><td>absent</td><td><strong>Adopt (all tiers)</strong> — honesty / anti-hedge instruction</td></tr>
-    <tr><td>"Write code that <strong>reads like the surrounding code</strong>: match comment density, naming, idiom" (<code># Harness</code>)</td><td>absent (scode only says "comment where non-obvious")</td><td><strong>Adopt (all tiers)</strong> — idiom matching</td></tr>
-    <tr><td><code># Context management</code> behavioral guidance: "when you have enough info, <strong>act</strong>; don't re-derive / re-litigate; give a <strong>recommendation, not an exhaustive survey</strong>"</td><td>absent (scode has only a 1-line auto-compress note)</td><td><strong>Adopt (all tiers)</strong> — also closes the "Context window management" Gap in the Memory table</td></tr>
-    <tr><td><code># Session-specific guidance</code>: <code>/&lt;skill-name&gt;</code> → invoke via Skill, only listed skills</td><td>absent</td><td><strong>Adopt (all tiers)</strong> if scode surfaces user-invocable skills</td></tr>
-    <tr><td>Dual-use security clause: "C2 frameworks, credential testing, exploit development require clear authorization context: pentesting, CTF, research" (IMPORTANT)</td><td>absent (scode's security line is shorter)</td><td><strong>Adopt (all tiers)</strong> — sharper safety scoping</td></tr>
-    <tr><td><strong>NEW in 2.1.229</strong> — <code># Delivering work</code> (opus-5 Mid, 2,002): act on the actual request; don't silently narrow/widen scope; finish the <em>whole</em> task; reserve blocking questions for genuinely unsafe cases; a reaffirmed request = the user's decision</td><td>absent (scode has no scope-discipline section)</td><td><strong>Adopt (all tiers)</strong> — strong scope/completion discipline</td></tr>
-    <tr><td><strong>NEW in 2.1.229</strong> — <code># Corrections</code> (opus-5 Mid, 1,406): avoid excessive self-correction; only correct when it changes the user's decisions; no apologies/rumination; a follow-up question ≠ you were wrong. Also <em>"don't call AgentTool / workflows / deep-research unless requested"</em></td><td>absent</td><td><strong>Adopt (all tiers)</strong> — anti-rumination + tool-restraint</td></tr>
-    <tr><td><strong>NEW in 2.1.229</strong> — <code># Communicating with the user</code> (fable-5 Mid, 4,105): write for a teammate catching up; lead with the outcome; everything needed goes in the final message; readable &gt; concise</td><td>partial — scode's <code># Tone</code>/<code># Output efficiency</code> overlap</td><td><strong>Adopt / merge</strong> — supersedes scode's terser tone/output guidance</td></tr>
-    <tr><td rowspan="7" data-status="gap"><strong>② In scode,<br>NOT in CC-lean</strong><br>(cut / compress)</td><td><code># Doing tasks</code> (2,196)</td><td>dropped entirely</td><td>Cut for lean models</td></tr>
-    <tr><td><code># Executing actions with care</code> + <code>Examples:</code> list (1,575)</td><td><strong>compressed to one <code># Harness</code> paragraph</strong></td><td>Replace verbose+Examples with the one-liner</td></tr>
-    <tr><td><code># Using your tools</code> + git-commit + PR procedure (3,657)</td><td>dropped; kept only "prefer dedicated tools" one-liner</td><td>Cut procedure</td></tr>
-    <tr><td><code># Tone and style</code> (564)</td><td>dropped; kept only <code>file_path:line_number</code></td><td>Cut emoji / short / no-colon rules</td></tr>
-    <tr><td><code># Output efficiency</code> (749)</td><td>dropped; brevity folded into <code># Context management</code></td><td>Cut</td></tr>
-    <tr><td><code># auto memory</code> verbose delta (~9,500)</td><td>collapsed to <code># Memory</code> (2,092)</td><td data-status="covered"><strong>Done by #406</strong> — compact 2,984 for all main-loop; see 3-way table</td></tr>
-    <tr><td><code>IMPORTANT: never generate/guess URLs</code> (intro)</td><td>dropped</td><td>Drop for lean models</td></tr>
-  </tbody>
-</table>
-
-<p class="table-caption">Tables A/B are about <em>size</em>; this one is about
-<em>content set difference</em>. Most of what lean-CC keeps (reversibility
-guidance, dedicated-tools preference, <code>file:line</code>, memory) scode also
-has — just in verbose form (row group ②). But lean-CC <em>added</em> a few
-small, high-value instructions for newest models that scode lacks entirely (row
-group ①, each confirmed absent by grep of <code>prompt.rs</code> +
-<code>memory/mod.rs</code>). Group-① items are tiny <em>additions</em>, not size
-trade-offs, so they are <strong>not tier-gated — adopt for all tiers</strong>
-(they help full/mid models too). Group-② is the size trade-off that <em>is</em>
-tier-gated.</p>
-
-<p class="table-title"><strong>Table D — memory prompt: 3-way (CC vs #406 vs scode).</strong> The one dimension already implemented on scode, so it needs a third column.</p>
-
-<table>
-  <thead><tr><th>Aspect</th><th>CC (2.1.233)</th><th>#406 (merged, scode)</th><th>Us — open decision</th></tr></thead>
-  <tbody>
-    <tr><td>Selection axis</td><td>per-model tier</td><td>per-agent-type (opt-in-full)</td><td data-status="gap-l2">?</td></tr>
-    <tr><td>Compact memory</td><td><code># Memory</code> 2,092 → lean/mid (opus-4-8 / opus-5 / fable-5)</td><td>compact <strong>2,984</strong> → main loop + built-in sub-agents + custom-without-<code>memory:</code> (<strong>all models</strong>)</td><td data-status="gap-l2">keep #406's (verified 2,984)</td></tr>
-    <tr><td>Full memory</td><td><code># auto memory</code> 12,833 → Full-tier</td><td>full <strong>12,489</strong> → only custom <code>.md</code> agents declaring <code>memory:</code></td><td data-status="gap-l2">keep #406's</td></tr>
-    <tr><td>Default <code>opus-4-6</code> gets</td><td><strong>Full 12,833</strong></td><td><strong>Compact 2,984</strong> ← divergence</td><td data-status="gap">⟵ <strong>the call</strong></td></tr>
-    <tr><td>What compact cuts</td><td>n/a</td><td>12 examples, <code>&lt;types&gt;</code> XML, Why/How prose, Plan/Task section</td><td data-status="covered">agree</td></tr>
-  </tbody>
-</table>
-
-<p class="table-caption">Everything else in Tables&nbsp;A–C is a <em>2-way</em>
-compare (CC vs scode) because #406 didn't touch it — only memory has a third
-position. <strong>The one call:</strong> CC gives the default <em>full</em>
-memory; #406 gives it <em>compact</em>. <strong>Recommendation: keep #406's
-compact-for-all</strong> — the 12-example block is bloat regardless of model
-capability, and #406's compact keeps the operational core <em>and</em> teaches
-scode's parser contract (which CC's <code># Memory</code> doesn't need to);
-mirroring CC's full-for-default would just re-add bloat. Independently verified:
-compact 2,984 / full 12,489 (raw literals), selector wired at 5 call sites,
-stale "200-line" claim removed, format round-trip test present, #406 merged CI
-all-green.</p>
-
-<p><strong>Approach (all models).</strong> Two rules, because scode runs models
-CC never does:</p>
-<ul>
-  <li><strong>Anthropic models</strong> — mirror CC's observed mapping (Table&nbsp;A): Lean to <code>opus-4-8</code> only; <code>opus-5</code> and <code>fable-5</code> to Mid; Full to the rest, <em>including the default <code>opus-4-6</code></em>. Don't invent a boundary where CC gives one.</li>
-  <li><strong>Non-Anthropic models</strong> (GPT / qwen / DeepSeek / local) — no CC reference exists, so scode picks the tier: <strong>Lean by default</strong> (no CC baggage to shed; capable models do better lean).</li>
-  <li><strong>Group-① additions</strong> — adopt on <em>all</em> tiers; small, high-value, not size trade-offs. As of 2.1.229 this now includes CC's new <code># Delivering work</code> / <code># Corrections</code> / <code># Communicating</code> sections.</li>
-</ul>
-<p><strong>Open decisions:</strong></p>
-<ul>
-  <li><strong>Four variants (2.1.229):</strong> CC serves true-Lean (opus-4-8), two <em>different</em> Mids (opus-5 vs fable-5), and Full. Mirror all four exactly (opus-5 → Delivering&nbsp;work + Corrections; fable-5 → Communicating), or collapse the two Mids into one scode Mid?</li>
-  <li><strong>Memory axis (post-#406):</strong> keep #406's compact-for-all (per-agent-type), or make memory per-tier to mirror CC (full for the default opus-4-6)? See Table&nbsp;D — recommendation is to keep #406.</li>
-</ul>
-<p><strong>Memory is out of the tiering hook</strong> — #406 already handles it
-(per-agent-type). The remaining hook is per-model gating in <code>build()</code>
-for the <em>main-prompt</em> sections only (today unconditional): a model→tier
-resolver + tier-specific section composition.
-Full-tier models keep today's prompt verbatim — <strong>including the current
-default <code>opus-4-6</code></strong> — so the change is zero-risk for default
-users; only opus-4-8 (and non-Anthropic) shift to Lean, opus-5/fable-5 to Mid.
-Intro/identity, Environment/Project/Runtime context, and tool descriptions
-are already aligned or terse; the <code>opus-4-1</code>→<code>opus-4-8</code>
-remap is CC's, not something scode replicates.</p>
+<p><strong>Memory</strong> is a separate axis, already handled by
+<a href="https://github.com/sudoprivacy/sudocode/pull/406">#406</a>
+(per-agent-type: a 2,984-char compact digest for the main loop + built-in
+sub-agents; the 12,489-char full only for custom <code>.md</code> agents declaring
+<code>memory:</code>). It is <em>not</em> part of the tier hook.</p>
 
 <h3>Memory recall — Sonnet side-query relevance ranking (P1)</h3>
 


### PR DESCRIPTION
Degrades the #system-prompt-alignment section to the decided architecture + references the new per-tier CC↔scode alignment worksheets (private repo, IP-safe).

- Removes the 4 exploration tables (A/B/C/D) + Approach + Open-decisions.
- Keeps: the decision + a tier-assignment table (public-safe).
- Adds: reference to `sudoprivacy/scode-prompt-alignment` (private) + links to the 4 password-protected worksheets (Full/Lean/Mid-opus5/Mid-fable5).
- No CC verbatim, no password in this public doc.