### PR TITLE
runtime: stop faking HOME/TMPDIR in the no-sandbox bash fallback

### DIFF
--- a/rust/crates/runtime/src/bash.rs
+++ b/rust/crates/runtime/src/bash.rs
@@ -540,11 +540,10 @@ fn prepare_command(
     sandbox_status: &SandboxStatus,
     create_dirs: bool,
 ) -> Command {
-    if create_dirs {
-        prepare_sandbox_dirs(cwd);
-    }
-
     if let Some(launcher) = build_linux_sandbox_command(command, cwd, sandbox_status) {
+        if create_dirs {
+            prepare_sandbox_dirs(cwd);
+        }
         let mut prepared = Command::new(launcher.program);
         prepared.args(launcher.args);
         prepared.current_dir(cwd);
@@ -552,12 +551,14 @@ fn prepare_command(
         return prepared;
     }
 
+    // Fallback path: no real sandbox is available (always the case off
+    // Linux — `build_linux_sandbox_command` is namespace-based). HOME and
+    // TMPDIR must stay untouched here: remapping them provides zero
+    // isolation while breaking every external tool that resolves `~`
+    // (auth configs, keychains, CLIs like `suh`). Only the real Linux
+    // launcher above redirects HOME, via `launcher.env`.
     let mut prepared = Command::new("sh");
     prepared.arg("-lc").arg(command).current_dir(cwd);
-    if sandbox_status.filesystem_active {
-        prepared.env("HOME", cwd.join(".sandbox-home"));
-        prepared.env("TMPDIR", cwd.join(".sandbox-tmp"));
-    }
     prepared
 }
 
@@ -567,23 +568,19 @@ fn prepare_tokio_command(
     sandbox_status: &SandboxStatus,
     create_dirs: bool,
 ) -> TokioCommand {
-    if create_dirs {
-        prepare_sandbox_dirs(cwd);
-    }
-
     let mut prepared =
         if let Some(launcher) = build_linux_sandbox_command(command, cwd, sandbox_status) {
+            if create_dirs {
+                prepare_sandbox_dirs(cwd);
+            }
             let mut cmd = TokioCommand::new(launcher.program);
             cmd.args(launcher.args);
             cmd.envs(launcher.env);
             cmd
         } else {
+            // No real sandbox: leave HOME/TMPDIR alone (see prepare_command).
             let mut cmd = TokioCommand::new("sh");
             cmd.arg("-lc").arg(command);
-            if sandbox_status.filesystem_active {
-                cmd.env("HOME", cwd.join(".sandbox-home"));
-                cmd.env("TMPDIR", cwd.join(".sandbox-tmp"));
-            }
             cmd
         };
 


### PR DESCRIPTION
On macOS (and any host where the Linux namespace sandbox is unavailable), the bash tool's `sh -lc` fallback remapped `HOME`/`TMPDIR` to `<cwd>/.sandbox-home` whenever `sandbox_status.filesystem_active` was set. But `filesystem_active` only means `enabled && filesystem_mode != off` — it says nothing about whether any real isolation exists (`scode sandbox` on macOS: `Supported false / Active false / Filesystem active true`). The result was isolation theater: zero actual sandboxing, while every external CLI that resolves `~` broke — auth configs, keychains, e.g. `suh` reading `~/.suh/wx/config.json`.

## Fix

The fallback branch (in both `prepare_command` and `prepare_tokio_command`) no longer touches `HOME`/`TMPDIR`. Only the real Linux launcher path redirects `HOME`, via `launcher.env` — that path is unchanged. `.sandbox-home`/`.sandbox-tmp` directories are now also only created when that launcher actually runs, so non-Linux workspaces stop accumulating empty sandbox dirs on every bash call.

## Verification

- macOS end-to-end, debug binary: `scode --print --permission-mode danger-full-access 'run: echo HOME=$HOME'` now prints the real `$HOME` (`/Users/...`); before the fix it printed `<cwd>/.sandbox-home`.
- `cargo fmt --check` clean; no new clippy warnings in the touched code.
- `runtime` lib (717) + integration suites, `pty_bash_execution`: all green. No existing test asserted the remap behavior.
