### PR TITLE
test(pty): deflake iocraft_repl_ctrlc_hint — settle before Ctrl-C

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -117,6 +117,11 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
         panic!("prompt: {e}\nPTY:\n{screen}");
     });
 
+    // Settle: on macOS CI the signal handler may not be fully wired
+    // when the prompt first renders. A brief pause avoids Ctrl-C
+    // arriving before the REPL's SIGINT handler is installed.
+    std::thread::sleep(Duration::from_millis(200));
+
     // Press Ctrl-C once — should show hint in footer area.
     sess.send("\x03").expect("send Ctrl-C");
 


### PR DESCRIPTION
## Summary

- Add 200ms settle delay before sending Ctrl-C in `iocraft_repl_ctrlc_hint_in_footer`

On macOS CI the SIGINT handler may not be fully wired when the prompt first renders, causing Ctrl-C to be swallowed or delivered to the wrong handler. The test then times out waiting for the "Press Ctrl-C again to exit" hint.

## Test plan
- [x] Test passes locally (macOS)
- [ ] CI macOS passes consistently