### PR TITLE
docs(design): recall row — nexus search deps A+B landed, C spec'd

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -312,10 +312,10 @@
   </td>
   <td class="cc"><div class="el"><code>MEMORY.md</code> index injected each session; <b>full entries surfaced on-demand by relevance</b> (recall in <code>&lt;system-reminder&gt;</code>); nightly <code>/dream</code> keeps the set small — so the finite window is patched by <i>recall + consolidation</i>, not full injection</div></td>
   <td>
-    <div class="el"><span class="was"><b>missing</b> — memory injected in full up to a char cap (<code>RENDERED_CHAR_CAP</code>); overflow dropped by <b>render order, not relevance</b>; no semantic recall over memory or transcripts</span> <span class="arw">→</span> <span class="tbd">? semantic/hybrid + recency recall via nexus search-plugin (DT_STREAM-index FR pending)</span></div>
+    <div class="el"><span class="was"><b>missing</b> — memory injected in full up to a char cap (<code>RENDERED_CHAR_CAP</code>); overflow dropped by <b>render order, not relevance</b>; no semantic recall over memory or transcripts</span> <span class="arw">→</span> <span class="tbd">? semantic/hybrid + recency recall via nexus search-plugin — <b>nexus deps A+B landed</b> (full-stream index, stream <code>modified_at_ms</code>); C (append-incremental) spec'd; co-hosted client = loopback tonic</span></div>
     <span class="b miss">gap</span></td>
   <td><div class="el"><b>→ sudocode:</b> memory is the agent's — sudowork has none</div> <span class="b na">n/a</span></td>
-  <td><div class="el">semantic/hybrid + recency over <span class="path">/agents/{name}/memory/</span> + <span class="path">/sessions/</span> (nexus search-plugin: FTS/ANN/fusion; needs the DT_STREAM-index FR)</div> <span class="b q">open?</span></td>
+  <td><div class="el">semantic/hybrid + recency over <span class="path">/agents/{name}/memory/</span> + <span class="path">/sessions/</span> (nexus search-plugin: FTS/ANN/fusion). DT_STREAM index <b>A+B landed</b> (nexus-vfs <a href="https://github.com/nexi-lab/nexus-vfs/issues/235">#235</a>/<a href="https://github.com/nexi-lab/nexus-vfs/issues/238">#238</a>, nexus #4682); append-incremental (C) spec'd; client = loopback tonic. See <a href="https://s.shareone.vip/s/nexus-search-architecture">nexus-search-architecture</a></div> <span class="b q">open?</span></td>
 </tr>
 
 <!-- RESUME -->


### PR DESCRIPTION
Updates the Memory recall/retrieval row after the nexus AI shipped the stream-search dependencies: full-stream indexing (nexus-vfs #235, nexus #4682) + stream `modified_at_ms` for recency (nexus-vfs #238). Append-incremental indexing (C) spec'd for next session; co-hosted client path = loopback tonic to the plugin gRPC. Cross-links the new nexus-search-architecture peer doc.