### PR TITLE
docs(design): relative-path audit — convention banner + relativize memory targets

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -151,6 +151,7 @@ agent-memory/&lt;type&gt;/           per-agent-type memory
 </div>
 
 <h2>The matrix</h2>
+<p class="note"><b>Path convention (read before touching any row's code):</b> the <b>sudocode</b> column's storage paths are <b>relative to the backend's <code>state_root()</code></b> (<span class="was">was</span> cells show today's concrete host path; <span class="to">to</span> cells show the relative target). Roots come from the <code>FsBackend</code>, never hardcoded in sudocode: std → <code>.scode/sessions/&lt;hash&gt;/</code> · nexus → <code>/sessions/</code>; cross-index links via <code>fs.link()</code> (DT_LINK on nexus · no-op on std). When you implement an item, write against the <b>relative path + <code>state_root()</code>/<code>link()</code></b> — see the Directory layout + Migration row.</p>
 <table>
 <thead><tr>
   <th style="width:6%">mega-type</th>
@@ -286,7 +287,7 @@ agent-memory/&lt;type&gt;/           per-agent-type memory
   <td class="item">Auto-memory (4 types)</td>
   <td class="cc"><div class="el"><span class="path">projects/&lt;git-root&gt;/memory/</span> — user/feedback/project/reference + <code>MEMORY.md</code> (keyed by git root)</div></td>
   <td>
-    <div class="el"><span class="was"><span class="path">~/.scode/projects/&lt;slug&gt;/memory/</span> + <code>MEMORY.md</code>, 4 types, prompt-driven Write</span> <span class="arw">→</span> <span class="to"><span class="path">/agents/{name}/memory/topics/&lt;type&gt;_&lt;slug&gt;.md</span> (frontmatter name/description/type; filename is itself a mini-summary) + <b>derived</b> <code>MEMORY.md</code> index</span></div>
+    <div class="el"><span class="was"><span class="path">~/.scode/projects/&lt;slug&gt;/memory/</span> + <code>MEMORY.md</code>, 4 types, prompt-driven Write</span> <span class="arw">→</span> <span class="to"><span class="path">memory/topics/&lt;type&gt;_&lt;slug&gt;.md</span> (relative to the agent-image <code>state_root()</code>; frontmatter name/description/type; filename is itself a mini-summary) + <b>derived</b> <code>MEMORY.md</code> index</span></div>
     <div class="el"><b>SSOT fix (decided):</b> <code>MEMORY.md</code> today is <b>hand-maintained</b> — a 4th, drift-prone copy of the summary (the index <code>hook</code> already diverges from the frontmatter <code>description</code> in live memory). Make it a <b>derived projection</b>: line = <code>- [name](file.md) — description</code>, computed from the topic files. <span class="path">topics/</span> = sole SSOT (co-exist/co-vanish); <b>no new field</b> — <code>description</code> IS the hook.</div>
     <div class="el"><b>Two tiers (per-module nexus opt-in):</b> (1) <b>compute-at-render</b> — provider-agnostic, primary, works standalone, kills the drift class; (2) optional <b>nexus-mode</b> — a registered VFS view synthesizes <code>MEMORY.md</code> from topic FileMetadata so the derived index is a real readable file for the search-plugin / humans / other agents (needs view-registry dynamic-path support; done-not-forced-in-prod). Same graceful-degrade shape as the transcript DT_STREAM (nexus when present, agnostic fallback).</div>
     <span class="b partial">storage done · derived-index (compute-at-render) spec'd</span></td>
@@ -297,7 +298,7 @@ agent-memory/&lt;type&gt;/           per-agent-type memory
   <td class="item">Agent memory (per agent-type)</td>
   <td class="cc"><div class="el"><span class="path">agent-memory/&lt;type&gt;/</span> (user) · <span class="path">.claude/agent-memory[-local]/&lt;type&gt;/</span> + git-distributable snapshots</div></td>
   <td>
-    <div class="el"><span class="was"><span class="path">&lt;base&gt;/agent-memory/&lt;agent_type&gt;/</span>, routed per-subagent (no cross-leak)</span> <span class="arw">→</span> <span class="to"><span class="path">/agents/{name}/memory/</span> (already per-agent)</span></div>
+    <div class="el"><span class="was"><span class="path">&lt;base&gt;/agent-memory/&lt;agent_type&gt;/</span>, routed per-subagent (no cross-leak)</span> <span class="arw">→</span> <span class="to"><span class="path">memory/</span> (already per-agent; agent-image <code>state_root()</code>)</span></div>
     <span class="b ok">done</span></td>
   <td><div class="el"><b>→ sudocode:</b> memory is the agent's — sudowork has none</div> <span class="b na">n/a</span></td>
   <td><div class="el"><span class="path">/agents/{name}/memory/</span> is already per-agent</div> <span class="b ok">design</span></td>


### PR DESCRIPTION
Anti-drift audit (paths only, no content rewrite): adds a **Path convention** banner atop the matrix so any future implementer sees the rule on the row they're touching — sudocode storage paths are **relative to the backend `state_root()`** (std `.scode/sessions/<hash>/` · nexus `/sessions/`), roots never hardcoded, links via `fs.link()`. Relativizes the memory `to` targets (`/agents/{name}/memory/…` → `memory/…`). Session/tool-output cells already use root-placeholders; `was` cells stay concrete (today's reality); CC/nexus columns + layout trees stay absolute (concrete reference/target).