### PR TITLE
fix(managed-agent): A2A reply-contract system prompt for co-hosted agents

### DIFF
--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -182,6 +182,33 @@ pub fn mailbox_sender<K: KernelSyscall + Send + Sync + 'static>(
     })
 }
 
+/// The system-prompt section that teaches a co-hosted agent the A2A reply
+/// contract it runs under, so the model addresses its reply correctly instead
+/// of guessing a recipient from the message text.
+///
+/// It is the prose counterpart of two mechanisms this module owns and MUST stay
+/// in step with them:
+/// * inbound framing — `run_loop` hands each message to the turn as
+///   `[message from <sender>]\n\n<body>`, so `<sender>` is the reply target;
+/// * the reply path — [`mailbox_sender`] wires the `send_message` tool as the
+///   ONLY way a co-hosted agent replies (writing to the sender's inbox).
+///
+/// Kept next to those two so the wording cannot drift from the framing/tool it
+/// describes. `self_id` is the agent's own name (`Mailbox::self_id`).
+#[must_use]
+pub fn cohost_a2a_prompt_section(self_id: &str) -> String {
+    format!(
+        "# Agent-to-agent messaging\n\
+         You are the agent \"{self_id}\", conversing with other agents by message. \
+         Each message you receive is shown as `[message from <sender>]` followed by \
+         its text. To reply, call the `send_message` tool with `to` set to that \
+         exact `<sender>` name — the agent that messaged you, never a word copied \
+         from the message text — and `body` set to your reply. Calling \
+         `send_message` is the only way to reply; if you do not call it you stay \
+         silent and the conversation ends."
+    )
+}
+
 /// Handle returned by [`spawn_task`].
 pub struct SpawnHandle {
     /// Shared abort signal — wired into the [`ConversationRuntime`] via
@@ -466,5 +493,19 @@ mod tests {
         assert_eq!(mb.self_id(), "scode");
         // LocalStream replies on the shared stream regardless of sender.
         assert_eq!(mb.reply_path("anyone"), "/proc/7/chat-with-me");
+    }
+
+    #[test]
+    fn cohost_prompt_teaches_reply_to_sender_via_send_message() {
+        let section = super::cohost_a2a_prompt_section("chatbot");
+        // Names the agent so the model knows its own identity …
+        assert!(section.contains("chatbot"));
+        // … names the ONLY reply path …
+        assert!(section.contains("send_message"));
+        // … mirrors the `[message from <sender>]` framing `run_loop` emits …
+        assert!(section.contains("[message from <sender>]"));
+        // … and encodes the fix: reply target is the sender, never a word
+        // lifted from the message body (the exact mistake this prevents).
+        assert!(section.contains("never a word copied"));
     }
 }

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 
 use managed_agent::{SpawnHandle as ManagedSpawnHandle, SpawnTask};
 use runtime::spawn_task::{
-    handle_send_message, mailbox_sender, AgentDescriptor, AgentState, KernelSyscall, Mailbox,
-    MailboxSender, SpawnHandle,
+    cohost_a2a_prompt_section, handle_send_message, mailbox_sender, AgentDescriptor, AgentState,
+    KernelSyscall, Mailbox, MailboxSender, SpawnHandle,
 };
 use runtime::{
     FsBackend, KernelFsBackend, PermissionMode, PermissionPolicy, SystemPromptBuilder, ToolError,
@@ -101,8 +101,14 @@ where
     // routes through the mailbox sender. --
     let tool_executor = ManagedToolExecutor { fs, send };
 
-    // -- SystemPrompt: minimal prompt for managed-agent context --
-    let system_prompt = SystemPromptBuilder::new().build();
+    // -- SystemPrompt: base managed-agent prompt + the A2A reply contract, so
+    // the co-hosted model addresses its reply to the message's `<sender>` via
+    // `send_message` instead of guessing a recipient from the message text. The
+    // contract text lives in `spawn_task` next to the `[message from …]` framing
+    // and the `send_message` reply path it describes. --
+    let system_prompt = SystemPromptBuilder::new()
+        .append_section(cohost_a2a_prompt_section(&desc.name))
+        .build();
 
     // -- PermissionPolicy: managed agents run with full access --
     // Nexus enforces permissions at the VFS layer (ReBAC +


### PR DESCRIPTION
## Problem

A co-hosted agent's system prompt carried **no** agent-to-agent guidance
(`SystemPromptBuilder::new().build()`). When a message arrived framed as
`[message from <sender>]`, the model had nothing telling it that the reply
target is `<sender>`, so it guessed a recipient from the message **body** —
observed live calling `send_message` with `to=<a word from the body>`. The
reply landed in a nonexistent inbox and the duet stalled with the co-host
apparently "silent".

This was misdiagnosed for a while as a kernel/stream bug. It is not: the
in-process `sys_read` delivers the frame, `parse_inbound` succeeds, the LLM
turn runs, and the `send_message` kernel write succeeds — the reply was just
**addressed wrong**.

## Fix

- `runtime::spawn_task::cohost_a2a_prompt_section(self_id)` — a system-prompt
  section co-located with the two mechanisms it describes so the wording can't
  drift: the `[message from <sender>]` framing `run_loop` emits, and the
  `send_message` reply path `mailbox_sender` wires. It names the agent, says
  replies go to the sender's **exact** name via `send_message`, and forbids
  copying a recipient out of the message body.
- `tools::managed_agent::spawn_managed_agent` injects it via
  `SystemPromptBuilder::append_section(...)`.

No kernel, syscall, or transport change — this is purely the co-host's prompt.

## Test

- New unit test `cohost_prompt_teaches_reply_to_sender_via_send_message`
  asserts the section names the agent, cites `send_message`, mirrors the
  `[message from <sender>]` framing, and encodes the anti-guess rule.

## Live verification (auth-on)

Standalone `scode` (operator, mTLS agent cert) → co-host (`chatbot`) duet now
round-trips under auth-on with real LLMs. The co-host reply lands in the
operator inbox, node-stamped:

```json
{"from":"chatbot","to":"operator","body":"PONG"}
```