### PR TITLE
feat(config): per-project account switching (auth_profile) + config layering/SSOT + docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -42,6 +42,57 @@ scode --auth proxy
 A reference deterministic proxy ships in the workspace as
 `mock-anthropic-service` and is documented in [`mock-parity-harness.md`](./mock-parity-harness.md).
 
+For config-file-based **named accounts** (instead of the `PROXY_*` env vars) and
+per-project switching, see [Named accounts](#named-accounts--per-project-selection).
+
+## Named accounts & per-project selection
+
+Instead of the `PROXY_*` environment variables, you can define **named proxy
+accounts** in config and switch between them per project — handy when different
+repos need different backends or keys.
+
+### Define accounts (global, once)
+
+In `~/.nexus/sudocode/sudocode.json`, every key under `auth_modes.proxy` is an
+account name mapping to `{ baseUrl, apiKey }`:
+
+```json
+{
+  "auth_modes": {
+    "proxy": {
+      "default": { "baseUrl": "https://gw.example.com/v1",  "apiKey": "sk-..." },
+      "clientA": { "baseUrl": "https://alt.example.com/v1", "apiKey": "sk-..." }
+    }
+  }
+}
+```
+
+### Select one with `auth_profile`
+
+`auth_profile` picks the active account. It resolves through the config layers
+(later layers override earlier ones):
+
+| Scope | File | Use for |
+|---|---|---|
+| Global default | `~/.nexus/sudocode/settings.json` | the account most repos use |
+| Per-project (shared) | `<repo>/.nexus/sudocode/settings.json` | commit it so the whole team uses it |
+| Per-project (local) | `<repo>/.nexus/sudocode/settings.local.json` | machine-only (gitignored) |
+
+```json
+{ "auth_profile": "clientA" }
+```
+
+So `cd <repo> && scode` automatically uses that repo's account — no flags. With
+no `auth_profile` set, scode falls back to the first account.
+
+Keys never leave the global `sudocode.json`: a per-project file references only
+an account **name**, so a committed `settings.json` carries no secrets — each
+developer defines the same-named account in their own global config. Confirm the
+resolved account with `scode doctor` (see [Verifying credentials](#verifying-credentials)).
+
+> Env vars still win: if `PROXY_AUTH_TOKEN` / `PROXY_BASE_URL` are set (see
+> [Proxy mode](#proxy-mode)) they override any `auth_profile` selection.
+
 ## Verifying credentials
 
 ```bash
@@ -49,4 +100,7 @@ scode doctor
 ```
 
 `scode doctor` reports the resolved auth mode, the environment variables it
-sees, and whether the resolved endpoint responds to a credential probe.
+sees, and whether the resolved endpoint responds to a credential probe. When a
+named account is selected (see [Named accounts](#named-accounts--per-project-selection)),
+it also prints an **Account** line, e.g.
+`account=clientA base_url=https://alt.example.com/v1 auth_profile=clientA`.

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -362,6 +362,7 @@ mod tests {
             auth_modes,
             models,
             web_search: Default::default(),
+            selected_account: None,
         }
     }
 

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -391,9 +391,15 @@ fn try_proxy_passthrough(
         }
     }
 
-    // Find the first proxy provider with a valid connection.
+    // Select the proxy account: the explicitly selected named account
+    // (`selected_account`, sourced from the layered settings' `auth_profile`)
+    // when set, otherwise the first available — the latter keeps existing
+    // single-account behavior byte-for-byte (regression-safe default).
     let proxy_providers = config.auth_modes.get("proxy")?;
-    let (provider_name, connection) = proxy_providers.iter().next()?;
+    let (provider_name, connection) = match config.selected_account.as_deref() {
+        Some(name) => proxy_providers.get_key_value(name)?,
+        None => proxy_providers.iter().next()?,
+    };
 
     // Pick API format from model_capabilities SSOT (preferred endpoint
     // type from sudorouter), falling back to openai-completions.
@@ -794,6 +800,7 @@ mod tests {
             auth_modes,
             models,
             web_search: Default::default(),
+            selected_account: None,
         }
     }
 

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -501,6 +501,11 @@ impl ConfigLoader {
                 path = global_path.display()
             )));
         };
+        // `extraBody` values are re-read from each layer's raw text (the custom
+        // JSON parser is lossy for arbitrary bodies — see `parse_extra_bodies`).
+        // Merge them per-alias with the same project-over-global precedence as
+        // the object merge below, so the resolved model view stays a single SSOT.
+        let mut extra_bodies = parse_extra_bodies(&base.source);
         let mut merged = base.object;
         let project_path = self
             .cwd
@@ -509,8 +514,12 @@ impl ConfigLoader {
             .join("sudocode.json");
         if let Some(project) = read_optional_json_object_with(backend, &project_path)? {
             deep_merge_objects(&mut merged, &project.object);
+            for (alias, body) in parse_extra_bodies(&project.source) {
+                extra_bodies.insert(alias, body);
+            }
         }
-        let mut config = parse_sudocode_from_object(&merged, &global_path.display().to_string())?;
+        let mut config =
+            parse_sudocode_from_object(&merged, &global_path.display().to_string(), &extra_bodies)?;
         // Wire the per-project account selection from the layered settings'
         // `auth_profile`. Single source of truth: the account (base_url + key)
         // stays defined once under `auth_modes`; here we only read *which* named
@@ -1367,7 +1376,7 @@ fn parse_sudocode_json_str_with_label(
             "{label}: expected JSON object at top level",
         )));
     };
