### PR TITLE
chore(deps): bump nexus-vfs pin to f3031eef1 (a2a inbox provisioning)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2352,7 +2352,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2473,8 +2473,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
 dependencies = [
+ "a2a",
  "contracts",
  "dashmap",
  "kernel",
@@ -2569,7 +2570,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=578f7ad7fa859d1ab66f14a48e9662ef5a9531b3#578f7ad7fa859d1ab66f14a48e9662ef5a9531b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
 
 [[package]]
 name = "nexus-vfs-client"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,13 +37,13 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ runtime = { path = "../runtime" }
 # loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
 # crate pins (transitive `kernel` unifies). default-features = false → no
 # subprocess-host (that's the raw-ACP path, not the in-process co-host).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
@@ -29,7 +29,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "578f7ad7fa859d1ab66f14a48e9662ef5a9531b3", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Bumps the nexus-vfs git pin `578f7ad → f3031eef1` in runtime + tools to pick up nexus-vfs #248 (a2a owns the mailbox provisioning contract; managed_agent provisions `/agents/{name}/chat-with-me` as a replicated DT_STREAM at spawn). Additive on the nexus-vfs side — sudocode builds clean against the new rev. Kept in lockstep with the nexus-side pin so `SpawnTask<Kernel>` is one type across the cohost link. Live-validated end-to-end (DT_STREAM-at-spawn + real-LLM PONG) via a local [patch] build before the nexus-vfs merge.