### PR TITLE
runtime: keep tool role in compaction messages so tool_results stay paired

### DIFF
--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -309,6 +309,34 @@ impl Default for CompactionConfig {
     }
 }
 
+/// Which path produced a [`CompactionResult`]'s summary.
+///
+/// The local heuristic summary is much lossier than the LLM one, so callers
+/// surface this to the user instead of reporting a silent downgrade.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompactionSummarySource {
+    /// The summary came from the LLM compaction call.
+    Llm,
+    /// The summary came from the local structural heuristic
+    /// ([`compact_session_sync`]). `fallback_reason` is set when the LLM
+    /// path was attempted first and failed.
+    Local { fallback_reason: Option<String> },
+}
+
+impl fmt::Display for CompactionSummarySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Llm => write!(f, "llm"),
+            Self::Local {
+                fallback_reason: None,
+            } => write!(f, "local"),
+            Self::Local {
+                fallback_reason: Some(reason),
+            } => write!(f, "local (LLM compaction failed: {reason})"),
+        }
+    }
+}
+
 /// Result of compacting a session into a summary plus preserved tail messages.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompactionResult {
@@ -316,6 +344,7 @@ pub struct CompactionResult {
     pub formatted_summary: String,
     pub compacted_session: Session,
     pub removed_message_count: usize,
+    pub summary_source: CompactionSummarySource,
 }
 
 // ---------------------------------------------------------------------------
@@ -509,9 +538,15 @@ fn build_compaction_messages(
                 return None;
             }
 
-            // Map System/Tool roles to User for the compaction conversation
+            // Map System to User for the compaction conversation. Tool keeps
+            // its role: the API client relies on it to merge consecutive
+            // tool results into one user message, which Anthropic requires
+            // for every `tool_use` in the preceding assistant message
+            // (parallel tool calls otherwise fail with `tool_use ids were
+            // found without tool_result blocks immediately after`).
             let role = match msg.role {
-                MessageRole::System | MessageRole::User | MessageRole::Tool => MessageRole::User,
+                MessageRole::System | MessageRole::User => MessageRole::User,
+                MessageRole::Tool => MessageRole::Tool,
                 MessageRole::Assistant => MessageRole::Assistant,
             };
 
@@ -690,7 +725,24 @@ pub async fn compact_session<C: ApiClient>(
         formatted_summary,
         compacted_session,
         removed_message_count: removed.len(),
+        summary_source: CompactionSummarySource::Llm,
     })
+}
+
+/// Local fallback for callers whose LLM compaction attempt failed with
+/// `error`; identical to [`compact_session_sync`] except that the result
+/// records why the lossier local summary was used.
+#[must_use]
+pub fn compact_session_sync_after_llm_failure(
+    session: &Session,
+    config: CompactionConfig,
+    error: &CompactionError,
+) -> CompactionResult {
+    let mut result = compact_session_sync(session, config);
+    result.summary_source = CompactionSummarySource::Local {
+        fallback_reason: Some(error.to_string()),
+    };
+    result
 }
 
 /// Synchronous fallback compaction for callers without an async runtime or
@@ -705,6 +757,9 @@ pub fn compact_session_sync(session: &Session, config: CompactionConfig) -> Comp
             formatted_summary: String::new(),
             compacted_session: session.clone(),
             removed_message_count: 0,
+            summary_source: CompactionSummarySource::Local {
+                fallback_reason: None,
+            },
         };
     }
 
@@ -747,6 +802,9 @@ pub fn compact_session_sync(session: &Session, config: CompactionConfig) -> Comp
         formatted_summary,
         compacted_session,
         removed_message_count: removed.len(),
