### PR TITLE
runtime: append caller system-prompt text to the static block

### DIFF
--- a/docs/acp.md
+++ b/docs/acp.md
@@ -79,10 +79,11 @@ caller's (e.g. a multi-tenant service's) decision.
 | Key | Effect |
 |---|---|
 | `systemPrompt` | **Override.** Replaces the built-in static system-prompt blocks (the `You are Sudo Code…` identity, `# System`, `# Doing tasks`, `# Executing actions with care`, `# Using your tools`, `# Tone and style`, `# Output efficiency`) with this text as the single static block. |
-| `appendSystemPrompt` | **Append.** Added as the last dynamic block — after the environment / project context, the discovered `AGENTS.md` instructions, the runtime-config summary and the auto-memory instructions (only the short plugin-capability inventory, when plugins are enabled, follows it). Being last gives it the highest recency weight, so it outranks workspace files such as `AGENTS.md`. |
+| `appendSystemPrompt` | **Append.** Added as the last **static** block, after the built-in identity and behaviour blocks and before every dynamic block (environment / project context, `AGENTS.md` instructions, runtime-config summary, auto-memory, plugin inventory, skill listing). A caller preamble is stable for the life of the session, so it belongs in the aggressively cached prefix; the cost is that the workspace-derived dynamic blocks now follow it rather than precede it. |
 
 The two compose: set both and the static blocks are replaced *and* the
