### PR TITLE
feat(task): add dependencies to TaskRegistry

### DIFF
--- a/rust/crates/runtime/src/task_registry.rs
+++ b/rust/crates/runtime/src/task_registry.rs
@@ -51,6 +51,8 @@ pub struct Task {
         skip_serializing_if = "Option::is_none"
     )]
     pub active_form: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<String>,
     pub task_packet: Option<TaskPacket>,
     pub status: TaskStatus,
     pub created_at: u64,
@@ -157,6 +159,7 @@ impl TaskRegistry {
         subject: &str,
         description: Option<&str>,
         active_form: Option<&str>,
+        dependencies: Vec<String>,
     ) -> Task {
         self.create_task_full(
             subject.to_owned(),
@@ -165,6 +168,7 @@ impl TaskRegistry {
             active_form.map(str::to_owned),
             None,
             TaskStatus::Pending,
+            dependencies,
         )
     }
 
@@ -176,6 +180,7 @@ impl TaskRegistry {
             None,
             None,
             TaskStatus::Created,
+            Vec::new(),
         )
     }
 
@@ -195,6 +200,7 @@ impl TaskRegistry {
             None,
             Some(packet),
             TaskStatus::Created,
+            Vec::new(),
         ))
     }
 
@@ -206,6 +212,7 @@ impl TaskRegistry {
         active_form: Option<String>,
         task_packet: Option<TaskPacket>,
         initial_status: TaskStatus,
+        dependencies: Vec<String>,
     ) -> Task {
         let mut inner = self.inner.lock().expect("registry lock poisoned");
         inner.counter += 1;
@@ -217,6 +224,7 @@ impl TaskRegistry {
             prompt,
             description,
             active_form,
+            dependencies,
             task_packet,
             status: initial_status,
             created_at: ts,
@@ -321,7 +329,7 @@ impl TaskRegistry {
         Ok(())
     }
 
-    /// Update structured fields on a task (subject, description, active_form, status).
+    /// Update structured fields on a task (subject, description, active_form, status, dependencies).
     /// Returns the updated task.
     pub fn update_fields(
         &self,
@@ -330,6 +338,7 @@ impl TaskRegistry {
         description: Option<&str>,
         active_form: Option<&str>,
         status: Option<TaskStatus>,
+        dependencies: Option<Vec<String>>,
     ) -> Result<Task, String> {
         let mut inner = self.inner.lock().expect("registry lock poisoned");
         let task = inner
@@ -348,10 +357,23 @@ impl TaskRegistry {
         if let Some(st) = status {
             task.status = st;
         }
+        if let Some(deps) = dependencies {
+            task.dependencies = deps;
+        }
         task.updated_at = now_secs();
         let result = task.clone();
         Self::save(&inner);
         Ok(result)
+    }
+
+    pub fn validate_dependencies(&self, deps: &[String]) -> Result<(), String> {
+        let inner = self.inner.lock().expect("registry lock poisoned");
+        for dep in deps {
+            if !inner.tasks.contains_key(dep) {
+                return Err(format!("dependency task not found: {dep}"));
+            }
+        }
+        Ok(())
     }
 
     pub fn remove(&self, task_id: &str) -> Option<Task> {
@@ -400,6 +422,7 @@ mod tests {
             "Fix login bug",
             Some("Investigate auth timeout"),
             Some("Fixing login bug"),
+            Vec::new(),
         );
         assert_eq!(task.status, TaskStatus::Pending);
         assert_eq!(task.subject, "Fix login bug");
@@ -636,11 +659,11 @@ mod tests {
 
         // Create tasks with persistence
         let registry = TaskRegistry::load(&path);
-        let t1 = registry.create_with_subject("First", Some("Do first"), Some("Doing first"));
+        let t1 = registry.create_with_subject("First", Some("Do first"), Some("Doing first"), Vec::new());
         registry
             .set_status(&t1.task_id, TaskStatus::InProgress)
             .unwrap();
-        let _t2 = registry.create_with_subject("Second", None, None);
+        let _t2 = registry.create_with_subject("Second", None, None, Vec::new());
 
         // Load into a new registry
         let registry2 = TaskRegistry::load(&path);
@@ -660,7 +683,7 @@ mod tests {
     #[test]
     fn update_fields_changes_subject_and_status() {
         let registry = TaskRegistry::new();
-        let task = registry.create_with_subject("Original", Some("desc"), None);
+        let task = registry.create_with_subject("Original", Some("desc"), None, Vec::new());
 
         let updated = registry
             .update_fields(
@@ -669,6 +692,7 @@ mod tests {
                 None,
                 Some("Renaming"),
                 Some(TaskStatus::Completed),
+                None,
             )
             .unwrap();
 
@@ -681,7 +705,7 @@ mod tests {
     #[test]
     fn pending_and_in_progress_statuses() {
         let registry = TaskRegistry::new();
-        let task = registry.create_with_subject("My task", None, None);
+        let task = registry.create_with_subject("My task", None, None, Vec::new());
         assert_eq!(task.status, TaskStatus::Pending);
 
         registry
@@ -689,5 +713,51 @@ mod tests {
             .unwrap();
         let fetched = registry.get(&task.task_id).unwrap();
         assert_eq!(fetched.status, TaskStatus::InProgress);
+    }
+
+    #[test]
+    fn creates_task_with_dependencies() {
+        let registry = TaskRegistry::new();
+        let t1 = registry.create_with_subject("First", None, None, Vec::new());
+        let t2 = registry.create_with_subject("Second", None, None, vec![t1.task_id.clone()]);
+        assert_eq!(t2.dependencies, vec![t1.task_id]);
+    }
+
+    #[test]
+    fn update_fields_sets_dependencies() {
+        let registry = TaskRegistry::new();
+        let t1 = registry.create_with_subject("A", None, None, Vec::new());
+        let t2 = registry.create_with_subject("B", None, None, Vec::new());
+        let updated = registry.update_fields(
+            &t2.task_id, None, None, None, None,
+            Some(vec![t1.task_id.clone()]),
+        ).unwrap();
+        assert_eq!(updated.dependencies, vec![t1.task_id]);
+    }
+
+    #[test]
+    fn validate_dependencies_rejects_missing() {
+        let registry = TaskRegistry::new();
+        let result = registry.validate_dependencies(&["nonexistent".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn persistence_preserves_dependencies() {
+        let dir = std::env::temp_dir().join(format!("task_dep_test_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("tasks.json");
+        let _ = std::fs::remove_file(&path);
+
+        let registry = TaskRegistry::load(&path);
+        let t1 = registry.create_with_subject("First", None, None, Vec::new());
+        let _t2 = registry.create_with_subject("Second", None, None, vec![t1.task_id.clone()]);
+
+        let registry2 = TaskRegistry::load(&path);
+        let tasks = registry2.list(None);
+        let t2_reloaded = tasks.iter().find(|t| t.subject == "Second").unwrap();
+        assert_eq!(t2_reloaded.dependencies, vec![t1.task_id]);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/rust/crates/runtime/src/task_registry.rs
+++ b/rust/crates/runtime/src/task_registry.rs
@@ -659,7 +659,12 @@ mod tests {
 
         // Create tasks with persistence
         let registry = TaskRegistry::load(&path);
-        let t1 = registry.create_with_subject("First", Some("Do first"), Some("Doing first"), Vec::new());
+        let t1 = registry.create_with_subject(
+            "First",
+            Some("Do first"),
+            Some("Doing first"),
+            Vec::new(),
+        );
         registry
             .set_status(&t1.task_id, TaskStatus::InProgress)
             .unwrap();
@@ -728,10 +733,16 @@ mod tests {
         let registry = TaskRegistry::new();
         let t1 = registry.create_with_subject("A", None, None, Vec::new());
         let t2 = registry.create_with_subject("B", None, None, Vec::new());
-        let updated = registry.update_fields(
-            &t2.task_id, None, None, None, None,
-            Some(vec![t1.task_id.clone()]),
-        ).unwrap();
+        let updated = registry
+            .update_fields(
+                &t2.task_id,
+                None,
+                None,
+                None,
+                None,
+                Some(vec![t1.task_id.clone()]),
+            )
+            .unwrap();
         assert_eq!(updated.dependencies, vec![t1.task_id]);
     }
 

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1159,7 +1159,12 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                     "description": { "type": "string", "description": "What needs to be done" },
                     "activeForm": { "type": "string", "description": "Present continuous form shown in spinner when in_progress (e.g. 'Running tests')" },
                     "prompt": { "type": "string", "description": "Alias for subject (backward compat)" },
-                    "metadata": { "type": "object" }
+                    "metadata": { "type": "object" },
+                    "dependencies": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Task IDs this task depends on (must complete before this task can start)"
+                    }
                 },
                 "required": ["subject", "description"],
                 "additionalProperties": false
@@ -1223,7 +1228,12 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                     "subject": { "type": "string", "description": "New subject for the task" },
                     "description": { "type": "string", "description": "New description" },
                     "activeForm": { "type": "string", "description": "Present continuous form for spinner" },
-                    "message": { "type": "string", "description": "Append a message to the task (backward compat)" }
+                    "message": { "type": "string", "description": "Append a message to the task (backward compat)" },
+                    "dependencies": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "New dependency list (replaces existing dependencies)"
+                    }
                 },
                 "required": ["taskId"],
                 "additionalProperties": false
@@ -1782,16 +1792,22 @@ fn run_task_create(input: TaskCreateInput) -> Result<String, String> {
         .or(input.prompt)
         .ok_or_else(|| "subject is required".to_string())?;
     let registry = global_task_registry();
+    // Validate dependencies exist
+    if !input.dependencies.is_empty() {
+        registry.validate_dependencies(&input.dependencies)?;
+    }
     let task = registry.create_with_subject(
         &subject,
         input.description.as_deref(),
         input.active_form.as_deref(),
+        input.dependencies,
     );
     to_pretty_json(json!({
         "task_id": task.task_id,
         "status": task.status,
         "subject": task.subject,
         "description": task.description,
+        "dependencies": task.dependencies,
         "created_at": task.created_at
     }))
 }
@@ -1805,6 +1821,7 @@ fn run_task_get(input: TaskIdInput) -> Result<String, String> {
             "status": task.status,
             "subject": task.subject,
             "description": task.description,
+            "dependencies": task.dependencies,
             "task_packet": task.task_packet,
             "created_at": task.created_at,
             "updated_at": task.updated_at,
@@ -1825,6 +1842,7 @@ fn run_task_list(input: Value) -> Result<String, String> {
                 "status": t.status,
                 "subject": t.subject,
                 "description": t.description,
+                "dependencies": t.dependencies,
                 "task_packet": t.task_packet,
                 "created_at": t.created_at,
                 "updated_at": t.updated_at
@@ -1951,6 +1969,13 @@ fn run_task_update(input: TaskUpdateInput) -> Result<String, String> {
         })
         .transpose()?;
 
+    // Validate dependencies if updating them
+    if let Some(deps) = &input.dependencies {
+        if !deps.is_empty() {
+            registry.validate_dependencies(deps)?;
+        }
+    }
+
     // Append legacy message if provided
     if let Some(msg) = &input.message {
         registry.update(&task_id, msg)?;
@@ -1963,6 +1988,7 @@ fn run_task_update(input: TaskUpdateInput) -> Result<String, String> {
         input.description.as_deref(),
         input.active_form.as_deref(),
         new_status,
+        input.dependencies,
     )?;
 
     // Verification watcher: record completion + check for streak nudge
@@ -1977,6 +2003,7 @@ fn run_task_update(input: TaskUpdateInput) -> Result<String, String> {
         "task_id": task.task_id,
         "status": task.status,
         "subject": task.subject,
+        "dependencies": task.dependencies,
     });
     if let Some(nudge) = verification_streak_nudge {
         result["verificationStreakNudge"] = json!(nudge);
@@ -3597,6 +3624,8 @@ struct TaskCreateInput {
     active_form: Option<String>,
     /// Backward compat alias for `subject`.
     prompt: Option<String>,
+    #[serde(default)]
+    dependencies: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3617,6 +3646,8 @@ struct TaskUpdateInput {
     #[serde(rename = "activeForm")]
     active_form: Option<String>,
     message: Option<String>,
+    #[serde(default)]
+    dependencies: Option<Vec<String>>,
 }
 
 impl TaskUpdateInput {


### PR DESCRIPTION
## Summary
- Add `dependencies: Vec<String>` to Task struct — single-direction dependency list (SSOT, no redundant blocks/blockedBy)
- TaskCreate and TaskUpdate tool schemas accept and validate dependencies
- `validate_dependencies()` method ensures all referenced task IDs exist
- 4 new tests: creation, update, validation, persistence round-trip

## Context
sudowork's TaskPanel renders DAG visualizations. Previously it used a separate `.tasks/dag_*/` file system. Now it reads from TaskRegistry's `.sudocode-tasks.json`. This PR adds the dependency field so the rendering layer can derive DAG structure from connected components at read time.

## Test plan
- [x] `cargo test -p runtime` — 23 tests pass (including 4 new dependency tests)
- [x] `cargo test -p tools --lib` — 117 tests pass
- [x] `cargo check -p runtime -p tools` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)