### PR TITLE
chore(release): bump version to 0.1.24

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "base64",
  "criterion",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "plugins",
  "runtime",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "commands",
  "runtime",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "api",
  "serde_json",
@@ -2573,7 +2573,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "serde",
  "serde_json",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3867,7 +3867,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "api",
  "arboard",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "chrono",
  "dirs",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Cuts scode **v0.1.24**, the first release to include the oversized tool-output offload (#447 core, #449 byte-windowed read-more, #451 nexus-backend verification). Version-only bump (workspace crates 0.1.23→0.1.24, lock synced). Tagging `v0.1.24` after merge triggers the release build; sudowork's runtime-versions pin is bumped in a companion PR.