-extra block is appended. Workspace-derived dynamic blocks (environment,
+extra block is appended after the replacement, still inside the static
+prefix. Workspace-derived dynamic blocks (environment,
 `AGENTS.md`, memory) are always kept, so an overridden prompt still knows
 which directory it is operating in.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,7 +61,8 @@ mode, and the tool / skill inventory.
 # Replace the built-in identity + behaviour blocks
 scode --system-prompt "You are a terse release bot." "cut a release"
 
-# Keep the defaults, add house rules as the final system-prompt block
+# Keep the defaults, add house rules as the final *static* block
+# (cached with the built-ins; dynamic workspace context still follows it)
 scode --append-system-prompt "Never push to main." "cut a release"
 
 # Both at once — they compose

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -125,14 +125,20 @@ impl SystemPrompt {
         self.static_sections = vec![text.into()];
     }
 
-    /// Append `text` as the last dynamic section.
+    /// Append `text` as the last static section.
     ///
-    /// Being last puts it closest to the conversation, so it outranks the
-    /// workspace-discovered `AGENTS.md` instructions and the auto-memory
-    /// instructions that precede it. Orthogonal to
-    /// [`Self::override_static_sections`]: the two compose.
-    pub fn append_dynamic_section(&mut self, text: impl Into<String>) {
-        self.dynamic_sections.push(text.into());
+    /// Caller-supplied instructions are stable for as long as the caller is
+    /// — a per-tenant preamble does not change between turns — so they belong
+    /// in the aggressively cached static block rather than the per-turn
+    /// dynamic one. Orthogonal to [`Self::override_static_sections`]: the two
+    /// compose, and appending after an override puts the appended text last
+    /// within the replacement block.
+    ///
+    /// The trade-off is ordering: the workspace-discovered `AGENTS.md`
+    /// instructions, the auto-memory block and the skill listing are all
+    /// dynamic, so they now follow this text rather than precede it.
+    pub fn append_static_section(&mut self, text: impl Into<String>) {
+        self.static_sections.push(text.into());
     }
 }
 
@@ -142,14 +148,15 @@ impl SystemPrompt {
 ///
 /// The two fields are orthogonal and may be combined: `system_prompt`
 /// replaces the static blocks, `append_system_prompt` adds a trailing
-/// dynamic block. Neither is truncated or escaped.
+/// static block. Both therefore land in the cacheable prefix. Neither is
+/// truncated or escaped.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SystemPromptOverrides {
     /// Replaces every static section (see
     /// [`SystemPrompt::override_static_sections`]).
     pub system_prompt: Option<String>,
-    /// Appended as the last dynamic section (see
-    /// [`SystemPrompt::append_dynamic_section`]).
+    /// Appended as the last static section (see
+    /// [`SystemPrompt::append_static_section`]).
     pub append_system_prompt: Option<String>,
 }
 
@@ -165,7 +172,7 @@ impl SystemPromptOverrides {
             prompt.override_static_sections(text.clone());
         }
         if let Some(text) = &self.append_system_prompt {
-            prompt.append_dynamic_section(text.clone());
+            prompt.append_static_section(text.clone());
         }
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/help.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/help.rs
@@ -822,7 +822,7 @@ pub(crate) fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "  --append-system-prompt TEXT  Append TEXT as the final system-prompt block; combines with"
+        "  --append-system-prompt TEXT  Append TEXT as the final static system-prompt block; combines with"
     )?;
     writeln!(out, "                              --system-prompt")?;
     writeln!(

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -2347,14 +2347,17 @@ async fn assert_bad_prompt_meta_rejected(
 
 /// Built-in identity block: present on the default prompt, gone under override.
 const DEFAULT_IDENTITY: &str = "You are Sudo Code";
-/// The dynamic block every session carries; the append must land after it.
+/// The first dynamic block every session carries. The append is a *static*
+/// section, so it must land before this — that ordering is what proves it
+/// sits in the cacheable prefix rather than the per-turn block.
 const MEMORY_HEADING: &str = "# auto memory";
 
 /// `_meta.sudocode.systemPrompt` (replace the built-in static blocks) and
-/// `_meta.sudocode.appendSystemPrompt` (append a trailing dynamic block) on
+/// `_meta.sudocode.appendSystemPrompt` (append a trailing static block) on
 /// `session/new`, checked on the wire body the model receives:
 ///  - neither → the default prompt (regression guard),
-///  - append only → appended after the auto-memory block, identity kept,
+///  - append only → appended at the end of the static block (before the
+///    dynamic auto-memory block), identity kept,
 ///  - override only → identity replaced, nothing appended,
 ///  - both → both take effect (the two are orthogonal),
 ///  - other sessions in the process are unaffected,
@@ -2394,10 +2397,20 @@ async fn acp_session_new_system_prompt_override_and_append_reach_model() {
         body.contains(DEFAULT_IDENTITY) && body.contains(APPEND),
         "append must reach the model with the identity block intact; body: {body}"
     );
-    let (memory_at, append_at) = (body.find(MEMORY_HEADING), body.find(APPEND));
+    let (identity_at, memory_at, append_at) = (
+        body.find(DEFAULT_IDENTITY),
+        body.find(MEMORY_HEADING),
+        body.find(APPEND),
+    );
     assert!(
-        memory_at.is_some() && append_at > memory_at,
-        "append must land after the auto-memory block: memory@{memory_at:?} append@{append_at:?}"
+        memory_at.is_some() && append_at.is_some() && append_at < memory_at,
+        "append is a static section, so it must precede the dynamic auto-memory \
+         block: append@{append_at:?} memory@{memory_at:?}"
+    );
+    assert!(
+        append_at > identity_at,
+        "append must come after the built-in identity block, i.e. last within \
+         the static block: identity@{identity_at:?} append@{append_at:?}"
     );
 
     // override only.


### PR DESCRIPTION
## Summary

`--append-system-prompt` / `_meta.sudocode.appendSystemPrompt` landed as the last **dynamic** section, which put caller-supplied text outside the cacheable prefix.

The request carries two system blocks, and the split is a caching boundary, not a "hardcoded vs computed" one (`prompt.rs:75-80`, assembled at `api_client.rs:220-221`). Measured on the wire:

```
block 0  10688 chars  cache_control={"scope":"global","type":"ephemeral"}   <- static_sections
block 1   4679 chars  cache_control={"type":"ephemeral"}                    <- dynamic_sections
```

A per-tenant preamble does not change between turns, so paying for it per turn was the wrong trade. This appends to `static_sections` instead: the text lands at the end of the static block — after an override when both are set, and before every dynamic section.

## This reverses a deliberate ordering

The old doc comment called being-last intentional: it put the append after the discovered `AGENTS.md` instructions and the auto-memory block, giving it the highest recency weight so it would outrank workspace files.

That is now inverted — `AGENTS.md`, auto-memory, the plugin inventory and the skill listing all follow the appended text. The trade is stated explicitly in the new doc comment rather than left implicit.

If recency weight matters more than cache residency for a given caller, that is an argument for a separate `--append-dynamic-prompt`, not for keeping the current placement: today there is no way to get the cached behaviour at all.

## Testing

```
cargo fmt --all --check          # clean
cargo test --workspace           # 104 test binaries, 0 failures
```

`acp_integration::acp_session_new_system_prompt_override_and_append_reach_model` asserted the old order and failed:

```
append must land after the auto-memory block: memory@Some(11727) append@Some(11158)
```

Its assertion now encodes the new contract — the append must precede the dynamic auto-memory block (proving it is in the cacheable prefix) and follow the built-in identity block (proving it is last within the static one). Both directions are checked, so a regression in either direction fails.

Verified on the wire against a local fake endpoint: with `--append-system-prompt "TENANT-PREAMBLE-XYZ"`, the text appears in block 0 under `{"scope":"global"}`, immediately after `# Output efficiency`, and is absent from block 1. Combined with `--system-prompt`, the rendered order is `REPLACED` → `APPENDED` → dynamic sections.

One full-suite run hit the known `interrupt_e2e` PTY flake; it passes in isolation and on a repeat full run, and this change touches neither interrupts nor the agent loop.

No unit tests added, per the test policy.

## Docs

- `docs/acp.md` — the `appendSystemPrompt` row and the compose paragraph.
- `docs/usage.md` — the example comment.
- `cli/help.rs` — the `--append-system-prompt` flag line.