### PR TITLE
runtime: compact before a context-window rejection wedges the session

### DIFF
--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -37,11 +37,11 @@ pub use providers::openai_compat::{
     OpenAiCompatClient, OpenAiCompatConfig,
 };
 pub use providers::registry::{
-    max_tokens_for_model, max_tokens_for_model_from_config, max_tokens_for_model_with_override,
-    model_token_limit, model_token_limit_from_config, preflight_message_request, resolve_model,
-    resolve_model_alias_from_config, resolve_provider_from_config, ApiFormat, Credential,
-    ModelConfigEntry, ModelProviderMapping, ModelTokenLimit, ProviderConnectionConfig,
-    ResolvedProvider, SudoCodeConfig,
+    estimate_request_overhead_tokens, max_tokens_for_model, max_tokens_for_model_from_config,
+    max_tokens_for_model_with_override, model_token_limit, model_token_limit_from_config,
+    preflight_message_request, resolve_model, resolve_model_alias_from_config,
+    resolve_provider_from_config, ApiFormat, Credential, ModelConfigEntry, ModelProviderMapping,
+    ModelTokenLimit, ProviderConnectionConfig, ResolvedProvider, SudoCodeConfig,
 };
 pub use providers::{detect_provider_kind, AuthMode, ProviderKind};
 pub use sse::{parse_frame, SseParser};

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -180,10 +180,26 @@ pub fn preflight_message_request(request: &MessageRequest) -> Result<(), ApiErro
 
 fn estimate_message_request_input_tokens(request: &MessageRequest) -> u32 {
     let mut estimate = estimate_serialized_tokens(&request.messages);
-    estimate = estimate.saturating_add(estimate_serialized_tokens(&request.system));
-    estimate = estimate.saturating_add(estimate_serialized_tokens(&request.tools));
+    estimate = estimate.saturating_add(estimate_request_overhead_tokens(
+        request.system.as_deref(),
+        request.tools.as_deref(),
+    ));
     estimate = estimate.saturating_add(estimate_serialized_tokens(&request.tool_choice));
     estimate
+}
+
+/// Estimated tokens of the per-request payload that conversation history
+/// compaction cannot shrink: the system prompt plus the tool definitions.
+///
+/// Uses the same serialized-bytes heuristic as [`preflight_message_request`]
+/// so callers that budget history against the context window agree with the
+/// preflight guard about where the line is.
+#[must_use]
+pub fn estimate_request_overhead_tokens(
+    system: Option<&str>,
+    tools: Option<&[crate::types::ToolDefinition]>,
+) -> u32 {
+    estimate_serialized_tokens(&system).saturating_add(estimate_serialized_tokens(&tools))
 }
 
 fn estimate_serialized_tokens<T: Serialize>(value: &T) -> u32 {

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -72,11 +72,15 @@ impl AcpError {
             return raw_message.clone();
         }
 
-        // Check for specific error types and provide friendly messages
+        // Check for specific error types and provide friendly messages.
+        // A context-window rejection that reaches here was not classified by
+        // the prompt path (which knows whether history was compactable), so
+        // do not guess a sub-class: a long history and a single oversized
+        // message are different problems with different fixes.
         if raw_message.contains("context_window_blocked")
             || raw_message.contains("Context window blocked")
         {
-            return "[context_window_exceeded][single_request_too_large] 图片或文本内容过大，超出了模型的处理限制。\n\n建议解决方案：\n1. 使用较小的图片（建议压缩或缩小图片尺寸）\n2. 简化输入内容\n3. 使用支持更大上下文的模型\n4. 清除对话历史后重新开始".to_string();
+            return "[context_window_exceeded] 请求超出了模型的上下文限制。\n\n建议解决方案：\n1. 压缩或清除对话历史后重新开始\n2. 使用较小的图片或简化输入内容\n3. 使用支持更大上下文的模型".to_string();
         }
 
         if raw_message.contains("authentication")

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -559,6 +559,11 @@ fn is_prompt_too_long(error_msg: &str) -> bool {
         || lower.contains("prompt_too_long")
         || lower.contains("maximum context length")
         || lower.contains("token limit")
+        // The API client's local preflight rejects an oversized compaction
+        // request before it leaves the process; treat it like the provider's
+        // own prompt-too-long so the head-truncation retry still applies.
+        || lower.contains("context_window_blocked")
+        || lower.contains("context window")
 }
 
 /// Drop the oldest ~20% of message groups from compaction input to make

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -271,6 +271,17 @@ impl std::error::Error for ToolError {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeError {
     message: String,
+    kind: RuntimeErrorKind,
+}
+
+/// Coarse classification of a [`RuntimeError`], for the few failures the
+/// runtime can recover from itself rather than surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeErrorKind {
+    Generic,
+    /// The request was rejected — locally by the API client's preflight or
+    /// by the provider — because it does not fit the model's context window.
+    ContextWindowBlocked,
 }
 
 impl RuntimeError {
@@ -278,7 +289,23 @@ impl RuntimeError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            kind: RuntimeErrorKind::Generic,
         }
+    }
+
+    /// An error whose cause is the request exceeding the context window.
+    /// `run_turn` reacts to this by compacting history and retrying once.
+    #[must_use]
+    pub fn context_window_blocked(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            kind: RuntimeErrorKind::ContextWindowBlocked,
+        }
+    }
+
+    #[must_use]
+    pub fn is_context_window_blocked(&self) -> bool {
+        self.kind == RuntimeErrorKind::ContextWindowBlocked
     }
 }
 
