### PR TITLE
runtime: drop the dead ModelFamilyIdentity plumbing

### DIFF
--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -43,10 +43,7 @@ pub use providers::registry::{
     ModelConfigEntry, ModelProviderMapping, ModelTokenLimit, ProviderConnectionConfig,
     ResolvedProvider, SudoCodeConfig,
 };
-pub use providers::{
-    detect_provider_kind, model_family_identity_for, model_family_identity_for_kind, AuthMode,
-    ProviderKind,
-};
+pub use providers::{detect_provider_kind, AuthMode, ProviderKind};
 pub use sse::{parse_frame, SseParser};
 pub use types::{
     CacheHints, ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent,

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -122,21 +122,6 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
     ProviderKind::Anthropic
 }
 
-#[must_use]
-pub const fn model_family_identity_for_kind(kind: ProviderKind) -> runtime::ModelFamilyIdentity {
-    match kind {
-        ProviderKind::Anthropic => runtime::ModelFamilyIdentity::Claude,
-        ProviderKind::Xai | ProviderKind::OpenAi | ProviderKind::Codex | ProviderKind::Gemini => {
-            runtime::ModelFamilyIdentity::Generic
-        }
-    }
-}
-
-#[must_use]
-pub fn model_family_identity_for(model: &str) -> runtime::ModelFamilyIdentity {
-    model_family_identity_for_kind(detect_provider_kind(model))
-}
-
 /// Env var names used by other provider backends. When Anthropic auth
 /// resolution fails we sniff these so we can hint the user that their
 /// credentials probably belong to a different provider and suggest the
