### PR TITLE
ci: build linux-arm64 release on ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,11 @@ jobs:
       matrix:
         include:
           - name: linux-arm64
-            os: ubuntu-24.04-arm
+            # Oldest hosted arm64 runner: the arm64 binary links glibc
+            # dynamically, so the build machine's glibc is the floor the
+            # binary demands at runtime — 22.04 = glibc 2.35. (linux-x64 is
+            # static musl; its runner version does not matter.)
+            os: ubuntu-22.04-arm
             bin: scode
             package_dir: scode-linux-arm64
             archive_name: scode-linux-arm64.tar.gz


### PR DESCRIPTION
## Summary

`scode-linux-arm64` is a glibc-dynamic build, so whatever glibc the build runner carries becomes the binary's runtime floor. On `ubuntu-24.04-arm` that floor is glibc 2.39 — the binary refuses to start on Ubuntu 22.04, Debian 12, and RHEL 9-era arm64 hosts. Building on `ubuntu-22.04-arm` lowers the requirement to glibc 2.35.

`scode-linux-x64` is unchanged: it is a static musl build (verified static in the workflow), so its runner version is irrelevant.

## Test plan

- YAML parses; `ubuntu-22.04-arm` is a GitHub-hosted runner label (GA for public repos).
- Real validation is the next tag build (or a `workflow_dispatch` run): check `objdump -T scode | grep GLIBC_` on the arm64 artifact tops out at 2.35.
