### PR TITLE
chore(nexus-vfs): bump kernel pin to ec149759 (auth-on cross-machine federation fixes)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2300,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2362,7 +2362,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2483,7 +2483,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "a2a",
  "contracts",
@@ -2590,7 +2590,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 
 [[package]]
 name = "nexus-vfs-client"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,14 +37,14 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false, features = ["runtime-bridge"] }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false, features = ["runtime-bridge"] }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ runtime = { path = "../runtime" }
 # loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
 # crate pins (transitive `kernel` unifies). default-features = false → no
 # subprocess-host (that's the raw-ACP path, not the in-process co-host).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 regex = "1"
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Bumps the nexus-vfs pin (`kernel`, `a2a`, `lib`, `managed-agent`) from `601c2af2` → `ec149759`.

`ec149759` is nexus-vfs **#256** — two auth-on cross-machine federation fixes:
- **enroll-token** now reads the accepted-hash set **live** (a token minted against a running founder is honored without a restart).
- the founder's self-signed node cert now carries its `--advertise-addr` IP in the **SAN**, so a cross-machine joiner can validate its server cert over Tailscale (mTLS handshake was failing before).

Keeps the co-host `kernel` rev in lockstep with the nexus daemon (which pins the same rev), so `SpawnTask<Kernel>` stays one monomorphised type across the seam. Cohost crates (`tools` + `runtime`) build clean against `ec149759`.

Enables the nexus-side pin bump so the shipped cohost binary carries the federation fixes — proven live by a Win↔Mac co-host↔co-host A2A duet under mTLS.