### PR TITLE
chore: drop dead CLAUDE.md code paths, scaffold AGENTS.md

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -154,7 +154,7 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
     SlashCommandSpec {
         name: "init",
         aliases: &[],
-        summary: "Create a starter CLAUDE.md for this repo",
+        summary: "Create a starter AGENTS.md for this repo",
         argument_hint: None,
         resume_supported: true,
     },

--- a/rust/crates/runtime/src/custom_agents.rs
+++ b/rust/crates/runtime/src/custom_agents.rs
@@ -12,11 +12,16 @@
 //! tools: [read_file, glob_search, grep_search]
 //! permissionMode: read-only
 //! memory: project
-//! omitClaudeMd: true
 //! ---
 //! You are a naming committee.  Reply with names, one per line.  Do
 //! not explain or elaborate.
 //! ```
+//!
+//! Unrecognised frontmatter keys are ignored. That includes CC's
+//! `omitClaudeMd`: Sudo Code never loads a CLAUDE.md hierarchy (only
+//! `AGENTS.md` is discovered), so the flag has nothing to switch off and
+//! is deliberately not modelled. Existing agent files that still carry it
+//! keep parsing; the key is a no-op.
 //!
 //! Files without frontmatter — or with frontmatter missing the
 //! required `name` and `description` fields — are silently skipped
@@ -62,14 +67,15 @@ use std::path::{Path, PathBuf};
 /// | `model`              | `model`                 | `Some("inherit")` means fall back to parent model.|
 /// | `permission_mode`    | `permissionMode`        | Threaded to `PermissionMode::from_str` at spawn.  |
 /// | `memory`             | `memory`                | `user` / `project` / `local`, or `None`.          |
-/// | `omit_claude_md`     | `omitClaudeMd`          | Slim-subagent kill-switch; default `false`.       |
 /// | `system_prompt`      | agent body              | Everything after the closing `---`.               |
 /// | `source_path`        | `filename` + `baseDir`  | Reconstructed on-demand from this path.           |
 ///
 /// Not (yet) ported: `disallowedTools`, `skills`, `mcpServers`,
 /// `hooks`, `color`, `effort`, `maxTurns`,
 /// `criticalSystemReminder_EXPERIMENTAL`, `requiredMcpServers`,
-/// `background`, `initialPrompt`, `isolation`. When a downstream commit
+/// `background`, `initialPrompt`, `isolation`. Intentionally not
+/// ported: `omitClaudeMd` (no CLAUDE.md loading exists to suppress; the
+/// key is accepted and ignored). When a downstream commit
 /// needs one of them, the parser can be extended without touching
 /// callers because [`load_md_agent_from_str`] is the sole entry point.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,9 +99,6 @@ pub struct CustomAgentDefinition {
     pub permission_mode: Option<String>,
     /// Memory scope: `user`, `project`, `local`, or `None`.
     pub memory: Option<String>,
-    /// When `true`, the parent CLAUDE.md hierarchy is omitted from the
-    /// child's system prompt — matches CC's cost-saving flag.
-    pub omit_claude_md: bool,
     /// Everything after the closing `---` delimiter, verbatim.  Used
     /// as the child's system-prompt body.
     pub system_prompt: String,
@@ -171,7 +174,6 @@ pub fn load_md_agent_from_str(contents: &str, source_path: &Path) -> Option<Cust
     let mut model: Option<String> = None;
     let mut permission_mode: Option<String> = None;
     let mut memory: Option<String> = None;
-    let mut omit_claude_md = false;
 
     for (key, raw_value) in parse_frontmatter_kv(frontmatter) {
         match key.as_str() {
@@ -185,14 +187,12 @@ pub fn load_md_agent_from_str(contents: &str, source_path: &Path) -> Option<Cust
                 permission_mode = Some(strip_quotes(&raw_value).to_string());
             }
             "memory" => memory = Some(strip_quotes(&raw_value).to_string()),
-            "omitClaudeMd" | "omit_claude_md" => {
-                omit_claude_md = parse_bool(&raw_value).unwrap_or(false);
-            }
             _ => {
-                // Unrecognised keys are silently accepted; a future
-                // commit that adds e.g. `color` or `effort` support
-                // will pick them up here without breaking existing
-                // frontmatter authored ahead of time.
+                // Unrecognised keys (including CC's `omitClaudeMd`, see
+                // module docs) are silently accepted; a future commit
+                // that adds e.g. `color` or `effort` support will pick
+                // them up here without breaking existing frontmatter
+                // authored ahead of time.
             }
         }
     }
