### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/RELEASE_NOTES_v0.2.1.md
+++ b/RELEASE_NOTES_v0.2.1.md
@@ -1,0 +1,15 @@
+# Sudo Code v0.2.1
+
+## What's New
+
+### Features
+- **Unified agent/pid tool system** (#536, #542) — 7 new tools aligned to the nexus agent/pid model: `agent_list`, `agent_spawn`, `send`, `pid_fork`, `pid_output`, `pid_status`, `pid_kill`. These replace the ad-hoc `Agent`, `SendMessage`/`send_message`, `TaskStop`, `TaskGet`, `TaskList`, `TaskOutput` tools with a consistent `{layer}_{verb}` naming convention. All old names are retained as deprecated aliases — zero breaking changes.
+- **Per-project account switching** (#541) — `auth_profile` in layered config lets each project use a different API key / auth mode without env-var juggling. Config is now layered: global → project → env, with the first explicit value winning.
+- **A2A blocking tail** (#526, #525) — both co-hosted and standalone scode receivers now wait on the kernel's blocking `DT_STREAM` tail instead of polling, cutting idle CPU and improving message delivery latency.
+
+### Changes
+- **Co-host state observer arity** (#531) — `state_callback` now takes `(AgentState, Option<String>)` so agents can report a reason string alongside state transitions (e.g. "awaiting input").
+- **nexus-vfs pin bumps** (#524, #527, #528) — three successive pins bringing in `NEXUS_ALLOW_HOSTNAME_ADVERTISE` opt-out, `sys_write` wakes `DT_STREAM` tail, and `ServiceBootCtx` widen.
+
+### Fixes
+- **PTY test deflake** — `config_tree` exit test settles overlay teardown before `/exit` to avoid race conditions.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "plugins",
  "runtime",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "commands",
  "runtime",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "api",
  "serde_json",
@@ -2604,7 +2604,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3899,7 +3899,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "api",
  "arboard",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
## Summary

Bump workspace version to 0.2.1.

See [RELEASE_NOTES_v0.2.1.md](RELEASE_NOTES_v0.2.1.md) for the full changelog.

### Highlights
- **Unified agent/pid tool system** (#536, #542) — 7 new canonical tools
- **Per-project auth_profile** (#541) — layered config for multi-account setups
- **A2A blocking tail** (#525, #526) — event-driven message delivery

After merge, tag `v0.2.1` to trigger the release workflow.