### PR TITLE
feat(a2a): standalone scode receiver waits on the blocking DT_STREAM tail (event-driven, not sleep-poll)

### DIFF
--- a/rust/crates/nexus-vfs-client/src/lib.rs
+++ b/rust/crates/nexus-vfs-client/src/lib.rs
@@ -45,11 +45,14 @@ enum VfsOp {
         auth_token: String,
         resp: mpsc::SyncSender<io::Result<u64>>,
     },
-    /// Non-blocking read of a DT_STREAM at `offset`; returns
-    /// `(data, next_offset, eof)`.
+    /// Read a DT_STREAM at `offset`; returns `(data, next_offset, eof)`.
+    /// When `blocking`, the server parks up to `timeout_ms` waiting for the
+    /// next frame (returning `eof` on timeout) — the event-driven mailbox tail.
     StreamReadAt {
         path: String,
         offset: u64,
+        blocking: bool,
+        timeout_ms: u64,
         auth_token: String,
         resp: mpsc::SyncSender<io::Result<(Vec<u8>, u64, bool)>>,
     },
@@ -160,164 +163,178 @@ impl NexusVfsClient {
                                 .connect_lazy()
                         }
                     };
-                    let mut client = NexusVfsServiceClient::new(ch);
+                    let client = NexusVfsServiceClient::new(ch);
                     while let Some(op) = rx.recv().await {
-                        match op {
-                            VfsOp::Read {
-                                path,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .read(ReadRequest {
-                                        path,
-                                        auth_token,
-                                        content_id: String::new(),
-                                        timeout_ms: 0,
-                                        offset: 0,
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.error_payload))
-                                    } else {
-                                        Ok(r.content)
-                                    }
-                                }));
+                        // Each op runs on its own task: a long op (a blocking
+                        // stream-tail read) must not block the others on this
+                        // connection. The tonic client clones cheaply and
+                        // multiplexes concurrent requests over the one HTTP/2
+                        // channel, so a receiver parked on the tail can't
+                        // starve the send half. Single-caller ordering is
+                        // unchanged — every sync method blocks on its reply
+                        // channel, so a caller can't issue its next op until
+                        // this one returns; only cross-thread use concurs.
+                        let mut client = client.clone();
+                        tokio::spawn(async move {
+                            match op {
+                                VfsOp::Read {
+                                    path,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .read(ReadRequest {
+                                            path,
+                                            auth_token,
+                                            content_id: String::new(),
+                                            timeout_ms: 0,
+                                            offset: 0,
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.error_payload))
+                                        } else {
+                                            Ok(r.content)
+                                        }
+                                    }));
+                                }
+                                VfsOp::Write {
+                                    path,
+                                    content,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .write(WriteRequest {
+                                            path,
+                                            content,
+                                            auth_token,
+                                            content_id: String::new(),
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.error_payload))
+                                        } else {
+                                            Ok(())
+                                        }
+                                    }));
+                                }
+                                VfsOp::Delete {
+                                    path,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .delete(DeleteRequest {
+                                            path,
+                                            auth_token,
+                                            recursive: false,
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.error_payload))
+                                        } else {
+                                            Ok(())
+                                        }
+                                    }));
+                                }
+                                VfsOp::Call {
+                                    method,
+                                    payload,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .call(CallRequest {
+                                            method,
+                                            payload,
+                                            auth_token,
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.payload))
+                                        } else {
+                                            Ok(r.payload)
+                                        }
+                                    }));
+                                }
+                                VfsOp::StreamWrite {
+                                    path,
+                                    data,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .stream_write_nowait(StreamWriteRequest {
+                                            path,
+                                            data,
+                                            auth_token,
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.error_payload))
+                                        } else {
+                                            Ok(r.offset)
+                                        }
+                                    }));
+                                }
+                                VfsOp::StreamReadAt {
+                                    path,
+                                    offset,
+                                    blocking,
+                                    timeout_ms,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .stream_read_at(StreamReadAtRequest {
+                                            path,
+                                            offset,
+                                            blocking,
+                                            timeout_ms,
+                                            auth_token,
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.error_payload))
+                                        } else {
+                                            Ok((r.data, r.next_offset, r.eof))
+                                        }
+                                    }));
+                                }
+                                VfsOp::EnsureStream {
+                                    path,
+                                    io_profile,
+                                    capacity,
+                                    auth_token,
+                                    resp,
+                                } => {
+                                    let r = client
+                                        .setattr(SetattrRequest {
+                                            path,
+                                            auth_token,
+                                            entry_type: DT_STREAM,
+                                            io_profile,
+                                            capacity,
+                                            ..Default::default()
+                                        })
+                                        .await;
+                                    let _ = resp.send(grpc_result(r, |r| {
+                                        if r.is_error {
+                                            Err(vfs_err(&r.error_payload))
+                                        } else {
+                                            Ok(r.created)
+                                        }
+                                    }));
+                                }
                             }
