### PR TITLE
refactor(memory): put the prompt seam behind a MemoryProvider trait

### DIFF
--- a/rust/crates/runtime/src/memory/loader.rs
+++ b/rust/crates/runtime/src/memory/loader.rs
@@ -222,11 +222,9 @@ pub fn load_entries(memory_dir: &Path) -> std::io::Result<Vec<MemoryEntry>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::ENV_LOCK;
     use std::fs;
-    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn temp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()

--- a/rust/crates/runtime/src/memory/mod.rs
+++ b/rust/crates/runtime/src/memory/mod.rs
@@ -15,6 +15,17 @@
 pub mod entry;
 pub mod index;
 pub mod loader;
+pub mod provider;
+
+/// One process-wide lock for every test in this module tree that mutates
+/// `HOME` or `SUDOCODE_MEMORY_DIR`.
+///
+/// `loader`, `provider` and this module's tests all resolve paths from the
+/// same process globals, so they have to serialize against the *same* mutex.
+/// Two module-local mutexes serialize nothing, which shows up as directories
+/// resolved against another test's `HOME`.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 use std::path::{Path, PathBuf};
 
@@ -24,6 +35,7 @@ pub use loader::{
     agent_memory_dir_for, default_memory_dir, default_memory_dir_for, MEMORY_DIR_ENV,
     MEMORY_INDEX_FILE,
 };
+pub use provider::{FileMemoryProvider, MemoryContext, MemoryProvider};
 
 use crate::prompt::SystemPromptBuilder;
 
