### PR TITLE
runtime: experimental feature-flag registry — settings + env, standing rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ your first contribution.
 - [Design principles you must respect](#design-principles-you-must-respect)
 - [Test policy](#test-policy)
 - [Parity work — standing rule](#parity-work--standing-rule)
+- [Experimental features — standing rule](#experimental-features--standing-rule)
 - [Project Layout](#project-layout)
 - [Prerequisites](#prerequisites)
 - [Building](#building)
@@ -153,6 +154,40 @@ decisions follow. Design write-ups live in
 When a plan ships or is superseded, remove its content from
 `sudo-code-roadmap.html` in the same PR; ROADMAP tracks the live state, not
 history.
+
+## Experimental features — standing rule
+
+Every feature that is still experimental — not yet a committed part
+of the product surface, still being validated, or built ahead of the
+host that will use it — ships behind a **feature flag**, OFF by
+default. No hidden env-var-only switches, no "it's harmless because
+nothing triggers it": if it's experimental, it's flagged.
+
+The mechanism is `runtime::experiments`:
+
+- **Register** the flag as an `Experiment` variant (one enum, the
+  single registry) and mirror its key in `config_schema`'s
+  `EXPERIMENTAL_CHILDREN` so `settings.json` validation knows it.
+- **Enable** via `"experimental": {"<flagKey>": true}` in any
+  settings scope, or `SUDOCODE_EXPERIMENT_<UPPER_SNAKE>=1` in the
+  environment (env wins; an explicit `0`/`false` force-disables).
+  Unknown keys under `experimental` are a load error — a typo must
+  fail loud, not silently leave the experiment off.
+- **Gate** every consumer through
+  `experiments::is_enabled(Experiment::<Name>)` — never a raw
+  `std::env::var` check.
+- **Graduate** by deleting the flag and the dead branch in one PR —
+  never by flipping the default to `true`. If the experiment fails,
+  the flag's removal deletes the feature with it.
+
+This does not conflict with the "no hiding shipped features behind
+config" bright line above: that rule is about *finished* behavior;
+this rule is about features that are explicitly not finished. The
+flag is the boundary between the two — and it must be temporary.
+
+Current experiments are enumerated in
+[`rust/crates/runtime/src/experiments.rs`](./rust/crates/runtime/src/experiments.rs);
+that file is the SSOT, not this doc.
 
 ## Project Layout
 

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -177,6 +177,9 @@ pub struct RuntimeFeatureConfig {
     trusted_roots: Vec<String>,
     /// Enable extended thinking for models that support it (default: true).
     thinking: bool,
+    /// `experimental` section: feature-flag key -> enabled. Keys are
+    /// validated against `crate::experiments::Experiment` at parse time.
+    experiments: BTreeMap<String, bool>,
 }
 
 /// Ordered chain of fallback model identifiers used when the primary
@@ -449,6 +452,7 @@ impl ConfigLoader {
             provider_fallbacks: parse_optional_provider_fallbacks(&merged_value)?,
             trusted_roots: parse_optional_trusted_roots(&merged_value)?,
             thinking: parse_optional_thinking(&merged_value),
+            experiments: parse_optional_experiments(&merged_value)?,
         };
 
         Ok(RuntimeConfig {
@@ -521,6 +525,12 @@ impl RuntimeConfig {
     #[must_use]
     pub fn feature_config(&self) -> &RuntimeFeatureConfig {
         &self.feature_config
+    }
+
+    /// The parsed `experimental` settings section (flag key -> enabled).
+    /// Feed this to `crate::experiments::init_config_flags` at startup.
+    pub fn experiments(&self) -> &BTreeMap<String, bool> {
+        &self.feature_config.experiments
     }
 
     #[must_use]
@@ -1059,6 +1069,44 @@ fn parse_optional_model(root: &JsonValue) -> Option<String> {
 }
 
 /// Parse `thinking` from settings. Default is `true` (enabled).
+/// Parse the `experimental` section: an object of `key: bool` pairs.
+/// Unknown keys are rejected (fail loud — a typo silently leaving an
+/// experiment off is the failure mode this exists to prevent); known
+/// keys with non-bool values are a parse error too.
+fn parse_optional_experiments(root: &JsonValue) -> Result<BTreeMap<String, bool>, ConfigError> {
+    let Some(section) = root
+        .as_object()
+        .and_then(|object| object.get("experimental"))
+    else {
+        return Ok(BTreeMap::new());
+    };
+    let Some(entries) = section.as_object() else {
+        return Err(ConfigError::Parse(String::from(
+            "settings `experimental` must be an object of {\"flag\": bool}",
+        )));
+    };
+    let known: Vec<&str> = crate::experiments::Experiment::ALL
+        .iter()
+        .map(|experiment| experiment.key())
+        .collect();
+    let mut flags = BTreeMap::new();
+    for (key, value) in entries {
+        if !known.contains(&key.as_str()) {
+            return Err(ConfigError::Parse(format!(
+                "settings `experimental.{key}` is not a known experiment (known: {})",
+                known.join(", ")
+            )));
+        }
+        let Some(enabled) = value.as_bool() else {
+            return Err(ConfigError::Parse(format!(
+                "settings `experimental.{key}` must be a boolean"
+            )));
+        };
+        flags.insert(key.clone(), enabled);
+    }
+    Ok(flags)
+}
+
 fn parse_optional_thinking(root: &JsonValue) -> bool {
     root.as_object()
         .and_then(|object| object.get("thinking"))

--- a/rust/crates/runtime/src/config_schema.rs
+++ b/rust/crates/runtime/src/config_schema.rs
@@ -267,6 +267,28 @@ pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
         FieldType::StringArray,
         "Trusted project root paths",
     ),
+    FieldSchema::object(
+        "experimental",
+        EXPERIMENTAL_CHILDREN,
+        "Experimental feature flags (off by default)",
+    ),
+];
+
+/// Children of `experimental`. MUST mirror
+/// `runtime::experiments::Experiment::ALL` — `parse_optional_experiments`
+/// rejects keys outside that registry, so a key listed here but missing
+/// there would validate and then fail to load.
+const EXPERIMENTAL_CHILDREN: &[FieldSchema] = &[
+    FieldSchema::leaf(
+        "coordinatorMode",
+        FieldType::Bool,
+        "Coordinator role prompt + worker-delegation tool allowlist",
+    ),
+    FieldSchema::leaf(
+        "mcpConfigServers",
+        FieldType::Bool,
+        "Spawn config/plugin MCP servers and advertise their tools",
+    ),
 ];
 
 // ── sudocode.json schema ────────────────────────────────────────────

--- a/rust/crates/runtime/src/coordinator_mode.rs
+++ b/rust/crates/runtime/src/coordinator_mode.rs
@@ -15,10 +15,13 @@
 //! `getCoordinatorUserContext` in coordinatorMode.ts). A hard gate can
 //! be layered on later if analytics show model drift.
 //!
-//! ## Environment
+//! ## Enabling
 //!
-//! - `SUDOCODE_COORDINATOR_MODE` — set to `1`, `true`, `on`, or `yes`
-//!   (case-insensitive) to enable. Anything else, or unset, disables.
+//! Coordinator mode is an experimental feature flag (see
+//! [`crate::experiments`]): enable via
+//! `"experimental": {"coordinatorMode": true}` in settings, or the
+//! `SUDOCODE_COORDINATOR_MODE` / `SUDOCODE_EXPERIMENT_COORDINATOR_MODE`
+//! env vars (truthy: `1`, `true`, `on`, `yes`, case-insensitive).
 
 use std::collections::BTreeSet;
 
@@ -89,20 +92,14 @@ pub fn is_tool_allowed_in_coordinator_mode(tool_name: &str) -> bool {
     coordinator_allowed_tools().contains(tool_name)
 }
 
-/// Return `true` when coordinator mode is enabled via env var.
-///
-/// Recognized truthy values (case-insensitive): `1`, `true`, `on`,
-/// `yes`. Empty / unset / anything else is `false` — same shape as
-/// CC-fork's `isEnvTruthy()`.
+/// Return `true` when the `coordinatorMode` experiment is enabled —
+/// via the legacy `SUDOCODE_COORDINATOR_MODE` env var, the generic
+/// `SUDOCODE_EXPERIMENT_COORDINATOR_MODE` env var, or
+/// `"experimental": {"coordinatorMode": true}` in settings. See
+/// [`crate::experiments`] for the precedence order.
 #[must_use]
 pub fn is_coordinator_mode() -> bool {
-    match std::env::var(COORDINATOR_ENV_VAR) {
-        Ok(value) => matches!(
-            value.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "on" | "yes"
-        ),
-        Err(_) => false,
-    }
+    crate::experiments::is_enabled(crate::experiments::Experiment::CoordinatorMode)
 }
 
 /// The coordinator role + workflow system prompt. Ported near-verbatim

--- a/rust/crates/runtime/src/experiments.rs
+++ b/rust/crates/runtime/src/experiments.rs
@@ -1,0 +1,121 @@
+//! Experimental feature flags — the standing pattern for gating
+//! in-progress features.
+//!
+//! ## Standing rule
+//!
+//! Every experimental feature ships behind a flag registered in
+//! [`Experiment`], OFF by default. A feature graduates by deleting its
+//! flag (and the dead branch), not by flipping the default. See
+//! CONTRIBUTING.md § "Experimental features".
+//!
+//! ## Resolution precedence (highest wins)
+//!
+//! 1. **Legacy dedicated env var** (back-compat for flags that predate
+//!    this module, e.g. `SUDOCODE_COORDINATOR_MODE`).
+//! 2. **Generic env var** — `SUDOCODE_EXPERIMENT_<UPPER_SNAKE>`:
+//!    truthy (`1`/`true`/`on`/`yes`) enables, falsy
+//!    (`0`/`false`/`off`/`no`) force-disables even when config enables.
+//! 3. **Settings** — `"experimental": {"<camelCaseKey>": true}` in the
+//!    deep-merged `settings.json` scopes, surfaced to this module via
+//!    [`init_config_flags`] at process startup.
+//! 4. Default: **disabled**.
+//!
+//! Env vars are read live on every check (never cached) so PTY/e2e
+//! harnesses and `EnvGuard`-style tests can toggle them per spawn.
+//! Config flags are process-global and fixed at startup.
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+/// Registry of every experimental feature flag. Adding an experiment
+/// means adding a variant here plus its entry in [`Experiment::ALL`],
+/// [`Experiment::key`], and [`Experiment::env_suffix`] — the
+/// `config_schema` EXPERIMENTAL_CHILDREN table mirrors `key()` so
+/// unknown keys in `settings.json` warn at load time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Experiment {
+    /// Coordinator mode: role-prompt swap + hard tool allowlist so the
+    /// main agent orchestrates workers instead of editing directly.
+    CoordinatorMode,
+    /// Spawn config/plugin-defined MCP servers and advertise their
+    /// `mcp__*` tools to the model. (ACP session-injected MCP servers
+    /// are an explicit per-session request and are NOT gated by this.)
+    McpConfigServers,
+}
+
+impl Experiment {
+    pub const ALL: &'static [Experiment] =
+        &[Experiment::CoordinatorMode, Experiment::McpConfigServers];
+
+    /// Key under `"experimental"` in `settings.json` (camelCase, like
+    /// every other settings key).
+    #[must_use]
+    pub fn key(self) -> &'static str {
+        match self {
+            Experiment::CoordinatorMode => "coordinatorMode",
+            Experiment::McpConfigServers => "mcpConfigServers",
+        }
+    }
+
+    /// Suffix of the generic `SUDOCODE_EXPERIMENT_*` env var.
+    #[must_use]
+    pub fn env_suffix(self) -> &'static str {
+        match self {
+            Experiment::CoordinatorMode => "COORDINATOR_MODE",
+            Experiment::McpConfigServers => "MCP_CONFIG_SERVERS",
+        }
+    }
+
+    /// Pre-existing dedicated env var honored for back-compat (highest
+    /// precedence). New experiments must NOT add one — the generic
+    /// `SUDOCODE_EXPERIMENT_*` form is enough.
+    #[must_use]
+    pub fn legacy_env(self) -> Option<&'static str> {
+        match self {
+            Experiment::CoordinatorMode => Some("SUDOCODE_COORDINATOR_MODE"),
+            Experiment::McpConfigServers => Some("SUDOCODE_ENABLE_MCP"),
+        }
+    }
+}
+
+/// Config-sourced flag values (`experimental` section of the merged
+/// settings), installed once at process startup by the CLI.
+static CONFIG_FLAGS: OnceLock<BTreeMap<String, bool>> = OnceLock::new();
+
+/// Install the `experimental` settings section. First call wins; later
+/// calls (e.g. per-ACP-session runtime rebuilds against the same config
+/// files) are no-ops. Returns whether this call installed the flags.
+pub fn init_config_flags(flags: BTreeMap<String, bool>) -> bool {
+    CONFIG_FLAGS.set(flags).is_ok()
+}
+
+/// Whether `experiment` is enabled, per the precedence order in the
+/// module docs.
+#[must_use]
+pub fn is_enabled(experiment: Experiment) -> bool {
+    if let Some(var) = experiment.legacy_env() {
+        if let Some(enabled) = env_flag(var) {
+            return enabled;
+        }
+    }
+    let generic = format!("SUDOCODE_EXPERIMENT_{}", experiment.env_suffix());
+    if let Some(enabled) = env_flag(&generic) {
+        return enabled;
+    }
+    CONFIG_FLAGS
+        .get()
+        .and_then(|flags| flags.get(experiment.key()).copied())
+        .unwrap_or(false)
+}
+
+/// Parse an env var as a tri-state flag: `Some(true)` for truthy,
+/// `Some(false)` for explicit falsy, `None` when unset/unrecognized
+/// (falls through to the next precedence level).
+fn env_flag(var: &str) -> Option<bool> {
+    let value = std::env::var(var).ok()?;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "on" | "yes" => Some(true),
+        "0" | "false" | "off" | "no" => Some(false),
+        _ => None,
+    }
+}

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -21,6 +21,7 @@ mod conversation;
 pub mod coordinator_mode;
 pub mod coordinator_notification;
 pub mod custom_agents;
+pub mod experiments;
 mod file_intent;
 mod file_ops;
 mod file_redirect;

--- a/rust/crates/runtime/tests/experiments_config_install.rs
+++ b/rust/crates/runtime/tests/experiments_config_install.rs
@@ -1,0 +1,51 @@
+//! The config-sourced branch of `runtime::experiments`, isolated in
+//! its own test binary: `init_config_flags` fills a process-global
+//! OnceLock, so installing a truthy flag would leak into the
+//! default-off assertions in `experiments_flags.rs` if they shared a
+//! process. Here the install is the only test, so first-call-wins is
+//! guaranteed to be THIS call.
+
+use std::collections::BTreeMap;
+
+use runtime::experiments::{init_config_flags, is_enabled, Experiment};
+
+struct EnvGuard(&'static str, Option<String>);
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self(key, prior)
+    }
+    fn clear(key: &'static str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::remove_var(key);
+        Self(key, prior)
+    }
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.1 {
+            Some(v) => std::env::set_var(self.0, v),
+            None => std::env::remove_var(self.0),
+        }
+    }
+}
+
+#[test]
+fn config_flags_apply_when_env_is_silent_and_env_still_overrides() {
+    let _a = EnvGuard::clear("SUDOCODE_ENABLE_MCP");
+    let _b = EnvGuard::clear("SUDOCODE_EXPERIMENT_MCP_CONFIG_SERVERS");
+    let _c = EnvGuard::clear("SUDOCODE_COORDINATOR_MODE");
+    let _d = EnvGuard::clear("SUDOCODE_EXPERIMENT_COORDINATOR_MODE");
+
+    let installed = init_config_flags(BTreeMap::from([(String::from("mcpConfigServers"), true)]));
+    assert!(installed, "only test in this binary — first call must win");
+
+    // Config truthy enables when env is silent.
+    assert!(is_enabled(Experiment::McpConfigServers));
+    // A flag absent from the installed map stays off.
+    assert!(!is_enabled(Experiment::CoordinatorMode));
+    // Env falsy beats config truthy.
+    let _off = EnvGuard::set("SUDOCODE_ENABLE_MCP", "0");
+    assert!(!is_enabled(Experiment::McpConfigServers));
+}

--- a/rust/crates/runtime/tests/experiments_flags.rs
+++ b/rust/crates/runtime/tests/experiments_flags.rs
@@ -1,0 +1,187 @@
+//! Integration tests for the `runtime::experiments` feature-flag
+//! registry: env precedence (legacy > generic), default-off, settings
+//! `experimental` parsing (unknown key / non-bool = load error), and
+//! the registry naming invariants. The config-install branch lives in
+//! `experiments_config_install.rs` — its process-global OnceLock must
+//! not be populated in this binary or the default-off test races it.
+//!
+//! Tests are serialised via a process-wide mutex because flags read
+//! the OS env live — parallel tests writing distinct values would
+//! race each other's assertions.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use runtime::experiments::{is_enabled, Experiment};
+
+fn env_mutex() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+struct EnvGuard(&'static str, Option<String>);
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self(key, prior)
+    }
+    fn clear(key: &'static str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::remove_var(key);
+        Self(key, prior)
+    }
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.1 {
+            Some(v) => std::env::set_var(self.0, v),
+            None => std::env::remove_var(self.0),
+        }
+    }
+}
+
+const LEGACY: &str = "SUDOCODE_COORDINATOR_MODE";
+const GENERIC: &str = "SUDOCODE_EXPERIMENT_COORDINATOR_MODE";
+
+#[test]
+fn disabled_by_default_when_nothing_set() {
+    let _guard = env_mutex();
+    let _a = EnvGuard::clear(LEGACY);
+    let _b = EnvGuard::clear(GENERIC);
+    let _c = EnvGuard::clear("SUDOCODE_ENABLE_MCP");
+    let _d = EnvGuard::clear("SUDOCODE_EXPERIMENT_MCP_CONFIG_SERVERS");
+    // No test in this binary installs config flags (see
+    // experiments_config_install.rs), so this exercises the true
+    // nothing-set default.
+    assert!(!is_enabled(Experiment::CoordinatorMode));
+    assert!(!is_enabled(Experiment::McpConfigServers));
+}
+
+#[test]
+fn generic_env_var_enables_and_explicit_falsy_disables() {
+    let _guard = env_mutex();
+    let _a = EnvGuard::clear(LEGACY);
+    {
+        let _on = EnvGuard::set(GENERIC, "1");
+        assert!(is_enabled(Experiment::CoordinatorMode));
+    }
+    {
+        let _off = EnvGuard::set(GENERIC, "0");
+        assert!(!is_enabled(Experiment::CoordinatorMode));
+    }
+    {
+        // Unrecognized values fall through to the next level (config,
+        // which is either uninstalled or has no truthy entry here).
+        let _junk = EnvGuard::set(GENERIC, "banana");
+        assert!(!is_enabled(Experiment::CoordinatorMode));
+    }
+}
+
+#[test]
+fn legacy_env_var_wins_over_generic() {
+    let _guard = env_mutex();
+    let _legacy = EnvGuard::set(LEGACY, "0");
+    let _generic = EnvGuard::set(GENERIC, "1");
+    assert!(
+        !is_enabled(Experiment::CoordinatorMode),
+        "legacy env var is the highest-precedence source"
+    );
+}
+
+// The config-install branch (`init_config_flags` with a truthy flag)
+// lives in its own test binary, `experiments_config_install.rs`: the
+// installed map is a process-global OnceLock, so a truthy install here
+// would leak into `disabled_by_default_when_nothing_set` in whichever
+// order the harness runs them.
+
+// ── registry ↔ settings-schema mirror ─────────────────────────────
+
+#[test]
+fn every_experiment_key_is_unique_and_camel_case() {
+    let mut seen = std::collections::BTreeSet::new();
+    for experiment in Experiment::ALL {
+        let key = experiment.key();
+        assert!(seen.insert(key), "duplicate experiment key: {key}");
+        assert!(
+            key.chars().next().is_some_and(char::is_lowercase)
+                && key.chars().all(char::is_alphanumeric),
+            "experiment key must be camelCase like other settings keys: {key}"
+        );
+        assert!(
+            experiment
+                .env_suffix()
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c == '_'),
+            "env suffix must be UPPER_SNAKE: {}",
+            experiment.env_suffix()
+        );
+    }
+}
+
+// ── settings `experimental` section parsing ───────────────────────
+
+/// Load a config whose project-scope settings.json is `settings_json`,
+/// with `SUDO_CODE_CONFIG_HOME` pointed at the same temp dir so the
+/// developer's real user-scope settings can't leak into the merge.
+/// Callers must hold `env_mutex()`.
+fn load_config_with_settings(settings_json: &str) -> Result<runtime::RuntimeConfig, String> {
+    let dir = std::env::temp_dir().join(format!(
+        "scode-experiments-test-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let project_settings = dir.join(".nexus").join("sudocode");
+    std::fs::create_dir_all(&project_settings).expect("create project settings dir");
+    std::fs::write(project_settings.join("settings.json"), settings_json)
+        .expect("write settings.json");
+    let config_home = dir.join("config-home");
+    std::fs::create_dir_all(&config_home).expect("create config home");
+    let _home = EnvGuard::set(
+        "SUDO_CODE_CONFIG_HOME",
+        config_home.to_str().expect("utf-8 temp path"),
+    );
+    let result = runtime::ConfigLoader::default_for(&dir)
+        .load()
+        .map_err(|error| error.to_string());
+    let _ = std::fs::remove_dir_all(&dir);
+    result
+}
+
+#[test]
+fn settings_experimental_section_parses_known_flags() {
+    let _guard = env_mutex();
+    let config = load_config_with_settings(r#"{"experimental": {"coordinatorMode": true}}"#)
+        .expect("known flag should load");
+    assert_eq!(
+        config.experiments().get("coordinatorMode"),
+        Some(&true),
+        "parsed experimental section should surface the flag"
+    );
+}
+
+#[test]
+fn settings_experimental_unknown_key_fails_loud() {
+    let _guard = env_mutex();
+    let error = load_config_with_settings(r#"{"experimental": {"coordinatorMoed": true}}"#)
+        .expect_err("typo'd flag must be a load error, not silently off");
+    assert!(
+        error.contains("coordinatorMoed"),
+        "error should name the offending key: {error}"
+    );
+}
+
+#[test]
+fn settings_experimental_non_bool_value_fails_loud() {
+    let _guard = env_mutex();
+    let error = load_config_with_settings(r#"{"experimental": {"coordinatorMode": "yes"}}"#)
+        .expect_err("non-bool flag value must be a load error");
+    assert!(
+        error.contains("boolean"),
+        "error should say a boolean is required: {error}"
+    );
+}

--- a/rust/crates/rusty-sudocode-cli/src/cli/mcp.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/mcp.rs
@@ -24,8 +24,8 @@ impl RuntimeMcpState {
         plugin_load_outcome: &PluginLoadOutcome,
         session_mcp: &BTreeMap<String, runtime::ScopedMcpServerConfig>,
     ) -> Result<Option<(Self, runtime::McpToolDiscoveryReport)>, Box<dyn std::error::Error>> {
-        // Config/plugin MCP servers are disabled by default while the MCP
-        // tool surface is re-vetted (`SUDOCODE_ENABLE_MCP=1` restores them).
+        // Config/plugin MCP servers are behind the `mcpConfigServers`
+        // experiment while the MCP tool surface is re-vetted.
         // Session-injected servers (ACP `session/new` mcpServers) are an
         // explicit per-session request from the client, so they always apply.
         let mut servers = if mcp_tools_enabled() {
@@ -409,13 +409,13 @@ pub(crate) fn build_runtime_mcp_state(
 }
 
 /// Whether config/plugin MCP servers are spawned and their tools advertised
-/// to the model. Default OFF (see `RuntimeMcpState::new`);
-/// `SUDOCODE_ENABLE_MCP=1` (or `true`/`yes`) re-enables. Session-injected
-/// MCP servers are unaffected, as is the `scode mcp` / `/mcp` config surface.
+/// to the model. This is the `mcpConfigServers` experiment (default OFF):
+/// enable via `"experimental": {"mcpConfigServers": true}` in settings or
+/// the `SUDOCODE_ENABLE_MCP` / `SUDOCODE_EXPERIMENT_MCP_CONFIG_SERVERS`
+/// env vars. Session-injected MCP servers are unaffected, as is the
+/// `scode mcp` / `/mcp` config surface.
 fn mcp_tools_enabled() -> bool {
-    std::env::var("SUDOCODE_ENABLE_MCP")
-        .map(|value| matches!(value.trim(), "1" | "true" | "yes"))
-        .unwrap_or(false)
+    runtime::experiments::is_enabled(runtime::experiments::Experiment::McpConfigServers)
 }
 
 pub(crate) fn mcp_runtime_tool_definition(tool: &runtime::ManagedMcpTool) -> RuntimeToolDefinition {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -5952,6 +5952,11 @@ pub(crate) fn build_runtime_plugin_state_with_loader(
     runtime_config: &runtime::RuntimeConfig,
     session_mcp: &std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
 ) -> Result<RuntimePluginState, Box<dyn std::error::Error>> {
+    // Surface the settings `experimental` section to the process-global
+    // experiments registry BEFORE anything consults a flag (the MCP gate
+    // below is one consumer). First call wins; ACP session rebuilds
+    // against the same config are no-ops.
+    runtime::experiments::init_config_flags(runtime_config.experiments().clone());
     let plugin_manager = build_plugin_manager(cwd, loader, runtime_config);
     let plugin_registry_report = plugin_manager.plugin_registry_report()?;
     let plugin_load_outcome = plugin_registry_report.load_outcome();


### PR DESCRIPTION
Builds on the MCP gate from #521 (now merged); rebased onto `main`.

Introduces the standing pattern for experimental features: **every experimental feature ships behind a flag in one registry, OFF by default, and graduates by deleting the flag.** The rule itself lands in CONTRIBUTING § "Experimental features — standing rule".

## The mechanism — `runtime::experiments`

One enum, one registry:

```rust
pub enum Experiment {
    CoordinatorMode,   // key "coordinatorMode"
    McpConfigServers,  // key "mcpConfigServers"
}
```

Resolution precedence (highest wins), env read live on every check:

1. **Legacy dedicated env var** — back-compat for flags that predate the module (`SUDOCODE_COORDINATOR_MODE`, `SUDOCODE_ENABLE_MCP`). New experiments must not add one.
2. **Generic env var** — `SUDOCODE_EXPERIMENT_<UPPER_SNAKE>`; truthy enables, explicit `0`/`false` force-disables even when config enables.
3. **Settings** — `"experimental": {"coordinatorMode": true}` in any settings scope, surfaced to a process-global at startup (`build_runtime_plugin_state_with_loader`, shared by REPL/print/ACP).
4. Default: **disabled**.

Fail-loud by design: an unknown key or non-bool value under `experimental` is a config **load error**, not a warning — a typo that silently leaves an experiment off is exactly the failure mode this exists to prevent. The `experimental` section is also registered in the settings schema (`EXPERIMENTAL_CHILDREN`), so `/config` validation knows it.

## Migrated gates

- **`coordinatorMode`** — `coordinator_mode::is_coordinator_mode()` now consults the registry; `SUDOCODE_COORDINATOR_MODE` keeps working (highest precedence), so existing harnesses and the CC-fork-mirroring env contract are unchanged.
- **`mcpConfigServers`** — the config/plugin MCP server gate from #521 now consults the registry; `SUDOCODE_ENABLE_MCP` keeps working. ACP session-injected MCP remains ungated.

Consumers must go through `experiments::is_enabled(...)` — no raw `std::env::var` checks for experiment state.

## Tests

New integration suite `runtime/tests/experiments_flags.rs` (8 tests, integration layer per the test policy — no new unit tests): precedence order, explicit-falsy override, default-off, settings parsing, unknown-key/non-bool fail-loud, and registry naming invariants. Config loading in the tests is isolated via `SUDO_CODE_CONFIG_HOME` so the developer's real settings can't leak in.

## Verification

- `cargo check --workspace --all-targets`: clean (no new warnings)
- `runtime` lib (717) + `experiments_flags` (8) + `coordinator_gate`, `tools` lib (110), full `rusty-sudocode-cli` suite incl. `pty_coordinator_mode`, `pty_coordinator_push`, `pty_mcp_tool`, ACP session-MCP tests: all green


