### PR TITLE
fix(bash): route the tool bridge through lib::rt::block_on_portable (current-thread co-host)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2352,7 +2352,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2473,7 +2473,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "a2a",
  "contracts",
@@ -2570,7 +2570,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 
 [[package]]
 name = "nexus-vfs-client"
@@ -3747,6 +3747,7 @@ dependencies = [
  "image",
  "kernel",
  "keyring",
+ "lib",
  "nexus-vfs-client",
  "nix 0.29.0",
  "plugins",

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,13 +37,14 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false, features = ["runtime-bridge"] }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -166,63 +166,27 @@ pub fn execute_bash_with_progress(
         });
     }
 
-    // Pick async implementation: streaming when a progress callback is
-    // provided, the original `command.output()` path otherwise.
-    let run_async = |handle_or_runtime: AsyncRunner| -> io::Result<BashCommandOutput> {
-        if on_progress.is_some() {
-            handle_or_runtime.block_on(execute_bash_streaming(
-                input,
-                sandbox_status,
-                cwd,
-                abort_signal.cloned(),
-                on_progress,
-            ))
-        } else {
-            handle_or_runtime.block_on_dyn(Box::pin(execute_bash_async(
-                input,
-                sandbox_status,
-                cwd,
-                abort_signal.cloned(),
-            )))
-        }
-    };
-
-    // If we are already inside a tokio runtime (e.g. when run_turn is
-    // driven by an outer block_on), use the current handle instead of
-    // creating a nested runtime which would panic.
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        run_async(AsyncRunner::Handle(handle))
+    // Run the command's async implementation to completion, correct for ANY
+    // ambient runtime flavor. The bespoke Handle-vs-Runtime split used to
+    // `block_in_place` on the ambient handle — correct under ACP's multi-thread
+    // runtime, but a PANIC under the co-host managed-agent's current-thread
+    // runtime (`spawn_task`). `lib::rt::block_on_portable` is the SSOT that
+    // handles all three contexts (see the nexus-vfs `lib::rt` module).
+    if on_progress.is_some() {
+        lib::rt::block_on_portable(execute_bash_streaming(
+            input,
+            sandbox_status,
+            cwd,
+            abort_signal.cloned(),
+            on_progress,
+        ))
     } else {
-        let runtime = Builder::new_current_thread().enable_all().build()?;
-        run_async(AsyncRunner::Runtime(runtime))
-    }
-}
-
-/// Helper to abstract over `tokio::runtime::Handle` vs owned `Runtime`.
-enum AsyncRunner {
-    Handle(tokio::runtime::Handle),
-    Runtime(tokio::runtime::Runtime),
-}
-
-impl AsyncRunner {
-    fn block_on<F: std::future::Future<Output = io::Result<BashCommandOutput>>>(
-        self,
-        future: F,
-    ) -> io::Result<BashCommandOutput> {
-        match self {
-            Self::Handle(handle) => tokio::task::block_in_place(|| handle.block_on(future)),
-            Self::Runtime(runtime) => runtime.block_on(future),
-        }
-    }
-
-    fn block_on_dyn(
-        self,
-        future: std::pin::Pin<Box<dyn std::future::Future<Output = io::Result<BashCommandOutput>>>>,
-    ) -> io::Result<BashCommandOutput> {
-        match self {
-            Self::Handle(handle) => tokio::task::block_in_place(|| handle.block_on(future)),
-            Self::Runtime(runtime) => runtime.block_on(future),
-        }
+        lib::rt::block_on_portable(execute_bash_async(
+            input,
+            sandbox_status,
+            cwd,
+            abort_signal.cloned(),
+        ))
     }
 }
 

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ runtime = { path = "../runtime" }
 # loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
 # crate pins (transitive `kernel` unifies). default-features = false → no
 # subprocess-host (that's the raw-ACP path, not the in-process co-host).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
@@ -29,7 +29,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
The Bash tool bridge `block_in_place`d on the ambient handle — correct under ACP (multi-thread) but a **panic** under the co-host managed-agent's **current-thread** runtime. Switches to `lib::rt::block_on_portable` (the nexus-vfs SSOT for the runtime-flavor hazard, PR nexus-vfs#249), deletes the bespoke `AsyncRunner`, bumps the nexus-vfs pin to `08460a79`, adds the `lib` dep. ACP's `block_in_place` is left (correct). Builds + bash tests green against the merged rev.