### PR TITLE
feat(config): per-model extraBody and token-limit overrides

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -72,6 +72,102 @@ Behavior: requests route to the DashScope endpoint
 `DASHSCOPE_API_KEY`. Some Qwen models also fall under the reasoning
 family above and receive both treatments.
 
+## Per-model extra request body — `extraBody`
+
+Some backends gate behavior on a request-body field that no
+Claude-shaped request carries. The canonical case: Alibaba DashScope
+turns the Qwen3.x reasoning chain **on** by default and only
+`"enable_thinking": false` in the body turns it off — so a "fast" model
+spends its latency budget on a thinking pass nobody asked for.
+
+Add the fields to the model entry in `sudocode.json`:
+
+```jsonc
+"models": {
+  "qwen3.7-flash": {
+    "alias": "qwen3.7-flash",
+    "name": "qwen3.7-flash",
+    "input": ["text"],
+    "providers": {
+      "api-key": {
+        "provider": "dashscope",
+        "model": "qwen3.7-flash",
+        "api": "openai-completions"
+      }
+    },
+    "extraBody": { "enable_thinking": false }
+  }
+}
+```
+
+- **Per model, not per process.** The setting hangs off the model entry,
+  so one running `scode` can serve a fast model with thinking off and a
+  deep model with thinking on, switching between them mid-session
+  (`/model`, ACP `session/setModel`). A process-wide flag could not.
+- **Values are arbitrary JSON** — bool, number (integer or float),
+  string, array, object, `null` — and reach the wire verbatim.
+- **Additive only.** A field `scode` computes itself is never
+  overwritten: `model`, `messages`, `input`, `system`, `instructions`,
+  `stream`, `stream_options`, `tools`, `tool_choice`, `max_tokens`,
+  `max_completion_tokens`, `max_output_tokens`, plus any tuning
+  parameter the caller explicitly set (`temperature`, `top_p`,
+  `reasoning_effort`, …). Everything else is inserted as given. The list
+  is `RESERVED_REQUEST_BODY_KEYS` in
+  `rust/crates/api/src/types.rs`.
+- **Absent means unchanged.** A model without `extraBody` sends exactly
+  the payload it sent before this field existed.
+- Applies to the `openai-completions` and `openai-responses` wire
+  formats and to `anthropic-messages`. Codex and Gemini clients ignore
+  it.
+
+## Per-model token limits — `maxOutputTokens` / `contextWindow`
+
+`scode` reads each model's context window and output-token ceiling from a
+capabilities table that is **compiled into the binary** (refreshed from
+sudorouter's `/v1/models` when available). A model the table has never
+heard of inherits the table's `default` entry — and when the real provider
+ceiling is lower, every request fails:
+
+```
+<400> InternalError.Algo.InvalidParameter: Range of max_tokens should be [1, 32768]
+```
+
+Two optional fields on the model entry override the table:
+
+```jsonc
+"qwen-flash": {
+  "alias": "qwen-flash",
+  "name": "qwen-flash",
+  "input": ["text"],
+  "providers": {
+    "api-key": { "provider": "bailian", "model": "qwen-flash", "api": "openai-completions" }
+  },
+  "maxOutputTokens": 32768,
+  "contextWindow": 1000000,
+  "extraBody": { "enable_thinking": false }
+}
+```
+
+- `maxOutputTokens` becomes the request's `max_tokens` for this model, taken
+  as written — the usual heuristic cap (32k for `opus`, 64k otherwise) does
+  not clamp it.
+- `contextWindow` feeds the context meter, the auto-compaction threshold and
+  the local preflight check.
+- Both are keyed by the **wire model ID** the entry maps to, so the override
+  reaches every code path that asks the capabilities table — main loop,
+  subagents, preflight — not just the request builder.
+- Absent means unchanged: the compiled table's numbers apply, exactly as
+  before.
+
+### `reasoning_effort` values
+
+`--reasoning-effort` accepts `none`, `minimal`, `low`, `medium`, `high`.
+`none` / `minimal` are part of OpenAI's own ladder and are what several
+OpenAI-compatible backends accept to switch reasoning off; on DashScope
+they are the only accepted values that do (`low` still reasons). The
+flag reaches the wire on the `acp` and REPL paths; `--print` does not
+send it. For a backend that wants a body field instead, use `extraBody`.
+
 ## Adding a model
 
 To add a new model that requires special handling:

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -59,8 +59,19 @@ impl ProviderClient {
                         ));
                     }
                 };
-                let client = AnthropicClient::from_auth_with_mode(auth, mode)
+                let mut client = AnthropicClient::from_auth_with_mode(auth, mode)
                     .with_base_url(resolved.base_url.clone());
