### PR TITLE
feat(acp,cli): let callers inject a system prompt

### DIFF
--- a/docs/acp.md
+++ b/docs/acp.md
@@ -55,6 +55,55 @@ session and independent across sessions:
   waits for turns in another directory to finish or to pause on user input
   before it starts, and a paused turn gives the directory back while it waits.
 
+### Per-session system prompt (`_meta.sudocode.*`)
+
+`session/new` and `session/load` accept two optional, orthogonal keys under
+the request's `_meta.sudocode` object. Both are plain strings, passed to the
+model verbatim — no truncation, no escaping, no size cap beyond the model's
+own context window, and no policy about who may use which: that is the
+caller's (e.g. a multi-tenant service's) decision.
+
+```json
+{
+  "cwd": "/work/tenant-a",
+  "mcpServers": [],
+  "_meta": {
+    "sudocode": {
+      "systemPrompt": "You are Tenant A's release bot. ...",
+      "appendSystemPrompt": "House rules: never push to main. ..."
+    }
+  }
+}
+```
+
+| Key | Effect |
+|---|---|
+| `systemPrompt` | **Override.** Replaces the built-in static system-prompt blocks (the `You are Sudo Code…` identity, `# System`, `# Doing tasks`, `# Executing actions with care`, `# Using your tools`, `# Tone and style`, `# Output efficiency`) with this text as the single static block. |
+| `appendSystemPrompt` | **Append.** Added as the last dynamic block — after the environment / project context, the discovered `AGENTS.md` instructions, the runtime-config summary and the auto-memory instructions (only the short plugin-capability inventory, when plugins are enabled, follows it). Being last gives it the highest recency weight, so it outranks workspace files such as `AGENTS.md`. |
+
+The two compose: set both and the static blocks are replaced *and* the
+extra block is appended. Workspace-derived dynamic blocks (environment,
+`AGENTS.md`, memory) are always kept, so an overridden prompt still knows
+which directory it is operating in.
+
+Rules:
+
+- A present key must be a non-empty string; an empty/whitespace string or a
+  non-string value is rejected with `invalid_params` (`-32602`) rather than
+  silently ignored.
+- The values are bound to the session for its whole lifetime — a
+  `session/setModel` rebuilds the runtime with them re-applied. They are
+  **not** persisted with the transcript; a client that wants them on a
+  resumed session passes them again on `session/load`.
+- They layer on top of the process-wide `--system-prompt` /
+  `--append-system-prompt` CLI flags of the `scode acp` process, if any:
+  a session `systemPrompt` replaces whatever the process default static
+  block is, and a session `appendSystemPrompt` is appended after the
+  process-level append.
+- The `initialize` response advertises `_meta.sudocode.systemPromptOverride:
+  true` and `_meta.sudocode.systemPromptAppend: true` so clients can
+  feature-detect.
+
 ### `session/load`
 
 `agentCapabilities.loadSession` is advertised. `session/load

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,6 +55,31 @@ scode doctor
 server status, config resolution, the permission policy, the sandbox
 mode, and the tool / skill inventory.
 
+## Custom system prompt
+
+```bash
+# Replace the built-in identity + behaviour blocks
+scode --system-prompt "You are a terse release bot." "cut a release"
+
+# Keep the defaults, add house rules as the final system-prompt block
+scode --append-system-prompt "Never push to main." "cut a release"
+
+# Both at once — they compose
+scode --system-prompt "..." --append-system-prompt "..." "cut a release"
+
+# Preview what the model will receive
+scode system-prompt --append-system-prompt "Never push to main."
+```
+
+`--system-prompt` swaps out the static blocks (`You are Sudo Code…`,
+`# System`, `# Doing tasks`, …); `--append-system-prompt` adds a trailing
+block after the workspace context (environment, `AGENTS.md`, auto-memory).
+Neither is truncated or escaped, and the workspace context is always kept.
+Both are global flags, so they also apply to `scode acp` as the process
+default that ACP sessions can further adjust per session via
+`_meta.sudocode.systemPrompt` / `appendSystemPrompt` — see
+[`acp.md`](./acp.md#per-session-system-prompt-_metasudocode).
+
 ## Models
 
 Select a model with `--model`. See [`models.md`](./models.md) for aliases

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -20,6 +20,7 @@ use crate::permissions::{
     PermissionMode, PermissionPromptDecision, PermissionPrompter, PermissionRequest,
     QuestionPromptAnswer, QuestionPromptRequest, QuestionPrompter,
 };
+use crate::prompt::SystemPromptOverrides;
 use crate::usage::UsageCostCurrency;
 use crate::workspace_root::WorkspaceRootScope;
 use agent_client_protocol::{
@@ -227,10 +228,17 @@ fn acp_mcp_servers_to_scoped(
 pub trait SdkAcpDelegate: Send + Sync + 'static {
     /// Create a new session for the given working directory, returning
     /// `(session_id, cwd, abort_signal)` on success.
+    ///
+    /// `prompt_overrides` carries the client's `_meta.sudocode.systemPrompt`
+    /// (replace the built-in static blocks) and
+    /// `_meta.sudocode.appendSystemPrompt` (append a trailing dynamic block)
+    /// from `session/new`; they apply for the whole lifetime of the session,
+    /// including runtime rebuilds on `session/setModel`.
     fn new_session(
         &self,
         cwd: PathBuf,
         mcp_servers: BTreeMap<String, ScopedMcpServerConfig>,
+        prompt_overrides: SystemPromptOverrides,
     ) -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
 
     /// Run a prompt turn. The implementation should call observer methods
@@ -288,11 +296,16 @@ pub trait SdkAcpDelegate: Send + Sync + 'static {
 
     /// Load an existing persisted session by its ID and working directory,
     /// returning `(session_id, cwd, abort_signal)` on success.
+    ///
+    /// `prompt_overrides` has the same meaning as on [`Self::new_session`];
+    /// it is not persisted with the transcript, so a client that wants it on
+    /// a resumed session passes it again on `session/load`.
     fn load_session(
         &self,
         session_id: &str,
         cwd: PathBuf,
         mcp_servers: BTreeMap<String, ScopedMcpServerConfig>,
+        prompt_overrides: SystemPromptOverrides,
     ) -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
 }
 
@@ -476,9 +489,56 @@ fn initialize_meta() -> Map<String, serde_json::Value> {
             "autoHandlesWrongModel": cap.auto_handles_wrong_model,
         }),
     );
