### PR TITLE
chore(deps): bump nexus-vfs pin → sys_write wakes DT_STREAM tail (#258)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2372,7 +2372,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2493,7 +2493,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "a2a",
  "contracts",
@@ -2600,7 +2600,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 
 [[package]]
 name = "nexus-vfs-client"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,14 +37,14 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false, features = ["runtime-bridge"] }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false, features = ["runtime-bridge"] }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ runtime = { path = "../runtime" }
 # loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
 # crate pins (transitive `kernel` unifies). default-features = false → no
 # subprocess-host (that's the raw-ACP path, not the in-process co-host).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 regex = "1"
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Bumps the nexus-vfs pin `2cc85ca7` → `dce2ba26` (nexus-vfs #258 only): the co-host's in-process kernel now carries the DT_STREAM wake fix — `sys_write` routes the append through `StreamManager::write_nowait` so a parked `read_at_blocking` tail wakes on the write.

Keeps runtime's in-process `kernel`/`a2a` on the SAME rev the nexus daemon uses (the pin comment's invariant). Pure bump: `runtime`/`tools` Cargo.toml + Cargo.lock. `cargo check -p runtime -p tools` green locally.