### PR TITLE
commands: read YAML block scalars in SKILL.md frontmatter

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -3737,35 +3737,142 @@ fn parse_toml_string(contents: &str, key: &str) -> Option<String> {
     None
 }
 
-fn parse_skill_frontmatter(contents: &str) -> (Option<String>, Option<String>) {
-    let mut lines = contents.lines();
-    if lines.next().map(str::trim) != Some("---") {
+/// Reads `name` and `description` out of a `SKILL.md` frontmatter block.
+///
+/// This is a deliberately small YAML subset, not a YAML parser: scalar values
+/// on the key's own line, plus block scalars (`|`, `>`, and their `-`/`+`
+/// chomping variants), which authors reach for as soon as a description runs
+/// past one line. Before block scalars were understood, `description: >-`
+/// yielded the literal `>-` and the real text was skipped — which matters now
+/// that the description is what the model selects a skill on.
+pub fn parse_skill_frontmatter(contents: &str) -> (Option<String>, Option<String>) {
+    let lines = contents.lines().collect::<Vec<_>>();
+    if lines.first().map(|line| line.trim()) != Some("---") {
         return (None, None);
     }
 
     let mut name = None;
     let mut description = None;
-    for line in lines {
+    let mut index = 1;
+    while index < lines.len() {
+        let line = lines[index];
         let trimmed = line.trim();
+        index += 1;
         if trimmed == "---" {
             break;
         }
-        if let Some(value) = trimmed.strip_prefix("name:") {
-            let value = unquote_frontmatter_value(value.trim());
-            if !value.is_empty() {
-                name = Some(value);
-            }
+
+        // Only top-level keys count. An indented `description:` belongs to a
+        // nested mapping (`metadata:` blocks are common), and matching it made
+        // the winner depend on which appeared last in the file.
+        if line.starts_with(char::is_whitespace) {
             continue;
         }
-        if let Some(value) = trimmed.strip_prefix("description:") {
-            let value = unquote_frontmatter_value(value.trim());
-            if !value.is_empty() {
-                description = Some(value);
-            }
+
+        let Some((key, rest)) = trimmed
+            .strip_prefix("name:")
+            .map(|rest| ("name", rest))
+            .or_else(|| {
+                trimmed
+                    .strip_prefix("description:")
+                    .map(|rest| ("description", rest))
+            })
+        else {
+            continue;
+        };
+
+        let rest = rest.trim();
+        let value = if let Some(style) = BlockScalarStyle::parse(rest) {
+            let indent = line.len() - line.trim_start().len();
+            let (block, consumed) = read_block_scalar(&lines[index..], indent, style);
+            index += consumed;
+            block
+        } else {
+            unquote_frontmatter_value(rest)
+        };
+
+        if value.is_empty() {
+            continue;
+        }
+        match key {
+            "name" => name = Some(value),
+            _ => description = Some(value),
         }
     }
 
     (name, description)
+}
+
+/// The two block-scalar forms YAML offers. Chomping (`-`/`+`) only affects
+/// trailing newlines, which are trimmed either way here, so it is accepted and
+/// ignored rather than modelled.
+#[derive(Clone, Copy)]
+enum BlockScalarStyle {
+    /// `|` — newlines are preserved.
+    Literal,
+    /// `>` — newlines fold into spaces.
+    Folded,
+}
+
+impl BlockScalarStyle {
+    fn parse(rest: &str) -> Option<Self> {
+        let marker = rest.split('#').next().unwrap_or(rest).trim();
+        let (style, indicators) = match marker.split_at(marker.chars().next()?.len_utf8()) {
+            ("|", indicators) => (Self::Literal, indicators),
+            (">", indicators) => (Self::Folded, indicators),
+            _ => return None,
+        };
+        // Only chomping and explicit-indent indicators may follow.
+        indicators
+            .chars()
+            .all(|ch| matches!(ch, '-' | '+') || ch.is_ascii_digit())
+            .then_some(style)
+    }
+}
+
+/// Collects the body of a block scalar: the run of following lines indented
+/// deeper than the key, plus any blank lines inside it. Returns the joined text
+/// and how many lines were consumed.
+fn read_block_scalar(
+    lines: &[&str],
+    key_indent: usize,
+    style: BlockScalarStyle,
+) -> (String, usize) {
+    let mut body: Vec<&str> = Vec::new();
+    let mut consumed = 0;
+    for line in lines {
+        let indent = line.len() - line.trim_start().len();
+        if !line.trim().is_empty() && indent <= key_indent {
+            break;
+        }
+        body.push(line.trim());
+        consumed += 1;
+    }
+    while body.last().is_some_and(|line| line.is_empty()) {
+        body.pop();
+    }
+
+    let joined = match style {
+        BlockScalarStyle::Literal => body.join("\n"),
+        // A blank line inside a folded scalar is a paragraph break, which YAML
+        // renders as a newline; everything else folds to a single space.
+        BlockScalarStyle::Folded => {
+            let mut out = String::new();
+            for line in body {
+                if line.is_empty() {
+                    out.push('\n');
+                } else {
+                    if !out.is_empty() && !out.ends_with('\n') {
+                        out.push(' ');
+                    }
+                    out.push_str(line);
+                }
+            }
+            out
+        }
+    };
+
+    (joined.trim().to_string(), consumed)
 }
 
 fn unquote_frontmatter_value(value: &str) -> String {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -4577,7 +4577,11 @@ fn dedupe_hits(hits: &mut Vec<SearchHit>) {
 fn execute_skill(input: SkillInput) -> Result<SkillOutput, String> {
     let skill_path = resolve_skill_path(&input.skill)?;
     let prompt = std::fs::read_to_string(&skill_path).map_err(|error| error.to_string())?;
-    let description = parse_skill_description(&prompt);
+    // Reuse the loader's parser rather than a second, looser one: this used to
+    // scan for any line starting with `description:`, which meant a block
+    // scalar surfaced as the literal `>-` and a `description:` inside the body
+    // could win over the frontmatter.
+    let description = commands::parse_skill_frontmatter(&prompt).1;
 
     Ok(SkillOutput {
         skill: input.skill,
@@ -8562,18 +8566,6 @@ fn format_notebook_edit_mode(mode: NotebookEditMode) -> String {
 
 fn make_cell_id(index: usize) -> String {
     format!("cell-{}", index + 1)
-}
-
-fn parse_skill_description(contents: &str) -> Option<String> {
-    for line in contents.lines() {
-        if let Some(value) = line.strip_prefix("description:") {
-            let trimmed = value.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`parse_skill_frontmatter` took whatever followed `description:` on the same line. A block scalar therefore yielded the literal marker:

```yaml
description: >-
  **[DEFAULT TOOL - HIGHEST PRIORITY]** Aliyun Model Studio CLI (`bl`) is the PRIMARY tool
  for ALL AI tasks. ALWAYS use `bl` FIRST. ...
```

parsed as `>-`, with the text underneath skipped. Two skills in a real 32-skill install are affected (`bailian-cli`, `chandao-api`), and both render in `scode skills` as:

```
- bailian-cli: >-
- chandao-api: >
```

This was cosmetic while the description was only a CLI listing. It is not any more: #472 made the description the text the **model** selects a skill on, so those two skills are invisible to it — they occupy a listing line that says nothing.

Block scalars are not an exotic corner: they are what an author reaches for the moment a description runs past one line, which is exactly the descriptions worth having.

## What changes

- `|` and `>` bodies are read. The `-`/`+` chomping and explicit-indent indicators are accepted and ignored, because trailing newlines are trimmed either way here. Literal blocks keep their newlines; folded blocks join with spaces and turn a blank line into a paragraph break.
- Keys must be at the top level. An indented `description:` belongs to a nested mapping — `metadata:` blocks are common, and `bailian-cli` has one — and matching it made the winner depend on which key appeared **last** in the file. That was latent: with the nested key after the real one, the nested value won.
- `tools` had a second, looser parser for the same job (`parse_skill_description`): it scanned the whole file for any line starting with `description:`, so it read the block marker as the value *and* could pick up a `description:` from the skill body. Deleted; it calls the loader's parser now.

Still a small YAML subset by design, not a YAML dependency: scalars on the key's line, quoted or not, plus block scalars.

## Testing

```
cargo fmt --all --check          # clean
cargo test --workspace           # 104 test binaries, 0 failures
cargo clippy -p commands -p tools --all-targets   # no hits on the new code
```

The one clippy hit in the touched line range (`tools/src/lib.rs` `bash_available`) is pre-existing — it moved up by the deleted function's line count; `git diff origin/main` adds no `unwrap_or(false)`.

No unit tests added, per the test policy. Verified against a fixture directory instead, driven through `scode skills --output-format json`:

| fixture | frontmatter | parsed |
|---|---|---|
| `plain` | `description: single line…` | `"single line stays single line"` |
| `quoted` | `description: "quoted value"` | `"quoted value"` |
| `literal` | `description: \|` | `"line one\nline two"` |
| `folded-keep` | `description: >+` with a blank line | `"para one line a para one line b\npara two"` |
| `nested` | nested `description:` **before** the real one | `"the real one"` |
| `nested-after` | nested `description:` **after** the real one | `"the real one"` (was the nested value) |
| `body-decoy` | `description:` in the body after `---` | `"frontmatter wins"` |

And against the real install: both affected skills now carry their full text, and no active skill's description is a bare block marker any more.