+    // Feature flags for clients: `session/new` / `session/load` accept
+    // `_meta.sudocode.systemPrompt` and `_meta.sudocode.appendSystemPrompt`
+    // (see `system_prompt_overrides_from_meta`).
+    sudocode_ns.insert("systemPromptOverride".to_string(), json!(true));
+    sudocode_ns.insert("systemPromptAppend".to_string(), json!(true));
     let mut meta = Map::new();
     meta.insert("sudocode".to_string(), json!(sudocode_ns));
     meta
+}
+
+/// `_meta.sudocode` key: replace the built-in static system-prompt blocks.
+pub const SYSTEM_PROMPT_META_KEY: &str = "systemPrompt";
+/// `_meta.sudocode` key: append a trailing dynamic system-prompt block.
+pub const APPEND_SYSTEM_PROMPT_META_KEY: &str = "appendSystemPrompt";
+
+/// Read `_meta.sudocode.systemPrompt` / `_meta.sudocode.appendSystemPrompt`
+/// from a `session/new` or `session/load` request.
+///
+/// Each key is optional and they compose. A present key must be a non-empty
+/// string, otherwise `invalid_params` — a client that mistypes a value
+/// learns about it instead of silently getting the default prompt. The
+/// text is passed through verbatim: no truncation, no escaping, no size
+/// cap (the model's context window is the real limit, and the API reports
+/// that explicitly).
+fn system_prompt_overrides_from_meta(
+    meta: Option<&agent_client_protocol_schema::Meta>,
+) -> Result<SystemPromptOverrides, AcpError> {
+    let ns = meta.and_then(|m| m.get("sudocode"));
+    Ok(SystemPromptOverrides {
+        system_prompt: non_empty_string_meta(ns, SYSTEM_PROMPT_META_KEY)?,
+        append_system_prompt: non_empty_string_meta(ns, APPEND_SYSTEM_PROMPT_META_KEY)?,
+    })
+}
+
+fn non_empty_string_meta(
+    sudocode_ns: Option<&serde_json::Value>,
+    key: &str,
+) -> Result<Option<String>, AcpError> {
+    let Some(value) = sudocode_ns.and_then(|ns| ns.get(key)) else {
+        return Ok(None);
+    };
+    match value.as_str() {
+        Some(text) if !text.trim().is_empty() => Ok(Some(text.to_string())),
+        Some(_) => Err(AcpError::invalid_params(format!(
+            "_meta.sudocode.{key} must not be empty"
+        ))),
+        None => Err(AcpError::invalid_params(format!(
+            "_meta.sudocode.{key} must be a string"
+        ))),
+    }
 }
 
 fn sudocode_meta_from_prompt_usage(u: &PromptUsage) -> Map<String, serde_json::Value> {
@@ -1107,6 +1167,14 @@ pub(crate) async fn run_acp_on_transport(
                 async move |req: NewSessionRequest,
                             responder: Responder<NewSessionResponse>,
                             cx: ConnectionTo<Client>| {
+                    let prompt_overrides =
+                        match system_prompt_overrides_from_meta(req.meta.as_ref()) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                responder.respond_with_error(acp_error_to_sdk(&e))?;
+                                return Ok(());
+                            }
+                        };
                     let d = Arc::clone(&delegate);
                     let registry = Arc::clone(&registry);
                     cx.spawn(async move {
@@ -1123,7 +1191,7 @@ pub(crate) async fn run_acp_on_transport(
                                 .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
                             let _scope = WorkspaceRootScope::enter(cwd);
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &req.cwd);
-                            d.new_session(req.cwd, mcp_servers)
+                            d.new_session(req.cwd, mcp_servers, prompt_overrides)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));
@@ -1549,6 +1617,14 @@ pub(crate) async fn run_acp_on_transport(
                 async move |req: LoadSessionRequest,
                             responder: Responder<LoadSessionResponse>,
                             cx: ConnectionTo<Client>| {
+                    let prompt_overrides =
+                        match system_prompt_overrides_from_meta(req.meta.as_ref()) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                responder.respond_with_error(acp_error_to_sdk(&e))?;
+                                return Ok(());
+                            }
+                        };
                     let d = Arc::clone(&delegate);
                     let registry = Arc::clone(&registry);
                     let sid = req.session_id.to_string();
@@ -1566,7 +1642,7 @@ pub(crate) async fn run_acp_on_transport(
                                 .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
                             let _scope = WorkspaceRootScope::enter(lease_cwd);
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &cwd);
-                            d.load_session(&sid, cwd, mcp_servers)
+                            d.load_session(&sid, cwd, mcp_servers, prompt_overrides)
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -190,7 +190,8 @@ pub use policy_engine::{
 pub use prompt::{
     load_system_prompt, load_system_prompt_for_agent, load_system_prompt_with, prepend_bullets,
     ContextFile, ModelFamilyIdentity, ProjectContext, PromptBuildError, SystemPrompt,
-    SystemPromptBuilder, FRONTIER_MODEL_NAME, SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+    SystemPromptBuilder, SystemPromptOverrides, FRONTIER_MODEL_NAME,
+    SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
 };
 pub use recovery_recipes::{
     attempt_recovery, recipe_for, EscalationPolicy, FailureScenario, RecoveryContext,

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -109,6 +109,65 @@ impl SystemPrompt {
     pub fn is_empty(&self) -> bool {
         self.static_sections.is_empty() && self.dynamic_sections.is_empty()
     }
+
+    /// Replace every static section — the built-in identity and behaviour
+    /// blocks (`You are Sudo Code…`, `# System`, `# Doing tasks`,
+    /// `# Executing actions with care`, `# Using your tools`,
+    /// `# Tone and style`, `# Output efficiency`) — with `text` as the
+    /// single static block.
+    ///
+    /// Dynamic sections (environment context, project context,
+    /// `AGENTS.md` instructions, runtime config, auto-memory, plugin
+    /// capabilities) are left untouched, so the caller-supplied prompt
+    /// still sees the workspace it is operating in. Callers that want a
+    /// blank-slate prompt can clear `dynamic_sections` themselves.
+    pub fn override_static_sections(&mut self, text: impl Into<String>) {
+        self.static_sections = vec![text.into()];
+    }
+
+    /// Append `text` as the last dynamic section.
+    ///
+    /// Being last puts it closest to the conversation, so it outranks the
+    /// workspace-discovered `AGENTS.md` instructions and the auto-memory
+    /// instructions that precede it. Orthogonal to
+    /// [`Self::override_static_sections`]: the two compose.
+    pub fn append_dynamic_section(&mut self, text: impl Into<String>) {
+        self.dynamic_sections.push(text.into());
+    }
+}
+
+/// Caller-supplied adjustments to the built system prompt — from the CLI
+/// (`--system-prompt` / `--append-system-prompt`) or from an ACP client
+/// (`_meta.sudocode.systemPrompt` / `_meta.sudocode.appendSystemPrompt`).
+///
+/// The two fields are orthogonal and may be combined: `system_prompt`
+/// replaces the static blocks, `append_system_prompt` adds a trailing
+/// dynamic block. Neither is truncated or escaped.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SystemPromptOverrides {
+    /// Replaces every static section (see
+    /// [`SystemPrompt::override_static_sections`]).
+    pub system_prompt: Option<String>,
+    /// Appended as the last dynamic section (see
+    /// [`SystemPrompt::append_dynamic_section`]).
+    pub append_system_prompt: Option<String>,
+}
+
+impl SystemPromptOverrides {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.system_prompt.is_none() && self.append_system_prompt.is_none()
+    }
+
+    /// Apply both adjustments to `prompt`: override first, then append.
+    pub fn apply(&self, prompt: &mut SystemPrompt) {
+        if let Some(text) = &self.system_prompt {
+            prompt.override_static_sections(text.clone());
+        }
+        if let Some(text) = &self.append_system_prompt {
+            prompt.append_dynamic_section(text.clone());
+        }
+    }
 }
 
 /// Contents of an instruction file included in prompt construction.

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -86,6 +86,16 @@ struct Cli {
     #[arg(long, global = true, num_args = 0..=1, default_missing_value = "")]
     resume: Option<String>,
 
+    /// Replace the built-in system prompt (identity + behaviour blocks) with TEXT.
+    /// Workspace context (AGENTS.md, environment, memory) is still appended.
+    #[arg(long, global = true, value_name = "TEXT")]
+    system_prompt: Option<String>,
+
+    /// Append TEXT as the final system-prompt block (after AGENTS.md and memory).
+    /// Combines with --system-prompt.
+    #[arg(long, global = true, value_name = "TEXT")]
+    append_system_prompt: Option<String>,
+
     #[command(subcommand)]
     command: Option<Cmd>,
 
@@ -419,25 +429,41 @@ fn parse_permission_mode_value(value: &str) -> Result<PermissionMode, String> {
 // Main entry point: parse CLI args via clap → CliAction
 // ---------------------------------------------------------------------------
 
-pub(crate) fn parse_args(args: &[String]) -> Result<CliAction, String> {
+/// Parse argv into the [`CliAction`] to run plus the process-wide
+/// `--system-prompt` / `--append-system-prompt` flags, which are not part of
+/// any [`CliAction`] because they apply to every prompt build regardless of
+/// the action.
+pub(crate) fn parse_args_with_prompt_overrides(
+    args: &[String],
+) -> Result<(CliAction, runtime::SystemPromptOverrides), String> {
     // Slash-commands (`scode /help`) use a `/` prefix that clap can't handle.
     // Route them before calling clap.
     if let Some(first) = args.first() {
         if first.starts_with('/') {
-            return parse_slash_command_invocation(args);
+            return parse_slash_command_invocation(args)
+                .map(|action| (action, runtime::SystemPromptOverrides::default()));
         }
     }
 
     // Intercept `<subcommand> --help [--output-format json]` before clap
     // so we can emit structured JSON help instead of clap's default text.
     if let Some(action) = parse_local_help_action(args) {
-        return action;
+        return action.map(|action| (action, runtime::SystemPromptOverrides::default()));
     }
 
     let cli = Cli::try_parse_from(std::iter::once("scode".to_string()).chain(args.iter().cloned()));
 
     match cli {
-        Ok(cli) => convert_cli_to_action(cli),
+        Ok(mut cli) => {
+            let prompt_overrides = runtime::SystemPromptOverrides {
+                system_prompt: non_empty(cli.system_prompt.take(), "--system-prompt")?,
+                append_system_prompt: non_empty(
+                    cli.append_system_prompt.take(),
+                    "--append-system-prompt",
+                )?,
+            };
+            convert_cli_to_action(cli).map(|action| (action, prompt_overrides))
+        }
         Err(e) => {
             // clap returns special error kinds for --help and --version.
             // Let them print to stdout and exit cleanly instead of going
@@ -449,6 +475,16 @@ pub(crate) fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 _ => Err(e.to_string()),
             }
         }
+    }
+}
+
+/// A prompt flag given as an empty / whitespace-only string is almost
+/// certainly a quoting mistake; reject it instead of silently sending a
+/// blank block.
+fn non_empty(value: Option<String>, flag: &str) -> Result<Option<String>, String> {
+    match value {
+        Some(text) if text.trim().is_empty() => Err(format!("{flag} must not be empty")),
+        other => Ok(other),
     }
 }
 
@@ -1277,7 +1313,9 @@ mod tests {
             .iter()
             .map(|word| (*word).to_string())
             .collect::<Vec<_>>();
-        parse_args(&args).expect("parse cli args")
+        parse_args_with_prompt_overrides(&args)
+            .expect("parse cli args")
+            .0
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -103,6 +103,7 @@ pub(crate) fn render_help_topic(topic: LocalHelpTopic) -> String {
   Usage            scode system-prompt [--cwd <path>] [--date YYYY-MM-DD] [--output-format <format>]
   Purpose          render the resolved system prompt that `scode` would send for the given cwd + date
   Options          --cwd overrides the workspace dir · --date injects a deterministic date stamp
+                   --system-prompt / --append-system-prompt are honoured, so the output previews them
   Formats          text (default), json
   Related          scode doctor · scode dump-manifests"
             .to_string(),
@@ -811,6 +812,19 @@ pub(crate) fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         out,
         "                              supported). ACP session-injected MCP servers bypass this."
     )?;
+    writeln!(
+        out,
+        "  --system-prompt TEXT       Replace the built-in system prompt (identity + behaviour"
+    )?;
+    writeln!(
+        out,
+        "                              blocks); workspace context (AGENTS.md, memory) still follows"
+    )?;
+    writeln!(
+        out,
+        "  --append-system-prompt TEXT  Append TEXT as the final system-prompt block; combines with"
+    )?;
+    writeln!(out, "                              --system-prompt")?;
     writeln!(
         out,
         "  --version, -V              Print version and build information locally"

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -50,11 +50,11 @@ use cli::api_client::{
 };
 use cli::args::{
     config_model_for_current_dir, default_permission_mode, format_unknown_slash_command,
-    load_sudocode_config_for_current_dir, load_sudocode_config_for_cwd, parse_args,
-    permission_mode_from_label, require_sudocode_config_for_cwd, resolve_model_alias,
-    resolve_model_alias_with_config, resolve_repl_model, try_resolve_bare_skill_prompt,
-    try_resolve_bare_skill_prompt_with_plugins, AllowedToolSet, CliAction, CliOutputFormat,
-    LocalHelpTopic,
+    load_sudocode_config_for_current_dir, load_sudocode_config_for_cwd,
+    parse_args_with_prompt_overrides, permission_mode_from_label, require_sudocode_config_for_cwd,
+    resolve_model_alias, resolve_model_alias_with_config, resolve_repl_model,
+    try_resolve_bare_skill_prompt, try_resolve_bare_skill_prompt_with_plugins, AllowedToolSet,
+    CliAction, CliOutputFormat, LocalHelpTopic,
 };
 use cli::export::{
     collect_session_prompt_history, parse_history_count, render_export_text,
@@ -432,7 +432,9 @@ fn extract_sudorouter_credentials(config: &api::SudoCodeConfig) -> Option<(Strin
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().skip(1).collect();
-    let action = parse_args(&args)?;
+    let (action, prompt_overrides) = parse_args_with_prompt_overrides(&args)?;
+    // Only writer in the process; a second `set` cannot happen.
+    let _ = CLI_PROMPT_OVERRIDES.set(prompt_overrides);
     // Informational commands (help, version, config, login, logout) are
     // dispatched immediately and must never block on a credential check.
     // If an ensure_authenticated() call is ever added below this point it
@@ -859,6 +861,14 @@ fn print_system_prompt(
         "unknown",
         resolve_model_identity(model),
     )?;
+    // Coordinator mode: when SUDOCODE_COORDINATOR_MODE is set,
+    // prepend the CC-fork coordinator role prompt so `scode
+    // print-system-prompt` reflects what the runtime would send.
+    runtime::coordinator_mode::apply_coordinator_prompt_if_enabled(&mut prompt);
+    // Same order as a live session (`build_system_prompt_for` →
+    // `build_runtime_with_plugin_state`): CLI prompt flags first, plugin
+    // capability summary last.
+    apply_cli_prompt_overrides(&mut prompt);
     // Mirror what build_runtime_with_plugin_state does for live sessions:
     // append active SudoCode plugin capabilities so system-prompt output
     // matches what the runtime actually sends.  Load failures captured inside
@@ -867,10 +877,6 @@ fn print_system_prompt(
     if let Some(section) = render_plugin_capabilities_section(&outcome.loaded_plugins) {
         prompt.dynamic_sections.push(section);
     }
-    // Coordinator mode: when SUDOCODE_COORDINATOR_MODE is set,
-    // prepend the CC-fork coordinator role prompt so `scode
-    // print-system-prompt` reflects what the runtime would send.
-    runtime::coordinator_mode::apply_coordinator_prompt_if_enabled(&mut prompt);
     let message = prompt.render();
     match output_format {
         CliOutputFormat::Text => println!("{message}"),
@@ -2609,6 +2615,10 @@ struct AcpCliSession {
     /// reused when the runtime is rebuilt (e.g. model switch) so they
     /// survive across the session's lifetime.
     session_mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
+    /// Caller-supplied system-prompt adjustments (`_meta.sudocode.systemPrompt`
+    /// / `appendSystemPrompt` on session/new or session/load). Kept on the
+    /// session so a runtime rebuild (model switch) re-applies them.
+    prompt_overrides: runtime::SystemPromptOverrides,
 }
 
 /// One live ACP session as held by [`AcpCliAgent`].
@@ -2701,6 +2711,7 @@ impl AcpCliAgent {
         &self,
         cwd: &Path,
         mcp_servers: &std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
+        prompt_overrides: runtime::SystemPromptOverrides,
     ) -> Result<AcpCliSession, AcpError> {
         let cwd = canonical_session_cwd(cwd)?;
         // Config, plugin/MCP state and the API client's `.env` lookup all
@@ -2708,9 +2719,7 @@ impl AcpCliAgent {
         let _scope = runtime::WorkspaceRootScope::enter(&cwd);
         let model = self.resolve_model_for_cwd(&cwd)?;
         let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
-        let system_prompt = build_system_prompt_for(&cwd, &model).map_err(|error| {
-            AcpError::internal(format!("failed to build system prompt: {error}"))
-        })?;
+        let system_prompt = build_acp_system_prompt(&cwd, &model, &prompt_overrides)?;
         let session_state = new_cli_session_for(&cwd)
             .map_err(|error| AcpError::internal(format!("failed to create session: {error}")))?;
         let handle = create_managed_session_handle_for(&cwd, &session_state.session_id).map_err(
@@ -2773,6 +2782,7 @@ impl AcpCliAgent {
             abort_signal,
             started_at: Instant::now(),
             session_mcp_servers: mcp_servers.clone(),
+            prompt_overrides,
         })
     }
 
@@ -2843,8 +2853,7 @@ impl AcpCliAgent {
         let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
         let auth_mode = resolve_model_switch_auth_mode(&resolved, self.auth_mode, &sudocode_config)
             .map_err(|e| AcpError::internal(format!("failed to resolve auth mode: {e}")))?;
-        let system_prompt = build_system_prompt_for(&cwd, &resolved)
-            .map_err(|e| AcpError::internal(format!("failed to build system prompt: {e}")))?;
+        let system_prompt = build_acp_system_prompt(&cwd, &resolved, &session.prompt_overrides)?;
         let mut runtime = build_runtime_for_cwd(
             &cwd,
             cloned_session,
@@ -3107,8 +3116,11 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         &self,
         cwd: PathBuf,
         mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
+        prompt_overrides: runtime::SystemPromptOverrides,
     ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
-        let session = self.inner.build_session(&cwd, &mcp_servers)?;
+        let session = self
+            .inner
+            .build_session(&cwd, &mcp_servers, prompt_overrides)?;
         let session_id = session.handle.id.clone();
         let session_cwd = session.cwd.clone();
         let abort_signal = session.abort_signal.clone();
@@ -3444,6 +3456,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         session_id: &str,
         cwd: PathBuf,
         mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
+        prompt_overrides: runtime::SystemPromptOverrides,
     ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
         let cwd = canonical_session_cwd(&cwd)?;
         // The session store, config and system prompt all resolve against
@@ -3455,9 +3468,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
         let model = self.inner.resolve_model_for_cwd(&cwd)?;
         let permission_mode = self.inner.resolve_permission_mode_for_cwd(&cwd)?;
-        let system_prompt = build_system_prompt_for(&cwd, &model).map_err(|e| {
-            runtime::AcpError::internal(format!("failed to build system prompt: {e}"))
-        })?;
+        let system_prompt = build_acp_system_prompt(&cwd, &model, &prompt_overrides)?;
         let sudocode_config =
             require_sudocode_config_for_cwd(&cwd).map_err(runtime::AcpError::internal)?;
         let auth_mode =
@@ -3506,6 +3517,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 abort_signal,
                 started_at: Instant::now(),
                 session_mcp_servers: mcp_servers,
+                prompt_overrides,
             },
         );
         Ok((loaded_session_id, cwd, signal))
@@ -5860,6 +5872,37 @@ fn build_system_prompt(model: &str) -> Result<SystemPrompt, Box<dyn std::error::
     build_system_prompt_for(&env::current_dir()?, model)
 }
 
+/// ACP variant of [`build_system_prompt_for`]: builds the process-default
+/// prompt for `cwd`/`model` (including any `--system-prompt` /
+/// `--append-system-prompt` CLI flags), then layers the session's
+/// `_meta.sudocode.systemPrompt` / `appendSystemPrompt` on top: the former
+/// swaps the static blocks, the latter appends a trailing dynamic block.
+/// Workspace-derived dynamic blocks (environment, `AGENTS.md`, memory,
+/// plugins) stay, so the caller's prompt still knows where it is running.
+fn build_acp_system_prompt(
+    cwd: &Path,
+    model: &str,
+    prompt_overrides: &runtime::SystemPromptOverrides,
+) -> Result<SystemPrompt, AcpError> {
+    let mut prompt = build_system_prompt_for(cwd, model)
+        .map_err(|e| AcpError::internal(format!("failed to build system prompt: {e}")))?;
+    prompt_overrides.apply(&mut prompt);
+    Ok(prompt)
+}
+
+/// Process-wide `--system-prompt` / `--append-system-prompt` flags, set once
+/// from `run()` and applied by every prompt build in this process (REPL,
+/// `--print`, `scode system-prompt`, and the ACP default a session starts
+/// from before its own `_meta` adjustments).
+static CLI_PROMPT_OVERRIDES: std::sync::OnceLock<runtime::SystemPromptOverrides> =
+    std::sync::OnceLock::new();
+
+fn apply_cli_prompt_overrides(prompt: &mut SystemPrompt) {
+    if let Some(overrides) = CLI_PROMPT_OVERRIDES.get() {
+        overrides.apply(prompt);
+    }
+}
+
 fn build_system_prompt_for(
     cwd: &Path,
     model: &str,
@@ -5881,6 +5924,7 @@ fn build_system_prompt_for(
     // takes primacy over the default identity. See
     // runtime::coordinator_mode for the full port.
     runtime::coordinator_mode::apply_coordinator_prompt_if_enabled(&mut prompt);
+    apply_cli_prompt_overrides(&mut prompt);
     Ok(prompt)
 }
 

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -485,6 +485,18 @@ async fn scenario_initialize(client: &mut AcpTestClient) {
     assert_eq!(img_cap["downsampleTargetBytes"].as_u64(), Some(512 * 1024));
     assert_eq!(img_cap["autoHandlesOversized"].as_bool(), Some(true));
     assert_eq!(img_cap["autoHandlesWrongModel"].as_bool(), Some(true));
+
+    // `_meta.sudocode.systemPromptOverride` / `systemPromptAppend` tell
+    // clients (apeiron, sudowork) that `session/new` / `session/load` honour
+    // `_meta.sudocode.systemPrompt` / `appendSystemPrompt` — see
+    // `acp_session_new_system_prompt_override_and_append_reach_model`.
+    for flag in ["systemPromptOverride", "systemPromptAppend"] {
+        assert_eq!(
+            result["_meta"]["sudocode"][flag].as_bool(),
+            Some(true),
+            "initialize must advertise _meta.sudocode.{flag}"
+        );
+    }
 }
 
 async fn scenario_session_new(client: &mut AcpTestClient, cwd: &std::path::Path) -> String {
@@ -2246,6 +2258,219 @@ async fn acp_session_new_mcp_survives_model_switch() {
         blob.contains("echo:hello from mcp parity"),
         "mcp should remain available after model switch; got: {blob}"
     );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// Run one `streaming_text` turn on `session_id` and return the raw body of
+/// the last `/v1/messages` request the mock received for it.
+async fn last_model_request_after_prompt(
+    client: &mut AcpTestClient,
+    server: &MockAnthropicService,
+    session_id: &str,
+    text: &str,
+) -> String {
+    let before = server.captured_requests().await.len();
+    let (_notifs, resp) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text {text}") }]
+            }),
+        )
+        .await;
+    assert!(
+        resp["result"].get("stopReason").is_some(),
+        "turn should complete: {resp}"
+    );
+    let requests = server.captured_requests().await;
+    assert!(requests.len() > before, "prompt should reach the model");
+    requests
+        .iter()
+        .rev()
+        .find(|r| !r.path.contains("count_tokens"))
+        .expect("a /v1/messages request")
+        .raw_body
+        .clone()
+}
+
+/// `session/new` carrying the given `_meta.sudocode` object; returns the raw response.
+async fn session_new_with_meta(
+    client: &mut AcpTestClient,
+    cwd: &std::path::Path,
+    sudocode_meta: Value,
+) -> Value {
+    let (_, resp) = client
+        .send_request(
+            "session/new",
+            json!({
+                "cwd": cwd.to_string_lossy(),
+                "mcpServers": [],
+                "_meta": { "sudocode": sudocode_meta },
+            }),
+        )
+        .await;
+    resp
+}
+
+fn session_id_of(resp: &Value) -> String {
+    resp["result"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("sessionId should be present; got: {resp}"))
+        .to_string()
+}
+
+/// Empty / non-string `_meta.sudocode.systemPrompt` / `appendSystemPrompt`
+/// values must be rejected with `invalid_params`, never silently ignored.
+async fn assert_bad_prompt_meta_rejected(
+    client: &mut AcpTestClient,
+    root: &std::path::Path,
+    valid_override: &str,
+) {
+    for bad_meta in [
+        json!({"systemPrompt": ""}),
+        json!({"systemPrompt": 42}),
+        json!({"appendSystemPrompt": "   "}),
+        json!({"appendSystemPrompt": ["x"]}),
+        json!({"systemPrompt": valid_override, "appendSystemPrompt": 7}),
+    ] {
+        let resp = session_new_with_meta(client, root, bad_meta.clone()).await;
+        assert_eq!(
+            resp["error"]["code"].as_i64(),
+            Some(-32602),
+            "bad _meta.sudocode {bad_meta} must be rejected with invalid_params; got: {resp}"
+        );
+    }
+}
+
+/// Built-in identity block: present on the default prompt, gone under override.
+const DEFAULT_IDENTITY: &str = "You are Sudo Code";
+/// The dynamic block every session carries; the append must land after it.
+const MEMORY_HEADING: &str = "# auto memory";
+
+/// `_meta.sudocode.systemPrompt` (replace the built-in static blocks) and
+/// `_meta.sudocode.appendSystemPrompt` (append a trailing dynamic block) on
+/// `session/new`, checked on the wire body the model receives:
+///  - neither → the default prompt (regression guard),
+///  - append only → appended after the auto-memory block, identity kept,
+///  - override only → identity replaced, nothing appended,
+///  - both → both take effect (the two are orthogonal),
+///  - other sessions in the process are unaffected,
+///  - both survive `session/setModel`, and `session/load` honours both,
+///  - empty / non-string values → `invalid_params` for either key.
+#[tokio::test]
+async fn acp_session_new_system_prompt_override_and_append_reach_model() {
+    const OVERRIDE: &str = "You are override-persona-3b9e1d. Reply tersely.";
+    const APPEND: &str = "Tenant rule append-4f7a20: always sign off with AHOY.";
+    const LOAD_OVERRIDE: &str = "You are load-persona-7c2f40. Reply in haiku.";
+
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("sysprompt-override");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let root = workspace.root.clone();
+
+    // neither: default prompt, nothing injected.
+    let plain = scenario_session_new(&mut client, &root).await;
+    let body = last_model_request_after_prompt(&mut client, &server, &plain, "p1").await;
+    assert!(
+        body.contains(DEFAULT_IDENTITY) && !body.contains(OVERRIDE) && !body.contains(APPEND),
+        "no _meta → default prompt; body: {body}"
+    );
+
+    // append only.
+    let resp =
+        session_new_with_meta(&mut client, &root, json!({"appendSystemPrompt": APPEND})).await;
+    let append_only = session_id_of(&resp);
+    let body = last_model_request_after_prompt(&mut client, &server, &append_only, "a1").await;
+    assert!(
+        body.contains(DEFAULT_IDENTITY) && body.contains(APPEND),
+        "append must reach the model with the identity block intact; body: {body}"
+    );
+    let (memory_at, append_at) = (body.find(MEMORY_HEADING), body.find(APPEND));
+    assert!(
+        memory_at.is_some() && append_at > memory_at,
+        "append must land after the auto-memory block: memory@{memory_at:?} append@{append_at:?}"
+    );
+
+    // override only.
+    let resp = session_new_with_meta(&mut client, &root, json!({"systemPrompt": OVERRIDE})).await;
+    let override_only = session_id_of(&resp);
+    let body = last_model_request_after_prompt(&mut client, &server, &override_only, "o1").await;
+    assert!(
+        body.contains(OVERRIDE) && !body.contains(DEFAULT_IDENTITY) && !body.contains(APPEND),
+        "override must replace the identity block; body: {body}"
+    );
+
+    // both.
+    let resp = session_new_with_meta(
+        &mut client,
+        &root,
+        json!({"systemPrompt": OVERRIDE, "appendSystemPrompt": APPEND}),
+    )
+    .await;
+    let both = session_id_of(&resp);
+    let body = last_model_request_after_prompt(&mut client, &server, &both, "b1").await;
+    assert!(
+        body.contains(OVERRIDE) && body.contains(APPEND) && !body.contains(DEFAULT_IDENTITY),
+        "override and append must compose; body: {body}"
+    );
+
+    // The default session in the same process is still untouched.
+    let body = last_model_request_after_prompt(&mut client, &server, &plain, "p2").await;
+    assert!(
+        body.contains(DEFAULT_IDENTITY) && !body.contains(OVERRIDE) && !body.contains(APPEND),
+        "other sessions must not inherit another session's _meta; body: {body}"
+    );
+
+    // setModel rebuilds the runtime; both adjustments must be re-applied.
+    let (_, set_resp) = client
+        .send_request(
+            "session/set_model",
+            json!({"sessionId": both, "modelId": "haiku"}),
+        )
+        .await;
+    assert!(
+        set_resp.get("error").is_none(),
+        "session/setModel should succeed; got: {set_resp}"
+    );
+    let body = last_model_request_after_prompt(&mut client, &server, &both, "b2").await;
+    assert!(
+        body.contains(OVERRIDE) && body.contains(APPEND) && !body.contains(DEFAULT_IDENTITY),
+        "override + append must survive a model switch; body: {body}"
+    );
+
+    // session/load accepts the same fields.
+    let (_, load_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": plain,
+                "cwd": root.to_string_lossy(),
+                "mcpServers": [],
+                "_meta": { "sudocode": { "systemPrompt": LOAD_OVERRIDE, "appendSystemPrompt": APPEND } },
+            }),
+        )
+        .await;
+    assert!(
+        load_resp.get("error").is_none(),
+        "session/load with _meta should succeed; got: {load_resp}"
+    );
+    let body = last_model_request_after_prompt(&mut client, &server, &plain, "p3").await;
+    assert!(
+        body.contains(LOAD_OVERRIDE) && body.contains(APPEND) && !body.contains(DEFAULT_IDENTITY),
+        "session/load override + append must reach the model; body: {body}"
+    );
+
+    // Validation: empty / non-string values are invalid_params for either key.
+    assert_bad_prompt_meta_rejected(&mut client, &root, OVERRIDE).await;
 
     client.shutdown().await;
     workspace.cleanup();


### PR DESCRIPTION
## What

Lets a caller supply its own system prompt to sudocode, through two
orthogonal knobs that compose:

| | ACP (`session/new`, `session/load`) | CLI |
|---|---|---|
| **Replace** the built-in identity + behaviour blocks | `_meta.sudocode.systemPrompt` | `--system-prompt` |
| **Append** a trailing block | `_meta.sudocode.appendSystemPrompt` | `--append-system-prompt` |

`initialize` advertises `systemPromptOverride` / `systemPromptAppend`
under `_meta.sudocode` so clients can detect support.

## Why

apeiron drives sudocode over ACP and needs a different system prompt
per tenant. Before this change there was no way to do that: the ACP
handlers read only `cwd` and `mcpServers`, and anything placed in
`_meta` was silently dropped. The only lever was an `AGENTS.md` in the
workspace, which is append-only, capped at 4k per file / 12k total,
and leaks across sibling workspaces because the scan walks every
ancestor directory up to `/`.

`_meta` is the right layer for this: one `scode acp` process serves
many sessions with different cwds, so a process-level lever (env var,
CLI flag) cannot vary per tenant, and writing the prompt into the
workspace makes it a file the tenant can read and edit.

## Behaviour

- Both keys optional and independent; setting both applies both.
- Override replaces the static blocks only. Workspace-derived dynamic
  sections (environment, `AGENTS.md`, memory, plugins) stay, so the
  supplied prompt still knows where it is running.
- Append lands last, after auto-memory, so it outranks `AGENTS.md`.
- Values pass through verbatim: no truncation, no escaping, no size
  cap. The 4k/12k caps guard the instruction-file scan against
  sweeping in a huge file; a value handed over by a trusted caller has
  no such risk, and the model's context window is the real limit.
- A present key that is empty, whitespace-only, or not a string is
  rejected with `invalid_params` rather than falling back to the
  default prompt.
- Overrides live on the session, so a `session/setModel` runtime
  rebuild re-applies them. They are not persisted with the transcript;
  a resumed session passes them again on `session/load`.
- `_meta` beats the CLI flag for the override; both appends appear,
  CLI first.
- No authorization logic here. Which callers may override versus only
  append is a policy question for the layer that owns identity.

## Verification

`scode acp` driven against a capture backend, asserting on the
`system` blocks that reach the model:

```
case:none          blocks=[10667, 4418]  identity=yes  override=no   append=no
case:append-only   blocks=[10667, 4456]  identity=yes  override=no   append=yes
case:override-only blocks=[32,    4418]  identity=no   override=yes  append=no
case:both          blocks=[32,    4456]  identity=no   override=yes  append=yes
```

The `none` row matches the pre-change baseline byte for byte, which is
the regression guard.

Bad values: `"  "` and `""` -> `must not be empty`; `["x"]` -> `must
be a string`.

Checks run locally: `cargo fmt --all --check`, `cargo clippy
--workspace`, `cargo test --workspace` (all green; the 16 ACP
integration tests include the new case). Each of the four commits
builds on its own.

## Note on scope

The second commit also reorders `print_system_prompt` to apply
coordinator mode before the plugin capability section, matching what a
live session does. `scode system-prompt` was printing sections in an
order the runtime never sends. It rides along because it touches the
same function this change edits; happy to split it out if preferred.

## Follow-up

`CLAUDE.md` is never loaded into the system prompt — the scan looks
only for `AGENTS.md` and `.nexus/sudocode/AGENTS.md` — yet `scode
init` was scaffolding one and `custom_agents.rs` parsed an
`omitClaudeMd` field nothing read. Spotted while tracing prompt
assembly for this change; fixed separately in #457.
