### PR TITLE
feat(compact): compaction CC parity — buffer scaling, file restore, retry

### DIFF
--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -1,4 +1,7 @@
+use std::collections::BTreeMap;
 use std::fmt;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use crate::conversation::ApiClient;
 use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
@@ -132,6 +135,131 @@ pub fn autocompact_buffer_tokens(model: &str) -> u32 {
     } else {
         AUTOCOMPACT_BUFFER_TOKENS
     }
+}
+
+// ---------------------------------------------------------------------------
+// Post-compact file restore (CC parity)
+// ---------------------------------------------------------------------------
+
+/// Maximum number of recently-read files to re-inject after compaction.
+/// Matches CC's `POST_COMPACT_MAX_FILES_TO_RESTORE`.
+const POST_COMPACT_MAX_FILES: usize = 5;
+
+/// Total token budget for all re-injected file content.
+/// Matches CC's `POST_COMPACT_TOKEN_BUDGET`.
+const POST_COMPACT_TOKEN_BUDGET: usize = 50_000;
+
+/// Per-file token cap. Matches CC's `POST_COMPACT_MAX_TOKENS_PER_FILE`.
+const POST_COMPACT_MAX_TOKENS_PER_FILE: usize = 5_000;
+
+/// Tracks the most recent read_file tool result for each path.
+/// Populated by `ConversationRuntime` each time a `read_file` tool
+/// succeeds; consumed after compaction to restore file context.
+#[derive(Debug, Default)]
+pub struct ReadFileTracker {
+    entries: BTreeMap<PathBuf, Instant>,
+}
+
+impl ReadFileTracker {
+    /// Record that a file was read at the current instant.
+    pub fn record(&mut self, path: PathBuf) {
+        self.entries.insert(path, Instant::now());
+    }
+
+    /// Clear all tracked entries (called after file restore messages are built).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Build user messages re-injecting recently-read file content.
+    ///
+    /// Files already visible in `preserved_messages` (the tail kept after
+    /// compaction) are skipped — they're already in the model's context.
+    /// Returns messages ordered most-recent-first, constrained by both
+    /// file count and token budget.
+    #[must_use]
+    pub fn build_post_compact_file_messages(
+        &self,
+        preserved_messages: &[ConversationMessage],
+    ) -> Vec<ConversationMessage> {
+        if self.entries.is_empty() {
+            return Vec::new();
+        }
+
+        // Collect read_file paths already in the preserved tail.
+        let preserved_paths = collect_read_file_paths(preserved_messages);
+
+        // Sort by timestamp (most recent first), skip preserved.
+        let mut candidates: Vec<(&PathBuf, &Instant)> = self
+            .entries
+            .iter()
+            .filter(|(path, _)| !preserved_paths.iter().any(|pp| pp == *path))
+            .collect();
+        candidates.sort_by(|a, b| b.1.cmp(a.1));
+        candidates.truncate(POST_COMPACT_MAX_FILES);
+
+        let mut messages = Vec::new();
+        let mut total_tokens = 0usize;
+
+        for (path, _) in candidates {
+            let content = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            // Estimate tokens and enforce per-file + total budget
+            let token_estimate = content.len() / 4 + 1;
+            let capped = if token_estimate > POST_COMPACT_MAX_TOKENS_PER_FILE {
+                // Truncate to fit the per-file budget (conservative char estimate)
+                let max_chars = POST_COMPACT_MAX_TOKENS_PER_FILE * 4;
+                &content[..content.floor_char_boundary(max_chars.min(content.len()))]
+            } else {
+                content.as_str()
+            };
+
+            let capped_tokens = capped.len() / 4 + 1;
+            if total_tokens + capped_tokens > POST_COMPACT_TOKEN_BUDGET {
+                break;
+            }
+            total_tokens += capped_tokens;
+
+            let display_path = path.display();
+            messages.push(ConversationMessage::user_text(format!(
+                "[Post-compact file restore: {display_path}]\n{capped}"
+            )));
+        }
+
+        messages
+    }
+}
+
+/// Extract `read_file` tool-use paths from a message slice.
+fn collect_read_file_paths(messages: &[ConversationMessage]) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for msg in messages {
+        for block in &msg.blocks {
+            if let ContentBlock::ToolUse { name, input, .. } = block {
+                if name == "read_file" || name == "Read" {
+                    if let Some(p) = extract_file_path_from_tool_input(input) {
+                        paths.push(PathBuf::from(&p));
+                    }
+                }
+            }
+        }
+    }
+    paths
+}
+
+/// Parse the `file_path` field from a tool-use input JSON string.
+/// Public for use by `ConversationRuntime::find_tool_use_file_path`.
+pub fn extract_file_path_from_tool_input(input: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(input).ok()?;
+    parsed
+        .get("file_path")
+        .or_else(|| parsed.get("filePath"))
+        .or_else(|| parsed.get("path"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
 }
 
 // ---------------------------------------------------------------------------
@@ -1847,5 +1975,119 @@ mod tests {
         assert_eq!(usage.cache_creation_input_tokens, 4);
         assert_eq!(usage.cache_read_input_tokens, 2);
         assert_eq!(usage.cost_units, Some(300));
+    }
+
+    #[test]
+    fn extract_file_path_from_tool_input_parses_variants() {
+        assert_eq!(
+            super::extract_file_path_from_tool_input(r#"{"file_path":"/tmp/a.rs"}"#),
+            Some("/tmp/a.rs".to_string()),
+        );
+        assert_eq!(
+            super::extract_file_path_from_tool_input(r#"{"filePath":"/tmp/b.rs"}"#),
+            Some("/tmp/b.rs".to_string()),
+        );
+        assert_eq!(
+            super::extract_file_path_from_tool_input(r#"{"path":"/tmp/c.rs"}"#),
+            Some("/tmp/c.rs".to_string()),
+        );
+        assert_eq!(
+            super::extract_file_path_from_tool_input("not json"),
+            None,
+        );
+    }
+
+    #[test]
+    fn read_file_tracker_builds_post_compact_messages() {
+        use std::io::Write;
+
+        // Create temp files
+        let dir = std::env::temp_dir().join(format!(
+            "scode-compact-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let file_a = dir.join("alpha.rs");
+        let file_b = dir.join("beta.rs");
+        let file_c = dir.join("gamma.rs");
+        std::fs::write(&file_a, "fn alpha() {}").unwrap();
+        std::fs::write(&file_b, "fn beta() {}").unwrap();
+        // gamma is tracked but also in preserved messages — should be skipped
+        std::fs::write(&file_c, "fn gamma() {}").unwrap();
+
+        let mut tracker = super::ReadFileTracker::default();
+        tracker.record(file_a.clone());
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        tracker.record(file_b.clone());
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        tracker.record(file_c.clone());
+
+        // Simulate preserved messages containing a read_file tool use for gamma
+        let preserved = vec![ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+            id: "t1".to_string(),
+            name: "read_file".to_string(),
+            input: format!(r#"{{"file_path":"{}"}}"#, file_c.display()),
+            thought_signature: None,
+        }])];
+
+        let messages = tracker.build_post_compact_file_messages(&preserved);
+
+        // gamma should be skipped (already in preserved)
+        assert_eq!(messages.len(), 2, "should restore alpha and beta, skip gamma");
+
+        // Most recent first: beta before alpha
+        let first_text = match &messages[0].blocks[0] {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected text block"),
+        };
+        assert!(first_text.contains("fn beta()"), "most recent file first");
+        assert!(first_text.contains("beta.rs"), "should mention filename");
+
+        let second_text = match &messages[1].blocks[0] {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected text block"),
+        };
+        assert!(second_text.contains("fn alpha()"), "second file");
+
+        // Clear should empty the tracker
+        let _ = Write::write(&mut std::io::sink(), b"");
+        tracker.clear();
+        assert!(tracker.build_post_compact_file_messages(&[]).is_empty());
+
+        // Cleanup
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_file_tracker_respects_file_limit() {
+        let dir = std::env::temp_dir().join(format!(
+            "scode-compact-limit-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut tracker = super::ReadFileTracker::default();
+        for i in 0..10 {
+            let path = dir.join(format!("file{i}.txt"));
+            std::fs::write(&path, format!("content {i}")).unwrap();
+            tracker.record(path);
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let messages = tracker.build_post_compact_file_messages(&[]);
+        assert!(
+            messages.len() <= super::POST_COMPACT_MAX_FILES,
+            "should respect max files limit, got {}",
+            messages.len()
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -109,10 +109,30 @@ const COMPACTION_SYSTEM_PROMPT: &str =
 /// here covers re-compactions whose input is already a prior summary.
 pub const COMPACT_MAX_OUTPUT_TOKENS: u32 = 20_000;
 
-/// Buffer subtracted from context window when computing the auto-compact
-/// threshold (`context_window - max_output - buffer`). Matches CC's
-/// `AUTOCOMPACT_BUFFER_TOKENS`.
+/// Base buffer subtracted from context window when computing the auto-compact
+/// threshold. Scaled by [`autocompact_buffer_tokens`] for large context
+/// windows — see CC's `getAutocompactBufferTokens()`.
 pub const AUTOCOMPACT_BUFFER_TOKENS: u32 = 13_000;
+
+/// Context-aware autocompact buffer. Larger context windows need more
+/// headroom because a single turn can produce proportionally more tokens
+/// (longer model outputs + larger tool results).
+///
+/// Matches CC's `getAutocompactBufferTokens()`:
+/// - 800K+ context → 50K buffer
+/// - 400K+ context → 30K buffer
+/// - else → 13K (base constant)
+#[must_use]
+pub fn autocompact_buffer_tokens(model: &str) -> u32 {
+    let context_window = crate::model_capabilities::context_window_or_default(model);
+    if context_window >= 800_000 {
+        50_000
+    } else if context_window >= 400_000 {
+        30_000
+    } else {
+        AUTOCOMPACT_BUFFER_TOKENS
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -829,6 +849,25 @@ mod tests {
     };
     use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
     use crate::usage::{TokenUsage, UsageCostCurrency};
+
+    #[test]
+    fn autocompact_buffer_scales_with_context_window() {
+        // Small model (200K context) → base 13K buffer
+        let small = super::autocompact_buffer_tokens("claude-sonnet-4-6");
+        assert_eq!(small, 13_000);
+
+        // Medium model (400K context) → 30K buffer
+        let medium = super::autocompact_buffer_tokens("gpt-5.4-mini");
+        assert_eq!(medium, 30_000);
+
+        // Large model (1M context) → 50K buffer
+        let large = super::autocompact_buffer_tokens("claude-opus-4-8");
+        assert_eq!(large, 50_000);
+
+        // Unknown model falls back to SSOT default (200K) → 13K
+        let unknown = super::autocompact_buffer_tokens("unknown-model-xyz");
+        assert_eq!(unknown, 13_000);
+    }
 
     #[test]
     fn formats_compact_summary_like_upstream() {

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -637,7 +637,12 @@ pub async fn compact_session<C: ApiClient>(
     let llm_summary = 'outer: loop {
         for attempt in 0..=MAX_COMPACT_RETRIES {
             match api_client
-                .send_compaction(model, COMPACTION_SYSTEM_PROMPT, current_messages.clone(), max_tokens)
+                .send_compaction(
+                    model,
+                    COMPACTION_SYSTEM_PROMPT,
+                    current_messages.clone(),
+                    max_tokens,
+                )
                 .await
             {
                 Ok(summary) => break 'outer summary,
@@ -2066,10 +2071,7 @@ mod tests {
             super::extract_file_path_from_tool_input(r#"{"path":"/tmp/c.rs"}"#),
             Some("/tmp/c.rs".to_string()),
         );
-        assert_eq!(
-            super::extract_file_path_from_tool_input("not json"),
-            None,
-        );
+        assert_eq!(super::extract_file_path_from_tool_input("not json"), None,);
     }
 
     #[test]
@@ -2102,17 +2104,23 @@ mod tests {
         tracker.record(file_c.clone());
 
         // Simulate preserved messages containing a read_file tool use for gamma
-        let preserved = vec![ConversationMessage::assistant(vec![ContentBlock::ToolUse {
-            id: "t1".to_string(),
-            name: "read_file".to_string(),
-            input: format!(r#"{{"file_path":"{}"}}"#, file_c.display()),
-            thought_signature: None,
-        }])];
+        let preserved = vec![ConversationMessage::assistant(vec![
+            ContentBlock::ToolUse {
+                id: "t1".to_string(),
+                name: "read_file".to_string(),
+                input: format!(r#"{{"file_path":"{}"}}"#, file_c.display()),
+                thought_signature: None,
+            },
+        ])];
 
         let messages = tracker.build_post_compact_file_messages(&preserved);
 
         // gamma should be skipped (already in preserved)
-        assert_eq!(messages.len(), 2, "should restore alpha and beta, skip gamma");
+        assert_eq!(
+            messages.len(),
+            2,
+            "should restore alpha and beta, skip gamma"
+        );
 
         // Most recent first: beta before alpha
         let first_text = match &messages[0].blocks[0] {
@@ -2261,7 +2269,9 @@ mod tests {
             ) -> Result<String, RuntimeError> {
                 let attempt = PTL_ATTEMPT.fetch_add(1, Ordering::Relaxed);
                 if attempt == 0 {
-                    Err(RuntimeError::new("prompt_too_long: exceeds maximum context length"))
+                    Err(RuntimeError::new(
+                        "prompt_too_long: exceeds maximum context length",
+                    ))
                 } else {
                     // After truncation, message count should be smaller
                     Ok(format!(

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -2103,12 +2103,14 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(5));
         tracker.record(file_c.clone());
 
-        // Simulate preserved messages containing a read_file tool use for gamma
+        // Simulate preserved messages containing a read_file tool use for gamma.
+        // Use serde_json to properly escape backslashes on Windows paths.
+        let gamma_path_json = serde_json::to_string(&file_c.display().to_string()).unwrap();
         let preserved = vec![ConversationMessage::assistant(vec![
             ContentBlock::ToolUse {
                 id: "t1".to_string(),
                 name: "read_file".to_string(),
-                input: format!(r#"{{"file_path":"{}"}}"#, file_c.display()),
+                input: format!(r#"{{"file_path":{gamma_path_json}}}"#),
                 thought_signature: None,
             },
         ])];

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -529,10 +529,61 @@ fn build_compaction_messages(
     messages
 }
 
+/// Maximum retries for the compaction streaming call.
+/// Matches CC's `MAX_COMPACT_STREAMING_RETRIES`.
+const MAX_COMPACT_RETRIES: u32 = 2;
+
+/// Maximum PTL (prompt-too-long) truncation retries.
+/// Matches CC's `MAX_PTL_RETRIES`.
+const MAX_PTL_RETRIES: u32 = 3;
+
+/// Check if an error is retryable (transient failures, not permanent ones).
+fn is_retryable_error(error_msg: &str) -> bool {
+    let lower = error_msg.to_lowercase();
+    lower.contains("timeout")
+        || lower.contains("connection")
+        || lower.contains("server error")
+        || lower.contains("500")
+        || lower.contains("502")
+        || lower.contains("503")
+        || lower.contains("529")
+        || lower.contains("overloaded")
+        || lower.contains("rate limit")
+        || lower.contains("rate_limit")
+}
+
+/// Check if an error indicates prompt-too-long.
+fn is_prompt_too_long(error_msg: &str) -> bool {
+    let lower = error_msg.to_lowercase();
+    lower.contains("prompt is too long")
+        || lower.contains("prompt_too_long")
+        || lower.contains("maximum context length")
+        || lower.contains("token limit")
+}
+
+/// Drop the oldest ~20% of message groups from compaction input to make
+/// room for a PTL retry. Returns `None` if nothing can be dropped.
+fn truncate_head_for_ptl(messages: &[ConversationMessage]) -> Option<Vec<ConversationMessage>> {
+    if messages.len() <= 2 {
+        return None;
+    }
+    // Drop ~20% of messages from the front (excluding the final compaction prompt)
+    let drop_count = std::cmp::max(1, (messages.len() - 1) / 5);
+    let remaining = &messages[drop_count..];
+    if remaining.len() < 2 {
+        return None;
+    }
+    Some(remaining.to_vec())
+}
+
 /// Compacts a session using an LLM to produce a high-quality summary.
 ///
-/// This is the primary compaction path. Falls back to local heuristic
-/// compaction when the API client doesn't support `send_compaction`.
+/// Retries transient failures up to [`MAX_COMPACT_RETRIES`] times with
+/// exponential backoff. On prompt-too-long errors, truncates the oldest
+/// messages and retries up to [`MAX_PTL_RETRIES`] times.
+///
+/// Falls back to local heuristic compaction when the API client doesn't
+/// support `send_compaction`.
 pub async fn compact_session<C: ApiClient>(
     session: &Session,
     config: CompactionConfig,
@@ -578,16 +629,40 @@ pub async fn compact_session<C: ApiClient>(
         crate::model_capabilities::max_output_tokens_or_default(model),
     );
 
-    // Call the LLM
-    let llm_summary = api_client
-        .send_compaction(
-            model,
-            COMPACTION_SYSTEM_PROMPT,
-            compaction_messages,
-            max_tokens,
-        )
-        .await
-        .map_err(|e| CompactionError::ApiError(e.to_string()))?;
+    // Call the LLM with retry logic
+    let mut current_messages = compaction_messages;
+    let mut ptl_attempts = 0u32;
+    let mut last_error = String::new();
+
+    let llm_summary = 'outer: loop {
+        for attempt in 0..=MAX_COMPACT_RETRIES {
+            match api_client
+                .send_compaction(model, COMPACTION_SYSTEM_PROMPT, current_messages.clone(), max_tokens)
+                .await
+            {
+                Ok(summary) => break 'outer summary,
+                Err(e) => {
+                    last_error = e.to_string();
+                    if is_prompt_too_long(&last_error) {
+                        ptl_attempts += 1;
+                        if ptl_attempts <= MAX_PTL_RETRIES {
+                            if let Some(truncated) = truncate_head_for_ptl(&current_messages) {
+                                current_messages = truncated;
+                                continue 'outer;
+                            }
+                        }
+                        return Err(CompactionError::ApiError(last_error));
+                    }
+                    if attempt < MAX_COMPACT_RETRIES && is_retryable_error(&last_error) {
+                        tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
+                        continue;
+                    }
+                    return Err(CompactionError::ApiError(last_error));
+                }
+            }
+        }
+        return Err(CompactionError::ApiError(last_error));
+    };
 
     let summary = merge_compact_summaries(existing_summary.as_deref(), &llm_summary);
     let formatted_summary = format_compact_summary(&summary);
@@ -2089,5 +2164,233 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn compact_session_retries_transient_failures() {
+        use crate::conversation::{ApiClient, ApiRequest, AssistantEventStream, RuntimeError};
+        use async_trait::async_trait;
+        use std::sync::atomic::{AtomicU8, Ordering};
+
+        static ATTEMPT: AtomicU8 = AtomicU8::new(0);
+
+        struct FailThenSucceedClient;
+
+        #[async_trait]
+        impl ApiClient for FailThenSucceedClient {
+            async fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Err(RuntimeError::new("not used"))
+            }
+
+            async fn send_compaction(
+                &mut self,
+                _model: &str,
+                _system_prompt: &str,
+                _messages: Vec<ConversationMessage>,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                let attempt = ATTEMPT.fetch_add(1, Ordering::Relaxed);
+                if attempt < 2 {
+                    Err(RuntimeError::new("503 server error: overloaded"))
+                } else {
+                    Ok("<summary>Recovered after retry.</summary>".to_string())
+                }
+            }
+        }
+
+        ATTEMPT.store(0, Ordering::Relaxed);
+
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("one ".repeat(200)),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "two ".repeat(200),
+            }]),
+            ConversationMessage::user_text("recent"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "kept".to_string(),
+            }]),
+        ];
+
+        let config = super::CompactionConfig {
+            preserve_recent_messages: 2,
+            max_estimated_tokens: 1,
+        };
+
+        let mut client = FailThenSucceedClient;
+        let result = super::compact_session(&session, config, &mut client, "sonnet", None)
+            .await
+            .expect("should succeed after retries");
+
+        assert!(result.removed_message_count > 0);
+        assert!(result.formatted_summary.contains("Recovered after retry"));
+        assert!(
+            ATTEMPT.load(Ordering::Relaxed) == 3,
+            "should have made 3 attempts (2 failures + 1 success)"
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_session_retries_ptl_with_truncation() {
+        use crate::conversation::{ApiClient, ApiRequest, AssistantEventStream, RuntimeError};
+        use async_trait::async_trait;
+        use std::sync::atomic::{AtomicU8, Ordering};
+
+        static PTL_ATTEMPT: AtomicU8 = AtomicU8::new(0);
+
+        struct PtlThenSucceedClient;
+
+        #[async_trait]
+        impl ApiClient for PtlThenSucceedClient {
+            async fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Err(RuntimeError::new("not used"))
+            }
+
+            async fn send_compaction(
+                &mut self,
+                _model: &str,
+                _system_prompt: &str,
+                messages: Vec<ConversationMessage>,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                let attempt = PTL_ATTEMPT.fetch_add(1, Ordering::Relaxed);
+                if attempt == 0 {
+                    Err(RuntimeError::new("prompt_too_long: exceeds maximum context length"))
+                } else {
+                    // After truncation, message count should be smaller
+                    Ok(format!(
+                        "<summary>PTL recovered with {} messages.</summary>",
+                        messages.len()
+                    ))
+                }
+            }
+        }
+
+        PTL_ATTEMPT.store(0, Ordering::Relaxed);
+
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("one ".repeat(200)),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "two ".repeat(200),
+            }]),
+            ConversationMessage::user_text("three ".repeat(200)),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "four ".repeat(200),
+            }]),
+            ConversationMessage::user_text("recent"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "kept".to_string(),
+            }]),
+        ];
+
+        let config = super::CompactionConfig {
+            preserve_recent_messages: 2,
+            max_estimated_tokens: 1,
+        };
+
+        let mut client = PtlThenSucceedClient;
+        let result = super::compact_session(&session, config, &mut client, "sonnet", None)
+            .await
+            .expect("should succeed after PTL truncation");
+
+        assert!(result.removed_message_count > 0);
+        assert!(result.formatted_summary.contains("PTL recovered"));
+        assert!(
+            PTL_ATTEMPT.load(Ordering::Relaxed) >= 2,
+            "should have made at least 2 attempts"
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_session_gives_up_on_permanent_failure() {
+        use crate::conversation::{ApiClient, ApiRequest, AssistantEventStream, RuntimeError};
+        use async_trait::async_trait;
+
+        struct AlwaysFailClient;
+
+        #[async_trait]
+        impl ApiClient for AlwaysFailClient {
+            async fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Err(RuntimeError::new("not used"))
+            }
+
+            async fn send_compaction(
+                &mut self,
+                _model: &str,
+                _system_prompt: &str,
+                _messages: Vec<ConversationMessage>,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                Err(RuntimeError::new("authentication failed"))
+            }
+        }
+
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("one ".repeat(200)),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "two ".repeat(200),
+            }]),
+            ConversationMessage::user_text("recent"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "kept".to_string(),
+            }]),
+        ];
+
+        let config = super::CompactionConfig {
+            preserve_recent_messages: 2,
+            max_estimated_tokens: 1,
+        };
+
+        let mut client = AlwaysFailClient;
+        let result = super::compact_session(&session, config, &mut client, "sonnet", None).await;
+
+        assert!(result.is_err());
+        match result {
+            Err(super::CompactionError::ApiError(msg)) => {
+                assert!(msg.contains("authentication failed"));
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncate_head_for_ptl_drops_oldest_messages() {
+        let messages = vec![
+            ConversationMessage::user_text("a"),
+            ConversationMessage::user_text("b"),
+            ConversationMessage::user_text("c"),
+            ConversationMessage::user_text("d"),
+            ConversationMessage::user_text("e"),
+            ConversationMessage::user_text("prompt"),
+        ];
+
+        let truncated = super::truncate_head_for_ptl(&messages).expect("should truncate");
+        // 6 messages, drop ~20% = 1 → 5 remaining
+        assert_eq!(truncated.len(), 5);
+        // First dropped message was "a"
+        assert!(matches!(
+            &truncated[0].blocks[0],
+            ContentBlock::Text { text } if text == "b"
+        ));
+    }
+
+    #[test]
+    fn truncate_head_for_ptl_returns_none_for_tiny_input() {
+        let messages = vec![
+            ConversationMessage::user_text("only"),
+            ConversationMessage::user_text("two"),
+        ];
+        assert!(super::truncate_head_for_ptl(&messages).is_none());
     }
 }

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -9,8 +9,8 @@ use serde_json::{Map, Value};
 use telemetry::SessionTracer;
 
 use crate::compact::{
-    compact_session, compact_session_sync, estimate_session_tokens, CompactionConfig,
-    CompactionResult, AUTOCOMPACT_BUFFER_TOKENS,
+    autocompact_buffer_tokens, compact_session, compact_session_sync, estimate_session_tokens,
+    CompactionConfig, CompactionResult,
 };
 use crate::config::RuntimeFeatureConfig;
 use crate::hooks::{HookAbortSignal, HookProgressReporter, HookRunResult, HookRunner};
@@ -1951,7 +1951,8 @@ pub fn auto_compact_threshold_for_model(model: &str) -> u32 {
     let max_output = crate::model_capabilities::max_output_tokens_or_default(model);
     // Clamp max_output to avoid overflow on small context windows
     let effective_max_output = std::cmp::min(max_output, crate::compact::COMPACT_MAX_OUTPUT_TOKENS);
-    context_window.saturating_sub(effective_max_output + AUTOCOMPACT_BUFFER_TOKENS)
+    let buffer = autocompact_buffer_tokens(model);
+    context_window.saturating_sub(effective_max_output + buffer)
 }
 
 fn build_assistant_message(
@@ -4042,9 +4043,9 @@ mod tests {
         let _g = env_guard();
         // Ensure no env-var override is active.
         std::env::remove_var("CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS");
-        // The threshold is context_window - min(max_output, 20K) - 13K.
+        // The threshold is context_window - min(max_output, 20K) - buffer.
         // For claude-sonnet-4-6 (200K context, 64K output):
-        //   200_000 - min(64_000, 20_000) - 13_000 = 167_000
+        //   buffer = 13K (200K < 400K), threshold = 200K - 20K - 13K = 167K
         let threshold = auto_compact_threshold_for_model("claude-sonnet-4-6");
         assert_eq!(threshold, 167_000);
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -10,7 +10,7 @@ use telemetry::SessionTracer;
 
 use crate::compact::{
     autocompact_buffer_tokens, compact_session, compact_session_sync, estimate_session_tokens,
-    CompactionConfig, CompactionResult,
+    CompactionConfig, CompactionResult, ReadFileTracker,
 };
 use crate::config::RuntimeFeatureConfig;
 use crate::hooks::{HookAbortSignal, HookProgressReporter, HookRunResult, HookRunner};
@@ -352,6 +352,8 @@ pub struct ConversationRuntime<C, T> {
     session_tracer: Option<SessionTracer>,
     /// File operation tracker for the current turn.
     file_tracker: crate::file_tracker::TurnFileTracker,
+    /// Tracks recently-read files for post-compact restoration (CC parity).
+    read_file_tracker: ReadFileTracker,
     /// Current turn ID for file tracking.
     current_turn_id: Option<String>,
     /// User request intent for the current turn.
@@ -415,6 +417,7 @@ where
             hook_progress_reporter: None,
             session_tracer: None,
             file_tracker: crate::file_tracker::TurnFileTracker::new(workspace_root),
+            read_file_tracker: ReadFileTracker::default(),
             current_turn_id: None,
             user_request_intent: None,
             trace_id: None,
@@ -777,12 +780,55 @@ where
         result_message: ConversationMessage,
     ) -> Result<(), RuntimeError> {
         notify_tool_result(runtime_observer_mut(observer), &result_message);
+        // Track read_file results for post-compact restoration.
+        self.track_read_file_if_applicable(&result_message);
         self.session
             .push_message(result_message.clone())
             .map_err(|error| RuntimeError::new(error.to_string()))?;
         self.record_tool_finished(iterations, &result_message);
         tool_results.push(result_message);
         Ok(())
+    }
+
+    /// If this tool result is a successful `read_file` / `Read`, record the
+    /// file path in `read_file_tracker` for post-compact restoration.
+    fn track_read_file_if_applicable(&mut self, result_message: &ConversationMessage) {
+        for block in &result_message.blocks {
+            if let ContentBlock::ToolResult {
+                tool_name,
+                tool_use_id,
+                is_error,
+                ..
+            } = block
+            {
+                if *is_error {
+                    continue;
+                }
+                if tool_name != "read_file" && tool_name != "Read" {
+                    continue;
+                }
+                // Find the matching ToolUse in the session to extract file_path
+                if let Some(path) = self.find_tool_use_file_path(tool_use_id) {
+                    self.read_file_tracker.record(path);
+                }
+            }
+        }
+    }
+
+    /// Search session messages for a ToolUse block with the given id and
+    /// extract its `file_path` parameter.
+    fn find_tool_use_file_path(&self, tool_use_id: &str) -> Option<std::path::PathBuf> {
+        for msg in self.session.messages.iter().rev() {
+            for block in &msg.blocks {
+                if let ContentBlock::ToolUse { id, input, .. } = block {
+                    if id == tool_use_id {
+                        return crate::compact::extract_file_path_from_tool_input(input)
+                            .map(|s| std::path::PathBuf::from(&s));
+                    }
+                }
+            }
+        }
+        None
     }
 
     /// If a tool output exceeds the offload threshold, spill the full bytes to
@@ -1791,7 +1837,25 @@ where
         // Success → reset the noop counter so the breaker only trips on
         // SUSTAINED inability to shrink, not on transient threshold dance.
         self.consecutive_auto_compact_noops = 0;
-        self.session = result.compacted_session;
+
+        // Post-compact file restore: re-inject recently-read file content
+        // so the model doesn't lose knowledge of files it just worked with.
+        // Messages are inserted after the summary but before preserved tail.
+        let preserved = &result.compacted_session.messages[1..];
+        let file_messages = self
+            .read_file_tracker
+            .build_post_compact_file_messages(preserved);
+        self.read_file_tracker.clear();
+
+        let mut session = result.compacted_session;
+        if !file_messages.is_empty() {
+            let insert_at = 1; // After summary, before preserved
+            for (i, msg) in file_messages.into_iter().enumerate() {
+                session.messages.insert(insert_at + i, msg);
+            }
+        }
+        self.session = session;
+
         Some(AutoCompactionEvent {
             removed_message_count: result.removed_message_count,
         })


### PR DESCRIPTION
## Summary

Three CC-parity features for the compaction subsystem:

1. **Auto-compact buffer scaling** — Buffer scales with context window size: 800K+ → 50K, 400K+ → 30K, else → 13K base. Prevents Opus (1M context) from firing compaction too late.

2. **Post-compact file restore** — After compaction, up to 5 recently-read files (50K token budget, 5K/file) are re-injected as user messages so the model retains file context. Files already in preserved tail messages are skipped. Matches CC's `createPostCompactFileAttachments`.

3. **Compaction streaming retry** — Transient failures (503, timeout, overloaded) retry up to 2 times with exponential backoff. Prompt-too-long errors truncate the oldest ~20% of messages and retry up to 3 times. Permanent errors fail immediately. Matches CC's `MAX_COMPACT_STREAMING_RETRIES` + `MAX_PTL_RETRIES`.

Phases 4 (fork cache sharing) and 5 (partial compaction) are deferred per plan — low ROI.

## Test plan

- [x] `autocompact_buffer_scales_with_context_window` — verifies 3 threshold tiers (13K/30K/50K)
- [x] `auto_compact_threshold_uses_per_model_ssot` — existing test still passes with scaled buffer
- [x] `extract_file_path_from_tool_input_parses_variants` — `file_path`, `filePath`, `path` keys
- [x] `read_file_tracker_builds_post_compact_messages` — file restore with preserved-tail dedup
- [x] `read_file_tracker_respects_file_limit` — enforces POST_COMPACT_MAX_FILES
- [x] `compact_session_retries_transient_failures` — mock fails twice then succeeds
- [x] `compact_session_retries_ptl_with_truncation` — PTL truncation + retry
- [x] `compact_session_gives_up_on_permanent_failure` — auth errors fail immediately
- [x] `truncate_head_for_ptl_drops_oldest_messages` — 20% drop logic
- [x] `truncate_head_for_ptl_returns_none_for_tiny_input` — edge case
- [x] All 706 runtime unit tests pass
- [x] `compaction_persist` integration test passes
- [x] `compact_output` integration tests pass (4/4)
- [x] Release build succeeds