@@ -1005,6 +1032,8 @@ where
         let mut prompt_cache_events = Vec::new();
         let mut iterations = 0;
         let mut retried_empty_post_tool_deliverable = false;
+        let mut retried_context_window_overflow = false;
+        let mut overflow_compaction: Option<AutoCompactionEvent> = None;
         let mut response_model: Option<String> = None;
 
         loop {
@@ -1041,7 +1070,7 @@ where
             };
             // Race the API stream (which includes the retry loop) against
             // the abort signal so ESC/Ctrl-C cancels even during retries.
-            let mut stream = {
+            let stream_result = {
                 let abort = &self.hook_abort_signal;
                 tokio::select! {
                     biased;
@@ -1061,13 +1090,36 @@ where
                             response_model: None,
                         });
                     }
-                    result = self.api_client.stream(request) => match result {
-                        Ok(stream) => stream,
-                        Err(error) => {
-                            self.record_turn_failed(iterations, &error);
-                            return Err(error);
+                    result = self.api_client.stream(request) => result,
+                }
+            };
+            let mut stream = match stream_result {
+                Ok(stream) => stream,
+                Err(error) => {
+                    // A context-window rejection is the one request failure
+                    // the runtime can fix on its own: compact the history and
+                    // resend. Once per turn — if the preserved tail is still
+                    // too large the error is real and must surface.
+                    if error.is_context_window_blocked() && !retried_context_window_overflow {
+                        retried_context_window_overflow = true;
+                        let config = CompactionConfig {
+                            max_estimated_tokens: 0,
+                            ..CompactionConfig::default()
+                        };
+                        if let Some(event) = self.compact_in_place(config).await {
+                            overflow_compaction =
+                                merge_auto_compaction(overflow_compaction, Some(event));
+                            continue;
                         }
                     }
+                    if error.is_context_window_blocked() && assistant_messages.is_empty() {
+                        // Nothing answered this prompt; keeping it would make
+                        // every retry start from a bigger history than the
+                        // one that was just rejected.
+                        self.discard_unanswered_user_turn();
+                    }
+                    self.record_turn_failed(iterations, &error);
+                    return Err(error);
                 }
             };
 
@@ -1159,7 +1211,10 @@ where
                             self.record_turn_failed(iterations, &error);
                             return Err(error);
                         }
-                        let auto_compaction = self.maybe_auto_compact().await;
+                        let auto_compaction = merge_auto_compaction(
+                            overflow_compaction,
+                            self.maybe_auto_compact().await,
+                        );
                         self.file_tracker.end_turn();
                         self.current_turn_id = None;
                         self.user_request_intent = None;
@@ -1608,7 +1663,8 @@ where
             }
         }
 
-        let auto_compaction = self.maybe_auto_compact().await;
+        let auto_compaction =
+            merge_auto_compaction(overflow_compaction, self.maybe_auto_compact().await);
 
         self.finish_current_turn_tracking();
 
@@ -1675,6 +1731,12 @@ where
     #[must_use]
     pub fn session(&self) -> &Session {
         &self.session
+    }
+
+    /// The system prompt sent with every request of this runtime.
+    #[must_use]
+    pub fn system_prompt(&self) -> &SystemPrompt {
+        &self.system_prompt
     }
 
     #[must_use]
@@ -1779,7 +1841,14 @@ where
     async fn maybe_auto_compact(&mut self) -> Option<AutoCompactionEvent> {
         let model = self.session.model.as_deref().unwrap_or("claude-sonnet-4-6");
         let threshold = auto_compact_threshold_for_model(model);
-        if self.usage_tracker.cumulative_usage().input_tokens < threshold {
+        // Compare the context the provider actually processed on the latest
+        // response (uncached input + cache reads + cache writes) against the
+        // window. The session-wide cumulative input count is the wrong
+        // metric on both kinds of provider: with prompt caching it is a few
+        // hundred tokens per turn and never reaches the threshold; without
+        // caching it grows quadratically, never decreases, and re-compacts
+        // after every turn once crossed.
+        if self.usage_tracker.current_turn_usage().context_tokens() < threshold {
             return None;
         }
 
@@ -1795,15 +1864,37 @@ where
             max_estimated_tokens: 0,
             ..CompactionConfig::default()
         };
+        let event = self.compact_in_place(config).await;
+        if event.is_some() {
+            // Success → reset the noop counter so the breaker only trips on
+            // SUSTAINED inability to shrink, not on transient threshold dance.
+            self.consecutive_auto_compact_noops = 0;
+        } else {
+            self.consecutive_auto_compact_noops =
+                self.consecutive_auto_compact_noops.saturating_add(1);
+        }
+        event
+    }
 
