### PR TITLE
chore(deps): bump nexus-vfs kernel d3b182951 -> dcee3e5d1 (managed-agent relocation)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2352,7 +2352,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2553,7 +2553,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
 
 [[package]]
 name = "nexus-vfs-client"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,13 +37,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dcee3e5d1959099e8a57ffa06444ed7204719f42", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dcee3e5d1959099e8a57ffa06444ed7204719f42", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dcee3e5d1959099e8a57ffa06444ed7204719f42", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
nexus relocated the `managed_agent` control plane + `subprocess` host into nexus-vfs (**nexus-vfs#241**, at `dcee3e5d1`). For the co-host build the assembly links `sudocode_runtime` in-process, so sudocode and nexus must resolve to **one** nexus-vfs `kernel` rev — otherwise `SpawnTask<Kernel>` is two distinct types and nexus's kernel-pin-consistency preflight fails.

Bump sudocode's nexus-vfs pin to match. Pulls #240 (ProcfsRegistry→SyntheticViewRegistry) + #241. `runtime` + `tools` compile clean against the new kernel; only the pin (Cargo.toml ×2 + Cargo.lock) moves.

Unblocks the nexus half of the relocation (nexus#4695).