+                // Per-model `extraBody` (sudocode.json) — same additive rule
+                // as the OpenAI-compatible path: sudocode's own fields win.
+                // `render_json_body` skips keys the serialized request already
+                // carries; the reserved list covers the ones it omits when
+                // unset (e.g. `stream` when false).
+                for (key, value) in &resolved.extra_body {
+                    if crate::types::is_reserved_request_body_key(key) {
+                        continue;
+                    }
+                    client = client.with_extra_body_param(key.clone(), value.clone());
+                }
                 Ok(Self::Anthropic(client))
             }
             ApiFormat::OpenAiCompletions | ApiFormat::OpenAiResponses => {
@@ -130,7 +141,8 @@ impl ProviderClient {
                 let config = OpenAiCompatConfig::openai();
                 let client = OpenAiCompatClient::new(api_key, config)
                     .with_api_format(resolved.api_format)
-                    .with_base_url(resolved.base_url.clone());
+                    .with_base_url(resolved.base_url.clone())
+                    .with_extra_body(resolved.extra_body.clone());
                 match resolved.kind {
                     ProviderKind::Xai => Ok(Self::Xai(client)),
                     _ => Ok(Self::OpenAi(client)),
@@ -342,6 +354,7 @@ mod tests {
                 name: "Qwen Plus".to_string(),
                 input: vec!["text".to_string()],
                 providers: qwen_providers,
+                ..Default::default()
             },
         );
 

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -2,17 +2,17 @@ use std::collections::{BTreeMap, VecDeque};
 use std::time::Duration;
 
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use crate::error::ApiError;
 use crate::http_transport::{
     parse_retry_after, request_id_from_headers, HttpTransport, RetryPolicy,
 };
 use crate::types::{
-    ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
-    InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,
-    MessageResponse, MessageStartEvent, MessageStopEvent, OutputContentBlock, StreamEvent,
-    ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
+    is_reserved_request_body_key, ContentBlockDelta, ContentBlockDeltaEvent,
+    ContentBlockStartEvent, ContentBlockStopEvent, InputContentBlock, InputMessage, MessageDelta,
+    MessageDeltaEvent, MessageRequest, MessageResponse, MessageStartEvent, MessageStopEvent,
+    OutputContentBlock, StreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
 };
 
 use super::registry::{preflight_message_request, ApiFormat};
@@ -101,6 +101,8 @@ pub struct OpenAiCompatClient {
     base_url: String,
     api_format: ApiFormat,
     retry_policy: RetryPolicy,
+    /// Per-model extra request-body fields (`models.<alias>.extraBody`).
+    extra_body: Map<String, Value>,
 }
 
 impl OpenAiCompatClient {
@@ -121,6 +123,7 @@ impl OpenAiCompatClient {
             base_url: read_base_url(config),
             api_format: ApiFormat::OpenAiCompletions,
             retry_policy: RetryPolicy::DEFAULT,
+            extra_body: Map::new(),
         }
     }
 
@@ -143,6 +146,16 @@ impl OpenAiCompatClient {
     #[must_use]
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        self
+    }
+
+    /// Attach per-model extra request-body fields (`models.<alias>.extraBody`).
+    ///
+    /// The fields are merged into every outbound payload built by this client.
+    /// The merge is additive: see [`merge_extra_body`] for the precedence rule.
+    #[must_use]
+    pub fn with_extra_body(mut self, extra_body: Map<String, Value>) -> Self {
+        self.extra_body = extra_body;
         self
     }
 
@@ -316,11 +329,12 @@ impl OpenAiCompatClient {
         }
 
         let url = endpoint_for_format(&self.base_url, self.api_format);
-        let body = match self.api_format {
+        let mut body = match self.api_format {
             ApiFormat::OpenAiCompletions => build_chat_completion_request(request, self.config()),
             ApiFormat::OpenAiResponses => build_responses_request(request),
             _ => unreachable!("OpenAiCompatClient only supports OpenAI-compatible formats"),
         };
+        merge_extra_body(&mut body, &self.extra_body);
 
         let headers = vec![
             ("content-type".to_string(), "application/json".to_string()),
@@ -1605,6 +1619,33 @@ pub fn check_request_body_size(
         })
     } else {
         Ok(())
+    }
+}
+
+/// Merges configured extra body fields into a built request payload.
+///
+/// Precedence rule (also documented in `docs/models.md`): **additive only**.
+/// A key is skipped when the payload builder already set it (`model`,
+/// `messages`, `stream`, `tools`, `max_tokens`, or any tuning parameter the
+/// caller explicitly requested) or when it is in
+/// [`RESERVED_REQUEST_BODY_KEYS`](crate::types::RESERVED_REQUEST_BODY_KEYS),
+/// so `extraBody` can never corrupt a request sudocode computed. Keys the
+/// builder did not emit (`enable_thinking`, `thinking_budget`, `top_k`, …)
+/// are inserted as-is, with their JSON value preserved verbatim.
+///
+/// A non-object payload (never produced by the builders) is left alone.
+pub fn merge_extra_body(payload: &mut Value, extra_body: &Map<String, Value>) {
+    if extra_body.is_empty() {
+        return;
+    }
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+    for (key, value) in extra_body {
+        if object.contains_key(key) || is_reserved_request_body_key(key) {
+            continue;
+        }
+        object.insert(key.clone(), value.clone());
     }
 }
 

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -7,6 +7,7 @@
 use std::path::PathBuf;
 
 use serde::Serialize;
+use serde_json::{Map, Value};
 
 use super::{AuthMode, ProviderKind};
 use crate::error::ApiError;
@@ -49,7 +50,7 @@ pub enum Credential {
 }
 
 /// Fully resolved provider information — everything needed to build a client.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedProvider {
     pub kind: ProviderKind,
     pub api_format: ApiFormat,
@@ -57,6 +58,10 @@ pub struct ResolvedProvider {
     pub credential: Credential,
     /// The wire model ID to send to the provider.
     pub model_id: String,
+    /// Per-model extra request-body fields from `models.<alias>.extraBody`.
+    /// Merged additively into the outbound payload by the provider client;
+    /// empty for models that do not configure it.
+    pub extra_body: Map<String, Value>,
 }
 
 /// Token-limit metadata for a wire model ID.
@@ -356,6 +361,7 @@ pub fn resolve_provider_from_config(
         base_url,
         credential,
         model_id: mapping.model.clone(),
+        extra_body: model_config.extra_body.clone(),
     })
 }
 
@@ -399,6 +405,8 @@ fn try_proxy_passthrough(
         base_url,
         credential,
         model_id: model_id.to_string(),
+        // Proxy passthrough has no `models.<alias>` entry to read from.
+        extra_body: Map::new(),
     })
 }
 
@@ -722,6 +730,7 @@ mod tests {
                 name: "Claude Opus 4.6".to_string(),
                 input: vec!["text".to_string()],
                 providers: opus_providers,
+                ..Default::default()
             },
         );
 
@@ -741,6 +750,7 @@ mod tests {
                 name: "Grok 3".to_string(),
                 input: vec!["text".to_string()],
                 providers: grok_providers,
+                ..Default::default()
             },
         );
 
@@ -769,6 +779,7 @@ mod tests {
                 name: "GPT 5.4 Mini".to_string(),
                 input: vec!["text".to_string()],
                 providers: codex_providers,
+                ..Default::default()
             },
         );
 
@@ -855,6 +866,7 @@ mod tests {
                 name: "GPT 5.4".to_string(),
                 input: vec!["text".to_string()],
                 providers: proxy_only_providers,
+                ..Default::default()
             },
         );
 
