### PR TITLE
fix(tools,config): LazyLock for seek regex + warn on extraBody parse fallback

### DIFF
--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -1375,6 +1375,7 @@ fn parse_web_search_section(root: &BTreeMap<String, JsonValue>) -> WebSearchConf
 /// `models` keys; shape validation stays in the main parser.
 fn parse_extra_bodies(content: &str) -> BTreeMap<String, serde_json::Map<String, SerdeValue>> {
     let Ok(root) = serde_json::from_str::<SerdeValue>(content) else {
+        eprintln!("warning: serde_json failed to re-parse config for extraBody extraction; extraBody values will be ignored");
         return BTreeMap::new();
     };
     let Some(models) = root.get("models").and_then(SerdeValue::as_object) else {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -3131,8 +3131,9 @@ fn seek_tool_output(
     let start_at = input.offset.unwrap_or(0);
 
     // Byte offsets of every line boundary (real or escaped), ascending.
-    let boundaries: Vec<(usize, usize)> = regex::Regex::new(r"\n|\\n")
-        .expect("static regex")
+    static NEWLINE_RE: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| regex::Regex::new(r"\n|\\n").unwrap());
+    let boundaries: Vec<(usize, usize)> = NEWLINE_RE
         .find_iter(content)
         .map(|m| (m.start(), m.end()))
         .collect();


### PR DESCRIPTION
## Summary
- **seek_tool_output** (#509): replace per-call `regex::Regex::new` with `std::sync::LazyLock` to avoid recompiling the static `\n|\\n` pattern on every invocation
- **parse_extra_bodies** (#499): emit `eprintln!` warning when `serde_json` fails to re-parse config for `extraBody` extraction, making the silent fallback observable instead of silently dropping user-configured values

## Test plan
- [x] `cargo test -p tools -p runtime` all pass
- [x] `cargo clippy` no new warnings
- [x] `cargo fmt` clean