+        summary_source: CompactionSummarySource::Local {
+            fallback_reason: None,
+        },
     }
 }
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -9,8 +9,9 @@ use serde_json::{Map, Value};
 use telemetry::SessionTracer;
 
 use crate::compact::{
-    autocompact_buffer_tokens, compact_session, compact_session_sync, estimate_session_tokens,
-    CompactionConfig, CompactionResult, ReadFileTracker,
+    autocompact_buffer_tokens, compact_session, compact_session_sync,
+    compact_session_sync_after_llm_failure, estimate_session_tokens, CompactionConfig,
+    CompactionError, CompactionResult, ReadFileTracker,
 };
 use crate::config::RuntimeFeatureConfig;
 use crate::hooks::{HookAbortSignal, HookProgressReporter, HookRunResult, HookRunner};
@@ -1631,7 +1632,9 @@ where
     }
 
     /// Compact using the LLM path. Falls back to sync if the API client
-    /// doesn't support `send_compaction`.
+    /// doesn't support `send_compaction` or the LLM call fails; the result's
+    /// `summary_source` records the fallback reason so the caller can
+    /// surface the lossier summary.
     pub async fn compact(
         &mut self,
         config: CompactionConfig,
@@ -1652,7 +1655,8 @@ where
         .await
         {
             Ok(result) => result,
-            Err(_) => compact_session_sync(&self.session, config),
+            Err(CompactionError::NothingToCompact) => compact_session_sync(&self.session, config),
+            Err(error) => compact_session_sync_after_llm_failure(&self.session, config, &error),
         }
     }
 