-    parse_sudocode_from_object(root_obj, label)
+    parse_sudocode_from_object(root_obj, label, &parse_extra_bodies(content))
 }
 
 /// Parse a `SudoCodeConfig` from an already-parsed (and possibly layer-merged)
@@ -1377,10 +1386,11 @@ fn parse_sudocode_json_str_with_label(
 fn parse_sudocode_from_object(
     root_obj: &BTreeMap<String, JsonValue>,
     label: &str,
+    extra_bodies: &BTreeMap<String, serde_json::Map<String, SerdeValue>>,
 ) -> Result<SudoCodeConfig, ConfigError> {
     let sentinel = Path::new(label);
     let auth_modes = parse_auth_modes_section(root_obj, sentinel)?;
-    let models = parse_sudocode_models_section(root_obj, sentinel, &parse_extra_bodies(content))?;
+    let models = parse_sudocode_models_section(root_obj, sentinel, extra_bodies)?;
     let web_search = parse_web_search_section(root_obj);
 
     Ok(SudoCodeConfig {

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -148,6 +148,11 @@ pub struct SudoCodeConfig {
     pub models: BTreeMap<String, ModelConfigEntry>,
     /// `web_search` → search provider configuration.
     pub web_search: WebSearchConfig,
+    /// Runtime-selected named account (from the layered settings' `auth_profile`).
+    /// `None` = default resolution (unchanged, regression-safe). Populated by the
+    /// caller from merged settings; the account itself stays defined once under
+    /// `auth_modes` (single source of truth — this is a reference, not a copy).
+    pub selected_account: Option<String>,
 }
 
 impl SudoCodeConfig {
@@ -474,21 +479,55 @@ impl ConfigLoader {
     }
 
     /// Load `sudocode.json` using a custom filesystem backend.
+    ///
+    /// Layered: the global `<config_home>/sudocode.json` is the required base
+    /// and the single source of truth for account/model definitions. An
+    /// optional project `<cwd>/.nexus/sudocode/sudocode.json` deep-merges on top
+    /// so per-project overrides (e.g. models, web_search) resolve consistently
+    /// with the rest of the layered config. Auth credentials stay defined once
+    /// globally and are referenced per-project via `auth_profile` (see slice 2),
+    /// never copied — enforcing a single source of truth.
     pub fn load_sudocode_config_with(
         &self,
         backend: &dyn crate::fs_backend::FsBackend,
     ) -> Result<SudoCodeConfig, ConfigError> {
-        let path = self.config_home.join("sudocode.json");
-        if !backend.exists(&path.to_string_lossy()).unwrap_or(false) {
+        let global_path = self.config_home.join("sudocode.json");
+        let Some(base) = read_optional_json_object_with(backend, &global_path)? else {
             return Err(ConfigError::Parse(format!(
                 "missing sudocode.json: expected at {path}\n\
                  Create this file to configure models and providers.\n\n\
                  To get started, copy the sample config:\n  \
                  cp crates/runtime/src/sudocode.sample.json {path}",
-                path = path.display()
+                path = global_path.display()
             )));
+        };
+        let mut merged = base.object;
+        let project_path = self
+            .cwd
+            .join(".nexus")
+            .join("sudocode")
+            .join("sudocode.json");
+        if let Some(project) = read_optional_json_object_with(backend, &project_path)? {
+            deep_merge_objects(&mut merged, &project.object);
         }
-        parse_sudocode_json_with(backend, &path)
+        let mut config = parse_sudocode_from_object(&merged, &global_path.display().to_string())?;
+        // Wire the per-project account selection from the layered settings'
+        // `auth_profile`. Single source of truth: the account (base_url + key)
+        // stays defined once under `auth_modes`; here we only read *which* named
+        // account is selected. Best-effort — settings errors leave it unset, so
+        // resolution falls back to the unchanged default.
+        if let Ok(runtime) = self.load() {
+            if let Some(profile) = runtime
+                .merged
+                .get("auth_profile")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|profile| !profile.is_empty())
+            {
+                config.selected_account = Some(profile.to_string());
+            }
+        }
+        Ok(config)
     }
 }
 
@@ -1328,8 +1367,18 @@ fn parse_sudocode_json_str_with_label(
             "{label}: expected JSON object at top level",
         )));
     };
-    let sentinel = Path::new(label);
+    parse_sudocode_from_object(root_obj, label)
+}
 
