### PR TITLE
refactor(spawn): report kernel AgentState directly; own SudoCodeSpawnAdapter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2352,7 +2352,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2471,6 +2471,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "managed-agent"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+dependencies = [
+ "contracts",
+ "dashmap",
+ "kernel",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,7 +2569,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dcee3e5d1959099e8a57ffa06444ed7204719f42#dcee3e5d1959099e8a57ffa06444ed7204719f42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
 
 [[package]]
 name = "nexus-vfs-client"
@@ -4817,6 +4833,7 @@ dependencies = [
  "flate2",
  "futures",
  "kernel",
+ "managed-agent",
  "plugins",
  "reqwest",
  "runtime",

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,13 +37,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dcee3e5d1959099e8a57ffa06444ed7204719f42", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dcee3e5d1959099e8a57ffa06444ed7204719f42", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -43,7 +43,7 @@ use std::thread;
 
 // Re-export kernel types so downstream crates (e.g. `tools`) can
 // reference them without adding a direct `kernel` dependency.
-pub use kernel::core::agents::registry::AgentDescriptor;
+pub use kernel::core::agents::registry::{AgentDescriptor, AgentState};
 pub use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
 
@@ -69,14 +69,6 @@ const WATCH_TIMEOUT_MS: u64 = 500;
 /// Per-call `sys_read` blocking timeout. `0` keeps the call
 /// non-blocking — data is already present because `sys_watch` woke us.
 const READ_TIMEOUT_MS: u64 = 0;
-
-/// Agent-state values surfaced via `state_callback`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AgentLoopState {
-    WarmingUp,
-    Ready,
-    Busy,
-}
 
 /// Where the co-hosted agent's chat mailbox lives — determines the path the
 /// loop reads for inbound messages and where each reply is written.
@@ -201,7 +193,7 @@ where
     K: KernelSyscall + Send + Sync + 'static,
     C: ApiClient + 'static,
     T: ToolExecutor + 'static,
-    F: Fn(AgentLoopState) + Send + 'static,
+    F: Fn(AgentState) + Send + 'static,
 {
     let abort_signal = HookAbortSignal::default();
     let abort_for_thread = abort_signal.clone();
@@ -245,7 +237,7 @@ fn run_loop<K, C, T, F>(
     K: KernelSyscall + Send + Sync + 'static,
     C: ApiClient + 'static,
     T: ToolExecutor + 'static,
-    F: Fn(AgentLoopState),
+    F: Fn(AgentState),
 {
     // Build a tokio runtime for async run_turn calls.
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -254,7 +246,7 @@ fn run_loop<K, C, T, F>(
         .expect("managed-agent tokio runtime");
 
     // -- WARMING_UP --
-    state_cb(AgentLoopState::WarmingUp);
+    state_cb(AgentState::WarmingUp);
 
     // The VFS-backed file tools are constructed by the spawn factory
     // (`tools::managed_agent::spawn_managed_agent`), which injects a
@@ -273,7 +265,7 @@ fn run_loop<K, C, T, F>(
     .with_hook_abort_signal(abort.clone());
 
     // -- READY --
-    state_cb(AgentLoopState::Ready);
+    state_cb(AgentState::Ready);
 
     // Inbox the loop reads/watches, and the id it filters its own writes by.
     // For A2A this is the replicated `/agents/<self>/chat-with-me`; replies
@@ -290,7 +282,7 @@ fn run_loop<K, C, T, F>(
                     if !bytes.is_empty() {
                         if let Some((sender, body)) = parse_inbound(bytes, &self_id) {
                             // -- BUSY --
-                            state_cb(AgentLoopState::Busy);
+                            state_cb(AgentState::Busy);
 
                             // Drive ONE turn on the inbound message. The sender is
                             // surfaced in the prompt so the agent can address a reply.
@@ -306,7 +298,7 @@ fn run_loop<K, C, T, F>(
                             }
 
                             // -- READY --
-                            state_cb(AgentLoopState::Ready);
+                            state_cb(AgentState::Ready);
                         }
                     }
                 }

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -14,6 +14,12 @@ flate2 = "1"
 futures = "0.3"
 plugins = { path = "../plugins" }
 runtime = { path = "../runtime" }
+# The managed-agent DI seam (`SpawnTask` + `SpawnHandle`) that
+# `SudoCodeSpawnAdapter` implements to host this crate's `spawn_managed_agent`
+# loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
+# crate pins (transitive `kernel` unifies). default-features = false → no
+# subprocess-host (that's the raw-ACP path, not the in-process co-host).
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
@@ -23,7 +29,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dcee3e5d1959099e8a57ffa06444ed7204719f42", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
 
 [lints]
 workspace = true

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -3,7 +3,8 @@
 //! Constructs the `ApiClient`, `ToolExecutor`, `SystemPrompt`, and
 //! `PermissionPolicy` dependencies from the `AgentDescriptor` metadata
 //! and calls `runtime::spawn_task::spawn_task` to launch the full LLM
-//! loop. The nexus cdylib's `SudoCodeSpawnAdapter` calls this.
+//! loop. The co-located [`SudoCodeSpawnAdapter`] (this file) wraps it as a
+//! `managed_agent::SpawnTask` that nexus injects at boot.
 //!
 //! Lives in the `tools` crate because it needs both the `api` crate
 //! (for `ProviderClient` / `resolve_provider_from_config`) and the
@@ -14,9 +15,9 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
+use managed_agent::{SpawnHandle as ManagedSpawnHandle, SpawnTask};
 use runtime::spawn_task::{
-    mailbox_sender, AgentDescriptor, AgentLoopState, KernelSyscall, Mailbox, MailboxSender,
-    SpawnHandle,
+    mailbox_sender, AgentDescriptor, AgentState, KernelSyscall, Mailbox, MailboxSender, SpawnHandle,
 };
 use runtime::{
     FsBackend, KernelFsBackend, ModelFamilyIdentity, PermissionMode, PermissionPolicy,
@@ -34,7 +35,7 @@ const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 
 /// Spawn a managed-agent loop with the full ConversationRuntime.
 ///
-/// The caller (nexus cdylib `SudoCodeSpawnAdapter`) invokes this after
+/// The caller ([`SudoCodeSpawnAdapter`], below) invokes this after
 /// `register_proc_entry` stamps the per-pid procfs subtree.
 ///
 /// # Arguments
@@ -54,7 +55,7 @@ pub fn spawn_managed_agent<K, F>(
 ) -> SpawnHandle
 where
     K: KernelSyscall + Send + Sync + 'static,
-    F: Fn(AgentLoopState) + Send + 'static,
+    F: Fn(AgentState) + Send + 'static,
 {
     let model = desc
         .labels
@@ -169,5 +170,60 @@ impl ToolExecutor for ManagedToolExecutor {
         })
         .await
         .map_err(|e| ToolError::new(format!("tool task join error: {e}")))?
+    }
+}
+
+/// The `SpawnTask` provider that hosts a `sudocode` agent loop as a nexus
+/// managed-agent runtime body — the co-host seam.
+///
+/// `ManagedAgentService` (nexus-vfs) calls [`SpawnTask::spawn`] after planting
+/// the per-pid procfs subtree; this impl builds the sudocode
+/// `ConversationRuntime` loop via [`spawn_managed_agent`] and binds it to the
+/// agent's REPLICATED A2A inbox `/agents/<name>/chat-with-me` (raft-replicated
+/// when federated), so two co-hosted agents on different hosts converse over
+/// A2A with no bridge/relay.
+///
+/// Lives here — next to [`spawn_managed_agent`], the loop it wraps — rather
+/// than at the nexus binary edge: the adapter IS sudocode's. nexus only injects
+/// `Arc::new(SudoCodeSpawnAdapter)` at boot via
+/// `managed_agent::install_managed_agent_with_spawn`. There is NO enum map:
+/// both `spawn_managed_agent`'s `state_callback` and `SpawnTask`'s observer
+/// speak `kernel::AgentState` directly (the SSOT).
+pub struct SudoCodeSpawnAdapter;
+
+impl<K> SpawnTask<K> for SudoCodeSpawnAdapter
+where
+    K: KernelSyscall + Send + Sync + 'static,
+{
+    fn spawn(
+        &self,
+        kernel: Arc<K>,
+        desc: AgentDescriptor,
+        state_observer: Arc<dyn Fn(AgentState) + Send + Sync>,
+    ) -> Box<dyn ManagedSpawnHandle> {
+        // The co-host agent's mailbox is its persistent, cross-machine A2A
+        // inbox `/agents/<name>/chat-with-me`, so a duet partner on another
+        // host addresses it by name; raft replicates the reply back.
+        let mailbox = Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: desc.name.clone(),
+        };
+        let handle = spawn_managed_agent(kernel, desc, mailbox, move |state| state_observer(state));
+        Box::new(SudoCodeSpawnHandle { inner: handle })
+    }
+}
+
+/// Wraps sudocode's [`SpawnHandle`] so the managed-agent service sees only the
+/// abort capability its `on_terminate` observer needs. `abort` signals the
+/// loop's shared `HookAbortSignal`; the worker thread observes it and exits on
+/// its next poll (idempotent — the observer may fire concurrently with an
+/// in-flight `cancel(Session)`).
+struct SudoCodeSpawnHandle {
+    inner: SpawnHandle,
+}
+
+impl ManagedSpawnHandle for SudoCodeSpawnHandle {
+    fn abort(&self) {
+        self.inner.abort_signal.abort();
     }
 }


### PR DESCRIPTION
## What
Second leg of the 3-repo DRY collapse (nexus-vfs head merged as `578f7ad`). Removes the runtime-side `AgentLoopState` mirror and pulls `SudoCodeSpawnAdapter` home.

- `spawn_task`'s `state_callback` is now `Fn(AgentState)` — `kernel::core::agents::registry::AgentState`, the SSOT the `AgentRegistry` actually stores. The loop already emitted exactly the `WarmingUp`/`Ready`/`Busy` subset; it now reports those `AgentState` values directly. No shadow enum, no map.
- `SudoCodeSpawnAdapter` (impl `managed_agent::SpawnTask`) moves out of nexus's binary edge (`cohost.rs`) into `tools`, next to `spawn_managed_agent` — the loop it wraps. `tools` deps the `managed-agent` crate for the `SpawnTask` + `SpawnHandle` DI contract. DI arrow `sudocode → managed-agent → kernel` (no cycle; `managed-agent` still never deps a runtime crate).

Because `spawn_managed_agent`'s callback and `SpawnTask`'s observer both speak `AgentState` now, the binary edge no longer maps enums — nexus just injects `Arc::new(SudoCodeSpawnAdapter)` and **deletes `cohost.rs`** (next PR).

## Pins
Bumped to nexus-vfs `578f7ad` (the `AgentLoopState`-collapse merge): runtime `kernel`+`a2a`, tools `kernel`(dev-dep)+`managed-agent`, `Cargo.lock`.

## Verification
`cargo check -p tools -p runtime` green; `cargo test -p tools --no-run` (incl. `cohost_live_llm`) compiles; `cargo fmt --check` clean; my code adds no clippy warnings (`clippy --workspace`, sudocode's gate, stays green).