-                            VfsOp::Write {
-                                path,
-                                content,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .write(WriteRequest {
-                                        path,
-                                        content,
-                                        auth_token,
-                                        content_id: String::new(),
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.error_payload))
-                                    } else {
-                                        Ok(())
-                                    }
-                                }));
-                            }
-                            VfsOp::Delete {
-                                path,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .delete(DeleteRequest {
-                                        path,
-                                        auth_token,
-                                        recursive: false,
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.error_payload))
-                                    } else {
-                                        Ok(())
-                                    }
-                                }));
-                            }
-                            VfsOp::Call {
-                                method,
-                                payload,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .call(CallRequest {
-                                        method,
-                                        payload,
-                                        auth_token,
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.payload))
-                                    } else {
-                                        Ok(r.payload)
-                                    }
-                                }));
-                            }
-                            VfsOp::StreamWrite {
-                                path,
-                                data,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .stream_write_nowait(StreamWriteRequest {
-                                        path,
-                                        data,
-                                        auth_token,
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.error_payload))
-                                    } else {
-                                        Ok(r.offset)
-                                    }
-                                }));
-                            }
-                            VfsOp::StreamReadAt {
-                                path,
-                                offset,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .stream_read_at(StreamReadAtRequest {
-                                        path,
-                                        offset,
-                                        blocking: false,
-                                        timeout_ms: 0,
-                                        auth_token,
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.error_payload))
-                                    } else {
-                                        Ok((r.data, r.next_offset, r.eof))
-                                    }
-                                }));
-                            }
-                            VfsOp::EnsureStream {
-                                path,
-                                io_profile,
-                                capacity,
-                                auth_token,
-                                resp,
-                            } => {
-                                let r = client
-                                    .setattr(SetattrRequest {
-                                        path,
-                                        auth_token,
-                                        entry_type: DT_STREAM,
-                                        io_profile,
-                                        capacity,
-                                        ..Default::default()
-                                    })
-                                    .await;
-                                let _ = resp.send(grpc_result(r, |r| {
-                                    if r.is_error {
-                                        Err(vfs_err(&r.error_payload))
-                                    } else {
-                                        Ok(r.created)
-                                    }
-                                }));
-                            }
-                        }
+                        });
                     }
                 });
             })
