### PR TITLE
chore(deps): bump nexus-vfs pin 2a62e6a5 → b98c08e62

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
 dependencies = [
  "contracts",
  "kernel",
@@ -163,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -867,7 +867,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
 dependencies = [
  "parking_lot",
  "serde",
@@ -937,7 +937,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -958,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1387,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1965,7 +1965,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2196,7 +2196,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2210,15 +2210,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2306,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2368,7 +2359,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2569,7 +2560,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2a62e6a5618d0008872c958d95db4e3ebaae6120#2a62e6a5618d0008872c958d95db4e3ebaae6120"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
 
 [[package]]
 name = "nexus-vfs-client"
@@ -3165,7 +3156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -3185,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3206,7 +3197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3219,7 +3210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3380,7 +3371,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3418,9 +3409,9 @@ dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3808,7 +3799,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4331,7 +4322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4490,7 +4481,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5214,7 +5205,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,13 +37,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2a62e6a5618d0008872c958d95db4e3ebaae6120", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2a62e6a5618d0008872c958d95db4e3ebaae6120", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2a62e6a5618d0008872c958d95db4e3ebaae6120", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Advances the nexus-vfs pin 30 commits (2a62e6a5 → b98c08e62, nexus-vfs main incl. the DT_STREAM P3 series + the plugin-host `sys_read`-collects-DT_STREAM shim from nexus-vfs#235). No API drift — the only recent kernel change sudocode consumes (`sys_readdir` gaining `ReaddirOpts`) was already adapted in `fs_backend.rs`. `cargo check --workspace` green.

Unblocks the downstream **nexus** repo bumping ITS nexus-vfs pin to b98c08e62 (for search-over-streams, nexus-vfs#229 P3): nexus's pin-consistency gate requires every transitive nexus-vfs pin — including sudocode's `runtime`/`tools` — to agree.