### PR TITLE
cohost: adopt Fn(AgentState, Option<String>) observer (nexus-vfs AwaitingInput)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "contracts",
  "kernel",
@@ -860,7 +860,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2372,7 +2372,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2493,7 +2493,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "a2a",
  "contracts",
@@ -2600,7 +2600,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 
 [[package]]
 name = "nexus-vfs-client"

--- a/rust/crates/runtime/Cargo.toml
+++ b/rust/crates/runtime/Cargo.toml
@@ -37,14 +37,14 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # Pinned to the SAME nexus-vfs rev the nexus daemon (rust/nexusd) uses, so
 # `SpawnTask<Kernel>` monomorphises to one type when nexusd links both
 # sudocode_runtime and the nexus service crates (co-host binary edge).
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
 # The A2A messaging substrate: SSOT for the mailbox message schema
 # (`MailboxEnvelope`) + the `/chat-with-me` path suffix. MUST be the same
 # nexus-vfs rev as `kernel` (a2a itself deps kernel; a mismatched rev = two
 # distinct `Kernel` types). Re-exported from `spawn_task` so downstream crates
 # use it without a direct a2a dependency.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false, features = ["runtime-bridge"] }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false, features = ["runtime-bridge"] }
 sha2 = "0.10"
 glob = "0.3"
 keyring = "3"

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -250,7 +250,7 @@ where
     K: KernelSyscall + Send + Sync + 'static,
     C: ApiClient + 'static,
     T: ToolExecutor + 'static,
-    F: Fn(AgentState) + Send + 'static,
+    F: Fn(AgentState, Option<String>) + Send + 'static,
 {
     let abort_signal = HookAbortSignal::default();
     let abort_for_thread = abort_signal.clone();
@@ -294,7 +294,7 @@ fn run_loop<K, C, T, F>(
     K: KernelSyscall + Send + Sync + 'static,
     C: ApiClient + 'static,
     T: ToolExecutor + 'static,
-    F: Fn(AgentState),
+    F: Fn(AgentState, Option<String>),
 {
     // Build a tokio runtime for async run_turn calls.
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -303,7 +303,7 @@ fn run_loop<K, C, T, F>(
         .expect("managed-agent tokio runtime");
 
     // -- WARMING_UP --
-    state_cb(AgentState::WarmingUp);
+    state_cb(AgentState::WarmingUp, None);
 
     // The VFS-backed file tools are constructed by the spawn factory
     // (`tools::managed_agent::spawn_managed_agent`), which injects a
@@ -322,7 +322,7 @@ fn run_loop<K, C, T, F>(
     .with_hook_abort_signal(abort.clone());
 
     // -- READY --
-    state_cb(AgentState::Ready);
+    state_cb(AgentState::Ready, None);
 
     // Inbox the loop reads/watches, and the id it filters its own writes by.
     // For A2A this is the replicated `/agents/<self>/chat-with-me`; replies
@@ -351,7 +351,7 @@ fn run_loop<K, C, T, F>(
                     if !bytes.is_empty() {
                         if let Some((sender, body)) = parse_inbound(bytes, &self_id) {
                             // -- BUSY --
-                            state_cb(AgentState::Busy);
+                            state_cb(AgentState::Busy, None);
 
                             // Drive ONE turn on the inbound message. The sender is
                             // surfaced in the prompt so the agent can address a reply.
@@ -367,7 +367,7 @@ fn run_loop<K, C, T, F>(
                             }
 
                             // -- READY --
-                            state_cb(AgentState::Ready);
+                            state_cb(AgentState::Ready, None);
                         }
                     }
                 }

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -240,7 +240,7 @@ fn spawn_real(kernel: Arc<Kernel>, desc: AgentDescriptor, mailbox: Mailbox) -> S
         NoTools,
         system_prompt,
         PermissionPolicy::new(PermissionMode::Allow),
-        |_state| {},
+        |_state, _reason| {},
     )
 }
 
@@ -273,7 +273,7 @@ fn spawn_sending(
         SendingTools { send },
         system_prompt,
         PermissionPolicy::new(PermissionMode::Allow),
-        |_state| {},
+        |_state, _reason| {},
     )
 }
 

--- a/rust/crates/tools/Cargo.toml
+++ b/rust/crates/tools/Cargo.toml
@@ -19,7 +19,7 @@ runtime = { path = "../runtime" }
 # loop as a nexus managed-agent runtime body. Same nexus-vfs rev the runtime
 # crate pins (transitive `kernel` unifies). default-features = false → no
 # subprocess-host (that's the raw-ACP path, not the in-process co-host).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 regex = "1"
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 # For the in-process co-host live proof (tests/cohost_live_llm.rs): builds a
 # real Kernel, plants the /proc mailbox stream, and drives spawn_managed_agent
 # through a real LLM turn. Same nexus-vfs rev the runtime crate pins.
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
 
 [lints]
 workspace = true

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -56,7 +56,7 @@ pub fn spawn_managed_agent<K, F>(
 ) -> SpawnHandle
 where
     K: KernelSyscall + Send + Sync + 'static,
-    F: Fn(AgentState) + Send + 'static,
+    F: Fn(AgentState, Option<String>) + Send + 'static,
 {
     let model = desc
         .labels
@@ -197,7 +197,7 @@ where
         &self,
         kernel: Arc<K>,
         desc: AgentDescriptor,
-        state_observer: Arc<dyn Fn(AgentState) + Send + Sync>,
+        state_observer: Arc<dyn Fn(AgentState, Option<String>) + Send + Sync>,
     ) -> Box<dyn ManagedSpawnHandle> {
         // The co-host agent's mailbox is its persistent, cross-machine A2A
         // inbox `/agents/<name>/chat-with-me`, so a duet partner on another
@@ -206,7 +206,9 @@ where
             base: "/agents".to_string(),
             self_name: desc.name.clone(),
         };
-        let handle = spawn_managed_agent(kernel, desc, mailbox, move |state| state_observer(state));
+        let handle = spawn_managed_agent(kernel, desc, mailbox, move |state, reason| {
+            state_observer(state, reason)
+        });
         Box::new(SudoCodeSpawnHandle { inner: handle })
     }
 }

--- a/rust/crates/tools/tests/cohost_live_llm.rs
+++ b/rust/crates/tools/tests/cohost_live_llm.rs
@@ -175,8 +175,8 @@ fn cohost_agent_replies_via_mailbox_with_real_llm() {
         path: format!("/proc/{pid}/chat-with-me"),
         self_id: agent_id.to_string(),
     };
-    let handle = spawn_managed_agent(Arc::clone(&kernel), desc, mailbox, |state| {
-        eprintln!("[agent state] {state:?}");
+    let handle = spawn_managed_agent(Arc::clone(&kernel), desc, mailbox, |state, reason| {
+        eprintln!("[agent state] {state:?} reason={reason:?}");
     });
 
     let ctx = user_ctx();


### PR DESCRIPTION
Companion to nexus-vfs#260 (merged): the `SpawnTask` state observer now carries an `AwaitingInput` reason.

- Thread `Option<String>` through `spawn_managed_agent` + `spawn_task`; the current allow-all, send_message-only loop never blocks on a prompt, so it reports WarmingUp/Ready/Busy with `reason=None`. `AwaitingInput` is emitted here once the runtime gains interactive prompts (permission / ask-user) — the plumbing is now in place.
- Pins nexus-vfs to `b5b969a0` (the #260 merge, now in main).

tools + runtime build green against the new trait.