@@ -384,10 +401,18 @@ impl NexusVfsClient {
     /// `(data, next_offset, eof)` — `eof == true` means no frame was
     /// available at `offset` yet. This is the A2A inbox POLL path (advance
     /// the caller's cursor to `next_offset` after each delivered frame).
+    /// Read one DT_STREAM frame at `offset`, returning `(data, next_offset,
+    /// eof)`. When `blocking`, the server parks up to `timeout_ms` for the next
+    /// frame and returns `eof=true` (empty) on timeout — the event-driven
+    /// mailbox tail (`read_at_blocking`), woken sub-millisecond by any write to
+    /// `path` (node-local inline or a replicated peer write). Pass
+    /// `blocking=false, timeout_ms=0` for a plain non-blocking drain.
     pub fn stream_read_at(
         &self,
         path: &str,
         offset: u64,
+        blocking: bool,
+        timeout_ms: u64,
         auth_token: &str,
     ) -> io::Result<(Vec<u8>, u64, bool)> {
         let (resp_tx, resp_rx) = mpsc::sync_channel(1);
@@ -395,6 +420,8 @@ impl NexusVfsClient {
             .send(VfsOp::StreamReadAt {
                 path: path.to_owned(),
                 offset,
+                blocking,
+                timeout_ms,
                 auth_token: auth_token.to_owned(),
                 resp: resp_tx,
             })

--- a/rust/crates/runtime/src/nexus_mailbox.rs
+++ b/rust/crates/runtime/src/nexus_mailbox.rs
@@ -260,13 +260,28 @@ pub struct Inbound {
     pub body: String,
 }
 
-/// Drain every frame in `self_agent`'s inbox from `cursor` forward
-/// (non-blocking — stops at the first `eof`). Returns the new inbound
-/// messages and the advanced cursor to persist for the next poll.
+/// Wait for and drain new frames in `self_agent`'s inbox from `cursor` forward.
 ///
-/// Skips our OWN writes (`from == self_agent`) so a shared read/write stream
-/// never echoes to us, and skips senderless / empty-body frames — the same
-/// filter the co-host loop applies in `parse_inbound`.
+/// `block_ms == 0` is a pure non-blocking drain (seek-to-tail / one-shot
+/// collect). `block_ms > 0` makes the FIRST read a blocking tail read: the
+/// server parks up to `block_ms` on the DT_STREAM's per-path condvar and wakes
+/// sub-millisecond on the next write (node-local or a replicated peer), so an
+/// idle receiver costs one parked RPC rather than a busy `sleep` loop. Once the
+/// first frame arrives the remaining buffered frames are drained non-blocking,
+/// so a burst surfaces in one call.
+///
+/// Why blocking `read_at_blocking` and not `sys_watch`/`Watch`: for the WAL
+/// mailbox both wake (the apply observer signals the file-watch AND the stream
+/// condvar), but a blocking read is ONE RPC that returns the next frame AT the
+/// cursor, whereas `sys_watch` returns only a "something changed" event and
+/// still needs a follow-up read — two round-trips and no cursor precision. The
+/// blocking read is the cursor-aware tail primitive the A2A mailbox is built
+/// on; `sys_watch` is the generic inotify-style path-change notifier.
+///
+/// Returns the new inbound messages and the advanced cursor to persist for the
+/// next poll. Skips our OWN writes (`from == self_agent`) so a shared
+/// read/write stream never echoes to us, and skips senderless / empty-body
+/// frames — the same filter the co-host loop applies in `parse_inbound`.
 ///
 /// # Errors
 /// Returns a `String` error if a `stream_read_at` RPC fails.
@@ -275,12 +290,25 @@ pub fn poll_new(
     self_agent: &str,
     mut cursor: u64,
     auth_token: &str,
+    block_ms: u64,
 ) -> Result<(Vec<Inbound>, u64), String> {
     let path = inbox_path(self_agent);
     let mut out = Vec::new();
+    let mut first = true;
     loop {
+        // Block only on the first read (park on the tail); every subsequent
+        // read in this call is a non-blocking drain of the already-buffered
+        // burst so the loop terminates at `eof`.
+        let blocking = first && block_ms > 0;
+        first = false;
         let (data, next, eof) = client
-            .stream_read_at(&path, cursor, auth_token)
+            .stream_read_at(
+                &path,
+                cursor,
+                blocking,
+                if blocking { block_ms } else { 0 },
+                auth_token,
+            )
             .map_err(|e| format!("A2A stream_read_at {path}@{cursor}: {e}"))?;
         if eof {
             break;

--- a/rust/crates/runtime/tests/nexus_mailbox_live.rs
+++ b/rust/crates/runtime/tests/nexus_mailbox_live.rs
@@ -15,6 +15,8 @@
 //! preserved and the assertion can pin it exactly.
 
 use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use nexus_vfs_client::NexusVfsClient;
 use runtime::nexus_mailbox::{ensure_inbox, poll_new, send};
@@ -33,18 +35,151 @@ fn live_inbox_roundtrip() {
 
     // Snapshot the tail so the assertion sees only the message we send below,
     // not any residue from a previous run of this probe.
-    let (_history, start) = poll_new(&client, me, 0, &auth).expect("seek to tail");
+    let (_history, start) = poll_new(&client, me, 0, &auth, 0).expect("seek to tail");
 
     // A "peer" writes into our inbox (simulates the receive direction), then we
     // poll it back — proving send + poll against the real DT_STREAM.
     let body = "hello over a real dt_stream";
     send(&client, "peer-x", me, body, &auth).expect("send to inbox");
 
-    let (msgs, next) = poll_new(&client, me, start, &auth).expect("poll new");
+    let (msgs, next) = poll_new(&client, me, start, &auth, 0).expect("poll new");
     assert!(next >= start, "cursor must not regress");
     assert!(
         msgs.iter().any(|m| m.from == "peer-x" && m.body == body),
         "expected the sent envelope back, got {msgs:?}"
+    );
+}
+
+/// Prove the receive loop's blocking tail (`poll_new` with `block_ms > 0`,
+/// backed by `stream_read_at(blocking=true)`) is an event-driven wakeup, not a
+/// poll: a receiver parked on an idle inbox wakes as soon as a peer writes, and
+/// on an idle inbox returns empty at the deadline instead of hanging. This is
+/// the exact wait the standalone `scode` receiver now uses in place of a
+/// `sleep` poll loop — the cursor-aware DT_STREAM tail primitive
+/// (`read_at_blocking`): one RPC that returns the next frame at the cursor,
+/// versus `sys_watch`'s change-event-then-separate-read. Run against a
+/// plaintext `serve-local` daemon:
+///
+/// ```text
+/// NEXUS_A2A_TEST_ENDPOINT=127.0.0.1:12022 \
+///   cargo test -p runtime --test nexus_mailbox_live live_blocking_read_wakes_on_write -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "requires a running nexusd-cluster; set NEXUS_A2A_TEST_ENDPOINT"]
+fn live_blocking_read_wakes_on_write() {
+    let endpoint =
+        std::env::var("NEXUS_A2A_TEST_ENDPOINT").expect("set NEXUS_A2A_TEST_ENDPOINT=host:port");
+    let auth = std::env::var("NEXUS_API_KEY").unwrap_or_default();
+    let client = Arc::new(NexusVfsClient::connect(&endpoint).expect("dial daemon"));
+
+    let me = "scode-blocking-read-probe";
+    ensure_inbox(&client, me, &auth).expect("ensure inbox");
+    // Fix the cursor at the current tail so the assertions see only what we
+    // write below, not residue from a previous run.
+    let (_history, tail) = poll_new(&client, me, 0, &auth, 0).expect("seek to tail");
+
+    // Negative path: an idle inbox with no writer must block for the whole
+    // timeout and return EMPTY at the deadline — never hang, never early-return.
+    let t0 = Instant::now();
+    let (idle_msgs, idle_next) =
+        poll_new(&client, me, tail, &auth, 800).expect("idle blocking read");
+    let idle_elapsed = t0.elapsed();
+    assert!(
+        idle_msgs.is_empty(),
+        "idle read must surface nothing, got {idle_msgs:?}"
+    );
+    assert_eq!(idle_next, tail, "idle read must not advance the cursor");
+    assert!(
+        idle_elapsed >= Duration::from_millis(700),
+        "idle read returned too early ({idle_elapsed:?}) — it did not park on the tail"
+    );
+
+    // Positive path: park the blocking read first, then a peer writes ~400ms
+    // later. The read must wake on that write well before its 5s deadline AND
+    // return the exact envelope — proving event-driven (not timeout) delivery.
+    let body = "wake up over the blocking tail";
+    let writer = {
+        // A SEPARATE connection: the receiver's blocking read monopolises its
+        // own client's single worker task, so the writer must not share it (a
+        // shared client would queue the write behind the 5s blocking read).
+        let endpoint = endpoint.clone();
+        let auth = auth.clone();
+        thread::spawn(move || {
+            let wclient = NexusVfsClient::connect(&endpoint).expect("writer dial");
+            thread::sleep(Duration::from_millis(400));
+            send(&wclient, "peer-block", me, body, &auth).expect("peer write");
+        })
+    };
+
+    let t1 = Instant::now();
+    let (msgs, next) = poll_new(&client, me, tail, &auth, 5_000).expect("armed blocking read");
+    let woke = t1.elapsed();
+    writer.join().expect("writer thread");
+
+    assert!(
+        msgs.iter()
+            .any(|m| m.from == "peer-block" && m.body == body),
+        "blocking read must surface the peer envelope, got {msgs:?}"
+    );
+    assert!(next > tail, "cursor must advance past the consumed frame");
+    assert!(
+        woke < Duration::from_millis(4_000),
+        "read woke on the timeout ({woke:?}), not the write event"
+    );
+    assert!(
+        woke >= Duration::from_millis(300),
+        "read returned before the write was issued ({woke:?}) — stale/instant wake"
+    );
+    println!("blocking read woke on write after {woke:?} (idle timeout was {idle_elapsed:?})");
+}
+
+/// Guard the concurrent-dispatch property that lets the receiver share the ONE
+/// `NexusVfsClient` with the send half: a blocking tail read parked on the
+/// client must NOT stall other ops on the SAME client. Each op runs on its own
+/// task (see `nexus-vfs-client`), so a quick op issued while a 1.5s blocking
+/// read is parked still returns promptly. If someone reverts the client to a
+/// serial single-worker loop, this fails — that regression is exactly what
+/// would starve an agent's sends behind its own receive.
+///
+/// ```text
+/// NEXUS_A2A_TEST_ENDPOINT=127.0.0.1:12022 \
+///   cargo test -p runtime --test nexus_mailbox_live live_blocking_read_does_not_stall_shared_client -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "requires a running nexusd-cluster; set NEXUS_A2A_TEST_ENDPOINT"]
+fn live_blocking_read_does_not_stall_shared_client() {
+    let endpoint =
+        std::env::var("NEXUS_A2A_TEST_ENDPOINT").expect("set NEXUS_A2A_TEST_ENDPOINT=host:port");
+    let auth = std::env::var("NEXUS_API_KEY").unwrap_or_default();
+
+    let me = "scode-starve-probe";
+    let shared = Arc::new(NexusVfsClient::connect(&endpoint).expect("dial shared"));
+    ensure_inbox(&shared, me, &auth).expect("ensure inbox");
+    let (_history, tail) = poll_new(&shared, me, 0, &auth, 0).expect("seek to tail");
+
+    // Park a 1.5s blocking read on the SHARED client (no writer → it holds its
+    // task the whole time).
+    let blocker = {
+        let shared = Arc::clone(&shared);
+        let auth = auth.clone();
+        thread::spawn(move || {
+            let _ = poll_new(&shared, me, tail, &auth, 1_500);
+        })
+    };
+    thread::sleep(Duration::from_millis(150)); // let the blocking read park
+
+    // A quick op on the SAME client must still return promptly — concurrent
+    // dispatch means it does not queue behind the 1.5s block.
+    let t = Instant::now();
+    let _ = shared.stat("/", &auth);
+    let shared_op = t.elapsed();
+    blocker.join().expect("blocker thread");
+
+    println!("shared_op while a 1.5s blocking read was parked: {shared_op:?}");
+    assert!(
+        shared_op < Duration::from_millis(500),
+        "a shared-client op must NOT be stalled behind the blocking read \
+         ({shared_op:?}) — the client is no longer dispatching ops concurrently"
     );
 }
 
@@ -121,7 +256,7 @@ fn live_collect_inbox() {
     // poll_new reads inbox_path(self_agent), so pass the target inbox name.
     // Its self-filter only drops the inbox owner's OWN writes (none here) —
     // a peer's stamped envelope (e.g. from a real scode send) still surfaces.
-    let (msgs, next) = poll_new(&client, &inbox, 0, &auth).expect("collect");
+    let (msgs, next) = poll_new(&client, &inbox, 0, &auth, 0).expect("collect");
     println!(
         "inbox /agents/{inbox}/chat-with-me — {} message(s), tail={next}",
         msgs.len()

--- a/rust/crates/rusty-sudocode-cli/src/cli/nexus_a2a.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/nexus_a2a.rs
@@ -16,20 +16,29 @@
 
 use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
-use std::time::Duration;
 
 use nexus_vfs_client::NexusVfsClient;
 use runtime::nexus_mailbox::{self, Config, Inbound};
 use runtime::spawn_task::MailboxSender;
 use runtime::HookAbortSignal;
 
-/// How often the receive poller checks the inbox. A2A is turn-scale, not
-/// latency-critical, so a coarse interval keeps idle cost negligible.
-const POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Blocking-tail wait per receive iteration. Each drain parks in a blocking
+/// `stream_read_at` (the DT_STREAM `read_at_blocking` primitive) up to this
+/// long, waking sub-millisecond on the next inbox write and returning empty at
+/// the deadline so the loop can re-check `abort`. This is event-driven, not a
+/// poll interval — an idle receiver costs one parked RPC, not a `sleep` spin.
+const INBOX_WAIT_MS: u64 = 500;
 
 /// The resolved, connected standalone A2A session.
 pub(crate) struct Session {
     config: Config,
+    /// The one daemon connection: `ensure_inbox`, the send half, the CLI tool
+    /// executor, and the blocking receive tail all share it. Safe to share
+    /// because [`NexusVfsClient`] dispatches each op on its own task — a
+    /// receiver parked in a blocking `stream_read_at` no longer stalls the
+    /// worker, so it can't starve concurrent sends. (An earlier revision split
+    /// off a second connection to dodge a single-worker stall; the client is
+    /// now concurrent, so one connection is correct and simpler.)
     client: Arc<NexusVfsClient>,
     sender: MailboxSender,
 }
@@ -84,25 +93,34 @@ pub(crate) fn session() -> Result<Option<&'static Session>, String> {
         .map_err(Clone::clone)
 }
 
-/// Spawn the background inbox poller (the receive half).
+/// Spawn the background inbox receiver (the receive half).
 ///
 /// Surfaces each new peer message to `sink` as it arrives. Starts at the
 /// stream tail — a fresh interactive session never replays history, the same
 /// seek-to-tail the co-host cold-start uses — and stops when `abort` fires.
+///
+/// Event-driven, not polling: each iteration parks in a blocking
+/// `stream_read_at` (via `poll_new`'s `block_ms`) until the daemon signals the
+/// next inbox write, then drains the burst. The block returns empty at the
+/// `INBOX_WAIT_MS` deadline so the loop can re-check `abort`. No `sleep` spin —
+/// an idle receiver costs one parked RPC, replacing the former poll interval.
 pub(crate) fn spawn_poller(
     session: &'static Session,
     abort: HookAbortSignal,
     sink: impl Fn(&Inbound) + Send + 'static,
 ) -> JoinHandle<()> {
+    // Shares `session.client`: the client dispatches ops concurrently, so
+    // parking here on the blocking tail cannot starve the send half.
     let client = Arc::clone(&session.client);
     let agent = session.config.agent.clone();
     let api_key = session.config.api_key.clone();
     std::thread::Builder::new()
-        .name("nexus-a2a-poller".into())
+        .name("nexus-a2a-receiver".into())
         .spawn(move || {
-            // Seek to tail: drain-and-discard once to fix the cursor at the
-            // current end, so only messages that arrive after startup surface.
-            let mut cursor = match nexus_mailbox::poll_new(&client, &agent, 0, &api_key) {
+            // Seek to tail: a non-blocking (block_ms=0) drain-and-discard once
+            // to fix the cursor at the current end, so only messages that
+            // arrive after startup surface.
+            let mut cursor = match nexus_mailbox::poll_new(&client, &agent, 0, &api_key, 0) {
                 Ok((_history, tail)) => tail,
                 Err(e) => {
                     eprintln!("[nexus-a2a] initial inbox seek failed: {e}");
@@ -110,17 +128,22 @@ pub(crate) fn spawn_poller(
                 }
             };
             while !abort.is_aborted() {
-                match nexus_mailbox::poll_new(&client, &agent, cursor, &api_key) {
+                // Block on the tail up to INBOX_WAIT_MS, then drain the burst.
+                match nexus_mailbox::poll_new(&client, &agent, cursor, &api_key, INBOX_WAIT_MS) {
                     Ok((msgs, next)) => {
                         for m in &msgs {
                             sink(m);
                         }
                         cursor = next;
                     }
-                    Err(e) => eprintln!("[nexus-a2a] inbox poll failed: {e}"),
+                    Err(e) => {
+                        eprintln!("[nexus-a2a] inbox poll failed: {e}");
+                        // Avoid a hot error loop if the daemon connection is
+                        // sick; the blocking read itself paces the happy path.
+                        std::thread::sleep(std::time::Duration::from_millis(INBOX_WAIT_MS));
+                    }
                 }
-                std::thread::sleep(POLL_INTERVAL);
             }
         })
-        .expect("spawn nexus-a2a poller thread")
+        .expect("spawn nexus-a2a receiver thread")
 }


### PR DESCRIPTION
## What

The standalone `scode` A2A receiver polled its inbox on a `sleep` loop. Make it **event-driven** with a blocking `stream_read_at` (`read_at_blocking`): the server parks on the DT_STREAM tail and wakes sub-millisecond on the next inbox write, instead of waking on a fixed interval.

## Why blocking read, not `sys_watch`/`Watch`

For the WAL mailbox **both wake** — the apply observer signals the file-watch AND the stream condvar on every applied `AppendStreamEntry`. The reason to use the blocking read is that it's **one RPC that returns the next frame at the cursor**, whereas `sys_watch` returns only a change event and needs a follow-up read (two round-trips, no cursor precision). `read_at_blocking` is the cursor-aware tail primitive the A2A mailbox is built on.

## Concurrent client dispatch (root fix, not a workaround)

The `NexusVfsClient` worker dispatched ops **serially** on one task, so a blocking tail read would monopolise the connection and starve the agent's own sends (measured 1.35s stall). Fix the root cause: dispatch each op on its own task — the tonic client clones cheaply and multiplexes over one HTTP/2 channel. Single-caller ordering is unchanged (every sync method blocks on its reply channel), so only cross-thread use (a parked receive + a concurrent send) now runs in parallel. **One connection suffices** — no dedicated receive connection.

## Changes
- `nexus-vfs-client`: `stream_read_at` takes `(blocking, timeout_ms)`; the worker spawns each op concurrently.
- `runtime::nexus_mailbox::poll_new`: `block_ms > 0` makes the first read a blocking tail read, then drains the burst non-blocking.
- `rusty-sudocode-cli`: the receive loop blocks on `poll_new` instead of `sleep`, sharing the one session client.

## Tests (live, vs serve-local)
- `live_blocking_read_wakes_on_write` — a 400ms-delayed peer write wakes the parked read at ~412ms (event-driven); an idle read times out empty. Green serial + parallel.
- `live_blocking_read_does_not_stall_shared_client` — a shared-client op returns in **882µs** while a 1.5s blocking read is parked, guarding the concurrent-dispatch fix.

## Cross-machine duet (accepted)
Win `scode` operator ↔ Mac `scode` mac-ai over the auth-on founder: mac-ai's real scode REPL popped operator's message instantly (event-driven receiver); mac-ai's reply landed stamped `from:"mac-ai"`, surfaced by operator's receiver primitive.

## Follow-up (out of scope)
The in-process co-host uses `sys_watch`+non-blocking read; it can converge onto the in-process `stream_read_at_blocking` for a single cursor-aware tail primitive. Separate code path (in-process kernel).