@@ -207,7 +207,6 @@ pub fn load_md_agent_from_str(contents: &str, source_path: &Path) -> Option<Cust
         model,
         permission_mode,
         memory,
-        omit_claude_md,
         system_prompt: body.trim_start_matches('\n').to_string(),
         source_path: source_path.to_path_buf(),
     })
@@ -320,14 +319,6 @@ fn parse_tools_list(raw: &str) -> Vec<String> {
     names.into_iter().collect()
 }
 
-fn parse_bool(raw: &str) -> Option<bool> {
-    match strip_quotes(raw).trim().to_ascii_lowercase().as_str() {
-        "true" | "yes" | "on" | "1" => Some(true),
-        "false" | "no" | "off" | "0" => Some(false),
-        _ => None,
-    }
-}
-
 /// Return the current user's home dir. Delegated so tests can shim it
 /// via env var without touching every call site.
 fn home_dir() -> Option<PathBuf> {
@@ -364,7 +355,6 @@ mod tests {
         assert_eq!(def.description, "Names things.");
         assert!(def.tools.is_none(), "no tools -> inherit default");
         assert!(def.model.is_none());
-        assert!(!def.omit_claude_md);
         assert!(def.system_prompt.contains("You are a namer."));
     }
 
@@ -424,7 +414,7 @@ body";
         assert_eq!(def.model.as_deref(), Some("opus"));
         assert_eq!(def.permission_mode.as_deref(), Some("read-only"));
         assert_eq!(def.memory.as_deref(), Some("project"));
-        assert!(def.omit_claude_md);
+        // `omitClaudeMd` is a CC-only key; it must be tolerated but has no field.
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -70,7 +70,7 @@ pub(crate) fn render_help_topic(topic: LocalHelpTopic) -> String {
             .to_string(),
         LocalHelpTopic::Init => "Init
   Usage            scode init [--output-format <format>]
-  Purpose          create .nexus/sudocode/, .scode.json, .gitignore, and CLAUDE.md in the current project
+  Purpose          create .nexus/sudocode/, .scode.json, .gitignore, and AGENTS.md in the current project
   Output           list of created vs. skipped files (idempotent: safe to re-run)
   Formats          text (default), json
   Related          scode status · scode doctor"

--- a/rust/crates/rusty-sudocode-cli/src/init.rs
+++ b/rust/crates/rusty-sudocode-cli/src/init.rs
@@ -144,11 +144,13 @@ pub(crate) fn initialize_repo(cwd: &Path) -> Result<InitReport, Box<dyn std::err
         status: ensure_gitignore_entries(&gitignore)?,
     });
 