+/// Parse a `SudoCodeConfig` from an already-parsed (and possibly layer-merged)
+/// JSON object. Shared by single-file parsing and the layered loader so that
+/// auth / models / web_search resolve from the same merged view as the rest of
+/// the config (one deterministic resolution, single source of truth per key).
+fn parse_sudocode_from_object(
+    root_obj: &BTreeMap<String, JsonValue>,
+    label: &str,
+) -> Result<SudoCodeConfig, ConfigError> {
+    let sentinel = Path::new(label);
     let auth_modes = parse_auth_modes_section(root_obj, sentinel)?;
     let models = parse_sudocode_models_section(root_obj, sentinel, &parse_extra_bodies(content))?;
     let web_search = parse_web_search_section(root_obj);
@@ -1338,6 +1387,7 @@ fn parse_sudocode_json_str_with_label(
         auth_modes,
         models,
         web_search,
+        selected_account: None,
     })
 }
 

--- a/rust/crates/runtime/src/config_schema.rs
+++ b/rust/crates/runtime/src/config_schema.rs
@@ -267,6 +267,11 @@ pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
         FieldType::StringArray,
         "Trusted project root paths",
     ),
+    FieldSchema::leaf(
+        "auth_profile",
+        FieldType::String,
+        "Named account under auth_modes.proxy to use for this scope",
+    ),
     FieldSchema::object(
         "experimental",
         EXPERIMENTAL_CHILDREN,

--- a/rust/crates/rusty-sudocode-cli/src/cli/args.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/args.rs
@@ -1384,6 +1384,7 @@ mod tests {
             auth_modes: BTreeMap::new(),
             models,
             web_search: Default::default(),
+            selected_account: None,
         };
 
         assert_eq!(

--- a/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
@@ -237,7 +237,11 @@ fn check_account_health(config_loader: &ConfigLoader) -> DiagnosticCheck {
         .get("proxy")
         .filter(|accounts| !accounts.is_empty())
     else {
-        return DiagnosticCheck::new("Account", DiagnosticLevel::Ok, "no proxy accounts configured");
+        return DiagnosticCheck::new(
+            "Account",
+            DiagnosticLevel::Ok,
+            "no proxy accounts configured",
+        );
     };
     let selected = config.selected_account.as_deref();
     let resolved = match selected {

--- a/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/doctor.rs
@@ -211,8 +211,58 @@ pub(crate) fn render_doctor_report() -> Result<DoctorReport, Box<dyn std::error:
             check_workspace_health(&context),
             check_sandbox_health(&context.sandbox_status),
             check_system_health(&cwd, config.as_ref().ok()),
+            check_account_health(&config_loader),
         ],
     })
+}
+
+/// Surface which named proxy account this project resolves to, so a user can
+/// confirm a per-project `auth_profile` selection actually takes effect. Mirrors
+/// the selection in `try_proxy_passthrough`: an explicit `auth_profile` picks
+/// that account by name; otherwise the first configured account is used.
+fn check_account_health(config_loader: &ConfigLoader) -> DiagnosticCheck {
+    let config = match config_loader.load_sudocode_config() {
+        Ok(config) => config,
+        Err(err) => {
+            return DiagnosticCheck::new(
+                "Account",
+                DiagnosticLevel::Warn,
+                "could not load config to resolve the proxy account",
+            )
+            .with_details(vec![err.to_string()]);
+        }
+    };
+    let Some(accounts) = config
+        .auth_modes
+        .get("proxy")
+        .filter(|accounts| !accounts.is_empty())
+    else {
+        return DiagnosticCheck::new("Account", DiagnosticLevel::Ok, "no proxy accounts configured");
+    };
+    let selected = config.selected_account.as_deref();
+    let resolved = match selected {
+        Some(name) => accounts.get_key_value(name),
+        None => accounts.iter().next(),
+    };
+    match resolved {
+        Some((name, connection)) => {
+            DiagnosticCheck::new("Account", DiagnosticLevel::Ok, "resolved proxy account")
+                .with_details(vec![format!(
+                    "account={name} base_url={} auth_profile={}",
+                    connection.base_url,
+                    selected.unwrap_or("<default: first>")
+                )])
+        }
+        None => DiagnosticCheck::new(
+            "Account",
+            DiagnosticLevel::Warn,
+            "auth_profile does not match any configured proxy account",
+        )
+        .with_details(vec![format!(
+            "auth_profile={} is not present in auth_modes.proxy",
+            selected.unwrap_or("<none>")
+        )]),
+    }
 }
 
 pub(crate) fn run_doctor(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -5251,7 +5251,15 @@ impl LiveCli {
                 Ok(())
             }
             _ => {
-                eprintln!("Unknown config key '{key}'. Available: auto-interrupt, queue");
+                // Everything else routes through the single SSOT config writer
+                // (`tools::set_config_setting`) so `/config set` persists to the
+                // scope-appropriate settings file instead of a session-only,
+                // divergent in-memory copy. `auto-interrupt`/`queue` above stay
+                // session toggles by design (no on-disk representation).
+                match tools::set_config_setting(key, value) {
+                    Ok(msg) => self.out_println(format!("{DIM}{msg}{RESET}")),
+                    Err(err) => eprintln!("Error: {err}"),
+                }
                 Ok(())
             }
         }