-        // Resolve model for the compaction call
+    /// Compact the live session and install the result.
+    ///
+    /// Tries LLM compaction first and falls back to the local structural
+    /// summary when the API client does not support it or the call fails.
+    /// Re-injects recently read files after the summary, replaces the
+    /// in-memory session, and rewrites the persisted transcript so a later
+    /// resume does not reload the pre-compaction history. Returns `None`
+    /// when nothing could be removed (session too small, or the tail
+    /// protection kept everything).
+    pub async fn compact_in_place(
+        &mut self,
+        config: CompactionConfig,
+    ) -> Option<AutoCompactionEvent> {
         let model = self
             .session
             .model
             .clone()
             .unwrap_or_else(|| "claude-sonnet-4-6".to_string());
 
-        // Try LLM-based compaction first; fall back to sync if unsupported
         let result = match compact_session(
             &self.session,
             config,
@@ -1814,11 +1905,7 @@ where
         .await
         {
             Ok(result) => result,
-            Err(crate::compact::CompactionError::NothingToCompact) => {
-                self.consecutive_auto_compact_noops =
-                    self.consecutive_auto_compact_noops.saturating_add(1);
-                return None;
-            }
+            Err(crate::compact::CompactionError::NothingToCompact) => return None,
             Err(_) => {
                 // LLM compaction failed (not supported or API error) — fall
                 // back to the synchronous local heuristic.
@@ -1827,14 +1914,8 @@ where
         };
 
         if result.removed_message_count == 0 {
-            self.consecutive_auto_compact_noops =
-                self.consecutive_auto_compact_noops.saturating_add(1);
             return None;
         }
-
-        // Success → reset the noop counter so the breaker only trips on
-        // SUSTAINED inability to shrink, not on transient threshold dance.
-        self.consecutive_auto_compact_noops = 0;
 
         // Post-compact file restore: re-inject recently-read file content
         // so the model doesn't lose knowledge of files it just worked with.
@@ -1853,10 +1934,48 @@ where
             }
         }
         self.session = session;
+        // `push_message` appends to the transcript incrementally; the file
+        // still holds the removed messages until it is rewritten.
+        if let Err(error) = self.session.rewrite_persisted() {
+            self.record_session_persist_error("compaction", &error.to_string());
+        }
 
         Some(AutoCompactionEvent {
             removed_message_count: result.removed_message_count,
         })
+    }
+
+    /// Drop the trailing user message of a turn that produced no assistant
+    /// output, and rewrite the transcript to match. Used when the request
+    /// was rejected for its size: leaving the prompt in place would make the
+    /// user's next attempt start from a larger history than the one that
+    /// just failed, and consecutive user messages would accumulate on disk.
+    fn discard_unanswered_user_turn(&mut self) {
+        if !self
+            .session
+            .messages
+            .last()
+            .is_some_and(|message| message.role == MessageRole::User)
+        {
+            return;
+        }
+        self.session.messages.pop();
+        if let Err(error) = self.session.rewrite_persisted() {
+            self.record_session_persist_error("discard_unanswered_user_turn", &error.to_string());
+        }
+    }
+
+    fn record_session_persist_error(&self, operation: &str, error: &str) {
+        let Some(session_tracer) = &self.session_tracer else {
+            return;
+        };
+        let mut attributes = Map::new();
+        attributes.insert(
+            "operation".to_string(),
+            Value::String(operation.to_string()),
+        );
+        attributes.insert("error".to_string(), Value::String(error.to_string()));
+        session_tracer.record("session_persist_error", attributes);
     }
 
     fn record_turn_started(&self, user_input: &str) {
@@ -1991,6 +2110,21 @@ where
         attributes.insert("iteration".to_string(), Value::from(iteration as u64));
         attributes.insert("error".to_string(), Value::String(error.to_string()));
         session_tracer.record("turn_failed", attributes);
+    }
+}
+
+/// Combine the compaction events of one turn (overflow recovery plus the
+/// post-turn auto-compaction) into the single event reported to callers.
+fn merge_auto_compaction(
+    first: Option<AutoCompactionEvent>,
+    second: Option<AutoCompactionEvent>,
+) -> Option<AutoCompactionEvent> {
+    match (first, second) {
+        (None, None) => None,
+        (Some(event), None) | (None, Some(event)) => Some(event),
+        (Some(a), Some(b)) => Some(AutoCompactionEvent {
+            removed_message_count: a.removed_message_count + b.removed_message_count,
+        }),
     }
 }
 