@@ -874,6 +886,7 @@ mod tests {
                 name: "Custom GPT 5.4".to_string(),
                 input: vec!["text".to_string()],
                 providers: custom_providers,
+                ..Default::default()
             },
         );
 

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -107,6 +107,13 @@ pub fn model_token_limit_from_config(
 /// while keeping sensible defaults for unknown models.
 #[must_use]
 pub fn max_tokens_for_model(model_id: &str) -> u32 {
+    // An explicit `models.<alias>.maxOutputTokens` is the user's own number
+    // for a model the compiled-in table may not know — take it as written,
+    // above or below the heuristic.
+    if let Some(configured) = runtime::model_capabilities::config_max_output_tokens(model_id) {
+        return configured;
+    }
+
     let heuristic = if model_id.contains("opus") {
         32_000
     } else {

--- a/rust/crates/api/src/types.rs
+++ b/rust/crates/api/src/types.rs
@@ -2,6 +2,35 @@ use runtime::{parse_usage_cost_currency, pricing_for_model, TokenUsage, UsageCos
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Top-level request-body fields that sudocode computes itself.
+///
+/// Per-model `extraBody` (`models.<alias>.extraBody` in `sudocode.json`) is
+/// additive: it may add fields the payload builder did not emit, but it can
+/// never take one of these over. The list is the union across wire formats
+/// (`OpenAI` chat completions / responses, Anthropic messages) so the rule
+/// reads the same regardless of which provider a model routes to.
+pub const RESERVED_REQUEST_BODY_KEYS: &[&str] = &[
+    "model",
+    "messages",
+    "input",
+    "system",
+    "instructions",
+    "stream",
+    "stream_options",
+    "tools",
+    "tool_choice",
+    "max_tokens",
+    "max_completion_tokens",
+    "max_output_tokens",
+];
+
+/// Whether `key` is a request-body field sudocode owns — see
+/// [`RESERVED_REQUEST_BODY_KEYS`].
+#[must_use]
+pub fn is_reserved_request_body_key(key: &str) -> bool {
+    RESERVED_REQUEST_BODY_KEYS.contains(&key)
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct MessageRequest {
     pub model: String,

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -530,6 +530,7 @@ async fn provider_client_dispatches_anthropic_requests() {
         base_url: server.base_url(),
         credential: Credential::ApiKey("test-key".to_string()),
         model_id: "claude-sonnet-4-6".to_string(),
+        extra_body: serde_json::Map::new(),
     };
     let client = ProviderClient::from_resolved(&resolved, None)
         .expect("anthropic provider client should be constructed");

--- a/rust/crates/api/tests/model_limits_from_config.rs
+++ b/rust/crates/api/tests/model_limits_from_config.rs
@@ -1,0 +1,91 @@
+//! `models.<alias>.maxOutputTokens` / `contextWindow` overrides.
+//!
+//! The model-capabilities table is compiled into the binary, so any model it
+//! has never heard of silently inherits the table's `default` entry — and a
+//! provider whose real ceiling is lower rejects every request
+//! (`qwen-flash` on DashScope: `Range of max_tokens should be [1, 32768]`
+//! against sudocode's default 64000). These cases pin the config-side patch.
+//!
+//! The overrides are process-global (they seed the capabilities SSOT), which
+//! is why this file is its own test binary.
+
+use std::collections::BTreeMap;
+
+use api::{
+    max_tokens_for_model, model_token_limit, ModelConfigEntry, ModelProviderMapping, SudoCodeConfig,
+};
+
+fn config_with(
+    alias: &str,
+    wire: &str,
+    max_output: Option<u32>,
+    window: Option<u32>,
+) -> SudoCodeConfig {
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "api-key".to_string(),
+        ModelProviderMapping {
+            provider: "bailian".to_string(),
+            model: wire.to_string(),
+            api: Some("openai-completions".to_string()),
+        },
+    );
+    let mut models = BTreeMap::new();
+    models.insert(
+        alias.to_string(),
+        ModelConfigEntry {
+            alias: alias.to_string(),
+            name: alias.to_string(),
+            input: vec!["text".to_string()],
+            providers,
+            max_output_tokens: max_output,
+            context_window: window,
+            ..Default::default()
+        },
+    );
+    SudoCodeConfig {
+        models,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn configured_limits_override_the_compiled_table() {
+    // A model the bundled table does not know: without an override it takes
+    // the 64k heuristic, which DashScope rejects.
+    assert_eq!(max_tokens_for_model("qwen-flash-test-only"), 64_000);
+
+    runtime::model_capabilities::apply_config_limits(&config_with(
+        "qwen-flash",
+        "qwen-flash-test-only",
+        Some(32_768),
+        Some(1_000_000),
+    ));
+
+    assert_eq!(max_tokens_for_model("qwen-flash-test-only"), 32_768);
+    let limit = model_token_limit("qwen-flash-test-only").expect("configured model is known");
+    assert_eq!(limit.max_output_tokens, 32_768);
+    assert_eq!(limit.context_window_tokens, 1_000_000);
+    assert_eq!(
+        runtime::model_capabilities::context_window_or_default("qwen-flash-test-only"),
+        1_000_000
+    );
+
+    // A provider-prefixed wire ID resolves to the same override.
+    assert_eq!(
+        max_tokens_for_model("dashscope/qwen-flash-test-only"),
+        32_768
+    );
+
+    // Models the config says nothing about are untouched.
+    assert_eq!(max_tokens_for_model("some-other-model"), 64_000);
+
+    // Re-seeding with a config that declares no limits clears the override.
+    runtime::model_capabilities::apply_config_limits(&config_with(
+        "qwen-flash",
+        "qwen-flash-test-only",
+        None,
+        None,
+    ));
+    assert_eq!(max_tokens_for_model("qwen-flash-test-only"), 64_000);
+}

--- a/rust/crates/api/tests/openai_compat_integration.rs
+++ b/rust/crates/api/tests/openai_compat_integration.rs
@@ -492,6 +492,7 @@ async fn provider_client_dispatches_xai_requests() {
         base_url: server.base_url(),
         credential: Credential::ApiKey("xai-test-key".to_string()),
         model_id: "grok-3".to_string(),
+        extra_body: serde_json::Map::new(),
     };
     let client = ProviderClient::from_resolved(&resolved, None)
         .expect("xAI provider client should be constructed");
@@ -511,6 +512,221 @@ async fn provider_client_dispatches_xai_requests() {
         request.headers.get("authorization").map(String::as_str),
         Some("Bearer xai-test-key")
     );
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Per-model `extraBody` (sudocode.json `models.<alias>.extraBody`)
+// ──────────────────────────────────────────────────────────────────────
+
+/// Baseline: a client with no configured extra body sends exactly the
+/// fields it sent before the feature existed. Guards the "absent =>
+/// zero wire change" contract for every existing user.
+#[tokio::test]
+async fn extra_body_absent_leaves_payload_untouched() {
+    let (state, _server, body) = capture_chat_completion_body(serde_json::Map::new()).await;
+    drop(state);
+
+    let mut keys = body
+        .as_object()
+        .expect("payload object")
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec![
+            "max_tokens",
+            "messages",
+            "model",
+            "stream",
+            "tool_choice",
+            "tools",
+        ]
+    );
+}
+
+/// Configured fields reach the wire verbatim, whatever their JSON type.
+#[tokio::test]
+async fn extra_body_fields_are_merged_into_the_request() {
+    let extra = json!({
+        "enable_thinking": false,
+        "thinking_budget": 0,
+        "top_k": 20,
+        "repetition_penalty": 1.05,
+        "response_format": {"type": "text"},
+        "stop_sequences": ["<eot>"],
+        "trace": null,
+    });
+    let extra = extra.as_object().expect("object literal").clone();
+    let (_state, _server, body) = capture_chat_completion_body(extra.clone()).await;
+
+    for (key, value) in &extra {
+        assert_eq!(
+            &body[key.as_str()],
+            value,
+            "field {key} should reach the wire"
+        );
+    }
+    // The computed payload is still intact alongside the additions.
+    assert_eq!(body["model"], json!("grok-3"));
+    assert_eq!(body["max_tokens"], json!(64));
+}
+
+/// The precedence rule: `extraBody` is additive. Fields sudocode computes
+/// itself win, so a bad config can never corrupt the request.
+#[tokio::test]
+async fn extra_body_cannot_override_computed_fields() {
+    let extra = json!({
+        "model": "hijacked-model",
+        "messages": [],
+        "stream": true,
+        "max_tokens": 999_999,
+        "tools": [],
+        "tool_choice": "none",
+        "enable_thinking": false,
+    });
+    let extra = extra.as_object().expect("object literal").clone();
+    let (_state, _server, body) = capture_chat_completion_body(extra).await;
+
+    assert_eq!(body["model"], json!("grok-3"));
+    assert_eq!(body["max_tokens"], json!(64));
+    assert_eq!(body["stream"], json!(false));
+    assert_eq!(body["messages"][0]["role"], json!("system"));
+    assert_eq!(body["tools"][0]["function"]["name"], json!("weather"));
+    assert_eq!(body["tool_choice"], json!("auto"));
+    // The non-reserved field in the same object still lands.
+    assert_eq!(body["enable_thinking"], json!(false));
+}
+
+/// `models.<alias>.extraBody` is carried by provider resolution, so two
+/// models in one config get different request bodies — the reason the
+/// setting hangs off the model entry rather than a process-wide flag.
+#[test]
+fn resolve_provider_from_config_carries_per_model_extra_body() {
+    use std::collections::BTreeMap;
+
+    use api::{
+        resolve_provider_from_config, AuthMode, ModelConfigEntry, ModelProviderMapping,
+        ProviderConnectionConfig, SudoCodeConfig,
+    };
+
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "api-key".to_string(),
+        ModelProviderMapping {
+            provider: "dashscope".to_string(),
+            model: "qwen3.7-flash".to_string(),
+            api: Some("openai-completions".to_string()),
+        },
+    );
+    let mut thinking_off = ModelConfigEntry {
+        alias: "qwen-fast".to_string(),
+        name: "qwen3.7-flash".to_string(),
+        input: vec!["text".to_string()],
+        providers: providers.clone(),
+        ..Default::default()
+    };
+    thinking_off
+        .extra_body
+        .insert("enable_thinking".to_string(), json!(false));
+
+    let mut deep_providers = BTreeMap::new();
+    deep_providers.insert(
+        "api-key".to_string(),
+        ModelProviderMapping {
+            provider: "dashscope".to_string(),
+            model: "qwen3.8-max".to_string(),
+            api: Some("openai-completions".to_string()),
+        },
+    );
+    let deep = ModelConfigEntry {
+        alias: "qwen-deep".to_string(),
+        name: "qwen3.8-max".to_string(),
+        input: vec!["text".to_string()],
+        providers: deep_providers,
+        ..Default::default()
+    };
+
+    let mut models = BTreeMap::new();
+    models.insert("qwen-fast".to_string(), thinking_off);
+    models.insert("qwen-deep".to_string(), deep);
+
+    let mut api_key_mode = BTreeMap::new();
+    api_key_mode.insert(
+        "dashscope".to_string(),
+        ProviderConnectionConfig {
+            base_url: "https://dashscope.example/compatible-mode/v1".to_string(),
+            api_key: Some("test-key".to_string()),
+            api_key_env: None,
+            token: None,
+            token_env: None,
+            auth_file: None,
+        },
+    );
+    let mut auth_modes = BTreeMap::new();
+    auth_modes.insert("api-key".to_string(), api_key_mode);
+
+    let config = SudoCodeConfig {
+        auth_modes,
+        models,
+        ..Default::default()
+    };
+
+    let fast = resolve_provider_from_config("qwen-fast", Some(AuthMode::ApiKey), &config)
+        .expect("fast model resolves");
+    assert_eq!(fast.extra_body.get("enable_thinking"), Some(&json!(false)));
+
+    let deep = resolve_provider_from_config("qwen-deep", Some(AuthMode::ApiKey), &config)
+        .expect("deep model resolves");
+    assert!(
+        deep.extra_body.is_empty(),
+        "a model without extraBody keeps an empty map: {:?}",
+        deep.extra_body
+    );
+}
+
+/// Drives one `/chat/completions` round-trip through `ProviderClient` with
+/// the given `extraBody` attached to the resolved model, and returns the
+/// JSON body the server saw.
+async fn capture_chat_completion_body(
+    extra_body: serde_json::Map<String, serde_json::Value>,
+) -> (
+    Arc<Mutex<Vec<CapturedRequest>>>,
+    TestServer,
+    serde_json::Value,
+) {
+    let state = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
+    let server = spawn_server(
+        state.clone(),
+        vec![http_response(
+            "200 OK",
+            "application/json",
+            "{\"id\":\"chatcmpl_extra\",\"model\":\"grok-3\",\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\",\"tool_calls\":[]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}",
+        )],
+    )
+    .await;
+
+    let resolved = ResolvedProvider {
+        kind: ProviderKind::Xai,
+        api_format: ApiFormat::OpenAiCompletions,
+        base_url: server.base_url(),
+        credential: Credential::ApiKey("xai-test-key".to_string()),
+        model_id: "grok-3".to_string(),
+        extra_body,
+    };
+    let client = ProviderClient::from_resolved(&resolved, None).expect("client should build");
+    client
+        .send_message(&sample_request(false), None)
+        .await
+        .expect("request should succeed");
+
+    let body = {
+        let captured = state.lock().await;
+        let request = captured.first().expect("server should capture request");
+        serde_json::from_str::<serde_json::Value>(&request.body).expect("json body")
+    };
+    (state, server, body)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/crates/api/tests/provider_client_integration.rs
+++ b/rust/crates/api/tests/provider_client_integration.rs
@@ -13,6 +13,7 @@ fn provider_client_routes_xai_through_from_resolved() {
         base_url: "https://api.x.ai/v1".to_string(),
         credential: Credential::ApiKey("xai-test-key".to_string()),
         model_id: "grok-3-mini".to_string(),
+        extra_body: serde_json::Map::new(),
     };
 
     let client = ProviderClient::from_resolved(&resolved, None)
@@ -29,6 +30,7 @@ fn provider_client_routes_generic_openai_responses_through_from_resolved() {
         base_url: "https://api.openai.com/v1".to_string(),
         credential: Credential::ApiKey("openai-test-key".to_string()),
         model_id: "gpt-5.5".to_string(),
+        extra_body: serde_json::Map::new(),
     };
 
     let client = ProviderClient::from_resolved(&resolved, None)
@@ -45,6 +47,7 @@ fn provider_client_routes_anthropic_through_from_resolved() {
         base_url: "https://api.anthropic.com".to_string(),
         credential: Credential::ApiKey("anthropic-test-key".to_string()),
         model_id: "claude-sonnet-4-6".to_string(),
+        extra_body: serde_json::Map::new(),
     };
 
     let client = ProviderClient::from_resolved(&resolved, None)

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -390,7 +390,7 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         name: "effort",
         aliases: &[],
         summary: "Set the effort level for responses",
-        argument_hint: Some("[low|medium|high]"),
+        argument_hint: Some("[none|minimal|low|medium|high]"),
         resume_supported: true,
     },
     SlashCommandSpec {

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 
+use serde_json::Value as SerdeValue;
+
 use crate::json::JsonValue;
 use crate::sandbox::{FilesystemIsolationMode, SandboxConfig};
 
@@ -89,7 +91,7 @@ pub struct ModelProviderMapping {
 /// Model entry in the config registry.
 ///
 /// Parsed from `models.<alias>` in `sudocode.json`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct ModelConfigEntry {
     /// Short alias (also the map key), e.g. `"opus"`.
     pub alias: String,
@@ -99,6 +101,21 @@ pub struct ModelConfigEntry {
     pub input: Vec<String>,
     /// Auth mode → provider mapping.
     pub providers: BTreeMap<String, ModelProviderMapping>,
+    /// Extra top-level fields merged into the outbound request body for this
+    /// model (`models.<alias>.extraBody`). Values are arbitrary JSON.
+    ///
+    /// Merge rule: additive only — a key that sudocode already computed for
+    /// the request (`model`, `messages`, `stream`, `tools`, `max_tokens`, …)
+    /// is never overwritten. Empty by default, i.e. no wire change.
+    pub extra_body: serde_json::Map<String, serde_json::Value>,
+    /// Output-token ceiling for this model (`models.<alias>.maxOutputTokens`),
+    /// overriding the compiled-in model-capabilities table. `None` keeps the
+    /// table's value.
+    pub max_output_tokens: Option<u32>,
+    /// Context-window size for this model (`models.<alias>.contextWindow`),
+    /// overriding the compiled-in model-capabilities table. `None` keeps the
+    /// table's value.
+    pub context_window: Option<u32>,
 }
 
 /// Web search configuration from `sudocode.json`.
@@ -123,7 +140,7 @@ impl Default for WebSearchConfig {
 }
 
 /// Top-level config from `sudocode.json`.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SudoCodeConfig {
     /// `auth_modes.<mode>.<provider_name>` → connection details.
     pub auth_modes: BTreeMap<String, BTreeMap<String, ProviderConnectionConfig>>,
@@ -1266,7 +1283,7 @@ fn parse_sudocode_json_str_with_label(
     let sentinel = Path::new(label);
 
     let auth_modes = parse_auth_modes_section(root_obj, sentinel)?;
-    let models = parse_sudocode_models_section(root_obj, sentinel)?;
+    let models = parse_sudocode_models_section(root_obj, sentinel, &parse_extra_bodies(content))?;
     let web_search = parse_web_search_section(root_obj);
 
     Ok(SudoCodeConfig {
@@ -1348,9 +1365,34 @@ fn parse_web_search_section(root: &BTreeMap<String, JsonValue>) -> WebSearchConf
     }
 }
 
+/// Re-read `models.<alias>.extraBody` with `serde_json`.
+///
+/// `crate::json::JsonValue` models numbers as `i64`, so it cannot round-trip
+/// float literals (`"temperature": 0.6`) or hand back a `serde_json::Value`
+/// without loss. `extraBody` is opaque pass-through data that must survive
+/// verbatim, so it is read from the same source text with `serde_json` — a
+/// strict superset of what the hand-rolled parser accepts. Keys are the raw
+/// `models` keys; shape validation stays in the main parser.
+fn parse_extra_bodies(content: &str) -> BTreeMap<String, serde_json::Map<String, SerdeValue>> {
+    let Ok(root) = serde_json::from_str::<SerdeValue>(content) else {
+        return BTreeMap::new();
+    };
+    let Some(models) = root.get("models").and_then(SerdeValue::as_object) else {
+        return BTreeMap::new();
+    };
+    models
+        .iter()
+        .filter_map(|(alias, entry)| {
+            let extra = entry.get("extraBody")?.as_object()?;
+            Some((alias.clone(), extra.clone()))
+        })
+        .collect()
+}
+
 fn parse_sudocode_models_section(
     root: &BTreeMap<String, JsonValue>,
     path: &Path,
+    extra_bodies: &BTreeMap<String, serde_json::Map<String, SerdeValue>>,
 ) -> Result<BTreeMap<String, ModelConfigEntry>, ConfigError> {
     let Some(value) = root.get("models") else {
         return Ok(BTreeMap::new());
@@ -1390,6 +1432,18 @@ fn parse_sudocode_models_section(
             BTreeMap::new()
         };
 
+        // `extraBody` must be an object; its values come from the serde_json
+        // pass (see `parse_extra_bodies`) so arbitrary JSON survives verbatim.
+        let extra_body = match entry.get("extraBody") {
+            None | Some(JsonValue::Null) => serde_json::Map::new(),
+            Some(JsonValue::Object(_)) => extra_bodies.get(alias).cloned().unwrap_or_default(),
+            Some(_) => {
+                return Err(ConfigError::Parse(format!(
+                    "{ctx}.extraBody: expected a JSON object of request-body fields"
+                )))
+            }
+        };
+
         result.insert(
             alias.to_ascii_lowercase(),
             ModelConfigEntry {
@@ -1397,6 +1451,9 @@ fn parse_sudocode_models_section(
                 name,
                 input,
                 providers,
+                extra_body,
+                max_output_tokens: optional_u32(entry, "maxOutputTokens", &ctx)?,
+                context_window: optional_u32(entry, "contextWindow", &ctx)?,
             },
         );
     }

--- a/rust/crates/runtime/src/json.rs
+++ b/rust/crates/runtime/src/json.rs
@@ -281,9 +281,35 @@ impl<'a> Parser<'a> {
             return Err(JsonError::new("invalid number"));
         }
 
+        // `JsonValue::Number` is an i64, so a fractional or exponent part
+        // cannot be represented. Consume and discard it rather than failing
+        // the whole document: config files may carry float literals in
+        // pass-through sections (e.g. `models.<alias>.extraBody`), which are
+        // re-read with serde_json where the exact value matters.
+        self.skip_number_tail();
+
         value
             .parse::<i64>()
             .map_err(|_| JsonError::new("number out of range"))
+    }
+
+    /// Consume an optional `.digits` fraction and `e[+-]digits` exponent.
+    fn skip_number_tail(&mut self) {
+        if self.peek() == Some('.') {
+            self.index += 1;
+            while matches!(self.peek(), Some('0'..='9')) {
+                self.index += 1;
+            }
+        }
+        if matches!(self.peek(), Some('e' | 'E')) {
+            self.index += 1;
+            if matches!(self.peek(), Some('+' | '-')) {
+                self.index += 1;
+            }
+            while matches!(self.peek(), Some('0'..='9')) {
+                self.index += 1;
+            }
+        }
     }
 
     fn expect(&mut self, expected: char) -> Result<(), JsonError> {

--- a/rust/crates/runtime/src/model_capabilities.rs
+++ b/rust/crates/runtime/src/model_capabilities.rs
@@ -11,7 +11,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -83,6 +83,82 @@ impl Default for ModelCapabilitiesFile {
 /// In-memory snapshot of the capabilities file, loaded once per session.
 static CAPABILITIES: OnceLock<ModelCapabilitiesFile> = OnceLock::new();
 
+/// Per-model limit overrides from `sudocode.json`, keyed by lowercase wire
+/// model ID. Seeded by [`apply_config_limits`] at startup; empty otherwise.
+static CONFIG_LIMITS: RwLock<Option<BTreeMap<String, ModelLimitOverride>>> = RwLock::new(None);
+
+/// Token-limit overrides a model entry may declare in `sudocode.json`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ModelLimitOverride {
+    pub max_output_tokens: Option<u32>,
+    pub context_window: Option<u32>,
+}
+
+impl ModelLimitOverride {
+    fn is_empty(self) -> bool {
+        self.max_output_tokens.is_none() && self.context_window.is_none()
+    }
+
+    fn apply(self, cap: &mut ModelCapability) {
+        if let Some(value) = self.max_output_tokens {
+            cap.max_output_tokens = value;
+        }
+        if let Some(value) = self.context_window {
+            cap.context_window = value;
+        }
+    }
+}
+
+/// Seed the per-model limit overrides from a parsed `sudocode.json`.
+///
+/// The compiled-in capabilities table cannot cover every model a user points
+/// `scode` at — an unknown model silently inherits the table's `default`
+/// entry, and a too-large `max_tokens` is rejected by the provider
+/// (`DashScope`
+/// answers `Range of max_tokens should be [1, 32768]`). `maxOutputTokens` /
+/// `contextWindow` on the model entry are the user-side patch for that.
+///
+/// Overrides are keyed by **wire model ID**, since that is what every
+/// capability lookup on the hot path has in hand. Two aliases mapping to the
+/// same wire ID therefore share one override; the last one wins (aliases are
+/// visited in sorted order). Calling this again replaces the previous set.
+pub fn apply_config_limits(config: &crate::config::SudoCodeConfig) {
+    let mut overrides: BTreeMap<String, ModelLimitOverride> = BTreeMap::new();
+    for entry in config.models.values() {
+        let over = ModelLimitOverride {
+            max_output_tokens: entry.max_output_tokens,
+            context_window: entry.context_window,
+        };
+        if over.is_empty() {
+            continue;
+        }
+        for mapping in entry.providers.values() {
+            overrides.insert(mapping.model.to_ascii_lowercase(), over);
+        }
+    }
+    let value = (!overrides.is_empty()).then_some(overrides);
+    if let Ok(mut guard) = CONFIG_LIMITS.write() {
+        *guard = value;
+    }
+}
+
+/// The configured `maxOutputTokens` for a wire model ID, if the user set one.
+///
+/// Callers that apply their own heuristic cap use this to tell "the table's
+/// number" (cap it) from "the user's number" (obey it).
+#[must_use]
+pub fn config_max_output_tokens(model_id: &str) -> Option<u32> {
+    let base = model_id.rsplit('/').next().unwrap_or(model_id);
+    config_limit_for(base).and_then(|over| over.max_output_tokens)
+}
+
+/// Look up the configured override for a wire model ID, if any.
+fn config_limit_for(base: &str) -> Option<ModelLimitOverride> {
+    let guard = CONFIG_LIMITS.read().ok()?;
+    let map = guard.as_ref()?;
+    map.get(&base.to_ascii_lowercase()).copied()
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -96,10 +172,20 @@ static CAPABILITIES: OnceLock<ModelCapabilitiesFile> = OnceLock::new();
 pub fn lookup(model_id: &str) -> Option<ModelCapability> {
     let base = model_id.rsplit('/').next().unwrap_or(model_id);
     let caps = CAPABILITIES.get_or_init(ModelCapabilitiesFile::default);
-    caps.models
+    let table_entry = caps
+        .models
         .iter()
         .find(|(id, _)| id.eq_ignore_ascii_case(base))
-        .map(|(_, cap)| cap.clone())
+        .map(|(_, cap)| cap.clone());
+    let Some(over) = config_limit_for(base) else {
+        return table_entry;
+    };
+    // A configured model is "known" even when the table has never heard of
+    // it: start from the table's `default` entry so the override lands on a
+    // complete capability rather than being dropped.
+    let mut cap = table_entry.unwrap_or_else(|| caps.default.clone());
+    over.apply(&mut cap);
+    Some(cap)
 }
 
 /// Returns `true` if the model is known to accept image input. Used by the

--- a/rust/crates/runtime/tests/sudocode_config_extra_body.rs
+++ b/rust/crates/runtime/tests/sudocode_config_extra_body.rs
@@ -1,0 +1,169 @@
+//! `models.<alias>` pass-through fields (`extraBody`, `maxOutputTokens`,
+//! `contextWindow`) parsed out of `sudocode.json`.
+//!
+//! The field is opaque pass-through data for the outbound request body, so
+//! the parser has to hand it back verbatim — including float literals, which
+//! the hand-rolled `crate::json` parser cannot represent (it is re-read with
+//! serde_json for exactly this reason). These cases pin that contract, plus
+//! the "absent means empty, and the rest of the entry is unaffected" default
+//! every existing config relies on.
+
+use std::fs;
+
+use runtime::ConfigLoader;
+
+fn temp_config_home(label: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "sudocode-extra-body-{label}-{}-{nanos}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("create temp config home");
+    path
+}
+
+fn write_config(label: &str, contents: &str) -> std::path::PathBuf {
+    let home = temp_config_home(label);
+    fs::write(home.join("sudocode.json"), contents).expect("write sudocode.json");
+    home
+}
+
+const CONFIG_WITH_EXTRA_BODY: &str = r#"{
+  "auth_modes": {
+    "api-key": {
+      "dashscope": {
+        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "apiKey": "test-key"
+      }
+    }
+  },
+  "models": {
+    "qwen-fast": {
+      "alias": "qwen-fast",
+      "name": "qwen3.7-flash",
+      "input": ["text"],
+      "providers": {
+        "api-key": { "provider": "dashscope", "model": "qwen3.7-flash", "api": "openai-completions" }
+      },
+      "maxOutputTokens": 32768,
+      "contextWindow": 1000000,
+      "extraBody": {
+        "enable_thinking": false,
+        "thinking_budget": 0,
+        "temperature": 0.6,
+        "response_format": { "type": "text" },
+        "stop_sequences": ["<eot>"],
+        "trace": null
+      }
+    },
+    "qwen-deep": {
+      "alias": "qwen-deep",
+      "name": "qwen3.8-max",
+      "input": ["text"],
+      "providers": {
+        "api-key": { "provider": "dashscope", "model": "qwen3.8-max", "api": "openai-completions" }
+      }
+    }
+  }
+}"#;
+
+#[test]
+fn extra_body_is_parsed_verbatim_per_model() {
+    let home = write_config("verbatim", CONFIG_WITH_EXTRA_BODY);
+    let config = ConfigLoader::new(&home, &home)
+        .load_sudocode_config()
+        .expect("config with extraBody should load");
+
+    let fast = config.models.get("qwen-fast").expect("qwen-fast entry");
+    assert_eq!(
+        fast.extra_body.get("enable_thinking"),
+        Some(&serde_json::json!(false))
+    );
+    assert_eq!(
+        fast.extra_body.get("thinking_budget"),
+        Some(&serde_json::json!(0))
+    );
+    // Floats survive: the runtime's own JSON value type is integer-only, so
+    // this is the case that regresses first if the serde_json pass is lost.
+    assert_eq!(
+        fast.extra_body.get("temperature"),
+        Some(&serde_json::json!(0.6))
+    );
+    assert_eq!(
+        fast.extra_body.get("response_format"),
+        Some(&serde_json::json!({"type": "text"}))
+    );
+    assert_eq!(
+        fast.extra_body.get("stop_sequences"),
+        Some(&serde_json::json!(["<eot>"]))
+    );
+    assert_eq!(fast.extra_body.get("trace"), Some(&serde_json::Value::Null));
+
+    // Token-limit overrides ride on the same entry.
+    assert_eq!(fast.max_output_tokens, Some(32_768));
+    assert_eq!(fast.context_window, Some(1_000_000));
+
+    // The rest of the entry parses exactly as before.
+    assert_eq!(fast.name, "qwen3.7-flash");
+    assert_eq!(
+        fast.providers
+            .get("api-key")
+            .map(|mapping| mapping.model.as_str()),
+        Some("qwen3.7-flash")
+    );
+
+    // Sibling model without the field is untouched.
+    let deep = config.models.get("qwen-deep").expect("qwen-deep entry");
+    assert!(
+        deep.extra_body.is_empty(),
+        "no extraBody means an empty map, not an inherited one: {:?}",
+        deep.extra_body
+    );
+    assert_eq!(deep.max_output_tokens, None);
+    assert_eq!(deep.context_window, None);
+}
+
+#[test]
+fn config_without_extra_body_parses_unchanged() {
+    let home = write_config("absent", runtime::config::SAMPLE_SUDOCODE_JSON);
+    let config = ConfigLoader::new(&home, &home)
+        .load_sudocode_config()
+        .expect("sample config should load");
+
+    assert!(!config.models.is_empty(), "sample config declares models");
+    for (alias, entry) in &config.models {
+        assert!(
+            entry.extra_body.is_empty(),
+            "model {alias} should have no extraBody"
+        );
+        assert_eq!(entry.max_output_tokens, None, "model {alias}");
+        assert_eq!(entry.context_window, None, "model {alias}");
+    }
+}
+
+#[test]
+fn non_object_extra_body_is_a_config_error() {
+    let home = write_config(
+        "not-an-object",
+        r#"{
+  "models": {
+    "qwen-fast": {
+      "name": "qwen3.7-flash",
+      "providers": {},
+      "extraBody": "enable_thinking=false"
+    }
+  }
+}"#,
+    );
+    let error = ConfigLoader::new(&home, &home)
+        .load_sudocode_config()
+        .expect_err("a string extraBody should be rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("extraBody"),
+        "error should name the offending field: {message}"
+    );
+}

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -71,7 +71,12 @@ struct Cli {
     base_commit: Option<String>,
 
     /// Reasoning effort level
-    #[arg(long, global = true, value_parser = ["low", "medium", "high"])]
+    ///
+    /// `none` / `minimal` are part of the OpenAI reasoning-effort ladder and
+    /// are what several OpenAI-compatible backends accept to turn reasoning
+    /// off entirely (DashScope Qwen3.x, for one); keeping them out of the
+    /// allow-list blocked a capability the wire already supports.
+    #[arg(long, global = true, value_parser = ["none", "minimal", "low", "medium", "high"])]
     reasoning_effort: Option<String>,
 
     /// Allow running in a broad (non-project) working directory

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -1204,12 +1204,20 @@ pub(crate) fn load_sudocode_config_for_current_dir() -> api::SudoCodeConfig {
 
 pub(crate) fn load_sudocode_config_for_cwd(cwd: &Path) -> api::SudoCodeConfig {
     let loader = ConfigLoader::default_for(cwd);
-    loader.load_sudocode_config().unwrap_or_default()
+    let config = loader.load_sudocode_config().unwrap_or_default();
+    runtime::model_capabilities::apply_config_limits(&config);
+    config
 }
 
 pub(crate) fn require_sudocode_config_for_cwd(cwd: &Path) -> Result<api::SudoCodeConfig, String> {
     let loader = ConfigLoader::default_for(cwd);
-    loader.load_sudocode_config().map_err(|e| e.to_string())
+    let config = loader.load_sudocode_config().map_err(|e| e.to_string())?;
+    // Seed the capability overrides here rather than at each startup site:
+    // every entry point (REPL, --print, acp, subagents) reaches the config
+    // through this pair, and a forgotten seeding call is invisible until a
+    // provider rejects `max_tokens` at request time.
+    runtime::model_capabilities::apply_config_limits(&config);
+    Ok(config)
 }
 
 // ---------------------------------------------------------------------------
@@ -1338,6 +1346,7 @@ mod tests {
                 name: "custom-openai/gpt-5.4".to_string(),
                 input: vec!["text".to_string()],
                 providers,
+                ..Default::default()
             },
         );
 

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -6876,6 +6876,7 @@ mod auth_mode_tests {
             name: alias.to_string(),
             input: vec!["text".to_string()],
             providers,
+            ..Default::default()
         }
     }
 

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -122,8 +122,12 @@ impl AnthropicRequestProfile {
                 "request body must serialize to a JSON object",
             ))
         })?;
+        // Additive: extra body params never clobber a field the serialized
+        // request itself carries (`model`, `messages`, `max_tokens`, …).
         for (key, value) in &self.extra_body {
-            object.insert(key.clone(), value.clone());
+            if !object.contains_key(key) {
+                object.insert(key.clone(), value.clone());
+            }
         }
         if !self.betas.is_empty() {
             object.insert(


### PR DESCRIPTION
## Summary

Adds three optional fields to a model entry in `sudocode.json` so a caller can correct the outbound request **per model** rather than per process, plus one CLI allow-list fix.

```jsonc
"qwen3.7-flash": {
  "alias": "qwen3.7-flash", "name": "qwen3.7-flash", "input": ["text"],
  "providers": { "api-key": { "provider": "dashscope", "model": "qwen3.7-flash", "api": "openai-completions" } },
  "extraBody": { "enable_thinking": false },   // merged into the request body
  "maxOutputTokens": 32768,                    // overrides the compiled-in capabilities table
  "contextWindow": 1000000
}
```

**Why `extraBody`.** DashScope turns the Qwen3.x reasoning chain on by default and *only* `"enable_thinking": false` in the body turns it off. `build_chat_completion_request()` emits a hardcoded field set with no merge point, so a "fast" model spends its latency budget on a thinking pass nobody asked for (measured: 2495 ms vs 436 ms on the same request). `with_extra_body_param()` existed on the anthropic client only, and nothing in the config could feed it.

**Why it hangs off the model entry.** The caller that hit this switches models inside one process, per session — "fast" wants thinking off, "deep thinking" wants it kept. A process-wide flag such as `--reasoning-effort` cannot express that.

**Why `maxOutputTokens`.** The model-capabilities table is compiled into the binary; a model it has never heard of inherits the table's `default` (64000 output tokens). `qwen-flash`'s real DashScope ceiling is 32768, so *every* request fails with `<400> Range of max_tokens should be [1, 32768]` and the user has no way to patch the table. This is not qwen-flash-specific — any unlisted model is a landmine, and it is what stands between `scode` and "point it at an arbitrary OpenAI-compatible endpoint".

**`--reasoning-effort none|minimal`.** `minimal` is part of OpenAI's own ladder; on OpenAI-compatible backends `none`/`minimal` are what actually switch reasoning off (on DashScope they are the only accepted values that do — `low` still reasons). The allow-list was blocking a capability the wire already supports.

## Design decisions and trade-offs

**`extraBody` is additive, never a replacement.** A key the payload builder already set, or one in the new `RESERVED_REQUEST_BODY_KEYS` (`model`, `messages`, `input`, `system`, `instructions`, `stream`, `stream_options`, `tools`, `tool_choice`, `max_tokens`, `max_completion_tokens`, `max_output_tokens`), is skipped. A misconfigured `extraBody` can at worst add a field the backend ignores; it can never corrupt a request sudocode computed. `AnthropicRequestProfile::render_json_body` stops clobbering existing fields for the same reason, so both wire formats follow one documented rule. Pinned by test.

**Attached to the provider client, not to `MessageRequest`.** Clients are built by `resolve_provider_from_config`, and a model switch rebuilds the runtime and with it the client — so client-level *is* per-model, and side requests (compaction, sub-agents) inherit it. `MessageRequest` construction sites are scattered and mostly spread `..Default::default()`, so a request-level field would silently miss most of them.

**Token limits seed the capabilities lookup instead of riding the request path.** Every consumer of the context window — status line, auto-compaction threshold, preflight, sub-agent clients — asks `model_capabilities` directly and holds only a wire model ID. Seeding there makes the override reach all of them without threading a new argument through each signature. Cost: overrides are keyed by wire model ID, so two aliases mapping to one wire ID share an override (last sorted alias wins). Documented in `docs/models.md` and at the function.

**Two JSON parsers for one file.** `crate::json::JsonValue` models numbers as `i64`: it can neither round-trip `"temperature": 0.6` nor produce a `serde_json::Value` without loss — and before this change *any* float literal anywhere in `sudocode.json` failed the whole document. `extraBody` is opaque pass-through data that has to survive verbatim, so it is read from the same source text a second time with `serde_json` (a strict superset of what the hand-rolled parser accepts), and `parse_number` now consumes and discards a fraction/exponent tail instead of erroring. The alternative — adding a float variant to `JsonValue` — ripples through 150+ use sites and the `Eq` derives of the session types, for no gain outside this field.

`ModelConfigEntry` / `SudoCodeConfig` / `ResolvedProvider` drop their `Eq` derive (`serde_json::Value` cannot satisfy it); `PartialEq` is kept and nothing in the tree required `Eq`.

**Absent means unchanged.** A config without these fields produces a byte-identical payload and the same token limits as before. Pinned by test.

## Testing

Per `CONTRIBUTING.md`'s test policy, everything new sits at the integration layer — no unit tests added.

- `cargo test --workspace` — green (105 test binaries, 0 failures)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — the tree has pre-existing diagnostics under the local clippy 1.92 (telemetry, plugins, nexus-vfs-client, runtime); every diagnostic was cross-checked line-by-line against this diff and **none falls inside a changed region**.
- New: `crates/api/tests/openai_compat_integration.rs` (+4) — injection reaches the wire for every JSON type; absent leaves the payload key set untouched; reserved fields cannot be overridden while a non-reserved key in the same object still lands; two models in one config resolve to different `extra_body`.
- New: `crates/api/tests/model_limits_from_config.rs` — override applies (incl. provider-prefixed IDs), unconfigured models untouched, re-seeding clears.
- New: `crates/runtime/tests/sudocode_config_extra_body.rs` — values parse verbatim (floats included), sample config unaffected, a non-object `extraBody` is a config error naming the field.

No PTY scenario was added: the behavior is a request-body detail with no terminal-visible surface. It was verified end-to-end against the live provider instead.

### Live verification (real DashScope key, MITM proxy capturing outbound body + upstream usage)

| Scenario | Outbound body | Upstream usage |
|---|---|---|
| Model with `extraBody` | `enable_thinking=false` | no `completion_tokens_details` → **reasoning_tokens = None**, completion_tokens 1 |
| Model without it (same wire model) | field absent | `reasoning_tokens: 28` |
| One process, one ACP session, `session/set_model` between turns | absent → present | 28 → None |
| `qwen-flash`, no `maxOutputTokens` | `max_tokens=64000` | `400 Range of max_tokens should be [1, 32768]` |
| `qwen-flash`, `maxOutputTokens: 32768` | `max_tokens=32768` | two-turn conversation with a Bash tool call completes |

The third row is the motivating usage exactly — one process, one session, model switched mid-session — and is the direct check that this is per-model and not per-process.

## Scope

- Wire formats: `openai-completions`, `openai-responses`, `anthropic-messages`. Codex and Gemini clients ignore `extraBody`.
- Proxy passthrough (a model with no `models.<alias>` entry) has nothing to read and sends an empty map, i.e. unchanged behavior.
- `docs/models.md` gains two sections and a `reasoning_effort` values note; `.github/scripts/check_doc_source_of_truth.py` passes.
