### PR TITLE
docs(roadmap): tiering CC 2.1.250 refresh

### DIFF
--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -1111,7 +1111,7 @@ capable ones can graduate later with eval evidence). Structure first; the per-ti
 essence, drop the dross; <em>not</em> mirror) — is in progress in the worksheets
 below.</p>
 
-<p class="table-title"><strong>Table — scode tier assignment</strong> (Claude tiers captured from CC&nbsp;2.1.241, 2026-08-23; content unchanged since 2.1.233).</p>
+<p class="table-title"><strong>Table — scode tier assignment</strong> (Claude tiers captured from CC&nbsp;2.1.250, 2026-08-23; content unchanged since 2.1.233).</p>
 
 <table>
   <thead><tr><th>Model</th><th>scode tier</th><th>Basis</th></tr></thead>
@@ -1130,8 +1130,8 @@ block-aligned on the right, with a per-block keep/drop decision) live in the
 private repo <a href="https://github.com/sudoprivacy/scode-prompt-alignment"><code>sudoprivacy/scode-prompt-alignment</code></a>.
 That repo is <strong>access-controlled</strong> because it holds CC's verbatim
 prompts (kept off this public repo). Each worksheet is independently verified
-<strong>100% coverage on both sides</strong> against CC&nbsp;2.1.241 (CC
-re-captured byte-identical across 2.1.233→2.1.241). This replaces the earlier four analysis tables,
+<strong>100% coverage on both sides</strong> against CC&nbsp;2.1.250 (CC
+re-captured byte-identical across 2.1.233→2.1.250). This replaces the earlier four analysis tables,
 which were an exploration artifact and have been retired. The worksheets are also
 published (password-protected, comment-enabled) for review:</p>
 


### PR DESCRIPTION
Re-scan: CC 2.1.250 (content byte-identical since 2.1.233) + sudocode #476 (removed # Project context / # Runtime config, folded into # Environment context). All 4 worksheets rebuilt from current main + re-verified BOTH 100%. Docs-only.