--- a/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/output_format_contract.rs
@@ -230,7 +230,7 @@ fn doctor_and_resume_status_emit_json_when_requested() {
     assert!(summary["failures"].as_u64().is_some());
 
     let checks = doctor["checks"].as_array().expect("doctor checks");
-    assert_eq!(checks.len(), 6);
+    assert_eq!(checks.len(), 7);
     let check_names = checks
         .iter()
         .map(|check| {
@@ -248,7 +248,8 @@ fn doctor_and_resume_status_emit_json_when_requested() {
             "install source",
             "workspace",
             "sandbox",
-            "system"
+            "system",
+            "account"
         ]
     );
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
@@ -70,3 +70,82 @@ fn config_set_auth_profile_persists_to_settings_local() {
         "settings.local.json must contain the persisted auth_profile selector; got:\n{content}"
     );
 }
+
+/// With `auth_profile` set, the resolver — surfaced via `scode doctor`'s Account
+/// check — selects the *named* proxy account, not the default first one. This is
+/// the payoff of the whole feature: a project points at its own account by name,
+/// and the credential still lives once in the global `sudocode.json`.
+#[test]
+fn doctor_resolves_selected_account_when_auth_profile_set() {
+    let env = TestEnv::new("auth-profile-resolve-selected");
+    write_two_account_config(&env);
+    // The project selects its own account by name.
+    write_auth_profile(&env, "team-b");
+
+    let mut sess = env.spawn(&["doctor"]);
+    sess.set_default_timeout(Duration::from_secs(30));
+
+    // Only the Account check prints `account=<resolved>`, so matching
+    // `account=team-b` proves the selector actually drove resolution.
+    sess.expect("account=team-b").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("doctor should resolve auth_profile=team-b: {e}\nPTY screen:\n{screen}");
+    });
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("doctor exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}
+
+/// Without `auth_profile`, the resolver keeps the pre-existing behavior — the
+/// first configured proxy account — so the default path is unchanged
+/// (regression guard for the "credentials untouched by default" promise).
+#[test]
+fn doctor_defaults_to_first_account_without_auth_profile() {
+    let env = TestEnv::new("auth-profile-resolve-default");
+    write_two_account_config(&env);
+    // No auth_profile persisted — exercise the default resolution path.
+
+    let mut sess = env.spawn(&["doctor"]);
+    sess.set_default_timeout(Duration::from_secs(30));
+
+    // First account is `sudorouter` (from the sample); its base_url is distinct
+    // from team-b's, so this proves the default did NOT pick the added account.
+    sess.expect("account=sudorouter").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("doctor should default to the first account: {e}\nPTY screen:\n{screen}");
+    });
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("doctor exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+}
+
+/// Write a global `sudocode.json` with two named proxy accounts (the real sample
+/// plus an added `team-b`) into the test's config home. Using the sample keeps
+/// the file valid; we only add one account so selection has something to choose.
+fn write_two_account_config(env: &TestEnv) {
+    let mut config: serde_json::Value =
+        serde_json::from_str(runtime::SAMPLE_SUDOCODE_JSON).expect("sample sudocode.json parses");
+    config["auth_modes"]["proxy"]["team-b"] = serde_json::json!({
+        "baseUrl": "http://team-b.test",
+        "apiKey": "test-key-team-b",
+    });
+    let serialized = serde_json::to_string_pretty(&config).expect("serialize sudocode.json");
+    fs::write(env.config_home().join("sudocode.json"), serialized)
+        .expect("write two-account sudocode.json");
+}
+
+/// Persist a project-scoped `auth_profile` selector to the same
+/// `settings.local.json` that `/config set auth_profile` writes to.
+fn write_auth_profile(env: &TestEnv, profile: &str) {
+    let dir = env.workspace_root().join(".nexus").join("sudocode");
+    fs::create_dir_all(&dir).expect("create project config dir");
+    fs::write(
+        dir.join("settings.local.json"),
+        format!("{{\n  \"auth_profile\": \"{profile}\"\n}}\n"),
+    )
+    .expect("write settings.local.json");
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
@@ -1,0 +1,72 @@
+//! PTY test: `/config set auth_profile <name>` persists the per-project account
+//! selector through the single, unified SSOT config writer.
+//!
+//! Real user journey (data flows across steps): in a project the user selects
+//! which named account (defined once in the global `sudocode.json`) this project
+//! should use. The selection is written to the project's
+//! `.nexus/sudocode/settings.local.json` via the one scope-aware, file-backed
+//! writer (`tools::set_config_setting`) — not a session-only, divergent
+//! in-memory toggle. We then read the file back to prove it truly landed on disk.
+//!
+//! This is PTY-only: `/config set` runs in the interactive async REPL. It uses
+//! the mock backend, so it needs no real credentials.
+//!
+//! ```bash
+//! cargo test --test pty_auth_profile
+//! ```
+
+mod common;
+
+use std::fs;
+use std::time::Duration;
+
+use common::TestEnv;
+
+/// `/config set auth_profile <name>` confirms in the REPL AND persists the value
+/// to the project's `settings.local.json` (the scope-appropriate SSOT file).
+#[test]
+fn config_set_auth_profile_persists_to_settings_local() {
+    let env = TestEnv::new("auth-profile-set");
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+    sess.set_default_timeout(Duration::from_secs(20));
+
+    sess.expect("❯").expect("async REPL prompt");
+
+    // Step 1: select a named account for this project.
+    sess.send("/config set auth_profile client-acct\r")
+        .expect("send /config set auth_profile");
+
+    // The unified SSOT writer echoes the persisted `key = value`. A session-only
+    // toggle or unknown-key path would instead say "Unknown config key" / error,
+    // so this line is proof the write went through `tools::set_config_setting`.
+    sess.expect("auth_profile = client-acct").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("should confirm auth_profile persisted: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.expect("❯").expect("prompt after set");
+    sess.send("/exit\r").expect("send exit");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+
+    // Step 2: the value must actually be on disk in the scope-appropriate file,
+    // proving it went through the file-backed SSOT writer (not memory-only).
+    let settings_local = env
+        .workspace_root()
+        .join(".nexus")
+        .join("sudocode")
+        .join("settings.local.json");
+    let content = fs::read_to_string(&settings_local).unwrap_or_else(|e| {
+        panic!(
+            "settings.local.json should exist at {}: {e}",
+            settings_local.display()
+        )
+    });
+    assert!(
+        content.contains("auth_profile") && content.contains("client-acct"),
+        "settings.local.json must contain the persisted auth_profile selector; got:\n{content}"
+    );
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
@@ -39,10 +39,11 @@ fn config_set_auth_profile_persists_to_settings_local() {
     // The unified SSOT writer echoes the persisted `key = value`. A session-only
     // toggle or unknown-key path would instead say "Unknown config key" / error,
     // so this line is proof the write went through `tools::set_config_setting`.
-    sess.expect("auth_profile = client-acct").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("should confirm auth_profile persisted: {e}\nPTY screen:\n{screen}");
-    });
+    sess.expect("auth_profile = client-acct")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("should confirm auth_profile persisted: {e}\nPTY screen:\n{screen}");
+        });
 
     sess.expect("❯").expect("prompt after set");
     sess.send("/exit\r").expect("send exit");

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7487,7 +7487,11 @@ pub fn set_config_setting(setting: &str, value: &str) -> Result<String, String> 
         let shown = output
             .new_value
             .as_ref()
-            .and_then(|v| v.as_str().map(str::to_string).or_else(|| Some(v.to_string())))
+            .and_then(|v| {
+                v.as_str()
+                    .map(str::to_string)
+                    .or_else(|| Some(v.to_string()))
+            })
             .unwrap_or_default();
         Ok(format!("{setting} = {shown}"))
     } else {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7474,6 +7474,35 @@ fn execute_sleep(
     })
 }
 