-    let claude_md = cwd.join("CLAUDE.md");
-    let content = render_init_claude_md(cwd);
+    // Sudo Code only loads `AGENTS.md` (see `runtime::prompt::discover_instruction_files`),
+    // so the scaffold must produce that file — not `CLAUDE.md`, which would never be read.
+    let agents_md = cwd.join("AGENTS.md");
+    let content = render_init_agents_md(cwd);
     artifacts.push(InitArtifact {
-        name: "CLAUDE.md",
-        status: write_file_if_missing(&claude_md, &content)?,
+        name: "AGENTS.md",
+        status: write_file_if_missing(&agents_md, &content)?,
     });
 
     Ok(InitReport {
@@ -205,10 +207,10 @@ fn ensure_gitignore_entries(path: &Path) -> Result<InitStatus, std::io::Error> {
     Ok(InitStatus::Updated)
 }
 
-pub(crate) fn render_init_claude_md(cwd: &Path) -> String {
+pub(crate) fn render_init_agents_md(cwd: &Path) -> String {
     let detection = detect_repo(cwd);
     let mut lines = vec![
-        "# CLAUDE.md".to_string(),
+        "# AGENTS.md".to_string(),
         String::new(),
         "This file provides guidance to Sudo Code (sudocode.dev) when working with code in this repository.".to_string(),
         String::new(),
@@ -256,7 +258,7 @@ pub(crate) fn render_init_claude_md(cwd: &Path) -> String {
     lines.push("## Working agreement".to_string());
     lines.push("- Prefer small, reviewable changes and keep generated bootstrap files aligned with actual repo workflows.".to_string());
     lines.push("- Keep shared defaults in `.scode.json`; reserve `.nexus/sudocode/settings.local.json` for machine-local overrides.".to_string());
-    lines.push("- Do not overwrite existing `CLAUDE.md` content automatically; update it intentionally when repo workflows change.".to_string());
+    lines.push("- Do not overwrite existing `AGENTS.md` content automatically; update it intentionally when repo workflows change.".to_string());
     lines.push(String::new());
 
     lines.join("\n")

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -5821,11 +5821,6 @@ fn print_skills_for_outcome(
     Ok(())
 }
 
-fn init_claude_md() -> Result<String, Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
-    Ok(initialize_repo(&cwd)?.render())
-}
-
 fn run_init(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
     let report = initialize_repo(&cwd)?;

--- a/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
@@ -213,7 +213,7 @@ fn dump_manifests_and_init_emit_json_when_requested() {
     fs::create_dir_all(&workspace).expect("workspace should exist");
     let init = assert_json_command(&workspace, &["--output-format", "json", "init"]);
     assert_eq!(init["kind"], "init");
-    assert!(workspace.join("CLAUDE.md").exists());
+    assert!(workspace.join("AGENTS.md").exists());
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn resumed_version_and_init_emit_structured_json_when_requested() {
         ],
     );
     assert_eq!(init["kind"], "init");
-    assert!(root.join("CLAUDE.md").exists());
+    assert!(root.join("AGENTS.md").exists());
 }
 
 #[test]

--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -2,7 +2,7 @@
 <!--
   Sudo Code Roadmap — single SSOT plan file.
   This is the canonical plan. Edit this file; publish to ShareOne with
-  the curl command in CLAUDE.md when you want to mirror it externally.
+  the curl command in CONTRIBUTING.md when you want to mirror it externally.
   Self-contained: no build step, no JS bundler, no Markdown
   transformation. Styled to render well both as `file://` open and as
   a ShareOne-hosted page.


### PR DESCRIPTION
## What

Removes the CLAUDE.md leftovers from sudocode's own code paths. Sudo
Code loads `AGENTS.md` and `.nexus/sudocode/AGENTS.md` only
(`runtime::prompt::discover_instruction_files`); every CLAUDE.md
reference in the codebase was either scaffolding a file nothing reads
or parsing a key nothing consumes.

- `scode init` / `/init` now scaffold `AGENTS.md`. Previously they
  wrote a `CLAUDE.md`, so anyone who followed the scaffold and put
  repo instructions in it got silence — no error, no warning, the file
  is simply never discovered.
- `omitClaudeMd` is gone from `CustomAgentDefinition`. It was parsed
  into a field that no call site ever read: a kill-switch for a
  CLAUDE.md hierarchy that does not exist here.
- Dropped the now-unused `init_claude_md` helper and `parse_bool`.
- The roadmap header pointed at CLAUDE.md for the ShareOne publishing
  recipe; that recipe lives in CONTRIBUTING.md (the root CLAUDE.md is
  a thin pointer to CONTRIBUTING.md).

## Not a breaking change for existing agent files

`omitClaudeMd` still parses. Removing the field does not make it an
error: unknown frontmatter keys fall through the existing catch-all
and are accepted silently, so agent `.md` files that carry the key
keep loading, with the key as a no-op. A test fixture keeps the key
specifically to pin that tolerance, and the module docs record why the
key is deliberately not modelled rather than merely unimplemented.

## Deliberately untouched

- The repo-root `CLAUDE.md` stays. It is a pointer that Claude Code
  reads on startup by convention, unrelated to sudocode's own prompt
  loading.
- No migration code. `CLAUDE.md` files already sitting in users'
  repositories are theirs; nothing here reads, moves, or deletes them.
  They simply keep having no effect on the system prompt, as before.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace`, `cargo test
--workspace` all clean (104 test binaries, zero failures). Each of the
five commits builds on its own.
