### PR TITLE
feat(runtime): back the nexus session transcript with a DT_STREAM

### DIFF
--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use crate::workspace_root::current_workspace_root;
 use kernel::kernel::syscall::{KernelSyscall, ReaddirOpts};
 use kernel::kernel::OperationContext;
+use kernel::meta_store::DT_STREAM;
 
 // ---------------------------------------------------------------------------
 // Metadata types
@@ -69,6 +70,32 @@ pub trait FsBackend: Send + Sync + 'static {
         let temp = format!("{path}.tmp.{}", std::process::id());
         self.write(&temp, data)?;
         self.rename(&temp, path)
+    }
+
+    /// Create `path` as an append-only log, ready for [`FsBackend::append`].
+    ///
+    /// The default creates an empty regular file (host FS / VFS DT_REG),
+    /// which `append` then extends. Backends with a native append-log
+    /// primitive override this — [`KernelFsBackend`] creates a durable
+    /// DT_STREAM so `append` becomes an O(1) frame write. `retention` is the
+    /// cold-storage budget in bytes for backends that spill cold segments
+    /// out of the hot tier (`0` = keep-forever); regular-file backends
+    /// ignore it.
+    fn create_append_log(&self, path: &str, _retention: u64) -> io::Result<()> {
+        if !self.exists(path)? {
+            if let Some(parent) = std::path::Path::new(path).parent() {
+                let _ = self.create_dir_all(&parent.to_string_lossy());
+            }
+            self.write(path, b"")?;
+        }
+        Ok(())
+    }
+
+    /// True when `path` is a native append-log (e.g. a VFS DT_STREAM) for
+    /// which `append` is an O(1) frame write and snapshot rewrite / rotation
+    /// do not apply. Regular-file backends return `false`.
+    fn is_append_stream(&self, _path: &str) -> io::Result<bool> {
+        Ok(false)
     }
 
     /// The absolute working root that relative paths resolve against and
