### PR TITLE
chore(deps): bump nexus-vfs pin 6cad75f7b -> d3b182951

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "contracts",
  "kernel",
@@ -163,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1380,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1958,7 +1958,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2189,7 +2189,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2352,7 +2352,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2553,7 +2553,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 
 [[package]]
 name = "nexus-vfs-client"
@@ -3364,7 +3364,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3402,9 +3402,9 @@ dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3792,7 +3792,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4315,7 +4315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4474,7 +4474,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,13 +37,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## What

Bump the co-host build's nexus-vfs pin (`kernel` + `a2a` in `runtime`, `kernel`
in `tools`) from `6cad75f7b` to `d3b182951`, and re-lock.

## Why

`d3b182951` is current nexus-vfs `main`; it carries two federation clean-slate
features just landed there (nexus-vfs #239: `reset` subcommand + raft
fail-loud-voter) plus #238 (`sys_stat` surfaces a DT_STREAM's last-append time).
Both are additive; the co-host runtime/tools consume `KernelSyscall` +
`a2a::MailboxEnvelope` + `KernelFsBackend`, none of which change.

The co-host `kernel`/`a2a` rev MUST stay in lockstep with the nexus daemon's
workspace pin (`nexus/rust/nexusd`) so `SpawnTask<Kernel>` is a single type
across the in-process seam. The matching nexus-side bump (nexus-vfs pin +
nexusd co-host `sudocode` pin) rides the corresponding develop PR.

## Test

CI (Linux) compiles `runtime` + `tools` against the new kernel. Change is a pure
git-rev bump with regenerated lock — no source changes.