@@ -1814,15 +1818,15 @@ where
         .await
         {
             Ok(result) => result,
-            Err(crate::compact::CompactionError::NothingToCompact) => {
+            Err(CompactionError::NothingToCompact) => {
                 self.consecutive_auto_compact_noops =
                     self.consecutive_auto_compact_noops.saturating_add(1);
                 return None;
             }
-            Err(_) => {
+            Err(error) => {
                 // LLM compaction failed (not supported or API error) — fall
                 // back to the synchronous local heuristic.
-                compact_session_sync(&self.session, config)
+                compact_session_sync_after_llm_failure(&self.session, config, &error)
             }
         };
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -90,9 +90,11 @@ pub use bash::{
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::{detect_branch_lock_collisions, BranchLockCollision, BranchLockIntent};
 pub use compact::{
-    compact_session, compact_session_sync, estimate_block_tokens, estimate_session_tokens,
-    format_compact_summary, get_compact_continuation_message, should_compact, CompactionConfig,
-    CompactionError, CompactionResult, AUTOCOMPACT_BUFFER_TOKENS, COMPACT_MAX_OUTPUT_TOKENS,
+    compact_session, compact_session_sync, compact_session_sync_after_llm_failure,
+    estimate_block_tokens, estimate_session_tokens, format_compact_summary,
+    get_compact_continuation_message, should_compact, CompactionConfig, CompactionError,
+    CompactionResult, CompactionSummarySource, AUTOCOMPACT_BUFFER_TOKENS,
+    COMPACT_MAX_OUTPUT_TOKENS,
 };
 pub use config::{
     default_config_home, load_plugin_mcp_servers, ConfigEntry, ConfigError, ConfigLoader,

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -501,6 +501,7 @@ pub(crate) fn format_compact_report(
     removed: usize,
     resulting_messages: usize,
     skipped: bool,
+    summary_source: &runtime::CompactionSummarySource,
 ) -> String {
     if skipped {
         format!(
@@ -514,7 +515,8 @@ pub(crate) fn format_compact_report(
             "Compact
   Result           compacted
   Messages removed {removed}
-  Messages kept    {resulting_messages}"
+  Messages kept    {resulting_messages}
+  Summary          {summary_source}"
         )
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -1166,7 +1166,12 @@ fn run_resume_command(
             result.compacted_session.save_to_path(session_path)?;
             Ok(ResumeCommandOutcome {
                 session: result.compacted_session,
-                message: Some(format_compact_report(removed, kept, skipped)),
+                message: Some(format_compact_report(
+                    removed,
+                    kept,
+                    skipped,
+                    &result.summary_source,
+                )),
                 json: Some(serde_json::json!({
                     "kind": "compact",
                     "skipped": skipped,
@@ -5733,7 +5738,12 @@ impl LiveCli {
         )?;
         self.replace_runtime(runtime)?;
         self.persist_session()?;
-        self.out_println(format_compact_report(removed, kept, skipped));
+        self.out_println(format_compact_report(
+            removed,
+            kept,
+            skipped,
+            &result.summary_source,
+        ));
         Ok(())
     }
 

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -342,9 +342,22 @@ fn spawn_stdio_client(workspace: &TestWorkspace) -> AcpTestClient {
 /// process, so a test can exercise the process-wide prompt flags a session's
 /// `_meta` overrides layer on top of.
 fn spawn_stdio_client_with_args(workspace: &TestWorkspace, extra: &[&str]) -> AcpTestClient {
+    spawn_stdio_client_with_args_and_env(workspace, extra, &[])
+}
+
+/// Like [`spawn_stdio_client_with_args`] but also sets extra environment
+/// variables on the `scode acp` process (`base_command` clears the
+/// environment, so runtime knobs such as the auto-compaction threshold have
+/// to be passed explicitly).
+fn spawn_stdio_client_with_args_and_env(
+    workspace: &TestWorkspace,
+    extra: &[&str],
+    env: &[(&str, &str)],
+) -> AcpTestClient {
     let mut cmd = base_command(workspace);
     cmd.arg("acp")
         .args(extra)
+        .envs(env.iter().copied())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -2914,6 +2927,162 @@ async fn acp_stdio_tool_call_update_carries_content_and_raw_output() {
     assert_eq!(
         &rederived, raw_output,
         "content text must be the verbatim tool output that rawOutput was built from"
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// Collect `(index, tool_use ids)` for every message in an Anthropic request
+/// body that carries `tool_use` blocks.
+fn tool_use_ids_by_message(messages: &[Value]) -> Vec<(usize, Vec<String>)> {
+    messages
+        .iter()
+        .enumerate()
+        .filter_map(|(index, message)| {
+            let ids = message["content"]
+                .as_array()
+                .map(|blocks| {
+                    blocks
+                        .iter()
+                        .filter(|block| block["type"].as_str() == Some("tool_use"))
+                        .filter_map(|block| block["id"].as_str().map(str::to_owned))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            (!ids.is_empty()).then_some((index, ids))
+        })
+        .collect()
+}
+
+/// Regression guard for LLM compaction of a conversation that contains a
+/// parallel tool call.
+///
+/// Anthropic requires every `tool_use` in an assistant message to be
+/// answered by a `tool_result` in the SAME next user message. The runtime
+/// stores each tool result as its own `Tool`-role message and relies on
+/// `convert_messages` to merge consecutive `Tool` messages into one user
+/// message; `build_compaction_messages` used to remap `Tool` to `User`
+/// before that merge, so the compaction request split the results across
+/// consecutive user messages and the API rejected it with
+/// `messages.N: tool_use ids were found without tool_result blocks
+/// immediately after`. The runtime then silently fell back to the lossy
+/// local summary. The mock does not validate pairing, so the assertion on
+/// the captured request body has to be explicit.
+#[tokio::test]
+async fn acp_stdio_llm_compaction_keeps_parallel_tool_results_paired() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-compaction-pairing");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    fs::write(workspace.root.join("fixture.txt"), "alpha parity line\n")
+        .expect("fixture.txt should be written");
+
+    // A one-token threshold makes the runtime's post-turn auto-compaction
+    // fire after every turn, which is the only way to drive the LLM
+    // compaction path over ACP.
+    let mut client = spawn_stdio_client_with_args_and_env(
+        &workspace,
+        &[],
+        &[("CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS", "1")],
+    );
+    scenario_initialize(&mut client).await;
+    let session = scenario_session_new(&mut client, &workspace.root).await;
+
+    // One parallel-tool turn followed by two plain text turns. Compaction
+    // preserves the last four messages and never splits a tool_use /
+    // tool_result exchange, so the first two compactions only remove the
+    // leading user prompt (or nothing); the compaction after the third turn
+    // is the one whose input spans the parallel tool_use / tool_result
+    // exchange.
+    for scenario in [
+        "multi_tool_turn_roundtrip",
+        "streaming_text",
+        "streaming_text",
+    ] {
+        let (_notifs, resp) = client
+            .send_request(
+                "session/prompt",
+                json!({
+                    "sessionId": session,
+                    "prompt": [{
+                        "type": "text",
+                        "text": format!("{SCENARIO_PREFIX}{scenario}")
+                    }]
+                }),
+            )
+            .await;
+        assert!(
+            resp["result"].get("stopReason").is_some(),
+            "{scenario} turn should complete normally: {resp}"
+        );
+    }
+
+    // Compaction requests are identified by their system prompt rather than
+    // the mock's scenario tag: the transcript being summarised still carries
+    // the PARITY_SCENARIO marker, which wins the mock's scenario detection.
+    let compaction_bodies = server
+        .captured_requests()
+        .await
+        .iter()
+        .filter(|request| !request.path.contains("count_tokens"))
+        .filter_map(|request| serde_json::from_str::<Value>(&request.raw_body).ok())
+        .filter(|body| {
+            body["system"]
+                .as_str()
+                .is_some_and(|system| system.contains("summarizing conversations"))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !compaction_bodies.is_empty(),
+        "auto-compaction should have sent at least one LLM compaction request"
+    );
+
+    let mut saw_parallel_tool_use = false;
+    for body in &compaction_bodies {
+        let messages = body["messages"]
+            .as_array()
+            .unwrap_or_else(|| panic!("compaction request should carry messages: {body}"));
+        for (index, tool_use_ids) in tool_use_ids_by_message(messages) {
+            if tool_use_ids.len() > 1 {
+                saw_parallel_tool_use = true;
+            }
+            let next = messages.get(index + 1).unwrap_or_else(|| {
+                panic!("compaction request messages.{index} has tool_use blocks but no following message: {body}")
+            });
+            assert_eq!(
+                next["role"].as_str(),
+                Some("user"),
+                "compaction request messages.{} must be the user message carrying the tool_results: {body}",
+                index + 1
+            );
+            let result_ids = next["content"]
+                .as_array()
+                .map(|blocks| {
+                    blocks
+                        .iter()
+                        .filter(|block| block["type"].as_str() == Some("tool_result"))
+                        .filter_map(|block| block["tool_use_id"].as_str().map(str::to_owned))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            for id in &tool_use_ids {
+                assert!(
+                    result_ids.contains(id),
+                    "compaction request messages.{index}: tool_use {id} has no tool_result in the \
+                     immediately following user message (messages.{} carries {result_ids:?}); \
+                     Anthropic rejects this shape with 400 `tool_use ids were found without \
+                     tool_result blocks immediately after`. Request: {body}",
+                    index + 1
+                );
+            }
+        }
+    }
+    assert!(
+        saw_parallel_tool_use,
+        "at least one compaction request should include the parallel tool_use pair; bodies: {compaction_bodies:?}"
     );
 
     client.shutdown().await;


### PR DESCRIPTION
## Problem

`/compact` (and post-turn auto-compaction) silently degrades to the lossy local summary whenever the conversation contains a parallel tool call. From a real user log (`~/.nexus/logs/scode.log`, event `request_failed`):

```
api returned 400 Bad Request (invalid_request_error): messages.3:`tool_use` ids were found without `tool_result` blocks immediately after: call_01_jyGy4y9iAr6NYvIZmkBI2933. Each `tool_use` block must have a corresponding `tool_result` block in the next message.
```

The compaction request carried this sequence:

```
3 assistant  tool_use(grep_search), tool_use(bash)      <- parallel tool calls
4 user       tool_result(grep_search)
5 user       tool_result(bash)                          <- must be in the SAME user message as #4
```

After the 400, `compact_session` returns `Err(ApiError)` and both callers (`ConversationRuntime::compact` and `maybe_auto_compact`) fall back to `compact_session_sync`, whose summary is just "N earlier messages compacted (user=.. assistant=.. tool=..), tools mentioned: ...". The user sees `Compact / Result compacted / Messages removed 38 / Messages kept 6` and has no way to tell the context was thrown away.

## Root cause

`rust/crates/runtime/src/compact.rs`, `build_compaction_messages`: it remapped `MessageRole::Tool` to `MessageRole::User` before the messages reached the API client. `convert_messages` in `rust/crates/rusty-sudocode-cli/src/cli/api_client.rs` merges consecutive **`Tool`**-role messages into the preceding user message precisely to satisfy Anthropic's pairing rule, but after the remap every tool_result was already a `User` message, so nothing merged. Normal turn requests never go through the remap, which is why only the compaction path (`AnthropicRuntimeClient::send_compaction`) was broken.

## Fix

- `build_compaction_messages` now only remaps `System -> User`; `Tool` keeps its role so `convert_messages` merges the results into one user message. (Other providers convert from the already-merged `InputMessage`s, so they are unaffected.)
- `CompactionResult` gains `summary_source: CompactionSummarySource` (`Llm` | `Local { fallback_reason }`). `compact_session` sets `Llm`, `compact_session_sync` sets `Local { None }`, and a new `compact_session_sync_after_llm_failure` records the error when the LLM path was tried and fell back.
- `ConversationRuntime::compact` / `maybe_auto_compact` no longer discard the error (`Err(_) => compact_session_sync(...)`); they use the fallback helper so the reason is kept.
- `format_compact_report` prints a new `Summary` line after the existing ones: `  Summary          llm`, `  Summary          local`, or `  Summary          local (LLM compaction failed: <reason>)`. Both callers (`LiveCli::compact` and the resume path in `main.rs`) pass the source through. The `skipped` report is unchanged.

## How it was verified

New integration test `acp_stdio_llm_compaction_keeps_parallel_tool_results_paired` in `rust/crates/rusty-sudocode-cli/tests/acp_integration.rs`: spawns `scode acp` with `CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS=1`, runs a `multi_tool_turn_roundtrip` turn (parallel `read_file` + `grep_search`) followed by two `streaming_text` turns so the auto-compaction input spans the parallel exchange, then asserts on every captured compaction request body (identified by its system prompt; the mock does not validate pairing) that each assistant `tool_use` is answered in the single, immediately following `user` message.

On `main` (test added, fix not applied) it fails for the right reason:

```
test acp_stdio_llm_compaction_keeps_parallel_tool_results_paired ... FAILED
panicked at crates/rusty-sudocode-cli/tests/acp_integration.rs:3072:17:
compaction request messages.0: tool_use toolu_multi_grep has no tool_result in the immediately following user message (messages.1 carries ["toolu_multi_read"]); Anthropic rejects this shape with 400 `tool_use ids were found without tool_result blocks immediately after`. Request: {"max_tokens":20000,"messages":[{"content":[{"id":"toolu_multi_read",...,"type":"tool_use"},{"id":"toolu_multi_grep",...,"type":"tool_use"}],"role":"assistant"},{"content":[{...,"tool_use_id":"toolu_multi_read","type":"tool_result"}],"role":"user"},{"content":[{...,"tool_use_id":"toolu_multi_grep","type":"tool_result"}],"role":"user"}, ...
```

With the fix:

```
test acp_stdio_llm_compaction_keeps_parallel_tool_results_paired ... ok
```

Full runs (all with an isolated `HOME`/`SUDO_CODE_CONFIG_HOME`):

- `cargo test -p runtime -p api --lib`: runtime 190 passed, api 717 passed
- `cargo test -p rusty-sudocode-cli --test acp_integration --test compact_output --test resume_slash_commands --test mock_parity_harness`: 20 / 4 / 12 / 1 passed
- `cargo fmt --all --check`: clean
- `cargo clippy -p runtime --no-deps --all-targets` and `-p rusty-sudocode-cli`: the baseline is already red on main (pedantic); cross-checked every diagnostic location against the lines added in this diff — 0 diagnostics on touched lines in either crate.

## Notes

PR #545 (context-window compaction) also touches `compact.rs` / `conversation.rs` / `main.rs`, but in different functions, so conflicts should be trivial.