@@ -272,8 +257,7 @@ mod tests {
 
     use super::{
         anthropic_missing_credentials, anthropic_missing_credentials_hint, detect_provider_kind,
-        load_dotenv_file, model_family_identity_for, model_family_identity_for_kind, parse_dotenv,
-        ProviderKind,
+        load_dotenv_file, parse_dotenv, ProviderKind,
     };
 
     /// Serializes every test in this module that mutates process-wide
@@ -548,52 +532,6 @@ NO_EQUALS_LINE
         let hint = anthropic_missing_credentials_hint();
 
         assert!(hint.is_none());
-    }
-
-    #[test]
-    fn maps_provider_kind_to_model_family_identity() {
-        let anthropic = ProviderKind::Anthropic;
-        let openai = ProviderKind::OpenAi;
-        let xai = ProviderKind::Xai;
-        let codex = ProviderKind::Codex;
-        let gemini = ProviderKind::Gemini;
-
-        assert_eq!(
-            model_family_identity_for_kind(anthropic),
-            runtime::ModelFamilyIdentity::Claude
-        );
-        assert_eq!(
-            model_family_identity_for_kind(openai),
-            runtime::ModelFamilyIdentity::Generic
-        );
-        assert_eq!(
-            model_family_identity_for_kind(xai),
-            runtime::ModelFamilyIdentity::Generic
-        );
-        assert_eq!(
-            model_family_identity_for_kind(codex),
-            runtime::ModelFamilyIdentity::Generic
-        );
-        assert_eq!(
-            model_family_identity_for_kind(gemini),
-            runtime::ModelFamilyIdentity::Generic
-        );
-    }
-
-    #[test]
-    fn maps_model_name_to_model_family_identity() {
-        assert_eq!(
-            model_family_identity_for("claude-opus-4-6"),
-            runtime::ModelFamilyIdentity::Claude
-        );
-        assert_eq!(
-            model_family_identity_for("openai/gpt-4.1-mini"),
-            runtime::ModelFamilyIdentity::Generic
-        );
-        assert_eq!(
-            model_family_identity_for("grok-3"),
-            runtime::ModelFamilyIdentity::Generic
-        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -189,9 +189,8 @@ pub use policy_engine::{
 };
 pub use prompt::{
     load_system_prompt, load_system_prompt_for_agent, load_system_prompt_with, prepend_bullets,
-    ContextFile, ModelFamilyIdentity, ProjectContext, PromptBuildError, SystemPrompt,
-    SystemPromptBuilder, SystemPromptOverrides, FRONTIER_MODEL_NAME,
-    SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+    ContextFile, ProjectContext, PromptBuildError, SystemPrompt, SystemPromptBuilder,
+    SystemPromptOverrides, SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
 };
 pub use recovery_recipes::{
     attempt_recovery, recipe_for, EscalationPolicy, FailureScenario, RecoveryContext,

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -38,39 +38,9 @@ impl From<ConfigError> for PromptBuildError {
 
 /// Marker separating static prompt scaffolding from dynamic runtime context.
 pub const SYSTEM_PROMPT_DYNAMIC_BOUNDARY: &str = "__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__";
-/// Human-readable label used for the "Model family" environment bullet
-/// when the provider is Anthropic.
-/// Fallback label when no model-specific display name is available.
-pub const FRONTIER_MODEL_NAME: &str = "Claude";
 
 const MAX_INSTRUCTION_FILE_CHARS: usize = 4_000;
 const MAX_TOTAL_INSTRUCTION_CHARS: usize = 12_000;
-
-/// Identity for the "Model family" line in the system prompt environment section.
-///
-/// `Named(display_name)` is preferred — it carries the human-readable name
-/// from `sudocode.json` (e.g. "Claude Opus 4.8", "GPT 5.4").
-/// The legacy `Claude` / `Generic` variants are fallbacks when the caller
-/// cannot resolve a display name.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum ModelFamilyIdentity {
-    /// Model with a known display name (from sudocode.json SSOT).
-    Named(String),
-    #[default]
-    Claude,
-    Generic,
-}
-
-impl ModelFamilyIdentity {
-    #[must_use]
-    pub fn family_label(&self) -> &str {
-        match self {
-            Self::Named(name) => name.as_str(),
-            Self::Claude => FRONTIER_MODEL_NAME,
-            Self::Generic => "an AI assistant",
-        }
-    }
-}
 
 /// Structured system prompt with an explicit static/dynamic split.
 ///
@@ -260,7 +230,6 @@ pub struct SystemPromptBuilder {
     output_style_prompt: Option<String>,
     os_name: Option<String>,
     os_version: Option<String>,
-    model_family: Option<ModelFamilyIdentity>,
     append_sections: Vec<String>,
     project_context: Option<ProjectContext>,
     config: Option<RuntimeConfig>,
@@ -283,12 +252,6 @@ impl SystemPromptBuilder {
     pub fn with_os(mut self, os_name: impl Into<String>, os_version: impl Into<String>) -> Self {
         self.os_name = Some(os_name.into());
         self.os_version = Some(os_version.into());
-        self
-    }
-
-    #[must_use]
-    pub fn with_model_family(mut self, model_family: ModelFamilyIdentity) -> Self {
-        self.model_family = Some(model_family);
         self
     }
 
@@ -604,16 +567,8 @@ pub fn load_system_prompt(
     current_date: impl Into<String>,
     os_name: impl Into<String>,
     os_version: impl Into<String>,
-    model_family: ModelFamilyIdentity,
 ) -> Result<SystemPrompt, PromptBuildError> {
-    load_system_prompt_with(
-        cwd,
-        current_date,
-        os_name,
-        os_version,
-        model_family,
-        &StdFsBackend,
-    )
+    load_system_prompt_with(cwd, current_date, os_name, os_version, &StdFsBackend)
 }
 
 /// Backend-parameterised variant of [`load_system_prompt`].
@@ -622,18 +577,9 @@ pub fn load_system_prompt_with(
     current_date: impl Into<String>,
     os_name: impl Into<String>,
     os_version: impl Into<String>,
-    model_family: ModelFamilyIdentity,
     fs: &dyn FsBackend,
 ) -> Result<SystemPrompt, PromptBuildError> {
-    load_system_prompt_impl(
-        cwd,
-        current_date,
-        os_name,
-        os_version,
-        model_family,
-        fs,
-        None,
-    )
+    load_system_prompt_impl(cwd, current_date, os_name, os_version, fs, None)
 }
 
 /// Same as [`load_system_prompt`] but injects the per-agent-type
@@ -651,7 +597,6 @@ pub fn load_system_prompt_for_agent(
     current_date: impl Into<String>,
     os_name: impl Into<String>,
     os_version: impl Into<String>,
-    model_family: ModelFamilyIdentity,
     agent_type: &str,
 ) -> Result<SystemPrompt, PromptBuildError> {
     load_system_prompt_impl(
@@ -659,7 +604,6 @@ pub fn load_system_prompt_for_agent(
         current_date,
         os_name,
         os_version,
-        model_family,
         &StdFsBackend,
         Some(agent_type),
     )
@@ -670,7 +614,6 @@ fn load_system_prompt_impl(
     current_date: impl Into<String>,
     os_name: impl Into<String>,
     os_version: impl Into<String>,
-    model_family: ModelFamilyIdentity,
     fs: &dyn FsBackend,
     agent_type: Option<&str>,
 ) -> Result<SystemPrompt, PromptBuildError> {
@@ -679,7 +622,6 @@ fn load_system_prompt_impl(
     let config = ConfigLoader::default_for(&cwd).load()?;
     let builder_base = SystemPromptBuilder::new()
         .with_os(os_name, os_version)
-        .with_model_family(model_family)
         .with_project_context(project_context)
         .with_runtime_config(config);
     // Preserves the previous per-branch choice exactly: sub-agent spawns ask
@@ -835,7 +777,7 @@ mod tests {
     use super::{
         collapse_blank_lines, display_context_path, normalize_instruction_content,
         render_instruction_content, render_instruction_files, truncate_instruction_content,
-        ContextFile, ModelFamilyIdentity, ProjectContext, SystemPromptBuilder,
+        ContextFile, ProjectContext, SystemPromptBuilder,
     };
     use crate::config::ConfigLoader;
     use std::fs;
@@ -1142,15 +1084,9 @@ mod tests {
         std::env::set_var("HOME", &root);
         std::env::set_var("SUDO_CODE_CONFIG_HOME", root.join("missing-home"));
         std::env::set_current_dir(&root).expect("change cwd");
-        let prompt = super::load_system_prompt(
-            &root,
-            "2026-03-31",
-            "linux",
-            "6.8",
-            ModelFamilyIdentity::Claude,
-        )
-        .expect("system prompt should load")
-        .render();
+        let prompt = super::load_system_prompt(&root, "2026-03-31", "linux", "6.8")
+            .expect("system prompt should load")
+            .render();
         std::env::set_current_dir(previous).expect("restore cwd");
         if let Some(value) = original_home {
             std::env::set_var("HOME", value);
@@ -1302,7 +1238,6 @@ mod tests {
         };
         let rendered = SystemPromptBuilder::new()
             .with_os("linux", "6.8")
-            .with_model_family(ModelFamilyIdentity::Claude)
             .with_project_context(project_context)
             .render();
         assert!(!rendered.contains("2026-03-31"));

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -23,8 +23,8 @@ use runtime::spawn_task::{
     mailbox_sender, spawn_task, Mailbox, MailboxEnvelope, MailboxSender, SpawnHandle,
 };
 use runtime::{
-    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, ModelFamilyIdentity,
-    PermissionMode, PermissionPolicy, RuntimeError, SystemPromptBuilder, ToolError, ToolExecutor,
+    ApiClient, ApiRequest, AssistantEvent, AssistantEventStream, PermissionMode, PermissionPolicy,
+    RuntimeError, SystemPromptBuilder, ToolError, ToolExecutor,
 };
 
 const DT_STREAM: i32 = 4;
@@ -165,9 +165,7 @@ fn make_desc(pid: &str, name: &str) -> AgentDescriptor {
 /// Spawn the REAL `run_loop` (via `spawn_task`) with the scripted mock —
 /// the exact loop the co-host runs, minus the network provider.
 fn spawn_real(kernel: Arc<Kernel>, desc: AgentDescriptor, mailbox: Mailbox) -> SpawnHandle {
-    let system_prompt = SystemPromptBuilder::new()
-        .with_model_family(ModelFamilyIdentity::Claude)
-        .build();
+    let system_prompt = SystemPromptBuilder::new().build();
     spawn_task(
         kernel,
         desc,
@@ -190,9 +188,7 @@ fn spawn_sending(
     reply_to: &str,
     reply_body: &str,
 ) -> SpawnHandle {
-    let system_prompt = SystemPromptBuilder::new()
-        .with_model_family(ModelFamilyIdentity::Claude)
-        .build();
+    let system_prompt = SystemPromptBuilder::new().build();
     let send = mailbox_sender(
         Arc::clone(&kernel),
         mailbox.clone(),

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -267,7 +267,6 @@ pub(crate) enum CliAction {
     PrintSystemPrompt {
         cwd: PathBuf,
         date: String,
-        model: String,
         output_format: CliOutputFormat,
     },
     Version {
@@ -601,7 +600,6 @@ fn convert_cli_to_action(cli: Cli) -> Result<CliAction, String> {
                 Ok(CliAction::PrintSystemPrompt {
                     cwd: resolved_cwd,
                     date: resolved_date,
-                    model: model.clone(),
                     output_format,
                 })
             }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -37,11 +37,10 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    base_url_for_mode, model_family_identity_for, resolve_startup_auth_source, AnthropicClient,
-    AuthMode, AuthSource, ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest,
-    MessageResponse, OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient,
-    ProviderKind, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
-    ToolResultContentBlock,
+    base_url_for_mode, resolve_startup_auth_source, AnthropicClient, AuthMode, AuthSource,
+    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
+    OutputContentBlock, PromptCache, ProviderClient as ApiProviderClient, ProviderKind,
+    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
 
 use cli::api_client::{
@@ -468,9 +467,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::PrintSystemPrompt {
             cwd,
             date,
-            model,
             output_format,
-        } => print_system_prompt(cwd, date, &model, output_format)?,
+        } => print_system_prompt(cwd, date, output_format)?,
         CliAction::Version { output_format } => print_version(output_format)?,
         CliAction::ResumeSession {
             session_path,
@@ -850,16 +848,9 @@ fn print_bootstrap_plan(output_format: CliOutputFormat) -> Result<(), Box<dyn st
 fn print_system_prompt(
     cwd: PathBuf,
     date: String,
-    model: &str,
     output_format: CliOutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut prompt = load_system_prompt(
-        cwd.clone(),
-        date,
-        env::consts::OS,
-        "unknown",
-        resolve_model_identity(model),
-    )?;
+    let mut prompt = load_system_prompt(cwd.clone(), date, env::consts::OS, "unknown")?;
     // Coordinator mode: when SUDOCODE_COORDINATOR_MODE is set,
     // prepend the CC-fork coordinator role prompt so `scode
     // print-system-prompt` reflects what the runtime would send.
@@ -2718,7 +2709,7 @@ impl AcpCliAgent {
         let _scope = runtime::WorkspaceRootScope::enter(&cwd);
         let model = self.resolve_model_for_cwd(&cwd)?;
         let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
-        let system_prompt = build_acp_system_prompt(&cwd, &model, &prompt_overrides)?;
+        let system_prompt = build_acp_system_prompt(&cwd, &prompt_overrides)?;
         let session_state = new_cli_session_for(&cwd)
             .map_err(|error| AcpError::internal(format!("failed to create session: {error}")))?;
         let handle = create_managed_session_handle_for(&cwd, &session_state.session_id).map_err(
@@ -2852,7 +2843,7 @@ impl AcpCliAgent {
         let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
         let auth_mode = resolve_model_switch_auth_mode(&resolved, self.auth_mode, &sudocode_config)
             .map_err(|e| AcpError::internal(format!("failed to resolve auth mode: {e}")))?;
-        let system_prompt = build_acp_system_prompt(&cwd, &resolved, &session.prompt_overrides)?;
+        let system_prompt = build_acp_system_prompt(&cwd, &session.prompt_overrides)?;
         let mut runtime = build_runtime_for_cwd(
             &cwd,
             cloned_session,
@@ -3467,7 +3458,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
         let model = self.inner.resolve_model_for_cwd(&cwd)?;
         let permission_mode = self.inner.resolve_permission_mode_for_cwd(&cwd)?;
-        let system_prompt = build_acp_system_prompt(&cwd, &model, &prompt_overrides)?;
+        let system_prompt = build_acp_system_prompt(&cwd, &prompt_overrides)?;
         let sudocode_config =
             require_sudocode_config_for_cwd(&cwd).map_err(runtime::AcpError::internal)?;
         let auth_mode =
@@ -4041,7 +4032,7 @@ impl LiveCli {
         permission_mode: PermissionMode,
         auth_mode: Option<AuthMode>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let system_prompt = build_system_prompt(&model)?;
+        let system_prompt = build_system_prompt()?;
         let session_state = new_cli_session()?;
         let session = create_managed_session_handle(&session_state.session_id)?;
         let cwd = env::current_dir()?;
@@ -4999,9 +4990,8 @@ impl LiveCli {
         session.model = Some(model.clone());
         let session_id = self.session.id.clone();
         let message_count = session.messages.len();
-        // Rebuild system prompt so the model identity line reflects the new model.
         let cwd = env::current_dir().unwrap_or_default();
-        let system_prompt = build_system_prompt_for(&cwd, &model)?;
+        let system_prompt = build_system_prompt_for(&cwd)?;
         let runtime = self.build_replacement_runtime(
             session,
             session_id,
@@ -5856,8 +5846,8 @@ fn init_json_value(report: &crate::init::InitReport, message: &str) -> serde_jso
     })
 }
 
-fn build_system_prompt(model: &str) -> Result<SystemPrompt, Box<dyn std::error::Error>> {
-    build_system_prompt_for(&env::current_dir()?, model)
+fn build_system_prompt() -> Result<SystemPrompt, Box<dyn std::error::Error>> {
+    build_system_prompt_for(&env::current_dir()?)
 }
 
 /// ACP variant of [`build_system_prompt_for`]: builds the process-default
@@ -5869,10 +5859,9 @@ fn build_system_prompt(model: &str) -> Result<SystemPrompt, Box<dyn std::error::
 /// plugins) stay, so the caller's prompt still knows where it is running.
 fn build_acp_system_prompt(
     cwd: &Path,
-    model: &str,
     prompt_overrides: &runtime::SystemPromptOverrides,
 ) -> Result<SystemPrompt, AcpError> {
-    let mut prompt = build_system_prompt_for(cwd, model)
+    let mut prompt = build_system_prompt_for(cwd)
         .map_err(|e| AcpError::internal(format!("failed to build system prompt: {e}")))?;
     prompt_overrides.apply(&mut prompt);
     Ok(prompt)
@@ -5891,10 +5880,7 @@ fn apply_cli_prompt_overrides(prompt: &mut SystemPrompt) {
     }
 }
 
-fn build_system_prompt_for(
-    cwd: &Path,
-    model: &str,
-) -> Result<SystemPrompt, Box<dyn std::error::Error>> {
+fn build_system_prompt_for(cwd: &Path) -> Result<SystemPrompt, Box<dyn std::error::Error>> {
     // Use the local date at session-start time (not the build date baked
     // into DEFAULT_DATE) so the cacheable system prompt reflects when the
     // user actually started talking. ConversationRuntime separately tracks
@@ -5905,7 +5891,6 @@ fn build_system_prompt_for(
         runtime::today_local(),
         env::consts::OS,
         "unknown",
-        resolve_model_identity(model),
     )?;
     // Coordinator mode: when the SUDOCODE_COORDINATOR_MODE env var is
     // set, prepend the ported CC-fork coordinator role prompt so it
@@ -5914,27 +5899,6 @@ fn build_system_prompt_for(
     runtime::coordinator_mode::apply_coordinator_prompt_if_enabled(&mut prompt);
     apply_cli_prompt_overrides(&mut prompt);
     Ok(prompt)
-}
-
-/// Resolve model identity for the system prompt from sudocode.json SSOT.
-///
-/// Looks up `models.<id>.name` in the loaded config; falls back to the
-/// provider-based enum identity if no entry exists.
-fn resolve_model_identity(model: &str) -> runtime::ModelFamilyIdentity {
-    let config = load_sudocode_config_for_current_dir();
-    // Try exact match by alias key.
-    if let Some(entry) = config.models.get(model) {
-        return runtime::ModelFamilyIdentity::Named(entry.name.clone());
-    }
-    // Case-insensitive alias search.
-    let lower = model.to_ascii_lowercase();
-    for entry in config.models.values() {
-        if entry.alias.eq_ignore_ascii_case(model) || entry.name.to_ascii_lowercase() == lower {
-            return runtime::ModelFamilyIdentity::Named(entry.name.clone());
-        }
-    }
-    // Fallback: use model ID as display name (better than a generic label).
-    runtime::ModelFamilyIdentity::Named(model.to_string())
 }
 
 fn build_runtime_plugin_state() -> Result<RuntimePluginState, Box<dyn std::error::Error>> {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -203,10 +203,10 @@ use std::time::{Duration, Instant};
 use command_group::CommandGroup;
 
 use api::{
-    max_tokens_for_model, model_family_identity_for, resolve_provider_from_config, ApiError,
-    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OutputContentBlock, ProviderClient, StreamEvent as ApiStreamEvent, SudoCodeConfig, ToolChoice,
-    ToolDefinition, ToolResultContentBlock,
+    max_tokens_for_model, resolve_provider_from_config, ApiError, ContentBlockDelta,
+    InputContentBlock, InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
+    ProviderClient, StreamEvent as ApiStreamEvent, SudoCodeConfig, ToolChoice, ToolDefinition,
+    ToolResultContentBlock,
 };
 use plugins::{PluginLoadOutcome, PluginManager, PluginTool};
 use runtime::{
@@ -4689,7 +4689,7 @@ fn prepare_agent_job(
         .filter(|name| !name.is_empty())
         .unwrap_or_else(|| slugify_agent_name(&input.description));
     let created_at = iso8601_now();
-    let system_prompt = build_agent_system_prompt(&normalized_subagent_type, &model)?;
+    let system_prompt = build_agent_system_prompt(&normalized_subagent_type)?;
     let allowed_tools = allowed_tools_for_subagent(&normalized_subagent_type);
 
     // Fork subagent: wrap the caller's directive with the non-negotiable
@@ -5474,7 +5474,7 @@ fn build_agent_runtime(
     .with_hook_abort_signal(job.abort_signal.clone()))
 }
 
-fn build_agent_system_prompt(subagent_type: &str, model: &str) -> Result<SystemPrompt, String> {
+fn build_agent_system_prompt(subagent_type: &str) -> Result<SystemPrompt, String> {
     let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     // Route sub-agents through the per-agent-type memory scope
     // (`<workspace>/agent-memory/<subagent_type>/`) so one agent's
@@ -5487,7 +5487,6 @@ fn build_agent_system_prompt(subagent_type: &str, model: &str) -> Result<SystemP
         runtime::today_local(),
         std::env::consts::OS,
         "unknown",
-        model_family_identity_for(model),
         subagent_type,
     )
     .map_err(|error| error.to_string())?;
@@ -11305,10 +11304,8 @@ mod tests {
         )
         .expect("write plan entry");
 
-        let explore_prompt =
-            build_agent_system_prompt("Explore", "claude-opus-4-8").expect("Explore prompt built");
-        let plan_prompt =
-            build_agent_system_prompt("Plan", "claude-opus-4-8").expect("Plan prompt built");
+        let explore_prompt = build_agent_system_prompt("Explore").expect("Explore prompt built");
+        let plan_prompt = build_agent_system_prompt("Plan").expect("Plan prompt built");
 
         std::env::remove_var("SUDOCODE_MEMORY_DIR");
 
@@ -11347,8 +11344,7 @@ mod tests {
         );
         let _home = HomeGuard::override_home(&home);
 
-        let prompt =
-            build_agent_system_prompt("committee", "claude-opus-4-8").expect("system prompt build");
+        let prompt = build_agent_system_prompt("committee").expect("system prompt build");
         let joined = prompt.dynamic_sections.join("\n---section---\n");
         assert!(
             joined.contains("NAMING_COMMITTEE_SENTINEL"),

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -19,8 +19,8 @@ use runtime::spawn_task::{
     SpawnHandle,
 };
 use runtime::{
-    FsBackend, KernelFsBackend, ModelFamilyIdentity, PermissionMode, PermissionPolicy,
-    SystemPromptBuilder, ToolError, ToolExecutor,
+    FsBackend, KernelFsBackend, PermissionMode, PermissionPolicy, SystemPromptBuilder, ToolError,
+    ToolExecutor,
 };
 
 use crate::{execute_tool_with_backend, ProviderRuntimeClient};
@@ -100,9 +100,7 @@ where
     let tool_executor = ManagedToolExecutor { fs, send };
 
     // -- SystemPrompt: minimal prompt for managed-agent context --
-    let system_prompt = SystemPromptBuilder::new()
-        .with_model_family(ModelFamilyIdentity::Claude)
-        .build();
+    let system_prompt = SystemPromptBuilder::new().build();
 
     // -- PermissionPolicy: managed agents run with full access --
     // Nexus enforces permissions at the VFS layer (ReBAC +


### PR DESCRIPTION
> **Merge order: this PR must merge after #476.** It is branched from
> `chore/drop-plugin-prompt-section`, not from `main`. On `main` the code
> below is still live and deleting it there breaks the build. Once #476
> lands, this diff reduces to the 9 files listed here.

## What this removes

#476 dropped the `- Model: <id>` bullet from the system prompt's
`# Environment context` section. That bullet was the **only** consumer of
a model-identity value plumbed across four crates, so the entire chain is
now dead. The compiler stays quiet about it because the traits derived on
`SystemPromptBuilder` (`Debug`, `Clone`, `PartialEq`, `Eq`) count as reads
of the `model_family` field.

Deleted:

| Crate | Item |
|---|---|
| `runtime` | `ModelFamilyIdentity` enum + `family_label()` |
| `runtime` | `FRONTIER_MODEL_NAME` const |
| `runtime` | `SystemPromptBuilder::model_family` field + `with_model_family()` |
| `runtime` | the `model_family` parameter on `load_system_prompt`, `load_system_prompt_with`, `load_system_prompt_for_agent`, `load_system_prompt_impl` |
| `runtime` | the `ModelFamilyIdentity` / `FRONTIER_MODEL_NAME` re-exports in `lib.rs` |
| `api` | `model_family_identity_for`, `model_family_identity_for_kind` + their re-exports |
| `tools` | the import and the `build_agent_system_prompt` call site |
| `tools` | `.with_model_family(ModelFamilyIdentity::Claude)` in `managed_agent.rs` |
| `rusty-sudocode-cli` | `resolve_model_identity()` and the `model_family_identity_for` import |
| `runtime` (tests) | two `.with_model_family(...)` call sites in `tests/spawn_task.rs` |

### Follow-on: orphaned `model` parameters

Dropping the parameter leaves `model` unused in every helper that only
existed to forward it, which rustc *does* warn about. Those signatures
shrink accordingly:

- `tools::build_agent_system_prompt(subagent_type)`
- `cli::print_system_prompt(cwd, date, output_format)`
- `cli::build_system_prompt()`, `build_system_prompt_for(cwd)`, `build_acp_system_prompt(cwd, prompt_overrides)`
- the `model` field on `CliAction::PrintSystemPrompt`

**No CLI surface changes.** `--model` is a global flag; only its (now
unused) forwarding into the `PrintSystemPrompt` action is removed. The
flag still parses and still selects the model everywhere else.

### Deliberately kept

- `detect_provider_kind` and `ProviderKind` — real provider routing, used
  by `registry.rs`, the auth-hint sniffer, and the CLI. Only the identity
  mapping built *on top* of them is gone.
- `load_sudocode_config_for_current_dir()` — `resolve_model_identity` was
  one of eight callers.
- `pty_subcommands::system_prompt_carries_no_model_identity` — it asserts
  the prompt contains no `Model family:` / `Model:` / `claude-sonnet`,
  which is still true and is the regression guard for this whole area.
  Kept and passing.
- The `sudo-code-roadmap.html` row referencing that PTY test — the test
  still exists, so the row is still accurate.

### Tests removed

Only tests whose entire subject was the deleted code, per the repo's
no-unit-tests rule:

- `api::providers::tests::maps_provider_kind_to_model_family_identity`
- `api::providers::tests::maps_model_name_to_model_family_identity`

Tests **adapted** (they exercise still-live behaviour, only the call
shape changed): `runtime::prompt::tests::load_system_prompt_reads_instruction_files_and_config`,
`renders_sections_with_project_context`, the three
`build_agent_system_prompt` call sites in `tools`, and the two
`SystemPromptBuilder` constructions in `runtime/tests/spawn_task.rs`.

## Verification

All run from the repo root on this branch.

```
$ bash scripts/fmt.sh --check
(clean, exit 0)

$ cd rust && cargo build --workspace
Finished `dev` profile — 0 errors.
Only pre-existing warnings (compact.rs unused `Path`, api http_transport
`StderrRetryNotifier`); none in a file this PR touches.

$ cd rust && cargo test --workspace
0 failures across every test binary. Ran twice, both clean; no flakes
observed in interrupt_e2e, runtime --lib or the PTY suites on either run.

$ cd rust && cargo test -p rusty-sudocode-cli --test pty_subcommands
10 passed; 0 failed — including system_prompt_carries_no_model_identity.
```

Clippy: rather than fight the pre-existing pedantic baseline, I captured
the full warning fingerprint (file + message, line numbers stripped) for
`runtime`/`api`/`tools`/`rusty-sudocode-cli` with `--all-targets` before
and after the change:

```
348 warnings before, 348 after, diff is empty — zero new warnings.
```

### Behaviour unchanged

```
$ cd rust && cargo build -p rusty-sudocode-cli
$ ./rust/target/debug/scode system-prompt | head -20
```

`# Environment context` still renders exactly:

```
# Environment context
 - Working directory: <cwd>
 - Platform: macos unknown
```

I also diffed the complete `scode system-prompt` output between this
branch and its parent commit: **byte-identical**.