@@ -4031,10 +4165,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auto_compacts_when_cumulative_input_threshold_is_crossed() {
+    async fn auto_compacts_when_context_threshold_is_crossed() {
         let _g = env_guard();
         // Env-var override sets threshold to 100 — test-only, independent of SSOT.
-        // Mock reports 200 input tokens → crosses 100 → triggers auto-compact.
+        // Mock reports a 200-token context on the latest response → crosses
+        // 100 → triggers auto-compact.
         std::env::set_var("CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS", "100");
         struct SimpleApi;
         #[async_trait]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -90,9 +90,10 @@ pub use bash::{
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};
 pub use compact::{
-    compact_session, compact_session_sync, estimate_block_tokens, estimate_session_tokens,
-    format_compact_summary, get_compact_continuation_message, should_compact, CompactionConfig,
-    CompactionError, CompactionResult, AUTOCOMPACT_BUFFER_TOKENS, COMPACT_MAX_OUTPUT_TOKENS,
+    autocompact_buffer_tokens, compact_session, compact_session_sync, estimate_block_tokens,
+    estimate_session_tokens, format_compact_summary, get_compact_continuation_message,
+    should_compact, CompactionConfig, CompactionError, CompactionResult, AUTOCOMPACT_BUFFER_TOKENS,
+    COMPACT_MAX_OUTPUT_TOKENS,
 };
 pub use config::{
     default_config_home, load_plugin_mcp_servers, ConfigEntry, ConfigError, ConfigLoader,

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -355,6 +355,19 @@ impl Session {
         Ok(())
     }
 
+    /// Rewrite the persisted transcript from the in-memory state.
+    ///
+    /// `push_message` appends incrementally, so any operation that *replaces*
+    /// `messages` (compaction, discarding an unanswered prompt) must call this
+    /// or the next load resurrects the pre-replacement history from disk.
+    /// A no-op for sessions without a persistence path.
+    pub fn rewrite_persisted(&self) -> Result<(), SessionError> {
+        match self.persistence_path() {
+            Some(path) => self.save_to_path(path.to_path_buf()),
+            None => Ok(()),
+        }
+    }
+
     pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, SessionError> {
         Self::load_from_path_with(&StdFsBackend, path)
     }

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -187,6 +187,20 @@ impl TokenUsage {
             + self.cache_read_input_tokens
     }
 
+    /// Size of the prompt the provider actually processed for this response:
+    /// uncached input plus everything served from or written to the prompt
+    /// cache. This is the current context-window occupancy, which is what
+    /// auto-compaction must compare against the window (CC parity: CC reads
+    /// the same three counters off the latest assistant message).
+    /// `input_tokens` alone is only the cache miss and drops to a few hundred
+    /// tokens per turn on caching providers.
+    #[must_use]
+    pub fn context_tokens(self) -> u32 {
+        self.input_tokens
+            .saturating_add(self.cache_creation_input_tokens)
+            .saturating_add(self.cache_read_input_tokens)
+    }
+
     #[must_use]
     pub fn estimate_cost_usd(self) -> UsageCostEstimate {
         self.estimate_cost_usd_with_pricing(ModelPricing::default_sonnet_tier())

--- a/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/api_client.rs
@@ -147,6 +147,32 @@ impl AnthropicRuntimeClient {
     pub(crate) fn session_tracer(&self) -> Option<&telemetry::SessionTracer> {
         self.client.session_tracer()
     }
+
+    /// Estimated tokens of the request parts that history compaction cannot
+    /// shrink — the rendered system prompt and the tool definitions this
+    /// client attaches — using the same heuristic as the API preflight.
+    pub(crate) fn fixed_request_overhead_tokens(
+        &self,
+        system_prompt: &runtime::SystemPrompt,
+    ) -> usize {
+        let system = (!system_prompt.is_empty()).then(|| system_prompt.render());
+        let tools = self
+            .enable_tools
+            .then(|| filter_tool_specs(&self.tool_registry, self.allowed_tools.as_ref()));
+        api::estimate_request_overhead_tokens(system.as_deref(), tools.as_deref()) as usize
+    }
+}
+
+/// Map an API failure to a runtime error, preserving the one classification
+/// the runtime acts on: a context-window rejection triggers compaction and a
+/// retry instead of ending the turn.
+fn runtime_error_from_api(session_id: &str, error: &api::ApiError) -> RuntimeError {
+    let message = format_user_visible_api_error(session_id, error);
+    if error.is_context_window_failure() {
+        RuntimeError::context_window_blocked(message)
+    } else {
+        RuntimeError::new(message)
+    }
 }
 
 pub(crate) fn resolve_cli_auth_source() -> Result<AuthSource, Box<dyn std::error::Error>> {
@@ -184,10 +210,15 @@ impl ApiClient for AnthropicRuntimeClient {
             .send_message(&request, None)
             .await
             .map_err(|error| {
-                RuntimeError::new(format!(
+                let message = format!(
                     "compaction API error: {}",
                     format_user_visible_api_error(&self.session_id, &error)
-                ))
+                );
+                if error.is_context_window_failure() {
+                    RuntimeError::context_window_blocked(message)
+                } else {
+                    RuntimeError::new(message)
+                }
             })?;
 
         // Extract text content from the response
@@ -478,23 +509,21 @@ impl AnthropicRuntimeClient {
             .client
             .stream_message(message_request, trace_id)
             .await
-            .map_err(|error| {
-                RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-            })?;
+            .map_err(|error| runtime_error_from_api(&self.session_id, &error))?;
 
         let prefetched_next = if apply_stall_timeout {
             match tokio::time::timeout(POST_TOOL_STALL_TIMEOUT, provider_stream.next_event()).await
             {
-                Ok(inner) => match inner.map_err(|error| {
-                    RuntimeError::new(format_user_visible_api_error(&self.session_id, &error))
-                })? {
-                    Some(event) => Some(Some(event)),
-                    None => {
-                        return Err(RuntimeError::new(
-                            "post-tool stall: model stream ended before first event",
-                        ));
+                Ok(inner) => {
+                    match inner.map_err(|error| runtime_error_from_api(&self.session_id, &error))? {
+                        Some(event) => Some(Some(event)),
+                        None => {
+                            return Err(RuntimeError::new(
+                                "post-tool stall: model stream ended before first event",
+                            ));
+                        }
                     }
-                },
+                }
                 Err(_elapsed) => {
                     return Err(RuntimeError::new(
                         "post-tool stall: model did not respond within timeout",

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -45,7 +45,7 @@ use api::{
 
 use cli::api_client::{
     collect_prompt_cache_events, collect_tool_results, collect_tool_uses, final_assistant_text,
-    AnthropicRuntimeClient,
+    max_tokens_for_model, AnthropicRuntimeClient,
 };
 use cli::args::{
     config_model_for_current_dir, default_permission_mode, format_unknown_slash_command,
@@ -3569,28 +3569,42 @@ impl AcpSdkDelegate {
             session.runtime.set_trace_id(tid);
         }
 
-        // Pre-send token estimation and auto-compact logic
+        // Pre-send context budget check.
+        //
+        // The request the provider sees is history + system prompt + tool
+        // definitions, and the window must also hold `max_tokens` of output.
+        // The API client's local preflight (`api::preflight_message_request`)
+        // rejects on exactly that sum, so history is budgeted against it here
+        // rather than against a bare percentage of the window: with the old
+        // 85% rule a long history sailed past this check and was then
+        // rejected by the preflight with no compaction ever having run —
+        // and, because ACP has no `/compact`, stayed rejected on every
+        // later prompt.
         let fallback_model = self.inner.current_model();
         let model = session
             .runtime
             .session()
             .model
-            .as_ref()
-            .unwrap_or(&fallback_model);
+            .clone()
+            .unwrap_or(fallback_model);
         // Context window comes from the model-capabilities SSOT file (per-model
         // entry, else the file's `default`). No hardcoded fallback here.
-        let context_limit = runtime::model_capabilities::context_window_or_default(model) as usize;
-
-        // Estimate current session tokens
+        let context_limit = runtime::model_capabilities::context_window_or_default(&model) as usize;
+        let max_output_tokens = max_tokens_for_model(&model) as usize;
+        let overhead_tokens = session
+            .runtime
+            .api_client()
+            .fixed_request_overhead_tokens(session.runtime.system_prompt());
+        let buffer_tokens = runtime::autocompact_buffer_tokens(&model) as usize;
+        let history_budget =
+            context_limit.saturating_sub(max_output_tokens + overhead_tokens + buffer_tokens);
+        let prompt_tokens = estimate_block_tokens(&ContentBlock::Text {
+            text: prompt.clone(),
+        });
         let estimated_tokens = estimate_session_tokens(session.runtime.session());
-        let threshold = (context_limit as f64 * 0.85) as usize; // 85% threshold
 
-        // If approaching limit, try auto-compact
-        if estimated_tokens > threshold {
-            // Check if we have enough messages to compact
+        if estimated_tokens + prompt_tokens > history_budget {
             let message_count = session.runtime.session().messages.len();
-            let can_compact = message_count > 4; // Need more than preserve_recent_messages
-
             if let Some(tracer) = session.runtime.session_tracer() {
                 tracer.record("auto_compact_check", {
                     let mut attrs = Map::new();
@@ -3598,7 +3612,22 @@ impl AcpSdkDelegate {
                         "estimated_tokens".to_string(),
                         Value::Number(estimated_tokens.into()),
                     );
-                    attrs.insert("threshold".to_string(), Value::Number(threshold.into()));
+                    attrs.insert(
+                        "prompt_tokens".to_string(),
+                        Value::Number(prompt_tokens.into()),
+                    );
+                    attrs.insert(
+                        "history_budget".to_string(),
+                        Value::Number(history_budget.into()),
+                    );
+                    attrs.insert(
+                        "overhead_tokens".to_string(),
+                        Value::Number(overhead_tokens.into()),
+                    );
+                    attrs.insert(
+                        "max_output_tokens".to_string(),
+                        Value::Number(max_output_tokens.into()),
+                    );
                     attrs.insert(
                         "context_limit".to_string(),
                         Value::Number(context_limit.into()),
@@ -3607,82 +3636,45 @@ impl AcpSdkDelegate {
                         "message_count".to_string(),
                         Value::Number(message_count.into()),
                     );
-                    attrs.insert("can_compact".to_string(), Value::Bool(can_compact));
                     attrs
                 });
             }
 
-            if can_compact {
-                // Perform compaction with aggressive settings for overflow scenario
-                let compaction_config = CompactionConfig {
-                    preserve_recent_messages: 2,
+            // LLM compaction with local fallback; installs the result and
+            // rewrites the transcript so a later resume does not reload the
+            // pre-compaction history.
+            let compaction = self
+                .inner
+                .tokio_runtime
+                .block_on(session.runtime.compact_in_place(CompactionConfig {
                     max_estimated_tokens: 0, // Force compaction
-                };
-                let result = compact_session_sync(session.runtime.session(), compaction_config);
-                if result.removed_message_count > 0 {
-                    // Update session with compacted version
-                    *session.runtime.session_mut() = result.compacted_session.clone();
-                    // Persist the compacted state immediately. The end-of-turn save_to_path is
-                    // skipped by the still-over-limit early return below (and by any later turn
-                    // error), which would otherwise leave the on-disk JSONL holding the full
-                    // uncompacted history — so the next resume reloads the pre-compaction session
-                    // and overflows again. Best-effort: a persist hiccup must not abort the turn.
-                    if let Err(persist_err) =
-                        session.runtime.session().save_to_path(&session.handle.path)
-                    {
-                        if let Some(tracer) = session.runtime.session_tracer() {
-                            tracer.record("auto_compact_persist_error", {
-                                let mut attrs = Map::new();
-                                attrs.insert(
-                                    "error".to_string(),
-                                    Value::String(persist_err.to_string()),
-                                );
-                                attrs
-                            });
-                        }
-                    }
-                    if let Some(tracer) = session.runtime.session_tracer() {
-                        tracer.record("auto_compact_result", {
-                            let mut attrs = Map::new();
-                            attrs.insert(
-                                "removed_messages".to_string(),
-                                Value::Number(result.removed_message_count.into()),
-                            );
-                            attrs
-                        });
-                    }
+                    ..CompactionConfig::default()
+                }));
+            if let Some(event) = compaction {
+                if let Some(tracer) = session.runtime.session_tracer() {
+                    tracer.record("auto_compact_result", {
+                        let mut attrs = Map::new();
+                        attrs.insert(
+                            "removed_messages".to_string(),
+                            Value::Number(event.removed_message_count.into()),
+                        );
+                        attrs
+                    });
                 }
+            }
 
-                // Re-estimate after compaction
-                let new_estimated_tokens = estimate_session_tokens(session.runtime.session());
-
-                // If still over limit after compaction, return friendly error
-                if new_estimated_tokens > context_limit {
-                    let user_message = format!(
-                        "[context_window_exceeded][history_context_too_large] 对话内容过长，即使压缩后仍超出模型限制。\n\n\
-                        当前估算: {} tokens\n\
-                        模型限制: {} tokens\n\n\
-                        建议解决方案：\n\
-                        1. 开始新对话\n\
-                        2. 使用支持更大上下文的模型\n\
-                        3. 减少图片或大文本内容的发送",
-                        new_estimated_tokens, context_limit
-                    );
-                    return Err(runtime::AcpError::internal(user_message));
-                }
-            } else {
-                // No messages to compact, but request is too large
-                let user_message = format!(
-                    "[context_window_exceeded][single_request_too_large] 当前请求内容过大，超出模型处理限制。\n\n\
-                    当前估算: {} tokens\n\
-                    模型限制: {} tokens\n\n\
-                    建议解决方案：\n\
-                    1. 使用较小的图片（压缩或缩小图片尺寸）\n\
-                    2. 简化输入内容\n\
-                    3. 使用支持更大上下文的模型",
-                    estimated_tokens, context_limit
-                );
-                return Err(runtime::AcpError::internal(user_message));
+            // Re-estimate after compaction against the hard limit the
+            // preflight enforces. Still over → surface a classified error
+            // instead of sending a request that will be rejected.
+            let new_estimated_tokens = estimate_session_tokens(session.runtime.session());
+            if new_estimated_tokens + prompt_tokens + overhead_tokens + max_output_tokens
+                > context_limit
+            {
+                return Err(runtime::AcpError::internal(context_overflow_user_message(
+                    session.runtime.session(),
+                    new_estimated_tokens + prompt_tokens + overhead_tokens + max_output_tokens,
+                    context_limit,
+                )));
             }
         }
         // Run the turn and get the TurnSummary directly
@@ -3693,6 +3685,19 @@ impl AcpSdkDelegate {
             .map_err(|e| {
                 if let Some(tracer) = session.runtime.session_tracer() {
                     tracer.record_prompt_error("runtime_error", e.to_string());
+                }
+                if e.is_context_window_blocked() {
+                    // The runtime already compacted and retried once; what is
+                    // left is either a tail that does not fit on its own or a
+                    // history it could not shrink. Classify from the session.
+                    let estimated = estimate_session_tokens(session.runtime.session())
+                        + overhead_tokens
+                        + max_output_tokens;
+                    return runtime::AcpError::internal(context_overflow_user_message(
+                        session.runtime.session(),
+                        estimated,
+                        context_limit,
+                    ));
                 }
                 runtime::AcpError::internal(e.to_string())
             })?;
@@ -3758,6 +3763,45 @@ impl AcpSdkDelegate {
             runtime::acp_sdk_server::AcpStopReason::EndTurn,
             prompt_usage,
         ))
+    }
+}
+
+/// User-facing message for a request that does not fit the context window,
+/// classified by what is left to shrink.
+///
+/// `[history_context_too_large]`: there is compactable history beyond the
+/// preserved tail, so compaction did not (or could not) bring the request
+/// under the limit. `[single_request_too_large]`: nothing but the summary
+/// and the most recent messages remain — the recent messages themselves are
+/// too large (typically a big paste or image), and compacting cannot help.
+fn context_overflow_user_message(
+    session: &Session,
+    estimated_tokens: usize,
+    context_limit: usize,
+) -> String {
+    let summary_prefix = usize::from(session.compaction.is_some());
+    let compactable = session.messages.len().saturating_sub(summary_prefix)
+        > CompactionConfig::default().preserve_recent_messages;
+    if compactable {
+        format!(
+            "[context_window_exceeded][history_context_too_large] 对话内容过长，即使压缩后仍超出模型限制。\n\n\
+            当前估算: {estimated_tokens} tokens\n\
+            模型限制: {context_limit} tokens\n\n\
+            建议解决方案：\n\
+            1. 开始新对话\n\
+            2. 使用支持更大上下文的模型\n\
+            3. 减少图片或大文本内容的发送"
+        )
+    } else {
+        format!(
+            "[context_window_exceeded][single_request_too_large] 最近的消息内容过大，压缩历史也无法放入模型上下文。\n\n\
+            当前估算: {estimated_tokens} tokens\n\
+            模型限制: {context_limit} tokens\n\n\
+            建议解决方案：\n\
+            1. 使用较小的图片（压缩或缩小图片尺寸）\n\
+            2. 简化输入内容\n\
+            3. 使用支持更大上下文的模型"
+        )
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -1054,6 +1054,183 @@ async fn scenario_session_load_rejects_other_cwd(
     );
 }
 
+/// Regression: a long history must be compacted before the request is sent,
+/// not rejected by the API client's context-window preflight.
+///
+/// Before the fix the ACP pre-send check only compacted above 85% of the
+/// context window, while the preflight rejects at
+/// `history + system + tools + max_tokens > window` — roughly 65% for a
+/// 200K model with 64K `max_tokens`. A history in that gap failed on every
+/// prompt with `context_window_blocked`, the failed prompt was persisted
+/// (growing the history), and ACP has no `/compact`, so the session was
+/// wedged for good. This seeds a transcript inside that gap and asserts the
+/// next prompt is answered from a compacted request.
+#[tokio::test]
+async fn acp_stdio_long_history_is_compacted_instead_of_rejected() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-long-history");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+
+    // --- Process A: create the session and run one turn so the transcript exists.
+    let session_id = {
+        let mut client = spawn_stdio_client(&workspace);
+        scenario_initialize(&mut client).await;
+        let session_id = scenario_session_new(&mut client, &workspace.root).await;
+        let (_notifs, resp) = client
+            .send_request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text") }]
+                }),
+            )
+            .await;
+        assert!(
+            resp["result"].get("stopReason").is_some(),
+            "seed turn should complete: {resp}"
+        );
+        client.shutdown().await;
+        session_id
+    };
+
+    // --- Rewrite the transcript with a history that fits the 85% rule but
+    // not the preflight: ~150K estimated tokens (bytes/4) of plain text
+    // against a 200K window with 64K max_tokens and ~7K of system+tools.
+    let transcript_path = find_session_transcript(&workspace.root, &session_id);
+    let mut session =
+        runtime::Session::load_from_path(&transcript_path).expect("seed transcript should load");
+    session.messages.clear();
+    let filler_line = "The conversation went on about the migration plan for a long while. ";
+    let filler = filler_line.repeat(30_000 / filler_line.len()); // ~30 KB per message
+    for turn in 0..10 {
+        session
+            .push_user_text(format!("user turn {turn}: {filler}"))
+            .expect("seed user message");
+        session
+            .push_message(runtime::ConversationMessage::assistant(vec![
+                runtime::ContentBlock::Text {
+                    text: format!("assistant turn {turn}: {filler}"),
+                },
+            ]))
+            .expect("seed assistant message");
+    }
+    session
+        .save_to_path(&transcript_path)
+        .expect("seeded transcript should persist");
+    let seeded_bytes = fs::metadata(&transcript_path)
+        .expect("seeded transcript metadata")
+        .len();
+    assert!(
+        seeded_bytes > 550_000,
+        "seed should be well past the preflight budget, got {seeded_bytes} bytes"
+    );
+
+    // --- Process B: load the session and prompt once.
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let (_load_notifs, load_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": session_id,
+                "cwd": workspace.root.to_string_lossy().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        load_resp.get("error").is_none(),
+        "session/load should succeed, got: {load_resp}"
+    );
+
+    let before = server.captured_requests().await.len();
+    let (_notifs, resp) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{
+                    "type": "text",
+                    "text": format!("{SCENARIO_PREFIX}streaming_text after long history")
+                }]
+            }),
+        )
+        .await;
+    assert!(
+        resp.get("error").is_none() && resp["result"].get("stopReason").is_some(),
+        "prompt on a long history must be answered, not rejected: {resp}"
+    );
+
+    let requests = server.captured_requests().await;
+    let new_requests = &requests[before..];
+    assert!(
+        new_requests
+            .iter()
+            .any(|request| request.scenario == "llm_compaction_roundtrip"),
+        "history should have been compacted through the LLM path; scenarios seen: {:?}",
+        new_requests
+            .iter()
+            .map(|request| request.scenario.as_str())
+            .collect::<Vec<_>>()
+    );
+    let turn_request = new_requests
+        .iter()
+        .rev()
+        .find(|request| request.stream)
+        .expect("the answered turn should have reached the mock as a streaming request");
+    assert!(
+        turn_request
+            .raw_body
+            .contains("continued from a previous conversation"),
+        "turn request should carry the compaction summary; body head: {}",
+        &turn_request.raw_body[..turn_request.raw_body.len().min(400)]
+    );
+    assert!(
+        turn_request.raw_body.len() < 250_000,
+        "turn request should be far below the seeded history ({seeded_bytes} bytes), got {} bytes",
+        turn_request.raw_body.len()
+    );
+
+    // The compacted transcript is what a later resume sees.
+    let reloaded =
+        runtime::Session::load_from_path(&transcript_path).expect("compacted transcript loads");
+    assert!(
+        reloaded.compaction.is_some() && reloaded.messages.len() < 20,
+        "transcript on disk should be compacted: compaction={:?} messages={}",
+        reloaded
+            .compaction
+            .as_ref()
+            .map(|c| c.removed_message_count),
+        reloaded.messages.len()
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// Locate `<root>/.scode/sessions/<fingerprint>/<id>/transcript.jsonl`.
+fn find_session_transcript(root: &std::path::Path, session_id: &str) -> PathBuf {
+    let sessions = root.join(".scode").join("sessions");
+    let entries = fs::read_dir(&sessions).expect("sessions dir should exist");
+    for entry in entries {
+        let candidate = entry
+            .expect("sessions dir entry")
+            .path()
+            .join(session_id)
+            .join("transcript.jsonl");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "no transcript for {session_id} under {}",
+        sessions.display()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Cross-session concurrency
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Long ACP sessions fail every prompt with `context_window_blocked`, surfaced to clients as `[single_request_too_large]`, and neither compaction nor a reload recovers them.

Root cause (full write-up with captures in `notes/compact-verification/README.md`): compaction was never triggered.

- The ACP pre-send check only compacted above **85%** of the context window.
- The API client's local preflight rejects at `history + system + tools + max_tokens > window`, which for a 200K model with 64K `max_tokens` is about **65%**.
- A history in that gap was rejected before any request left the process. The rejected prompt was still persisted, ACP has no `/compact`, and the post-turn auto-compaction never runs on a failed turn, so the session stayed wedged (also across `session/load`).
- Independently, auto-compaction keyed on the session-cumulative `input_tokens`: with prompt caching it never fires; without caching it fires at turn 5 and then re-compacts after every turn.

## Fix

1. **ACP pre-send check budgets history the way the preflight does** (`context_window − max_tokens − system/tools estimate − buffer`, new prompt included) and compacts through the LLM path. `api::estimate_request_overhead_tokens` shares the preflight's estimator so the two checks cannot drift apart again.
2. **Auto-compaction triggers on the latest response's context size** (`input + cache_read + cache_creation`, CC parity) instead of the cumulative count.
3. **`run_turn` compacts and resends once** when a request is rejected for the context window (local preflight or provider `prompt is too long`), and drops the unanswered prompt from the transcript if that still fails. `compact_in_place` now rewrites the persisted transcript, so a resume no longer reloads the pre-compaction history.
4. **Context-window errors are classified from the session shape**: `history_context_too_large` when compactable history remains, `single_request_too_large` only when the summary plus the recent tail is itself too big. The ACP fallback no longer labels every overflow as a single oversized request.

## Verification

- New integration test `acp_stdio_long_history_is_compacted_instead_of_rejected` seeds a ~600 KB transcript inside the gap; fails on `main`, passes here.
- Live against a capturing mock (scripts + captures in `notes/compact-verification/`):
  - Original 16-turn scenario: 11/16 turns succeeded on `main`, 16/16 here. Turn 11 triggers compaction; the next request drops from 484 KB to 149 KB.
  - Provider-side rejection (mock returns `prompt is too long` above 60K estimated tokens): 10/10 turns succeed, the rejected request is compacted and resent with no error reaching the client.
- `cargo test`: acp_integration 20, mock_parity_harness 4, resume_slash_commands + compact_output 13, runtime lib 717, api lib 190 — all green. `cargo fmt --check` clean; no new clippy warnings in touched files.

## Notes

- Overlaps with `fix/single-request-too-large` (same files for the error classification); merge order to be decided.
- `notes/compact-verification/` holds the investigation report, repro scripts and raw captures; happy to drop it from the PR if it should not live in the repo.