@@ -198,26 +210,27 @@ pub fn append_to_builder_with(
     cwd: Option<&Path>,
     variant: MemoryPromptVariant,
 ) -> SystemPromptBuilder {
-    let owned;
-    let dir = if let Some(d) = memory_dir {
-        d
-    } else if let Some(cwd) = cwd {
-        owned = default_memory_dir_for(cwd);
-        owned.as_path()
-    } else {
-        owned = default_memory_dir();
-        owned.as_path()
-    };
-    loader::ensure_memory_dir_exists(dir);
-    match MemoryIndex::load(dir) {
-        Ok(idx) => builder.append_section(idx.render_for_prompt_with(dir, variant)),
-        _ => {
-            let empty = MemoryIndex {
-                directory: dir.to_path_buf(),
-                ..Default::default()
-            };
-            builder.append_section(empty.render_for_prompt_with(dir, variant))
-        }
+    let ctx = MemoryContext::resolve(memory_dir, cwd, None, variant);
+    append_from_provider(builder, &FileMemoryProvider::new(), &ctx)
+}
+
+/// Append whatever `provider` contributes for `ctx`.
+///
+/// A provider that reports itself unavailable, or that contributes nothing,
+/// leaves the builder untouched rather than emitting an empty memory
+/// heading. This is the single seam every memory backend goes through.
+#[must_use]
+pub fn append_from_provider(
+    builder: SystemPromptBuilder,
+    provider: &dyn MemoryProvider,
+    ctx: &MemoryContext,
+) -> SystemPromptBuilder {
+    if !provider.is_available() {
+        return builder;
+    }
+    match provider.system_prompt_block(ctx) {
+        Some(block) => builder.append_section(block),
+        None => builder,
     }
 }
 
@@ -433,10 +446,7 @@ mod tests {
     use super::*;
     use crate::prompt::SystemPromptBuilder;
     use std::fs;
-    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn temp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()

--- a/rust/crates/runtime/src/memory/provider.rs
+++ b/rust/crates/runtime/src/memory/provider.rs
@@ -1,0 +1,239 @@
+//! Pluggable memory providers.
+//!
+//! Memory reaches the model through exactly one seam: a block of text
+//! appended to the system prompt at build time. This module turns that seam
+//! into a trait so backends other than the on-disk files in [`super::loader`]
+//! can supply it.
+//!
+//! Two methods, split by *when* they run:
+//!
+//! - [`MemoryProvider::system_prompt_block`] is synchronous, because prompt
+//!   building is. It runs once per prompt build.
+//! - [`MemoryProvider::prefetch`] is async and query-scoped, meant to run in
+//!   the turn loop *before* the prompt is rendered so a provider can recall
+//!   against what the user just asked. Nothing calls it yet — it is declared
+//!   here so the shape is fixed before backends start arriving.
+//!
+//! Note the asymmetry with MCP. An MCP server can expose memory as tools the
+//! model chooses to call, but nothing on the MCP path writes into the system
+//! prompt, so it cannot recall on the model's behalf before the model knows
+//! to ask. Closing that gap is why this trait exists rather than leaving
+//! memory to a well-known MCP server.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use super::loader::{
+    agent_memory_dir_for, default_memory_dir, default_memory_dir_for, ensure_memory_dir_exists,
+};
+use super::{MemoryIndex, MemoryPromptVariant};
+
+/// Where a memory lookup is happening, resolved once at the call site.
+///
+/// Directory resolution reproduces, in order, what callers used to do by
+/// hand: an explicit directory wins, then per-agent scoping, then the
+/// project-scoped default, then the process-wide default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryContext {
+    /// Working directory the session was started in, when known.
+    pub cwd: Option<PathBuf>,
+    /// Sub-agent type this lookup is scoped to, when the caller is a spawn.
+    /// Previously this was smuggled in as a pre-computed directory; keeping
+    /// it here lets a provider scope by agent without parsing a path.
+    pub agent_type: Option<String>,
+    /// Which edition of the auto-memory instructions the call site wants.
+    pub variant: MemoryPromptVariant,
+    /// Directory the fields above resolved to.
+    pub memory_dir: PathBuf,
+}
+
+impl MemoryContext {
+    /// Resolve a context from the pieces a call site actually has.
+    #[must_use]
+    pub fn resolve(
+        memory_dir: Option<&Path>,
+        cwd: Option<&Path>,
+        agent_type: Option<&str>,
+        variant: MemoryPromptVariant,
+    ) -> Self {
+        let dir = match (memory_dir, cwd, agent_type) {
+            (Some(dir), _, _) => dir.to_path_buf(),
+            (None, Some(cwd), Some(agent)) => agent_memory_dir_for(cwd, agent),
+            (None, Some(cwd), None) => default_memory_dir_for(cwd),
+            (None, None, _) => default_memory_dir(),
+        };
+        Self {
+            cwd: cwd.map(Path::to_path_buf),
+            agent_type: agent_type.map(str::to_string),
+            variant,
+            memory_dir: dir,
+        }
+    }
+
+    #[must_use]
+    pub fn memory_dir(&self) -> &Path {
+        &self.memory_dir
+    }
+}
+
+/// A source of remembered context for the model.
+#[async_trait]
+pub trait MemoryProvider: Send + Sync {
+    /// Stable identifier, used in diagnostics and configuration.
+    fn name(&self) -> &str;
+
+    /// Whether this provider can run right now. A provider that needs a
+    /// network service or a missing binary reports `false` and is skipped,
+    /// rather than failing the prompt build.
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    /// Text to append to the system prompt. `None` means "contribute
+    /// nothing" and must not be used to signal an error.
+    fn system_prompt_block(&self, ctx: &MemoryContext) -> Option<String>;
+
+    /// Recall scoped to a query, for the turn loop to await before the
+    /// prompt is rendered. Providers that only inject static context leave
+    /// this at the default.
+    async fn prefetch(&self, _query: &str, _ctx: &MemoryContext) -> Option<String> {
+        None
+    }
+}
+
+/// The on-disk provider: `MEMORY.md` plus one file per entry, rendered whole.
+///
+/// This is the behaviour every session has today, moved behind the trait
+/// without changing a byte of what it emits.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FileMemoryProvider;
+
+impl FileMemoryProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl MemoryProvider for FileMemoryProvider {
+    // The trait deliberately returns `&str` rather than `&'static str`: a
+    // provider fronting an MCP server takes its name from configuration and
+    // cannot hand back a literal. This impl happens to have one.
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "file"
+    }
+
+    fn system_prompt_block(&self, ctx: &MemoryContext) -> Option<String> {
+        let dir = ctx.memory_dir();
+        ensure_memory_dir_exists(dir);
+        // Always render, even with zero entries: the block carries the
+        // auto-memory instructions telling the model where to write.
+        let index = MemoryIndex::load(dir).unwrap_or_else(|_| MemoryIndex {
+            directory: dir.to_path_buf(),
+            ..Default::default()
+        });
+        Some(index.render_for_prompt_with(dir, ctx.variant))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::ENV_LOCK;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Same hand-rolled helper the sibling `loader` tests use; the crate has
+    // no `tempfile` dev-dependency and this change does not add one.
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("runtime-memory-provider-{prefix}-{nanos}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    #[test]
+    fn explicit_dir_wins_over_cwd_and_agent() {
+        let dir = temp_dir("explicit");
+        let ctx = MemoryContext::resolve(
+            Some(&dir),
+            Some(Path::new("/some/cwd")),
+            Some("x"),
+            MemoryPromptVariant::Compact,
+        );
+        assert_eq!(ctx.memory_dir(), dir.as_path());
+        assert_eq!(ctx.agent_type.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn agent_type_scopes_under_agent_memory() {
+        // HOME is process-global and other tests move it; hold the lock
+        // across both the resolve and the expectation.
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cwd = temp_dir("agent-cwd");
+        let ctx =
+            MemoryContext::resolve(None, Some(&cwd), Some("explore"), MemoryPromptVariant::Full);
+        assert_eq!(ctx.memory_dir(), agent_memory_dir_for(&cwd, "explore"));
+    }
+
+    #[test]
+    fn no_agent_type_uses_project_scoped_dir() {
+        // HOME is process-global and other tests move it; hold the lock
+        // across both the resolve and the expectation.
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cwd = temp_dir("project-cwd");
+        let ctx = MemoryContext::resolve(None, Some(&cwd), None, MemoryPromptVariant::Compact);
+        assert_eq!(ctx.memory_dir(), default_memory_dir_for(&cwd));
+    }
+
+    #[test]
+    fn file_provider_renders_instructions_when_empty() {
+        let dir = temp_dir("empty");
+        let ctx = MemoryContext::resolve(Some(&dir), None, None, MemoryPromptVariant::Compact);
+        let block = FileMemoryProvider::new()
+            .system_prompt_block(&ctx)
+            .expect("file provider always contributes a block");
+        assert!(block.contains("# auto memory"), "block was: {block}");
+    }
+
+    #[test]
+    fn file_provider_honors_the_variant() {
+        let dir = temp_dir("variant");
+        let compact = MemoryContext::resolve(Some(&dir), None, None, MemoryPromptVariant::Compact);
+        let full = MemoryContext::resolve(Some(&dir), None, None, MemoryPromptVariant::Full);
+        let provider = FileMemoryProvider::new();
+        let compact_block = provider.system_prompt_block(&compact).expect("compact");
+        let full_block = provider.system_prompt_block(&full).expect("full");
+        assert!(
+            full_block.len() > compact_block.len(),
+            "full edition should be longer: {} vs {}",
+            full_block.len(),
+            compact_block.len()
+        );
+    }
+
+    #[test]
+    fn file_provider_renders_entries() {
+        let dir = temp_dir("entries");
+        fs::write(
+            dir.join("thing.md"),
+            "---\nname: thing\ndescription: a thing\nmetadata:\n  type: project\n---\n\nbody text\n",
+        )
+        .expect("write entry");
+        let ctx = MemoryContext::resolve(Some(&dir), None, None, MemoryPromptVariant::Compact);
+        let block = FileMemoryProvider::new()
+            .system_prompt_block(&ctx)
+            .expect("file provider always contributes a block");
+        assert!(block.contains("body text"), "block was: {block}");
+    }
+}

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -658,23 +658,18 @@ fn load_system_prompt_impl(
         .with_model_family(model_family)
         .with_project_context(project_context)
         .with_runtime_config(config);
-    let builder = match agent_type {
-        Some(agent) => {
-            let dir = crate::memory::agent_memory_dir_for(&cwd, agent);
-            crate::memory::append_to_builder_with(
-                builder_base,
-                Some(&dir),
-                Some(&cwd),
-                memory_prompt_variant_for_agent(agent, &cwd),
-            )
-        }
-        None => crate::memory::append_to_builder_with(
-            builder_base,
-            None,
-            Some(&cwd),
-            crate::memory::MemoryPromptVariant::Compact,
-        ),
+    // Preserves the previous per-branch choice exactly: sub-agent spawns ask
+    // the agent definition, the main loop always takes the compact edition.
+    let variant = match agent_type {
+        Some(agent) => memory_prompt_variant_for_agent(agent, &cwd),
+        None => crate::memory::MemoryPromptVariant::Compact,
     };
+    let memory_ctx = crate::memory::MemoryContext::resolve(None, Some(&cwd), agent_type, variant);
+    let builder = crate::memory::append_from_provider(
+        builder_base,
+        &crate::memory::FileMemoryProvider::new(),
+        &memory_ctx,
+    );
     Ok(builder.build())
 }
 


### PR DESCRIPTION
## What

Memory reaches the model through exactly one seam — a block of text appended to the system prompt. This puts that seam behind a trait so backends other than the on-disk files can supply it.

**Pure refactor.** No behaviour change, no new dependency, no config surface, no caller outside this crate changes.

## Why a trait, and not just an MCP server

sudocode can already point at a memory MCP server today with zero code — mem0 and Zep/Graphiti both ship one. That covers the half where the model *decides* to look something up.

It cannot cover the other half, and the other half is the point of memory:

- `prompt.rs` contains no MCP reference. `resources/read` and `prompts/get` are fully implemented at the transport layer, but the only consumers are model-invoked tools (`tools/src/lib.rs`) and the human `/mcp` command (`cli/mcp.rs`).
- Hooks cannot cover it either: `HookEvent` has exactly three variants — `PreToolUse`, `PostToolUse`, `PostToolUseFailure` — all tool-scoped, with no turn- or prompt-level event to hang injection on.

So MCP can answer when the model thinks to ask, and can never recall on its behalf beforehand. A seam in prompt building is the only place that gap closes, and this PR adds exactly that seam and nothing else.

## Shape

```rust
#[async_trait]
pub trait MemoryProvider: Send + Sync {
    fn name(&self) -> &str;
    fn is_available(&self) -> bool { true }
    fn system_prompt_block(&self, ctx: &MemoryContext) -> Option<String>;
    async fn prefetch(&self, _query: &str, _ctx: &MemoryContext) -> Option<String> { None }
}
```

Two methods split by *when* they run. `system_prompt_block` is sync because prompt building is. `prefetch` is async and query-scoped, meant for the turn loop to await before rendering — **nothing calls it yet**; it is declared so the shape is fixed before backends start arriving.

`MemoryContext` resolves the directory once, in the same order call sites previously did by hand. Two things get better on the way:

- `agent_type` becomes a first-class field instead of being smuggled in as a pre-computed path, so a provider can scope by agent without parsing one.
- `variant` travels with it, so the `Compact`/`Full` split from #406 survives the move.

`FileMemoryProvider` is today's on-disk behaviour, byte for byte. `append_to_builder{,_with}` keep their signatures and delegate.

## Test lock fix, included

`memory/mod.rs` and `memory/loader.rs` each declared their own `ENV_LOCK` while both mutate the process-global `HOME` — two mutexes serializing nothing.

That hazard does not surface on main (25/25 clean). The new resolution-order tests read `HOME` often enough to expose it: **6 of 12 runs failed**, resolving paths against another test's `HOME`, and one run took the pre-existing `agent_memory_dir_lives_under_workspace_agent_memory_subdir` down with it. Both modules now share one `pub(crate)` lock. **30/30 clean** afterwards.

## Verification

| | |
|---|---|
| runtime unit tests | 37 pass, incl. existing budget / dedup / staleness / scoping cases |
| **`pty_memory.rs` + `pty_agent_memory_scoping.rs`** | **12 pass, unmodified** — the real regression bar |
| `cargo fmt` | clean |
| `cargo clippy` | 3 warnings in touched files, all pre-existing (`loader.rs:149`, `loader.rs:159`, `mod.rs:290`); none in `provider.rs` |

The PTY tests are the bar that matters: they cover `SUDOCODE_MEMORY_DIR`, project slug resolution and per-agent isolation end to end, and they were not touched.

## Not in this PR

- `prefetch` has no caller. Wiring it into the turn loop is a follow-up.
- No second provider. The intended next one is an `McpProvider` that turns `prefetch` into one `memory_search` call against a configured MCP server — that single implementation reaches every backend that ships an MCP server, instead of one Rust client per vendor.
- The 16 000-char render budget and its alphabetical drop order are untouched. Retrieval is what actually fixes that, and retrieval needs this trait first.