@@ -178,6 +205,12 @@ impl FsBackend for Arc<dyn FsBackend> {
     }
     fn write_atomic(&self, path: &str, data: &[u8]) -> io::Result<()> {
         (**self).write_atomic(path, data)
+    }
+    fn create_append_log(&self, path: &str, retention: u64) -> io::Result<()> {
+        (**self).create_append_log(path, retention)
+    }
+    fn is_append_stream(&self, path: &str) -> io::Result<bool> {
+        (**self).is_append_stream(path)
     }
     fn working_root(&self) -> io::Result<String> {
         (**self).working_root()
@@ -374,6 +407,44 @@ impl<K: KernelSyscall> KernelFsBackend<K> {
         let ctx = OperationContext::new(owner_id, zone_id, false, Some(agent_name), true);
         Self::new(kernel, ctx, workspace_root)
     }
+
+    /// True when the entry at `path` is a DT_STREAM (native append-log).
+    fn is_stream_entry(&self, path: &str) -> bool {
+        self.kernel
+            .sys_stat(path, &self.ctx.zone_id)
+            .is_some_and(|s| s.entry_type == DT_STREAM)
+    }
+
+    /// Read an entire DT_STREAM as the concatenation of its record payloads.
+    ///
+    /// Each [`FsBackend::append`] wrote one framed record; `sys_read` returns
+    /// one *deframed* payload plus the next offset, so walking from offset 0
+    /// to the live tail and concatenating reproduces the original append
+    /// stream byte-for-byte. Cold segments spilled out of the hot tier are
+    /// fetched transparently by the kernel. Non-blocking (`timeout_ms = 0`):
+    /// the walk stops at the tail rather than parking for new data.
+    fn read_stream_all(&self, path: &str) -> io::Result<Vec<u8>> {
+        let mut out = Vec::new();
+        let mut offset: u64 = 0;
+        loop {
+            let result = self
+                .kernel
+                .sys_read(path, &self.ctx, 0, offset)
+                .map_err(kernel_err)?;
+            match result.data {
+                Some(payload) if !payload.is_empty() => {
+                    out.extend_from_slice(&payload);
+                    match result.stream_next_offset {
+                        Some(next) if next as u64 > offset => offset = next as u64,
+                        // No forward progress (tail reached / unknown) — stop.
+                        _ => break,
+                    }
+                }
+                _ => break,
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Map a kernel error to an `io::Error`.
@@ -383,6 +454,11 @@ fn kernel_err(e: impl std::fmt::Debug) -> io::Error {
 
 impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> {
     fn read(&self, path: &str) -> io::Result<Vec<u8>> {
+        // A DT_STREAM is read by walking its framed records to the tail; a
+        // single `sys_read` would return only the first record's payload.
+        if self.is_stream_entry(path) {
+            return self.read_stream_all(path);
+        }
         self.kernel
             .sys_read(path, &self.ctx, 0, 0)
             .map_err(kernel_err)
@@ -401,13 +477,75 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
     }
 
     fn append(&self, path: &str, data: &[u8]) -> io::Result<()> {
-        // Compose: read existing content, concatenate, write back.
-        // Kernel pipes/streams have append semantics at offset != 0 but
-        // regular files don't, so the read-concat-write path is safest.
+        // A DT_STREAM appends `data` as one framed record in O(1): `sys_write`
+        // pushes to the log tail (the offset arg is ignored for streams).
+        // Regular files have no O(1) append, so fall back to read-concat-write
+        // (kernel `sys_write` is a whole-object replace, not an OS append).
+        if self.is_stream_entry(path) {
+            return self
+                .kernel
+                .sys_write(path, &self.ctx, data, 0)
+                .map_err(kernel_err)
+                .map(|_| ());
+        }
         let existing = self.read(path).unwrap_or_default();
         let mut combined = existing;
         combined.extend_from_slice(data);
         self.write(path, &combined)
+    }
+
+    fn create_append_log(&self, path: &str, retention: u64) -> io::Result<()> {
+        // Idempotent: an existing entry (DT_STREAM to append to, or a DT_REG
+        // from a prior degraded run) is left as-is.
+        if self.kernel.sys_stat(path, &self.ctx.zone_id).is_some() {
+            return Ok(());
+        }
+        if let Some(parent) = std::path::Path::new(path).parent() {
+            let _ = self.create_dir_all(&parent.to_string_lossy());
+        }
+        // Prefer a durable, raft-replicated WAL DT_STREAM: O(1) frame append,
+        // tail-read via `sys_stat.size`, unbounded via cold-segment auto-spill
+        // (`capacity` == retention budget in bytes; 0 = keep-forever). The
+        // "wal" profile requires federation (NEXUS_PEERS); when it is
+        // unavailable we degrade to a DT_REG so the transcript stays durable
+        // on the local metastore — never a bounded, node-local "memory"
+        // stream that would silently lose history on restart.
+        let created_stream = self
+            .kernel
+            .sys_setattr(
+                path,
+                DT_STREAM as i32,
+                "",    // backend_name
+                None,  // backend
+                None,  // metastore
+                None,  // raft_backend
+                "wal", // io_profile — durable raft-replicated stream
+                &self.ctx.zone_id,
+                false,              // is_external
+                retention as usize, // capacity == cold-storage retention budget
+                None,               // read_fd
+                None,               // write_fd
+                None,               // mime_type
+                None,               // modified_at_ms
+                None,               // content_id
+                None,               // size
+                None,               // version
+                None,               // created_at_ms
+                None,               // link_target
+                None,               // source
+                None,               // remote_metastore
+            )
+            .is_ok();
+        if !created_stream {
+            // Degrade to a durable regular file; `append` detects the
+            // non-stream entry and uses read-concat-write.
+            self.write(path, b"")?;
+        }
+        Ok(())
+    }
+
+    fn is_append_stream(&self, path: &str) -> io::Result<bool> {
+        Ok(self.is_stream_entry(path))
     }
 
     fn delete(&self, path: &str) -> io::Result<()> {

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -12,6 +12,11 @@ use crate::usage::{parse_usage_cost_currency, TokenUsage};
 const SESSION_VERSION: u32 = 1;
 const ROTATE_AFTER_BYTES: u64 = 256 * 1024;
 const MAX_ROTATED_FILES: usize = 3;
+/// Cold-storage retention budget (bytes) for a transcript backed by a native
+/// append-log (nexus DT_STREAM). `0` = keep-forever: cold segments spill out
+/// of the hot tier but are never dropped, so the whole transcript stays
+/// readable. Ignored by regular-file backends.
+const TRANSCRIPT_RETENTION_BYTES: u64 = 0;
 static SESSION_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 static LAST_TIMESTAMP_MS: AtomicU64 = AtomicU64::new(0);
 
@@ -675,7 +680,12 @@ impl Session {
         self.append_persisted_prompt_entry(entry_ref)
     }
 
-    fn render_jsonl_snapshot(&self) -> Result<String, SessionError> {
+    /// The full session rendered as an ordered list of JSONL record lines
+    /// (no trailing newlines): meta → compaction → prompts → messages. The
+    /// single source for both the snapshot writer ([`Self::render_jsonl_snapshot`])
+    /// and the append-log bootstrap ([`Self::bootstrap_append_log`]) so the
+    /// two never drift in record order or content.
+    fn snapshot_lines(&self) -> Result<Vec<String>, SessionError> {
         let mut lines = vec![self.meta_record()?.render()];
         if let Some(compaction) = &self.compaction {
             lines.push(compaction.to_jsonl_record()?.render());
@@ -690,9 +700,34 @@ impl Session {
                 .iter()
                 .map(|message| message_record(message).render()),
         );
-        let mut rendered = lines.join("\n");
+        Ok(lines)
+    }
+
+    fn render_jsonl_snapshot(&self) -> Result<String, SessionError> {
+        let mut rendered = self.snapshot_lines()?.join("\n");
         rendered.push('\n');
         Ok(rendered)
+    }
+
+    /// Bootstrap an empty/missing transcript to the full in-memory snapshot.
+    ///
+    /// On a backend with a native append-log ([`FsBackend::is_append_stream`]
+    /// — the nexus DT_STREAM), each record is written as one framed
+    /// [`FsBackend::append`]; snapshot rewrite and size rotation do not apply
+    /// (the stream's internal cold-spill subsumes rotation). On a regular-file
+    /// backend it stays the atomic snapshot rewrite + rotation via
+    /// [`Self::save_to_path`].
+    fn bootstrap_append_log(&self, path: &Path) -> Result<(), SessionError> {
+        let backend = self.backend();
+        let path_str = path.to_string_lossy();
+        backend.create_append_log(&path_str, TRANSCRIPT_RETENTION_BYTES)?;
+        if backend.is_append_stream(&path_str)? {
+            for line in self.snapshot_lines()? {
+                backend.append(&path_str, format!("{line}\n").as_bytes())?;
+            }
+            return Ok(());
+        }
+        self.save_to_path(path)
     }
 
     fn append_persisted_message(&self, message: &ConversationMessage) -> Result<(), SessionError> {
@@ -705,7 +740,7 @@ impl Session {
         let needs_bootstrap = !backend.exists(&path_str)?
             || backend.stat(&path_str).map(|m| m.len == 0).unwrap_or(true);
         if needs_bootstrap {
-            self.save_to_path(path)?;
+            self.bootstrap_append_log(path)?;
             return Ok(());
         }
 
@@ -727,7 +762,7 @@ impl Session {
         let needs_bootstrap = !backend.exists(&path_str)?
             || backend.stat(&path_str).map(|m| m.len == 0).unwrap_or(true);
         if needs_bootstrap {
-            self.save_to_path(path)?;
+            self.bootstrap_append_log(path)?;
             return Ok(());
         }
 

--- a/rust/crates/runtime/src/session_control.rs
+++ b/rust/crates/runtime/src/session_control.rs
@@ -112,9 +112,7 @@ impl SessionStore {
     #[must_use]
     pub fn create_handle(&self, session_id: &str) -> SessionHandle {
         let id = session_id.to_string();
-        let path = self
-            .sessions_root
-            .join(format!("{id}.{PRIMARY_SESSION_EXTENSION}"));
+        let path = session_transcript_path(&self.sessions_root, &id);
         SessionHandle { id, path }
     }
 
@@ -152,7 +150,7 @@ impl SessionStore {
 
     pub fn resolve_managed_path(&self, session_id: &str) -> Result<PathBuf, SessionControlError> {
         for extension in [PRIMARY_SESSION_EXTENSION, LEGACY_SESSION_EXTENSION] {
-            let path = self.sessions_root.join(format!("{session_id}.{extension}"));
+            let path = session_path_with_ext(&self.sessions_root, session_id, extension);
             if path.exists() {
                 return Ok(path);
             }
@@ -320,6 +318,23 @@ pub fn workspace_fingerprint(workspace_root: &Path) -> String {
 pub const PRIMARY_SESSION_EXTENSION: &str = "jsonl";
 pub const LEGACY_SESSION_EXTENSION: &str = "json";
 pub const LATEST_SESSION_REFERENCE: &str = "latest";
+
+/// Join a managed session's transcript filename onto `sessions_root` for a
+/// given extension. The one place the `<session_id>.<ext>` on-disk name is
+/// formed.
+#[must_use]
+fn session_path_with_ext(sessions_root: &Path, session_id: &str, extension: &str) -> PathBuf {
+    sessions_root.join(format!("{session_id}.{extension}"))
+}
+
+/// The single source of truth for a managed session's transcript path:
+/// `<sessions_root>/<session_id>.<PRIMARY_SESSION_EXTENSION>`. Handle
+/// creation and primary-extension resolution route through this so the
+/// on-disk name is defined in exactly one place.
+#[must_use]
+pub fn session_transcript_path(sessions_root: &Path, session_id: &str) -> PathBuf {
+    session_path_with_ext(sessions_root, session_id, PRIMARY_SESSION_EXTENSION)
+}
 
 const SESSION_REFERENCE_ALIASES: &[&str] = &[LATEST_SESSION_REFERENCE, "last", "recent"];
 

--- a/rust/crates/runtime/tests/fs_backend_vfs.rs
+++ b/rust/crates/runtime/tests/fs_backend_vfs.rs
@@ -201,6 +201,57 @@ fn oversized_tool_output_offloads_onto_the_vfs() {
 }
 
 #[test]
+fn create_append_log_without_federation_yields_a_durable_regular_file() {
+    // A durable "wal" DT_STREAM needs federation (NEXUS_PEERS), absent on a
+    // bare test kernel. `create_append_log` must then degrade to a DT_REG —
+    // durable on the local metastore — and NEVER a bounded, node-local
+    // "memory" stream that would silently lose the transcript on restart.
+    let kernel = kernel_with_root_backend();
+    let fs = vfs_backend(&kernel);
+    let path = "/ws/sessions/sid-2.jsonl";
+
+    fs.create_append_log(path, 0)
+        .expect("create_append_log should succeed");
+    assert!(
+        !fs.is_append_stream(path).unwrap(),
+        "no federation → transcript degrades to a regular file, not a stream"
+    );
+
+    // The regular-file append path (read-concat-write) round-trips unchanged.
+    fs.append(path, b"line-1\n").unwrap();
+    fs.append(path, b"line-2\n").unwrap();
+    assert_eq!(fs.read(path).unwrap(), b"line-1\nline-2\n");
+}
+
+#[test]
+fn dt_stream_append_frames_read_back_deframed() {
+    // A DT_STREAM created directly on the kernel (node-local, federation-free)
+    // stands in for the durable wal stream: the framing contract that
+    // `KernelFsBackend` append/read relies on is identical. Each append is one
+    // framed record; read walks every frame to the tail and concatenates the
+    // deframed payloads back into the original append byte stream.
+    let kernel = kernel_with_root_backend();
+    let path = "/ws/transcript-stream.jsonl";
+    kernel
+        .create_stream(path, 64 * 1024)
+        .expect("create DT_STREAM");
+
+    let fs = vfs_backend(&kernel);
+    assert!(
+        fs.is_append_stream(path).unwrap(),
+        "an entry created as a DT_STREAM reports as an append-log"
+    );
+
+    fs.append(path, b"{\"a\":1}\n").unwrap();
+    fs.append(path, b"{\"b\":2}\n").unwrap();
+    assert_eq!(
+        fs.read(path).unwrap(),
+        b"{\"a\":1}\n{\"b\":2}\n",
+        "reading a DT_STREAM reproduces the appended records in order"
+    );
+}
+
+#[test]
 fn glob_and_grep_walk_the_vfs_trie() {
     let kernel = kernel_with_root_backend();
     let fs = vfs_backend(&kernel);


### PR DESCRIPTION
## What

On the in-process nexus path (`KernelFsBackend`), the session transcript was a DT_REG whose per-message append was read-concat-write — **O(n) per append, O(n²) over a session**. nexus finished the DT_STREAM unbounded-log end-state (nexi-lab/nexus-vfs#229: cold-segment auto-spill out of raft, transparent hot/cold offset reads, retention, search-over-streams), so the transcript collapses to a **single keep-forever DT_STREAM**: O(1) frame append (`sys_write`), tail-read (`sys_stat.size`), transparent cold-read, searchable. Rotation is subsumed by the stream's internal cold-spill.

Resolves the transcript row of the [agent-context-storage-matrix](https://s.shareone.vip/s/agent-context-storage-matrix) (design landed in #466).

## How

- `FsBackend` gains `create_append_log(path, retention)` + `is_append_stream(path)` (defaults: empty regular file / `false`).
- `KernelFsBackend` creates a durable raft-replicated **wal** DT_STREAM; when federation is absent (no `NEXUS_PEERS`) it **degrades to a durable DT_REG** — never a bounded, node-local "memory" stream that would silently lose history on restart.
- `KernelFsBackend.append`/`read` are stream-aware: append is an O(1) framed `sys_write`; read walks every frame to the live tail and concatenates the deframed payloads. **`StdFsBackend` is unchanged** (its OS append is already O(1), CC-aligned).
- Session bootstrap routes through the append-log (per-record appends on a stream; snapshot rewrite + rotation only on regular files).
- `session_transcript_path()` is the single source of truth for the on-disk transcript name.

## Compatibility

- Pinned nexus rev already contains #229 + the `sys_stat`-reports-tail change (bumped in #465). No ABI/trait change to nexus; everything routes through the existing `KernelSyscall` trait.
- Standalone (StdFsBackend) and remote (gRPC) paths are behavior-unchanged (trait defaults).
- Paired nexus-side work: sudowork `messages`-table → view over the transcript (nexus-2 #84).

## Tests

- `dt_stream_append_frames_read_back_deframed` — DT_STREAM frame append → deframed read round-trip.
- `create_append_log_without_federation_yields_a_durable_regular_file` — the no-federation degrade path.
- Full runtime lib suite (660) + fs_backend_vfs integration (7) green; workspace builds clean; clippy + rustfmt clean.