+/// SSOT entrypoint for writing a config setting. Both the agent `config`
+/// tool and the CLI `/config set` route through here, so there is exactly one
+/// scope-aware, file-backed writer (`supported_config_setting` → scope → file,
+/// read-modify-write). No caller keeps a divergent in-memory copy.
+pub fn set_config_setting(setting: &str, value: &str) -> Result<String, String> {
+    let output = execute_config(ConfigInput {
+        setting: setting.to_string(),
+        value: Some(ConfigValue::String(value.to_string())),
+    })?;
+    if output.success {
+        let shown = output
+            .new_value
+            .as_ref()
+            .and_then(|v| v.as_str().map(str::to_string).or_else(|| Some(v.to_string())))
+            .unwrap_or_default();
+        Ok(format!("{setting} = {shown}"))
+    } else {
+        Err(output
+            .error
+            .unwrap_or_else(|| String::from("failed to set config")))
+    }
+}
+
+/// Whether `setting` is a known, writable config setting (single allowlist).
+#[must_use]
+pub fn is_supported_config_setting(setting: &str) -> bool {
+    supported_config_setting(setting.trim()).is_some()
+}
+
 fn execute_config(input: ConfigInput) -> Result<ConfigOutput, String> {
     let setting = input.setting.trim();
     if setting.is_empty() {
@@ -7701,6 +7730,16 @@ fn supported_config_setting(setting: &str) -> Option<ConfigSettingSpec> {
             scope: ConfigScope::Global,
             kind: ConfigKind::String,
             path: &["theme"],
+            options: None,
+        },
+        // Per-project selector for which named account (under `auth_modes`) to
+        // use. Scope = Settings (project `settings.local.json`, gitignored): a
+        // reference only — the account itself (base_url + key) stays defined
+        // once in the global `sudocode.json` (single source of truth).
+        "auth_profile" => ConfigSettingSpec {
+            scope: ConfigScope::Settings,
+            kind: ConfigKind::String,
+            path: &["auth_profile"],
             options: None,
         },
         "editorMode" => ConfigSettingSpec {


### PR DESCRIPTION
## What

Per-project **SudoRouter account switching** via `auth_profile`, on top of a unified config-layering + single-SSOT-writer refactor.

- **Named accounts**: `auth_modes.proxy.<name> = {baseUrl, apiKey}` in global `sudocode.json`.
- **Selection**: `auth_profile` resolves through layers — global `settings.json` → project `settings.json` (committed) → `settings.local.json` (local). Per-project file references a **name only**, so committed config carries no secrets.
- **`scode doctor`**: new **Account** check shows the resolved account + base_url.
- Default (no `auth_profile`) is byte-identical — regression-safe.
- **Docs**: `docs/authentication.md` gains a "Named accounts & per-project selection" section (extends the auth SSOT; no duplicate doc).

## Verify

`scode doctor` in a repo with `auth_profile` set resolves that account; elsewhere falls back to the default. Live-verified end to end.