### PR TITLE
fix(runtime): durable per-agent inbox cursor — no re-reply storm on respawn

### DIFF
--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -274,7 +274,19 @@ fn run_loop<K, C, T, F>(
     let self_id = mailbox.self_id().to_string();
     let ctx = OperationContext::new(&desc.owner_id, &desc.zone_id, false, Some(&self_id), true);
 
-    let mut next_offset: u64 = 0;
+    // Durable per-agent read cursor (node-local). A (re)spawned agent RESUMES
+    // from the offset it last PROCESSED instead of replaying its whole inbox and
+    // re-answering every historical message — the #81 re-reply storm, observed
+    // live in the Win↔Mac duet when a respawned agent re-answered the entire
+    // conversation. First spawn (no cursor yet) loads 0 and delivers all waiting
+    // messages, so there is NO seek-to-tail delivery race. The cursor is a
+    // node-local DT_REG (`sys_write` create-or-overwrites it; it lives in the
+    // node's durable metastore, so it survives a daemon restart); each node's
+    // agent owns its own cursor. All cursor I/O degrades GRACEFULLY (load → 0,
+    // save ignored) so a missing / unmounted cursor path never wedges the agent —
+    // only the no-replay guarantee weakens to "replay from 0".
+    let cursor_path = cursor_path_for(&self_id);
+    let mut next_offset: u64 = load_cursor(kernel.as_ref(), &cursor_path, &ctx);
     while !abort.is_aborted() {
         match kernel.sys_read(&inbox_path, &ctx, READ_TIMEOUT_MS, next_offset) {
             Ok(result) => {
@@ -303,7 +315,16 @@ fn run_loop<K, C, T, F>(
                     }
                 }
                 if let Some(advanced) = result.stream_next_offset {
-                    next_offset = advanced as u64;
+                    let advanced = advanced as u64;
+                    // Persist the cursor only on REAL forward progress (a message
+                    // was consumed) — never on idle no-op reads, which would
+                    // rewrite the same offset every watch tick. Saving here (after
+                    // the turn ran) makes a crash mid-turn re-process only that one
+                    // message on respawn (at-least-once), never the whole history.
+                    if advanced > next_offset {
+                        next_offset = advanced;
+                        save_cursor(kernel.as_ref(), &cursor_path, &ctx, next_offset);
+                    }
                 }
             }
             Err(e) => {
@@ -343,6 +364,45 @@ fn parse_inbound(bytes: &[u8], self_agent_id: &str) -> Option<(String, String)> 
         return None;
     }
     Some((env.from, env.body))
+}
+
+/// Node-local path holding a co-host agent's durable inbox read cursor. Keyed by
+/// the agent's stable identity (NOT its pid) so it survives respawn; sanitised to
+/// a flat, path-safe leaf so `sys_write` auto-creates the DT_REG without needing
+/// intermediate directories.
+fn cursor_path_for(agent_id: &str) -> String {
+    let safe: String = agent_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("/.cohost-cursor-{safe}")
+}
+
+/// Read the persisted cursor (a decimal offset). Any failure — path unmounted,
+/// not-yet-created, or unparsable — yields 0, i.e. start from the inbox head.
+fn load_cursor<K: KernelSyscall>(kernel: &K, path: &str, ctx: &OperationContext) -> u64 {
+    kernel
+        .sys_read(path, ctx, 0, 0)
+        .ok()
+        .and_then(|r| r.data)
+        .and_then(|bytes| {
+            std::str::from_utf8(&bytes)
+                .ok()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+        })
+        .unwrap_or(0)
+}
+
+/// Overwrite the persisted cursor with `offset`. Best-effort: a write failure
+/// only weakens the no-replay guarantee (never correctness), so it is ignored.
+fn save_cursor<K: KernelSyscall>(kernel: &K, path: &str, ctx: &OperationContext, offset: u64) {
+    let _ = kernel.sys_write(path, ctx, offset.to_string().as_bytes(), 0);
 }
 
 // Loop tests live under `runtime/tests/spawn_task.rs` as an integration

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -123,6 +123,72 @@ fn mount(kernel: &Kernel, mount_point: &str) {
         .add_mount(mount_point, "root", None, false);
 }
 
+/// Mount `mount_point` backed by an in-memory `ObjectStore` so DT_REG **content**
+/// (not just metadata) round-trips. The `None`-backend `mount` above carries
+/// only metadata, so a DT_REG write "succeeds" but the read returns FileNotFound
+/// — the durable cursor is a DT_REG, so its persistence needs a content backend
+/// (production uses host-fs at `/`).
+fn mount_with_backend(kernel: &Kernel, mount_point: &str) {
+    kernel.vfs_router_arc().add_mount(
+        mount_point,
+        "root",
+        Some(Arc::new(MemStore::default())),
+        false,
+    );
+}
+
+/// Minimal PAS-style in-memory `ObjectStore` for tests: stores DT_REG content by
+/// its (path-derived) content_id. Only the three required trait methods.
+#[derive(Default)]
+struct MemStore {
+    blobs: std::sync::Mutex<std::collections::HashMap<String, Vec<u8>>>,
+}
+
+impl kernel::abc::object_store::ObjectStore for MemStore {
+    fn name(&self) -> &str {
+        "memtest"
+    }
+    fn write_content(
+        &self,
+        content: &[u8],
+        content_id: &str,
+        _ctx: &OperationContext,
+        offset: u64,
+    ) -> Result<kernel::abc::object_store::WriteResult, kernel::abc::object_store::StorageError>
+    {
+        let mut blobs = self.blobs.lock().unwrap();
+        let entry = blobs.entry(content_id.to_string()).or_default();
+        if offset == 0 {
+            entry.clear();
+        }
+        let off = offset as usize;
+        let end = off + content.len();
+        if entry.len() < end {
+            entry.resize(end, 0);
+        }
+        entry[off..end].copy_from_slice(content);
+        Ok(kernel::abc::object_store::WriteResult {
+            content_id: content_id.to_string(),
+            version: String::new(),
+            size: entry.len() as u64,
+        })
+    }
+    fn read_content(
+        &self,
+        content_id: &str,
+        _ctx: &OperationContext,
+    ) -> Result<Vec<u8>, kernel::abc::object_store::StorageError> {
+        self.blobs
+            .lock()
+            .unwrap()
+            .get(content_id)
+            .cloned()
+            .ok_or_else(|| {
+                kernel::abc::object_store::StorageError::NotFound(content_id.to_string())
+            })
+    }
+}
+
 fn plant_stream(kernel: &Kernel, path: &str) {
     kernel
         .sys_setattr(
@@ -569,5 +635,152 @@ fn text_only_turn_writes_no_reply_the_ping_pong_fix() {
         count_from(&kernel, "/agents/win-ai/chat-with-me", &ctx, "win-ai"),
         0,
         "the agent wrote to its own inbox on a silent turn"
+    );
+}
+
+#[test]
+fn probe_dt_reg_round_trips_on_test_mount() {
+    // Isolation probe: does a DT_REG (the cursor's shape) actually persist +
+    // read back on the test's `/` mount? If not, the respawn test's failure is
+    // a test-mount artifact, not the fix.
+    let kernel = Arc::new(Kernel::new());
+    mount_with_backend(&kernel, "/");
+    let ctx = user_ctx();
+    let w = kernel
+        .sys_write(
+            &[WriteRequest {
+                path: "/.probe-cursor".to_string(),
+                content: b"42".to_vec(),
+                offset: 0,
+            }],
+            &ctx,
+        )
+        .pop()
+        .expect("write vec empty");
+    assert!(w.is_ok(), "DT_REG write failed on test mount");
+    let r = kernel
+        .sys_read(
+            &[ReadRequest {
+                path: "/.probe-cursor".to_string(),
+                offset: 0,
+                len: None,
+                timeout_ms: 0,
+            }],
+            &ctx,
+        )
+        .pop()
+        .expect("read vec empty")
+        .expect("read err");
+    assert_eq!(
+        r.data.as_deref(),
+        Some(&b"42"[..]),
+        "DT_REG content did not persist/round-trip on the test `/` mount"
+    );
+}
+
+#[test]
+fn respawn_resumes_from_durable_cursor_and_does_not_replay_history() {
+    // #81 root fix: a RESPAWNED co-host agent must resume past what it already
+    // processed — via its durable node-local cursor — NOT replay the whole inbox
+    // and re-answer every historical message (the storm seen live when Mac
+    // respawned mac-ai and it re-answered the entire conversation).
+    let kernel = Arc::new(Kernel::new());
+    mount_with_backend(&kernel, "/"); // durable cursor lives at /.cohost-cursor-<name>
+    mount(&kernel, "/agents");
+    plant_stream(&kernel, "/agents/win-ai/chat-with-me");
+    plant_stream(&kernel, "/agents/user-test/chat-with-me");
+    let ctx = user_ctx();
+
+    // Spawn #1: deliver + reply to one message; the cursor advances + persists.
+    let h1 = spawn_sending(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai-1", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+        "user-test",
+        REPLY_TEXT,
+    );
+    write_envelope(
+        &kernel,
+        "/agents/win-ai/chat-with-me",
+        &ctx,
+        "user-test",
+        "win-ai",
+        "first",
+    );
+    let r1 = wait_for_reply(
+        &kernel,
+        "/agents/user-test/chat-with-me",
+        &ctx,
+        "win-ai",
+        Duration::from_secs(5),
+    );
+    assert!(r1.is_some(), "spawn #1 did not reply to its message");
+    thread::sleep(Duration::from_millis(200)); // let the cursor save land
+    h1.abort_signal.abort();
+    let _ = h1.join.join();
+    assert_eq!(
+        count_from(&kernel, "/agents/user-test/chat-with-me", &ctx, "win-ai"),
+        1,
+        "spawn #1 should reply exactly once"
+    );
+
+    // Spawn #2 = RESPAWN of the SAME identity into the SAME inbox (still holds
+    // "first"). The durable cursor must make it resume PAST "first" → no re-reply.
+    let h2 = spawn_sending(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai-2", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+        "user-test",
+        REPLY_TEXT,
+    );
+    thread::sleep(Duration::from_millis(700)); // ample time to (wrongly) replay
+    h2.abort_signal.abort();
+    let _ = h2.join.join();
+    assert_eq!(
+        count_from(&kernel, "/agents/user-test/chat-with-me", &ctx, "win-ai"),
+        1,
+        "respawn re-replied to an already-processed message — durable cursor not honored (#81 storm)"
+    );
+
+    // Liveness: a NEW message after respawn IS answered (the cursor didn't
+    // over-skip live traffic, the way a naive seek-to-tail would).
+    write_envelope(
+        &kernel,
+        "/agents/win-ai/chat-with-me",
+        &ctx,
+        "user-test",
+        "win-ai",
+        "second",
+    );
+    let h3 = spawn_sending(
+        Arc::clone(&kernel),
+        make_desc("cohost-win-ai-3", "win-ai"),
+        Mailbox::A2aInbox {
+            base: "/agents".to_string(),
+            self_name: "win-ai".to_string(),
+        },
+        "user-test",
+        REPLY_TEXT,
+    );
+    // Poll for a SECOND reply (spawn #1's is still in the inbox, so a plain
+    // "any reply?" check would spuriously succeed on the stale one).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while count_from(&kernel, "/agents/user-test/chat-with-me", &ctx, "win-ai") < 2
+        && Instant::now() < deadline
+    {
+        thread::sleep(Duration::from_millis(50));
+    }
+    h3.abort_signal.abort();
+    let _ = h3.join.join();
+    assert_eq!(
+        count_from(&kernel, "/agents/user-test/chat-with-me", &ctx, "win-ai"),
+        2,
+        "exactly two replies total ('first' + 'second'); the respawn replayed NONE"
     );
 }


### PR DESCRIPTION
## The bug (live-observed, Win↔Mac duet)

A respawned co-host agent **re-answered its entire inbox history**. Root cause: the A2A inbox loop hardcoded `next_offset = 0`, so every (re)spawn re-reads the whole inbox and replies to every historical message. A first spawn into an empty inbox looked fine (tail 0), so it only surfaced on respawn.

## The fix — durable per-agent read cursor

- Persist the read position as a **node-local DT_REG** `/.cohost-cursor-<name>` (keyed by the agent's stable identity, not its pid).
- **Load** on spawn; **save** after each *real* advance — after the turn, so a crash mid-turn re-does only that one message (at-least-once), never the history; and never on idle no-op reads.
- **First spawn** (no cursor) loads 0 → delivers all waiting messages → **no seek-to-tail delivery race**. (A naive seek-to-tail was tried first and reverted — it broke the "post-spawn message is delivered" contract, which the existing tests correctly caught.)
- Survives **daemon restart** via the node metastore; each node's agent owns its own cursor.
- All cursor I/O **degrades gracefully** (load → 0) so a missing/unmounted cursor path never wedges the agent — only the no-replay guarantee weakens to "replay from 0".

Uses only existing kernel primitives (`sys_read`/`sys_write` create-or-overwrite a DT_REG); no signature changes to `spawn_task`, no kernel change (streams are offset-based by contract, so the cursor is legitimately a client concern).

## Tests

- **Respawn regression** (`respawn_resumes_from_durable_cursor_and_does_not_replay_history`): spawn → process → **respawn must NOT replay**, and a **fresh post-respawn message IS answered** (guards against over-skipping). **Negative control verified**: forcing `offset=0` makes it fail.
- A DT_REG-round-trip **probe** + a tiny in-memory `ObjectStore` so the cursor's *content* persists in-test (the `None`-backend mount carries only metadata; production `/` is host-fs).
- The 6 existing `spawn_task` tests are unchanged and still pass (graceful cursor I/O).