### PR TITLE
release: v0.1.28

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "plugins",
  "runtime",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "commands",
  "runtime",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "api",
  "serde_json",
@@ -2574,7 +2574,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3869,7 +3869,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "api",
  "arboard",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "chrono",
  "dirs",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Bumps the workspace version to `0.1.28` (`rust/Cargo.toml` + `rust/Cargo.lock`), matching the shape of every prior release bump.

`cargo check --locked --workspace` is green — the lockfile is in sync.

Release notes for the GitHub Release body are drafted in `RELEASE_NOTES_v0.1.28.md` (left untracked, as prior releases keep notes in the Release body rather than in-repo).

Tagging is deliberately **not** done here — `v0.1.28` gets tagged on `main` after this merges.