### PR TITLE
docs(matrix): qualify live-pointer sudowork badge (own binding, converges in nexus)

### DIFF
--- a/docs/design/agent-context-storage-matrix.html
+++ b/docs/design/agent-context-storage-matrix.html
@@ -389,7 +389,7 @@ agent-memory/&lt;type&gt;/           per-agent-type memory
   <td>
     <div class="el"><b>stays (SQLite):</b> the conversation list + each conversation's session binding. ("Which conversation is open/active" lives in the <b>renderer, not SQLite</b> — open tabs + active tab persist in <b>localStorage</b>, and the active one is the <span class="path">/conversation/&lt;id&gt;</span> route. sudowork has no "persistent-assistant" concept.)</div>
     <div class="el"><span class="was"><code>extra.acpSessionId</code> / <code>mossSessionId</code> = sudowork's authoritative <b>conversation→session binding</b> — which engine session-id is this conversation's <b>live</b> one (written from the <code>session/new|load</code> response, read at resume). <b>Not a redundant copy</b>: standalone scode stores no per-conversation pointer (it recomputes "latest" by scan — see col 3), and a conversation cycles through many session-ids (only the latest is kept), so sudowork must own the binding; as a <i>live</i> pointer, latest-is-correct.</span> <span class="arw">→</span> <span class="to">converges only in the <b>nexus end-state</b>: defer "which pid/session is live" to the engine's <b>AgentRegistry</b> pid-FSM + durable session-id (col 6)</span></div>
-    <span class="b partial">partial</span></td>
+    <span class="b partial">partial — own binding (works), converges in nexus end-state</span></td>
   <td>
     <div class="el"><b>resume key = session-id</b> (durable UUID)</div>
     <div class="el"><b>AgentRegistry</b> pid FSM (kernel SSOT) = "which pid is live"; MAS registers pid keyed by session-id</div>


### PR DESCRIPTION
Follow-up to #535/#537: the sudowork cell's bare `partial` read like unfinished work after reclassifying `acpSessionId` from dup→stays. It's a correct, necessary conversation→session binding today; the `partial` is purely convergence (defers to the engine's AgentRegistry only in the nexus end-state). Qualified the badge to say so. Docs-only.