### PR TITLE
chore(release): bump version to 0.1.27

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "plugins",
  "runtime",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "commands",
  "runtime",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "api",
  "serde_json",
@@ -2557,7 +2557,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a3455
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "serde",
  "serde_json",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3851,7 +3851,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "api",
  "arboard",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "chrono",
  "dirs",
@@ -4808,7 +4808,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Version bump for the 0.1.27 release. Only `rust/Cargo.toml` and `rust/Cargo.lock`, matching the shape of every prior release commit.

Tagging `v0.1.27` at the resulting commit triggers `release.yml`, which builds the binaries and publishes the GitHub release.

## What ships since v0.1.26

25 commits. The user-facing ones:

- **#472 — skills are listed in the system prompt.** A `# Available skills` section names every discoverable skill with its description, so the model can call `Skill(skill="<name>")` without the user naming it first. Plugin-provided skill roots are included, so a plugin can inject a skill set the model then finds on its own. Sized by a character budget, degrading to name-only rather than clipping descriptions.
- **#476 — the system prompt's context layer is trimmed.** The anonymous plugin inventory is gone (every capability it summarised now has a channel that names it); `# Environment context`, `# Project context` and `# Runtime config` fold into one section; the model identity leaves the prompt, which makes the dynamic block byte-stable across a `/model` switch; `--append-system-prompt` now lands in the cacheable prefix.
- **#480 — YAML block scalars in `SKILL.md` frontmatter are read.** `description: >-` used to parse as the literal `>-`, which was cosmetic until #472 made the description the text the model selects on. Two skills in a real 32-skill install were affected.
- **#477, #479 — per-session directory session layout**, with dual-read compatibility for the flat layout.

Plus design-doc updates to `sudo-code-roadmap.html`.

## Verification

```
bash scripts/fmt.sh --check     # clean
cargo build --workspace         # ok
cargo test --workspace          # 104 test binaries, 0 failures
./target/debug/scode --version  # scode 0.1.27
```

## Not in this release

#478 (drop the dead `ModelFamilyIdentity` plumbing) is ready but held for the next one. It is a pure deletion with no user-visible behaviour change — `scode system-prompt` renders byte-identically.