### PR TITLE
chore(nexus-vfs): bump pin to 2cc85ca7 (hostname-advertise opt-out)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2372,7 +2372,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2493,7 +2493,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "a2a",
  "contracts",
@@ -2600,7 +2600,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 
 [[package]]
 name = "nexus-vfs-client"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,14 +37,14 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false, features = ["runtime-bridge"] }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false, features = ["runtime-bridge"] }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ runtime = { path = "../runtime" }
 # loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
 # crate pins (transitive `kernel` unifies). default-features = false → no
 # subprocess-host (that's the raw-ACP path, not the in-process co-host).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 regex = "1"
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Re-pins nexus-vfs (kernel/a2a/lib/managed-agent) ec149759 → 2cc85ca7 (nexus-vfs #257: NEXUS_ALLOW_HOSTNAME_ADVERTISE opt-out for Docker/k8s federation). Keeps the co-host kernel in lockstep with the nexus daemon; cohost crates build clean.