### PR TITLE
feat(acp): /compact, available_commands_update and an ACP slash-command table

### DIFF
--- a/docs/acp.md
+++ b/docs/acp.md
@@ -152,8 +152,16 @@ table, so clients can build a command palette without hard-coding it:
 Names carry no leading slash; send them as `/name …` in `session/prompt`.
 `input.hint` is present only for commands that take arguments. The
 notification follows the response on the same connection, so the client
-already knows the session id when it arrives. The same table drives `/help`
-and the unknown-command hint, so the three never disagree.
+already knows the session id when it arrives; be ready to receive
+`session/update` for a session as soon as its `session/new` response is in,
+because this one follows immediately. The same table drives `/help` and the
+unknown-command hint, so the three never disagree.
+
+`session/cancel` applies to `/compact`: a cancel during the model round-trip
+drops the call, a cancel that lands after it discards the result; either way
+the transcript in memory and on disk is left untouched and the prompt ends
+with `stopReason: "cancelled"`. The other commands are local and complete
+before a cancel could matter.
 
 **`/clear` and the old transcript.** Before the reset the previous transcript
 is archived as its own managed session — a fork branch named `cleared` with a
@@ -161,7 +169,10 @@ new session id, the full message history, compaction state, and lineage back
 to the live session id. The `/clear` reply names that id (`Archived as
 <id>`), and `session/load {sessionId: <id>, cwd}` reopens it as a separate
 session; `scode session list` in the same directory shows it too. The live
-session id continues with an empty transcript.
+session id continues with an empty transcript. The archive is a plain fork:
+it does not carry its own copy of tool results that were offloaded to the
+live session's storage, so once the live session is deleted, "read more"
+references inside the archive stop resolving.
 
 **Automatic compaction.** When a turn compacts the transcript on its own —
 either the pre-turn overflow guard or the in-turn threshold path — the
@@ -169,7 +180,9 @@ either the pre-turn overflow guard or the in-turn threshold path — the
 alongside the existing `contextWindowTokens`, `estimatedSessionTokens`,
 cost and `cumulativeUsage` fields. The key is absent when no automatic
 compaction happened; `/compact` itself never sets it (its report is the
-text reply).
+text reply). Like the rest of `_meta.sudocode`, it rides on the success
+response, so a turn that fails after compacting reports the error and no
+`autoCompacted`.
 
 ### `session/load`
 

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -105,6 +105,72 @@ Rules:
   true` and `_meta.sudocode.systemPromptAppend: true` so clients can
   feature-detect.
 
+### Slash commands
+
+A `session/prompt` whose text starts with `/` is a slash command, not a model
+turn: it runs on the session's lane like any prompt, streams its result as
+`agent_message_chunk` text, and completes with `stopReason: "end_turn"` and
+no `usage`. The ACP agent implements a fixed subset of the REPL commands:
+
+| Command | Effect |
+|---|---|
+| `/help` | List the commands in this table (the REPL-only ones are not shown). |
+| `/status` | Model, usage, git and config status for this session. |
+| `/cost` | Cumulative token usage for this session. |
+| `/model [<model-id>]` | Show the current model, or switch this session to another model. |
+| `/compact` | Summarise older messages to free context. LLM summary first; if the model call is unavailable or fails, the local structural summary. No token threshold — an explicit request always compacts when there is anything beyond the preserved recent tail. The compacted transcript is persisted immediately. The reply reports the method used, messages removed / kept, and the estimated token count before and after. |
+| `/clear` | Reset the session **in place**: session id, transcript file, working directory, model and permission mode are kept; the transcript is replaced by an empty one. **No `--confirm` is required** (the client's UI owns that confirmation); `--confirm` is accepted and ignored. |
+| `/config [section]` | Show the effective configuration (read-only; `/config set` is REPL-only). |
+| `/diff` | Staged and unstaged git changes in the session directory. |
+| `/doctor` | Local health checks for auth, config and workspace. |
+
+Any other `/command` is answered with a one-line text hint naming the command
+and listing this table.
+
+**Discovery.** Right after a successful `session/new` or `session/load`
+response, the agent sends one `session/update` notification advertising the
+table, so clients can build a command palette without hard-coding it:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "…",
+    "update": {
+      "sessionUpdate": "available_commands_update",
+      "availableCommands": [
+        { "name": "compact", "description": "Summarise older messages to free context (LLM summary, local fallback)" },
+        { "name": "clear", "description": "Start a fresh transcript in this session; the old one is archived" },
+        { "name": "model", "description": "…", "input": { "hint": "<model-id>" } }
+      ]
+    }
+  }
+}
+```
+
+Names carry no leading slash; send them as `/name …` in `session/prompt`.
+`input.hint` is present only for commands that take arguments. The
+notification follows the response on the same connection, so the client
+already knows the session id when it arrives. The same table drives `/help`
+and the unknown-command hint, so the three never disagree.
+
+**`/clear` and the old transcript.** Before the reset the previous transcript
+is archived as its own managed session — a fork branch named `cleared` with a
+new session id, the full message history, compaction state, and lineage back
+to the live session id. The `/clear` reply names that id (`Archived as
+<id>`), and `session/load {sessionId: <id>, cwd}` reopens it as a separate
+session; `scode session list` in the same directory shows it too. The live
+session id continues with an empty transcript.
+
+**Automatic compaction.** When a turn compacts the transcript on its own —
+either the pre-turn overflow guard or the in-turn threshold path — the
+`session/prompt` response carries `_meta.sudocode.autoCompacted: true`
+alongside the existing `contextWindowTokens`, `estimatedSessionTokens`,
+cost and `cumulativeUsage` fields. The key is absent when no automatic
+compaction happened; `/compact` itself never sets it (its report is the
+text reply).
+
 ### `session/load`
 
 `agentCapabilities.loadSession` is advertised. `session/load

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -119,7 +119,6 @@ no `usage`. The ACP agent implements a fixed subset of the REPL commands:
 | `/cost` | Cumulative token usage for this session. |
 | `/model [<model-id>]` | Show the current model, or switch this session to another model. |
 | `/compact` | Summarise older messages to free context. LLM summary first; if the model call is unavailable or fails, the local structural summary. No token threshold — an explicit request always compacts when there is anything beyond the preserved recent tail. The compacted transcript is persisted immediately. The reply reports the method used, messages removed / kept, and the estimated token count before and after. |
-| `/clear` | Reset the session **in place**: session id, transcript file, working directory, model and permission mode are kept; the transcript is replaced by an empty one. **No `--confirm` is required** (the client's UI owns that confirmation); `--confirm` is accepted and ignored. |
 | `/config [section]` | Show the effective configuration (read-only; `/config set` is REPL-only). |
 | `/diff` | Staged and unstaged git changes in the session directory. |
 | `/doctor` | Local health checks for auth, config and workspace. |
@@ -141,7 +140,6 @@ table, so clients can build a command palette without hard-coding it:
       "sessionUpdate": "available_commands_update",
       "availableCommands": [
         { "name": "compact", "description": "Summarise older messages to free context (LLM summary, local fallback)" },
-        { "name": "clear", "description": "Start a fresh transcript in this session; the old one is archived" },
         { "name": "model", "description": "…", "input": { "hint": "<model-id>" } }
       ]
     }
@@ -162,17 +160,6 @@ drops the call, a cancel that lands after it discards the result; either way
 the transcript in memory and on disk is left untouched and the prompt ends
 with `stopReason: "cancelled"`. The other commands are local and complete
 before a cancel could matter.
-
-**`/clear` and the old transcript.** Before the reset the previous transcript
-is archived as its own managed session — a fork branch named `cleared` with a
-new session id, the full message history, compaction state, and lineage back
-to the live session id. The `/clear` reply names that id (`Archived as
-<id>`), and `session/load {sessionId: <id>, cwd}` reopens it as a separate
-session; `scode session list` in the same directory shows it too. The live
-session id continues with an empty transcript. The archive is a plain fork:
-it does not carry its own copy of tool results that were offloaded to the
-live session's storage, so once the live session is deleted, "read more"
-references inside the archive stop resolving.
 
 **Automatic compaction.** When a turn compacts the transcript on its own —
 either the pre-turn overflow guard or the in-turn threshold path — the

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -98,12 +98,6 @@ const ACP_SLASH_COMMANDS: &[AcpSlashCommandSpec] = &[
         holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
-        name: "clear",
-        description: "Start a fresh transcript in this session; the old one is archived",
-        input_hint: None,
-        holds_cwd_lease: true,
-    },
-    AcpSlashCommandSpec {
         name: "config",
         description: "Show the effective configuration (read-only)",
         input_hint: Some("[section]"),

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -71,46 +71,55 @@ const ACP_SLASH_COMMANDS: &[AcpSlashCommandSpec] = &[
         name: "help",
         description: "List the slash commands available in ACP mode",
         input_hint: None,
+        holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
         name: "status",
         description: "Show model, usage, git and config status for this session",
         input_hint: None,
+        holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
         name: "cost",
         description: "Show cumulative token usage for this session",
         input_hint: None,
+        holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
         name: "model",
         description: "Show the current model, or switch this session to another model",
         input_hint: Some("<model-id>"),
+        holds_cwd_lease: true,
     },
     AcpSlashCommandSpec {
         name: "compact",
         description: "Summarise older messages to free context (LLM summary, local fallback)",
         input_hint: None,
+        holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
         name: "clear",
         description: "Start a fresh transcript in this session; the old one is archived",
         input_hint: None,
+        holds_cwd_lease: true,
     },
     AcpSlashCommandSpec {
         name: "config",
         description: "Show the effective configuration (read-only)",
         input_hint: Some("[section]"),
+        holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
         name: "diff",
         description: "Show staged and unstaged git changes in the session directory",
         input_hint: None,
+        holds_cwd_lease: false,
     },
     AcpSlashCommandSpec {
         name: "doctor",
         description: "Run local health checks for auth, config and workspace",
         input_hint: None,
+        holds_cwd_lease: false,
     },
 ];
 

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -8,6 +8,7 @@ use plugins::{
     discover_marketplace_manifest, MarketplaceDiscoveryError, MarketplaceManifest, PluginError,
     PluginLoadFailure, PluginLoadOutcome, PluginManager, PluginSummary,
 };
+use runtime::acp_sdk_server::AcpSlashCommandSpec;
 use runtime::{
     compact_session_sync, CompactionConfig, ConfigLoader, ConfigSource, McpOAuthConfig,
     McpServerConfig, ScopedMcpServerConfig, Session,
@@ -57,6 +58,100 @@ pub struct SlashCommandSpec {
 pub enum SkillSlashDispatch {
     Local,
     Invoke(String),
+}
+
+/// The slash commands the ACP agent (`scode acp`) accepts in `session/prompt`.
+///
+/// Single source of truth for the `available_commands_update` broadcast,
+/// `/help` under ACP, and the unknown-command hint — add a command here when
+/// the ACP delegate learns to handle it, nowhere else. Names are the
+/// `SlashCommand::parse` names without the leading slash.
+const ACP_SLASH_COMMANDS: &[AcpSlashCommandSpec] = &[
+    AcpSlashCommandSpec {
+        name: "help",
+        description: "List the slash commands available in ACP mode",
+        input_hint: None,
+    },
+    AcpSlashCommandSpec {
+        name: "status",
+        description: "Show model, usage, git and config status for this session",
+        input_hint: None,
+    },
+    AcpSlashCommandSpec {
+        name: "cost",
+        description: "Show cumulative token usage for this session",
+        input_hint: None,
+    },
+    AcpSlashCommandSpec {
+        name: "model",
+        description: "Show the current model, or switch this session to another model",
+        input_hint: Some("<model-id>"),
+    },
+    AcpSlashCommandSpec {
+        name: "compact",
+        description: "Summarise older messages to free context (LLM summary, local fallback)",
+        input_hint: None,
+    },
+    AcpSlashCommandSpec {
+        name: "clear",
+        description: "Start a fresh transcript in this session; the old one is archived",
+        input_hint: None,
+    },
+    AcpSlashCommandSpec {
+        name: "config",
+        description: "Show the effective configuration (read-only)",
+        input_hint: Some("[section]"),
+    },
+    AcpSlashCommandSpec {
+        name: "diff",
+        description: "Show staged and unstaged git changes in the session directory",
+        input_hint: None,
+    },
+    AcpSlashCommandSpec {
+        name: "doctor",
+        description: "Run local health checks for auth, config and workspace",
+        input_hint: None,
+    },
+];
+
+/// The ACP slash-command table (see [`ACP_SLASH_COMMANDS`]).
+#[must_use]
+pub fn acp_slash_commands() -> &'static [AcpSlashCommandSpec] {
+    ACP_SLASH_COMMANDS
+}
+
+/// `/help` output under ACP: only the commands the ACP delegate implements,
+/// rendered from the same table the client was sent.
+#[must_use]
+pub fn render_acp_slash_command_help() -> String {
+    let width = ACP_SLASH_COMMANDS
+        .iter()
+        .map(|spec| spec.usage().len())
+        .max()
+        .unwrap_or(0);
+    let mut lines = vec!["Slash commands (ACP mode)".to_string()];
+    lines.extend(ACP_SLASH_COMMANDS.iter().map(|spec| {
+        format!(
+            "  {:<width$}  {}",
+            spec.usage(),
+            spec.description,
+            width = width
+        )
+    }));
+    lines.join("\n")
+}
+
+/// Hint returned for a slash command the ACP delegate does not implement:
+/// names the rejected command and lists the table.
+#[must_use]
+pub fn format_acp_unsupported_slash_command(input: &str) -> String {
+    let name = input.split_whitespace().next().unwrap_or(input);
+    let available = ACP_SLASH_COMMANDS
+        .iter()
+        .map(|spec| format!("/{}", spec.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("`{name}` is not supported in ACP mode. Available: {available}")
 }
 
 const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use api::{InputContentBlock, MessageRequest, MessageResponse, OutputContentBlock, Usage};
 use serde_json::{json, Value};
@@ -160,7 +160,15 @@ enum Scenario {
     ForkSubagentRecursionGuardRoundtrip,
     LlmCompactionRoundtrip,
     AskUserQuestionRoundtrip,
+    /// `streaming_text`, answered after [`DELAYED_TEXT_LATENCY`]. Gives a
+    /// test a window to cancel a request in flight — including an LLM
+    /// compaction request, since compaction requests are classified by the
+    /// markers of the messages being summarised.
+    DelayedText,
 }
+
+/// How long [`Scenario::DelayedText`] holds a request before answering.
+pub const DELAYED_TEXT_LATENCY: Duration = Duration::from_secs(3);
 
 impl Scenario {
     fn parse(value: &str) -> Option<Self> {
@@ -196,6 +204,7 @@ impl Scenario {
                 Some(Self::ForkSubagentRecursionGuardRoundtrip)
             }
             "llm_compaction_roundtrip" => Some(Self::LlmCompactionRoundtrip),
+            "delayed_text" => Some(Self::DelayedText),
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             _ => None,
         }
@@ -232,6 +241,7 @@ impl Scenario {
             Self::SleepOverMaxRoundtrip => "sleep_over_max_roundtrip",
             Self::ForkSubagentRecursionGuardRoundtrip => "fork_subagent_recursion_guard_roundtrip",
             Self::LlmCompactionRoundtrip => "llm_compaction_roundtrip",
+            Self::DelayedText => "delayed_text",
             Self::AskUserQuestionRoundtrip => "ask_user_question_roundtrip",
         }
     }
@@ -260,6 +270,9 @@ async fn handle_connection(
         raw_body,
     });
 
+    if scenario == Scenario::DelayedText {
+        tokio::time::sleep(DELAYED_TEXT_LATENCY).await;
+    }
     let response = build_http_response(&request, scenario);
     socket.write_all(response.as_bytes()).await?;
     Ok(())
@@ -467,7 +480,7 @@ fn build_http_response(request: &MessageRequest, scenario: Scenario) -> String {
 #[allow(clippy::too_many_lines)]
 fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
     match scenario {
-        Scenario::StreamingText => streaming_text_sse(),
+        Scenario::StreamingText | Scenario::DelayedText => streaming_text_sse(),
         Scenario::MarkdownRenderingShowcase => markdown_showcase_sse(),
         Scenario::ReadFileRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => final_text_sse(&format!(
@@ -781,7 +794,7 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
         Scenario::MarkdownRenderingShowcase => {
             text_message_response("msg_markdown_showcase", MARKDOWN_SHOWCASE_DOC)
         }
-        Scenario::StreamingText => text_message_response(
+        Scenario::StreamingText | Scenario::DelayedText => text_message_response(
             "msg_streaming_text",
             "Mock streaming says hello from the parity harness.",
         ),
@@ -1169,6 +1182,7 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
 fn request_id_for(scenario: Scenario) -> &'static str {
     match scenario {
         Scenario::StreamingText => "req_streaming_text",
+        Scenario::DelayedText => "req_delayed_text",
         Scenario::MarkdownRenderingShowcase => "req_markdown_showcase",
         Scenario::ReadFileRoundtrip => "req_read_file_roundtrip",
         Scenario::GrepChunkAssembly => "req_grep_chunk_assembly",

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -28,16 +28,17 @@ use agent_client_protocol::{
     Dispatch, Error, Handled, JsonRpcRequest, JsonRpcResponse, Responder,
 };
 use agent_client_protocol_schema::{
-    AgentCapabilities, CancelNotification, ClientRequest, CloseSessionRequest,
-    CloseSessionResponse, ContentBlock, ContentChunk, ExtRequest, Implementation,
-    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, McpServer, NewSessionRequest, NewSessionResponse,
-    PermissionOption, PermissionOptionId, PermissionOptionKind, PromptCapabilities, PromptRequest,
-    PromptResponse, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    AgentCapabilities, AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate,
+    CancelNotification, ClientRequest, CloseSessionRequest, CloseSessionResponse, ContentBlock,
+    ContentChunk, ExtRequest, Implementation, InitializeRequest, InitializeResponse,
+    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, McpServer,
+    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionId,
+    PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
     SessionCapabilities, SessionCloseCapabilities, SessionInfo, SessionListCapabilities,
     SessionNotification, SessionUpdate, SetSessionModelRequest, SetSessionModelResponse,
     StopReason, TextContent, ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate,
-    ToolCallUpdateFields, ToolKind, Usage,
+    ToolCallUpdateFields, ToolKind, UnstructuredCommandInput, Usage,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map};
@@ -276,6 +277,12 @@ pub trait SdkAcpDelegate: Send + Sync + 'static {
         observer: &mut SdkSessionObserver,
     ) -> Result<(), AcpError>;
 
+    /// The slash commands [`Self::handle_slash_command`] accepts. Broadcast
+    /// to the client as `available_commands_update` right after `session/new`
+    /// and `session/load` succeed, so it must describe exactly what the
+    /// delegate implements.
+    fn available_commands(&self) -> &'static [AcpSlashCommandSpec];
+
     /// List active session IDs with their cwds.
     fn list_sessions(&self) -> Vec<(String, PathBuf)>;
 
@@ -475,6 +482,10 @@ pub struct PromptUsage {
     pub cost_currency: Option<UsageCostCurrency>,
     /// Cumulative usage for the entire session, exposed via _meta.sudocode.cumulativeUsage
     pub cumulative_usage: Option<CumulativeUsage>,
+    /// `true` when the transcript was compacted automatically during this
+    /// turn (pre-turn overflow protection or the in-turn threshold path),
+    /// exposed via `_meta.sudocode.autoCompacted`.
+    pub auto_compacted: bool,
 }
 
 /// Cumulative token usage for the entire session.
@@ -485,6 +496,58 @@ pub struct CumulativeUsage {
     pub total_tokens: u64,
     pub cached_read_tokens: Option<u64>,
     pub cached_write_tokens: Option<u64>,
+}
+
+/// One slash command the ACP agent accepts inside `session/prompt`.
+///
+/// The single table of these (owned by the `commands` crate, wired in by the
+/// delegate) is the source of truth for three things at once: the
+/// `available_commands_update` notification, `/help` under ACP, and the
+/// unknown-command hint. Keep them in one place so they cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AcpSlashCommandSpec {
+    /// Command name without the leading slash (`compact`, not `/compact`).
+    pub name: &'static str,
+    /// One-line, human-readable description shown by the client.
+    pub description: &'static str,
+    /// Placeholder for the argument text when the command takes any
+    /// (`<model-id>`); `None` for argument-less commands.
+    pub input_hint: Option<&'static str>,
+}
+
+impl AcpSlashCommandSpec {
+    /// `/name <hint>` as the user would type it.
+    #[must_use]
+    pub fn usage(&self) -> String {
+        match self.input_hint {
+            Some(hint) => format!("/{} {hint}", self.name),
+            None => format!("/{}", self.name),
+        }
+    }
+}
+
+impl From<&AcpSlashCommandSpec> for AvailableCommand {
+    fn from(spec: &AcpSlashCommandSpec) -> Self {
+        AvailableCommand::new(spec.name, spec.description).input(
+            spec.input_hint.map(|hint| {
+                AvailableCommandInput::Unstructured(UnstructuredCommandInput::new(hint))
+            }),
+        )
+    }
+}
+
+/// The `session/update` notification advertising `specs` to the client
+/// (`sessionUpdate: "available_commands_update"`, `availableCommands: [...]`).
+fn available_commands_notification(
+    session_id: &str,
+    specs: &[AcpSlashCommandSpec],
+) -> SessionNotification {
+    SessionNotification::new(
+        session_id.to_string(),
+        SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(
+            specs.iter().map(AvailableCommand::from).collect(),
+        )),
+    )
 }
 
 /// Build the `_meta` map for the `initialize` response. Currently advertises
@@ -587,6 +650,9 @@ fn sudocode_meta_from_prompt_usage(u: &PromptUsage) -> Map<String, serde_json::V
             }),
         );
     }
+    if u.auto_compacted {
+        sudocode_meta.insert("autoCompacted".to_string(), json!(true));
+    }
     sudocode_meta
 }
 
@@ -624,6 +690,7 @@ mod tests {
                 cached_read_tokens: Some(3),
                 cached_write_tokens: Some(0),
             }),
+            auto_compacted: false,
         });
 
         assert_eq!(meta["costUnits"], serde_json::json!(43_700));
@@ -1195,6 +1262,8 @@ pub(crate) async fn run_acp_on_transport(
                         };
                     let d = Arc::clone(&delegate);
                     let registry = Arc::clone(&registry);
+                    let commands = delegate.available_commands();
+                    let cx_notify = cx.clone();
                     cx.spawn(async move {
                         let lease = registry.cwd_lease();
                         let result = tokio::task::spawn_blocking(move || {
@@ -1217,7 +1286,13 @@ pub(crate) async fn run_acp_on_transport(
                         match result {
                             Ok((session_id, cwd, signal)) => {
                                 registry.register(session_id.clone(), signal, cwd);
-                                responder.respond(NewSessionResponse::new(session_id))?;
+                                responder.respond(NewSessionResponse::new(session_id.clone()))?;
+                                // Advertise the slash commands once the client
+                                // knows the session id (the response goes out
+                                // first on the same queue).
+                                let _ = cx_notify.send_notification(
+                                    available_commands_notification(&session_id, commands),
+                                );
                             }
                             Err(e) => {
                                 responder.respond_with_error(acp_error_to_sdk(&e))?;
@@ -1645,6 +1720,8 @@ pub(crate) async fn run_acp_on_transport(
                         };
                     let d = Arc::clone(&delegate);
                     let registry = Arc::clone(&registry);
+                    let commands = delegate.available_commands();
+                    let cx_notify = cx.clone();
                     let sid = req.session_id.to_string();
                     let cwd = req.cwd;
                     cx.spawn(async move {
@@ -1667,8 +1744,13 @@ pub(crate) async fn run_acp_on_transport(
 
                         match result {
                             Ok((session_id, cwd, signal)) => {
-                                registry.register(session_id, signal, cwd);
+                                registry.register(session_id.clone(), signal, cwd);
                                 responder.respond(LoadSessionResponse::new())?;
+                                // Same broadcast as `session/new`: a loaded
+                                // session accepts the same commands.
+                                let _ = cx_notify.send_notification(
+                                    available_commands_notification(&session_id, commands),
+                                );
                             }
                             Err(e) => {
                                 responder.respond_with_error(acp_error_to_sdk(&e))?;

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -515,8 +515,8 @@ pub struct AcpSlashCommandSpec {
     /// Placeholder for the argument text when the command takes any
     /// (`<model-id>`); `None` for argument-less commands.
     pub input_hint: Option<&'static str>,
-    /// `true` for commands that rebuild the session runtime (`/model`,
-    /// `/clear`), which is a runtime-construction path and therefore runs
+    /// `true` for commands that rebuild the session runtime (`/model`),
+    /// which is a runtime-construction path and therefore runs
     /// under the process-cwd lease (see [`WorkspaceCwdLease`]). Everything
     /// else — in particular `/compact`, which waits on a model round-trip —
     /// runs outside the lease so it never stalls `session/new` / `session/load`
@@ -1407,8 +1407,8 @@ pub(crate) async fn run_acp_on_transport(
                             // `unknown sessionId` error.
                             let _scope = session_cwd.clone().map(WorkspaceRootScope::enter);
                             // The slash commands that rebuild the session
-                            // runtime (`/model`, `/clear` — `holds_cwd_lease`
-                            // in the command table) are runtime-construction
+                            // runtime (`/model` — `holds_cwd_lease` in the
+                            // command table) are runtime-construction
                             // paths (see `WorkspaceCwdLease`), so they run
                             // under the lease: short, never parked on the
                             // user. The others — notably `/compact`, which

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -269,13 +269,15 @@ pub trait SdkAcpDelegate: Send + Sync + 'static {
         prompter: Box<dyn QuestionPrompter>,
     ) -> Result<(), AcpError>;
 
-    /// Handle a slash command, returning text output.
+    /// Handle a slash command. Text output goes through `observer`; the
+    /// returned stop reason is `EndTurn` unless the command honoured a
+    /// `session/cancel` (then `Cancelled`).
     fn handle_slash_command(
         &self,
         session_id: &str,
         input: &str,
         observer: &mut SdkSessionObserver,
-    ) -> Result<(), AcpError>;
+    ) -> Result<StopReason, AcpError>;
 
     /// The slash commands [`Self::handle_slash_command`] accepts. Broadcast
     /// to the client as `available_commands_update` right after `session/new`
@@ -513,6 +515,28 @@ pub struct AcpSlashCommandSpec {
     /// Placeholder for the argument text when the command takes any
     /// (`<model-id>`); `None` for argument-less commands.
     pub input_hint: Option<&'static str>,
+    /// `true` for commands that rebuild the session runtime (`/model`,
+    /// `/clear`), which is a runtime-construction path and therefore runs
+    /// under the process-cwd lease (see [`WorkspaceCwdLease`]). Everything
+    /// else — in particular `/compact`, which waits on a model round-trip —
+    /// runs outside the lease so it never stalls `session/new` / `session/load`
+    /// of sessions in other directories.
+    pub holds_cwd_lease: bool,
+}
+
+/// Whether the slash command in `prompt` (`/name …`) is one that must run
+/// under the process-cwd lease, per the delegate's command table. Unknown
+/// commands only ever print a hint, so they do not.
+fn slash_command_holds_cwd_lease(prompt: &str, specs: &[AcpSlashCommandSpec]) -> bool {
+    let name = prompt
+        .trim_start()
+        .strip_prefix('/')
+        .and_then(|rest| rest.split_whitespace().next());
+    name.is_some_and(|name| {
+        specs
+            .iter()
+            .any(|spec| spec.name == name && spec.holds_cwd_lease)
+    })
 }
 
 impl AcpSlashCommandSpec {
@@ -1337,6 +1361,7 @@ pub(crate) async fn run_acp_on_transport(
 
                     let d = Arc::clone(&delegate);
                     let registry = Arc::clone(&registry);
+                    let commands = delegate.available_commands();
                     let sid = req.session_id.to_string();
                     let cx_inner = cx.clone();
                     let cx_perm = cx.clone();
@@ -1348,6 +1373,8 @@ pub(crate) async fn run_acp_on_transport(
                         let session_cwd = registry.cwd(&sid);
                         let cwd_lease = registry.cwd_lease();
                         let is_slash_command = prompt_text.starts_with('/');
+                        let holds_cwd_lease =
+                            is_slash_command && slash_command_holds_cwd_lease(&prompt_text, commands);
 
                         // Set up permission-prompt bridge channels.
                         let (bridge_tx, mut bridge_rx) = tokio::sync::mpsc::unbounded_channel::<(
@@ -1379,13 +1406,15 @@ pub(crate) async fn run_acp_on_transport(
                             // no cwd and fall through to the delegate's
                             // `unknown sessionId` error.
                             let _scope = session_cwd.clone().map(WorkspaceRootScope::enter);
-                            // Slash commands are the exception: `/model`
-                            // rebuilds the session runtime, which is a
-                            // runtime-construction path (see
-                            // `WorkspaceCwdLease`), so they run under the
-                            // lease. They are short and never park on the
-                            // user.
-                            let _cwd_guard = match (is_slash_command, session_cwd) {
+                            // The slash commands that rebuild the session
+                            // runtime (`/model`, `/clear` — `holds_cwd_lease`
+                            // in the command table) are runtime-construction
+                            // paths (see `WorkspaceCwdLease`), so they run
+                            // under the lease: short, never parked on the
+                            // user. The others — notably `/compact`, which
+                            // waits on a model round-trip — run outside it so
+                            // they cannot stall other directories' sessions.
+                            let _cwd_guard = match (holds_cwd_lease, session_cwd) {
                                 (true, Some(cwd)) => Some(cwd_lease.acquire(&cwd).map_err(|e| {
                                     AcpError::internal(format!("failed to enter session cwd: {e}"))
                                 })?),
@@ -1412,7 +1441,7 @@ pub(crate) async fn run_acp_on_transport(
                                     &prompt_text_for_blocking,
                                     &mut observer,
                                 )
-                                .map(|()| (StopReason::EndTurn, None))
+                                .map(|stop| (stop, None))
                             } else {
                                 d.run_prompt_with_prompter(
                                     &sid_for_blocking,

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -316,6 +316,27 @@ pub struct TurnSummary {
     pub response_model: Option<String>,
 }
 
+/// Which path produced a [`CompactionResult`] from
+/// [`ConversationRuntime::compact_with_method`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionMethod {
+    /// The model summarised the removed messages (`send_compaction`).
+    LlmSummary,
+    /// The LLM call was unavailable or failed; the local structural
+    /// summary was used instead.
+    LocalHeuristic,
+}
+
+impl CompactionMethod {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LlmSummary => "llm summary",
+            Self::LocalHeuristic => "local heuristic",
+        }
+    }
+}
+
 /// Details about automatic session compaction applied during a turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AutoCompactionEvent {
@@ -1637,6 +1658,18 @@ where
         config: CompactionConfig,
         custom_instructions: Option<&str>,
     ) -> CompactionResult {
+        self.compact_with_method(config, custom_instructions)
+            .await
+            .0
+    }
+
+    /// [`Self::compact`] that also reports which path produced the result,
+    /// for callers that surface the outcome to the user (ACP `/compact`).
+    pub async fn compact_with_method(
+        &mut self,
+        config: CompactionConfig,
+        custom_instructions: Option<&str>,
+    ) -> (CompactionResult, CompactionMethod) {
         let model = self
             .session
             .model
@@ -1651,8 +1684,11 @@ where
         )
         .await
         {
-            Ok(result) => result,
-            Err(_) => compact_session_sync(&self.session, config),
+            Ok(result) => (result, CompactionMethod::LlmSummary),
+            Err(_) => (
+                compact_session_sync(&self.session, config),
+                CompactionMethod::LocalHeuristic,
+            ),
         }
     }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -113,8 +113,8 @@ pub use config_validate::{
 };
 pub use conversation::{
     auto_compact_threshold_for_model, ApiClient, ApiRequest, AssistantEvent, AssistantEventStream,
-    AutoCompactionEvent, ConversationRuntime, PromptCacheEvent, RuntimeError, RuntimeObserver,
-    StaticToolExecutor, ToolDispatchContext, ToolError, ToolExecutor, TurnSummary,
+    AutoCompactionEvent, CompactionMethod, ConversationRuntime, PromptCacheEvent, RuntimeError,
+    RuntimeObserver, StaticToolExecutor, ToolDispatchContext, ToolError, ToolExecutor, TurnSummary,
     FORK_BOILERPLATE_TAG,
 };
 pub use file_intent::{detect_file_intent, FileIntent, FileOpKind, UserRequestIntent};

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -519,6 +519,52 @@ pub(crate) fn format_compact_report(
     }
 }
 
+/// `/compact` report under ACP: what happened, how, and the effect on the
+/// transcript. `method` is `None` when nothing was removed.
+pub(crate) fn format_acp_compact_report(
+    before_tokens: usize,
+    after_tokens: usize,
+    removed: usize,
+    kept: usize,
+    method: Option<runtime::CompactionMethod>,
+) -> String {
+    match method {
+        Some(method) => format!(
+            "Compact
+  Result           compacted
+  Method           {}
+  Messages removed {removed}
+  Messages kept    {kept}
+  Estimated tokens {before_tokens} before, {after_tokens} after",
+            method.as_str()
+        ),
+        None => format!(
+            "Compact
+  Result           skipped
+  Reason           nothing to compact beyond the preserved recent messages
+  Messages kept    {kept}
+  Estimated tokens {after_tokens}"
+        ),
+    }
+}
+
+/// `/clear` report under ACP: the session id is kept, the transcript moved.
+pub(crate) fn format_acp_clear_report(
+    session_id: &str,
+    archived_session_id: &str,
+    model: &str,
+    permission_mode: &str,
+) -> String {
+    format!(
+        "Session cleared
+  Mode             in place (session id kept)
+  Session          {session_id}
+  Archived as      {archived_session_id} (reopen with session/load)
+  Preserved model  {model}
+  Permission mode  {permission_mode}"
+    )
+}
+
 pub(crate) fn format_auto_compaction_notice(removed: usize) -> String {
     format!("[auto-compacted: removed {removed} messages]")
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -548,23 +548,6 @@ pub(crate) fn format_acp_compact_report(
     }
 }
 
-/// `/clear` report under ACP: the session id is kept, the transcript moved.
-pub(crate) fn format_acp_clear_report(
-    session_id: &str,
-    archived_session_id: &str,
-    model: &str,
-    permission_mode: &str,
-) -> String {
-    format!(
-        "Session cleared
-  Mode             in place (session id kept)
-  Session          {session_id}
-  Archived as      {archived_session_id} (reopen with session/load)
-  Preserved model  {model}
-  Permission mode  {permission_mode}"
-    )
-}
-
 pub(crate) fn format_auto_compaction_notice(removed: usize) -> String {
     format!("[auto-compacted: removed {removed} messages]")
 }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2858,7 +2858,8 @@ impl AcpCliAgent {
         // this the resumed/switched session keeps its OLD model — which then drives the wrong
         // context-window in the pre-turn auto-compaction and can wedge the session on overflow.
         cloned_session.model = Some(resolved.clone());
-        self.rebuild_session_runtime(session, cloned_session, &resolved)?;
+        session.runtime =
+            self.build_replacement_session_runtime(session, cloned_session, &resolved)?;
         self.model
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -2871,13 +2872,15 @@ impl AcpCliAgent {
         ))
     }
 
-    /// Rebuild `session`'s runtime around `session_state` for `model`,
-    /// keeping everything else the session owns: cwd, handle, injected MCP
-    /// servers, prompt overrides, abort signal and the *active* permission
-    /// mode (a `session/setPermissionMode` must survive the rebuild). Shared
-    /// by `/model` (new model, same transcript) and `/clear` (same model,
-    /// fresh transcript). The caller holds the session lock.
-    fn rebuild_session_runtime(
+    /// Build a replacement runtime for `session` around `session_state` and
+    /// `model`, keeping everything else the session owns: cwd, handle,
+    /// injected MCP servers, prompt overrides, abort signal and the *active*
+    /// permission mode (a `session/setPermissionMode` must survive the
+    /// rebuild). The caller installs it with `session.runtime = …` once any
+    /// step that may still fail (e.g. persisting) has succeeded. Shared by
+    /// `/model` (new model, same transcript) and `/clear` (same model, fresh
+    /// transcript). The caller holds the session lock.
+    fn build_replacement_session_runtime(
         &self,
         session: &mut AcpCliSession,
         session_state: Session,
@@ -2919,18 +2922,28 @@ impl AcpCliAgent {
                 .map_or(true, |cfg| cfg.thinking());
             rt.api_client_mut().set_thinking_enabled(thinking);
         }
-
-        session.runtime = runtime;
-        Ok(())
+        Ok(runtime)
     }
 
-    /// `/compact` under ACP. Mirrors the REPL command: LLM summary first,
-    /// local heuristic when that is unavailable; no token threshold because
-    /// the user asked explicitly. The compacted transcript is persisted at
-    /// once (same reasoning as the pre-turn overflow path in
-    /// `run_prompt_impl`). The caller holds the session lock.
-    fn handle_acp_compact(&self, session: &mut AcpCliSession) -> Result<String, AcpError> {
+    /// `/compact` under ACP. Same strategy as the REPL command (LLM summary
+    /// first, local heuristic when that is unavailable) but with no token
+    /// threshold, because the user asked explicitly. The compacted transcript
+    /// is persisted at once (same reasoning as the pre-turn overflow path in
+    /// `run_prompt_impl`). A `session/cancel` during the model round-trip
+    /// drops the call; one that lands after it discards the result. Either
+    /// way the transcript in memory and on disk is left untouched and the
+    /// turn ends with `Cancelled`. The caller holds the session lock; the
+    /// server runs this *outside* the process-cwd lease.
+    fn handle_acp_compact(
+        &self,
+        session: &mut AcpCliSession,
+    ) -> Result<(String, runtime::acp_sdk_server::AcpStopReason), AcpError> {
+        use runtime::acp_sdk_server::AcpStopReason;
         let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
+        // Fresh turn: a cancel left over from an earlier turn must not abort
+        // this one (mirrors `run_prompt_impl`).
+        session.abort_signal.reset();
+        let abort_signal = session.abort_signal.clone();
         let before_tokens = estimate_session_tokens(session.runtime.session());
         let config = CompactionConfig {
             max_estimated_tokens: 0,
@@ -2952,10 +2965,6 @@ impl AcpCliAgent {
             ));
         };
         let removed = result.removed_message_count;
-        // Fresh turn: a cancel left over from an earlier turn must not abort
-        // this one (mirrors `run_prompt_impl`).
-        session.abort_signal.reset();
-        let abort_signal = session.abort_signal.clone();
         if removed > 0 {
             *session.runtime.session_mut() = result.compacted_session;
             session
@@ -3022,9 +3031,12 @@ impl AcpCliAgent {
             ClearMode::InPlace,
         )
         .map_err(|e| AcpError::internal(format!("failed to clear session: {e}")))?;
-        self.rebuild_session_runtime(session, cleared.fresh, &model)?;
-        session
-            .runtime
+        let mut runtime = self.build_replacement_session_runtime(session, cleared.fresh, &model)?;
+        // Persist the empty transcript *before* installing the new runtime:
+        // if the write fails, memory and disk both still hold the old
+        // transcript (plus the archive), instead of a cleared session that
+        // reloads its old history.
+        runtime
             .session()
             .save_to_path(&session.handle.path)
             .map_err(|e| AcpError::internal(format!("failed to persist cleared session: {e}")))?;
@@ -3039,18 +3051,6 @@ impl AcpCliAgent {
     }
 }
 
-/// How `/clear` replaces the live transcript.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClearMode {
-    /// REPL: the fresh transcript gets a new session id and file; the previous
-    /// transcript stays on disk under its own id.
-    NewSessionId,
-    /// ACP: the session id and file are kept for the fresh transcript, and the
-    /// previous transcript is archived under a new id first.
-    InPlace,
-}
-
-/// Outcome of [`clear_session_state`].
 /// Resolve once `signal` is aborted. Polls as well as awaiting the signal's
 /// notification, so an `abort()` that races the subscription is still seen
 /// promptly.
@@ -3066,6 +3066,18 @@ async fn wait_for_abort(signal: &runtime::HookAbortSignal) {
     }
 }
 
+/// How `/clear` replaces the live transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClearMode {
+    /// REPL: the fresh transcript gets a new session id and file; the previous
+    /// transcript stays on disk under its own id.
+    NewSessionId,
+    /// ACP: the session id and file are kept for the fresh transcript, and the
+    /// previous transcript is archived under a new id first.
+    InPlace,
+}
+
+/// Outcome of [`clear_session_state`].
 struct ClearedSession {
     /// Empty transcript to rebuild the runtime around (persistence path set).
     fresh: Session,
@@ -3420,6 +3432,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             }
         };
 
+        let mut stop = AcpStopReason::EndTurn;
         let response = match &command {
             SlashCommand::Model { model } => {
                 let locked = self.lock_session(session_id)?;
@@ -3434,7 +3447,6 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 let (report, compact_stop) = self.inner.handle_acp_compact(&mut session)?;
                 stop = compact_stop;
                 report
-        let mut stop = AcpStopReason::EndTurn;
             }
             // `--confirm` is accepted but not required: an ACP client confirms
             // in its own UI before sending the command.

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -61,15 +61,15 @@ use cli::export::{
     PromptHistoryEntry,
 };
 use cli::format::{
-    describe_tool_progress, first_visible_line, format_auth_report, format_auth_switch_report,
-    format_auto_compaction_notice, format_bughunter_report, format_commit_preflight_report,
-    format_commit_skipped_report, format_compact_report, format_cost_report,
-    format_internal_prompt_progress_line, format_issue_report, format_model_report,
-    format_model_switch_report, format_permission_prompt_box, format_permissions_report,
-    format_permissions_switch_report, format_pr_report, format_resume_report,
-    format_sandbox_report, format_tool_call_start, format_tool_result,
-    format_turn_status_line_with_branch, format_ultraplan_report, render_messages,
-    render_resume_usage, render_version_report, truncate_for_summary,
+    describe_tool_progress, first_visible_line, format_acp_clear_report, format_acp_compact_report,
+    format_auth_report, format_auth_switch_report, format_auto_compaction_notice,
+    format_bughunter_report, format_commit_preflight_report, format_commit_skipped_report,
+    format_compact_report, format_cost_report, format_internal_prompt_progress_line,
+    format_issue_report, format_model_report, format_model_switch_report,
+    format_permission_prompt_box, format_permissions_report, format_permissions_switch_report,
+    format_pr_report, format_resume_report, format_sandbox_report, format_tool_call_start,
+    format_tool_result, format_turn_status_line_with_branch, format_ultraplan_report,
+    render_messages, render_resume_usage, render_version_report, truncate_for_summary,
 };
 use cli::git::{
     enforce_broad_cwd_policy, git_output, parse_git_status_branch, parse_git_status_metadata,
@@ -2858,21 +2858,46 @@ impl AcpCliAgent {
         // this the resumed/switched session keeps its OLD model — which then drives the wrong
         // context-window in the pre-turn auto-compaction and can wedge the session on overflow.
         cloned_session.model = Some(resolved.clone());
+        self.rebuild_session_runtime(session, cloned_session, &resolved)?;
+        self.model
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone_from(&resolved);
+
+        Ok(format_model_switch_report(
+            &previous,
+            &resolved,
+            message_count,
+        ))
+    }
+
+    /// Rebuild `session`'s runtime around `session_state` for `model`,
+    /// keeping everything else the session owns: cwd, handle, injected MCP
+    /// servers, prompt overrides, abort signal and the *active* permission
+    /// mode (a `session/setPermissionMode` must survive the rebuild). Shared
+    /// by `/model` (new model, same transcript) and `/clear` (same model,
+    /// fresh transcript). The caller holds the session lock.
+    fn rebuild_session_runtime(
+        &self,
+        session: &mut AcpCliSession,
+        session_state: Session,
+        model: &str,
+    ) -> Result<(), AcpError> {
         let cwd = session.cwd.clone();
         let handle_id = session.handle.id.clone();
         let session_mcp = session.session_mcp_servers.clone();
+        let permission_mode = session.runtime.permission_policy_mut().active_mode();
 
         let sudocode_config = load_sudocode_config_for_cwd(&cwd);
-        let permission_mode = self.resolve_permission_mode_for_cwd(&cwd)?;
-        let auth_mode = resolve_model_switch_auth_mode(&resolved, self.auth_mode, &sudocode_config)
+        let auth_mode = resolve_model_switch_auth_mode(model, self.auth_mode, &sudocode_config)
             .map_err(|e| AcpError::internal(format!("failed to resolve auth mode: {e}")))?;
         let system_prompt = build_acp_system_prompt(&cwd, &session.prompt_overrides)?;
         let mut runtime = build_runtime_for_cwd(
             &cwd,
-            cloned_session,
+            session_state,
             &handle_id,
             RuntimeConfig {
-                model: resolved.clone(),
+                model: model.to_string(),
                 system_prompt,
                 enable_tools: true,
                 emit_output: false,
@@ -2896,16 +2921,161 @@ impl AcpCliAgent {
         }
 
         session.runtime = runtime;
-        self.model
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone_from(&resolved);
+        Ok(())
+    }
 
-        Ok(format_model_switch_report(
-            &previous,
-            &resolved,
-            message_count,
+    /// `/compact` under ACP. Mirrors the REPL command: LLM summary first,
+    /// local heuristic when that is unavailable; no token threshold because
+    /// the user asked explicitly. The compacted transcript is persisted at
+    /// once (same reasoning as the pre-turn overflow path in
+    /// `run_prompt_impl`). The caller holds the session lock.
+    fn handle_acp_compact(&self, session: &mut AcpCliSession) -> Result<String, AcpError> {
+        let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
+        let before_tokens = estimate_session_tokens(session.runtime.session());
+        let config = CompactionConfig {
+            max_estimated_tokens: 0,
+            ..CompactionConfig::default()
+        };
+        let (result, method) = self
+            .tokio_runtime
+            .block_on(session.runtime.compact_with_method(config, None));
+        let removed = result.removed_message_count;
+        if removed > 0 {
+            *session.runtime.session_mut() = result.compacted_session;
+            session
+                .runtime
+                .session()
+                .save_to_path(&session.handle.path)
+                .map_err(|e| {
+                    AcpError::internal(format!("failed to persist compacted session: {e}"))
+                })?;
+        }
+        let kept = session.runtime.session().messages.len();
+        let after_tokens = estimate_session_tokens(session.runtime.session());
+        if let Some(tracer) = session.runtime.session_tracer() {
+            tracer.record("slash_compact", {
+                let mut attrs = Map::new();
+                attrs.insert(
+                    "method".to_string(),
+                    Value::String(method.as_str().to_string()),
+                );
+                attrs.insert(
+                    "removed_messages".to_string(),
+                    Value::Number(removed.into()),
+                );
+                attrs.insert(
+                    "tokens_before".to_string(),
+                    Value::Number(before_tokens.into()),
+                );
+                attrs.insert(
+                    "tokens_after".to_string(),
+                    Value::Number(after_tokens.into()),
+                );
+                attrs
+            });
+        }
+        Ok(format_acp_compact_report(
+            before_tokens,
+            after_tokens,
+            removed,
+            kept,
+            (removed > 0).then_some(method),
         ))
+    }
+
+    /// `/clear` under ACP: reset the session **in place**. The session id,
+    /// file, cwd, model and permission mode are kept; the transcript is
+    /// archived under a new session id (still resumable / `session/load`-able)
+    /// and replaced by an empty one. No `--confirm` needed — the client's UI
+    /// owns that decision. The caller holds the session lock.
+    fn handle_acp_clear(&self, session: &mut AcpCliSession) -> Result<String, AcpError> {
+        let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
+        let model = session
+            .runtime
+            .session()
+            .model
+            .clone()
+            .unwrap_or_else(|| self.current_model());
+        let cleared = clear_session_state(
+            &session.cwd,
+            session.runtime.session(),
+            &session.handle,
+            ClearMode::InPlace,
+        )
+        .map_err(|e| AcpError::internal(format!("failed to clear session: {e}")))?;
+        self.rebuild_session_runtime(session, cleared.fresh, &model)?;
+        session
+            .runtime
+            .session()
+            .save_to_path(&session.handle.path)
+            .map_err(|e| AcpError::internal(format!("failed to persist cleared session: {e}")))?;
+        let permission_mode = session.runtime.permission_policy_mut().active_mode();
+        Ok(format_acp_clear_report(
+            &session.handle.id,
+            &cleared.previous.id,
+            &model,
+            permission_mode.as_str(),
+        ))
+    }
+}
+
+/// How `/clear` replaces the live transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClearMode {
+    /// REPL: the fresh transcript gets a new session id and file; the previous
+    /// transcript stays on disk under its own id.
+    NewSessionId,
+    /// ACP: the session id and file are kept for the fresh transcript, and the
+    /// previous transcript is archived under a new id first.
+    InPlace,
+}
+
+/// Outcome of [`clear_session_state`].
+struct ClearedSession {
+    /// Empty transcript to rebuild the runtime around (persistence path set).
+    fresh: Session,
+    /// Where `fresh` lives.
+    handle: SessionHandle,
+    /// Where the previous transcript lives — a managed session, so it stays
+    /// resumable (`/resume <id>`, `session/load`).
+    previous: SessionHandle,
+}
+
+/// `/clear` core shared by the REPL and ACP: keep the previous transcript on
+/// disk as its own managed session and hand back a fresh one that keeps the
+/// workspace root. The caller rebuilds its runtime around `fresh` (model and
+/// permission mode live in the runtime config, so they carry over).
+fn clear_session_state(
+    cwd: &Path,
+    current: &Session,
+    current_handle: &SessionHandle,
+    mode: ClearMode,
+) -> Result<ClearedSession, Box<dyn std::error::Error>> {
+    match mode {
+        ClearMode::NewSessionId => {
+            let fresh = new_cli_session_for(cwd)?;
+            let handle = create_managed_session_handle_for(cwd, &fresh.session_id)?;
+            Ok(ClearedSession {
+                fresh: fresh.with_persistence_path(handle.path.clone()),
+                handle,
+                previous: current_handle.clone(),
+            })
+        }
+        ClearMode::InPlace => {
+            // Archive as a fork branch named "cleared": a new id with the full
+            // transcript, compaction state and lineage back to the live id.
+            let archived = current.fork(Some("cleared".to_string()));
+            let previous = create_managed_session_handle_for(cwd, &archived.session_id)?;
+            archived.save_to_path(&previous.path)?;
+            let mut fresh = new_cli_session_for(cwd)?;
+            fresh.session_id.clone_from(&current_handle.id);
+            fresh.model.clone_from(&current.model);
+            Ok(ClearedSession {
+                fresh: fresh.with_persistence_path(current_handle.path.clone()),
+                handle: current_handle.clone(),
+                previous,
+            })
+        }
     }
 }
 
@@ -3222,6 +3392,18 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                     .handle_acp_model_switch(&mut session, model.clone())?
             }
             SlashCommand::Help => render_acp_slash_command_help(),
+            SlashCommand::Compact => {
+                let locked = self.lock_session(session_id)?;
+                let mut session = locked.get();
+                self.inner.handle_acp_compact(&mut session)?
+            }
+            // `--confirm` is accepted but not required: an ACP client confirms
+            // in its own UI before sending the command.
+            SlashCommand::Clear { .. } => {
+                let locked = self.lock_session(session_id)?;
+                let mut session = locked.get();
+                self.inner.handle_acp_clear(&mut session)?
+            }
             SlashCommand::Status => {
                 let locked = self.lock_session(session_id)?;
                 let session = locked.get();
@@ -5113,20 +5295,24 @@ impl LiveCli {
             return Ok(false);
         }
 
-        let previous_session = self.session.clone();
-        let session_state = new_cli_session()?;
-        let next_handle = create_managed_session_handle(&session_state.session_id)?;
+        let cwd = runtime::current_workspace_root()?;
+        let cleared = clear_session_state(
+            &cwd,
+            self.runtime.session(),
+            &self.session,
+            ClearMode::NewSessionId,
+        )?;
         let runtime = self.build_replacement_runtime(
-            session_state.with_persistence_path(next_handle.path.clone()),
-            next_handle.id.clone(),
+            cleared.fresh,
+            cleared.handle.id.clone(),
             self.config.clone(),
         )?;
-        self.session = next_handle;
+        self.session = cleared.handle;
         self.replace_runtime(runtime)?;
         self.out_println(format!(
             "Session cleared\n  Mode             fresh session\n  Previous session {}\n  Resume previous  /resume {}\n  Preserved model  {}\n  Permission mode  {}\n  New session      {}\n  Session file     {}",
-            previous_session.id,
-            previous_session.id,
+            cleared.previous.id,
+            cleared.previous.id,
             self.config.model,
             self.config.permission_mode.as_str(),
             self.session.id,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2882,7 +2882,7 @@ impl AcpCliAgent {
         session: &mut AcpCliSession,
         session_state: Session,
         model: &str,
-    ) -> Result<(), AcpError> {
+    ) -> Result<BuiltRuntime, AcpError> {
         let cwd = session.cwd.clone();
         let handle_id = session.handle.id.clone();
         let session_mcp = session.session_mcp_servers.clone();
@@ -2936,10 +2936,26 @@ impl AcpCliAgent {
             max_estimated_tokens: 0,
             ..CompactionConfig::default()
         };
-        let (result, method) = self
-            .tokio_runtime
-            .block_on(session.runtime.compact_with_method(config, None));
+        let compaction = self.tokio_runtime.block_on(async {
+            tokio::select! {
+                result = session.runtime.compact_with_method(config, None) => Some(result),
+                () = wait_for_abort(&abort_signal) => None,
+            }
+        });
+        let Some((result, method)) = compaction.filter(|_| !abort_signal.is_aborted()) else {
+            if let Some(tracer) = session.runtime.session_tracer() {
+                tracer.record("slash_compact_cancelled", Map::new());
+            }
+            return Ok((
+                "Compact\n  Result           cancelled\n  Transcript       unchanged".to_string(),
+                AcpStopReason::Cancelled,
+            ));
+        };
         let removed = result.removed_message_count;
+        // Fresh turn: a cancel left over from an earlier turn must not abort
+        // this one (mirrors `run_prompt_impl`).
+        session.abort_signal.reset();
+        let abort_signal = session.abort_signal.clone();
         if removed > 0 {
             *session.runtime.session_mut() = result.compacted_session;
             session
@@ -2974,12 +2990,15 @@ impl AcpCliAgent {
                 attrs
             });
         }
-        Ok(format_acp_compact_report(
-            before_tokens,
-            after_tokens,
-            removed,
-            kept,
-            (removed > 0).then_some(method),
+        Ok((
+            format_acp_compact_report(
+                before_tokens,
+                after_tokens,
+                removed,
+                kept,
+                (removed > 0).then_some(method),
+            ),
+            AcpStopReason::EndTurn,
         ))
     }
 
@@ -3009,7 +3028,8 @@ impl AcpCliAgent {
             .session()
             .save_to_path(&session.handle.path)
             .map_err(|e| AcpError::internal(format!("failed to persist cleared session: {e}")))?;
-        let permission_mode = session.runtime.permission_policy_mut().active_mode();
+        let permission_mode = runtime.permission_policy_mut().active_mode();
+        session.runtime = runtime;
         Ok(format_acp_clear_report(
             &session.handle.id,
             &cleared.previous.id,
@@ -3031,6 +3051,21 @@ enum ClearMode {
 }
 
 /// Outcome of [`clear_session_state`].
+/// Resolve once `signal` is aborted. Polls as well as awaiting the signal's
+/// notification, so an `abort()` that races the subscription is still seen
+/// promptly.
+async fn wait_for_abort(signal: &runtime::HookAbortSignal) {
+    loop {
+        if signal.is_aborted() {
+            return;
+        }
+        tokio::select! {
+            () = signal.cancelled() => {}
+            () = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+    }
+}
+
 struct ClearedSession {
     /// Empty transcript to rebuild the runtime around (persistence path set).
     fresh: Session,
@@ -3368,19 +3403,20 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         session_id: &str,
         input: &str,
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
-    ) -> Result<(), runtime::AcpError> {
+    ) -> Result<runtime::acp_sdk_server::AcpStopReason, runtime::AcpError> {
+        use runtime::acp_sdk_server::AcpStopReason;
         use runtime::RuntimeObserver as _;
         let command = match SlashCommand::parse(input) {
             Ok(Some(command)) => command,
             Ok(None) => {
                 observer.on_text_delta(&format_acp_unsupported_slash_command(input));
-                return Ok(());
+                return Ok(AcpStopReason::EndTurn);
             }
             Err(error) => {
                 observer.on_text_delta(&format!(
                     "{error}\n  Help             /help lists the commands available in ACP mode"
                 ));
-                return Ok(());
+                return Ok(AcpStopReason::EndTurn);
             }
         };
 
@@ -3395,7 +3431,10 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             SlashCommand::Compact => {
                 let locked = self.lock_session(session_id)?;
                 let mut session = locked.get();
-                self.inner.handle_acp_compact(&mut session)?
+                let (report, compact_stop) = self.inner.handle_acp_compact(&mut session)?;
+                stop = compact_stop;
+                report
+        let mut stop = AcpStopReason::EndTurn;
             }
             // `--confirm` is accepted but not required: an ACP client confirms
             // in its own UI before sending the command.
@@ -3487,7 +3526,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         };
 
         observer.on_text_delta(&response);
-        Ok(())
+        Ok(stop)
     }
 
     fn available_commands(&self) -> &'static [runtime::acp_sdk_server::AcpSlashCommandSpec] {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -97,14 +97,15 @@ use cli::tool_executor::{
     clear_pending_plan_execution, permission_policy, take_pending_plan_execution, CliToolExecutor,
 };
 use commands::{
-    classify_skills_slash_command, handle_agents_slash_command, handle_agents_slash_command_json,
+    acp_slash_commands, classify_skills_slash_command, format_acp_unsupported_slash_command,
+    handle_agents_slash_command, handle_agents_slash_command_json,
     handle_mcp_slash_command_json_with_plugins, handle_mcp_slash_command_with_plugins,
     handle_plugins_slash_command, handle_skills_slash_command, handle_skills_slash_command_json,
     handle_skills_slash_command_json_with_plugins, handle_skills_slash_command_with_plugins,
-    render_skills_prompt_section, render_slash_command_help, render_slash_command_help_filtered,
-    resolve_skill_invocation, resolve_skill_invocation_with_plugins,
-    resume_supported_slash_commands, slash_command_specs, validate_slash_command_input,
-    SkillSlashDispatch, SlashCommand,
+    render_acp_slash_command_help, render_skills_prompt_section, render_slash_command_help,
+    render_slash_command_help_filtered, resolve_skill_invocation,
+    resolve_skill_invocation_with_plugins, resume_supported_slash_commands, slash_command_specs,
+    validate_slash_command_input, SkillSlashDispatch, SlashCommand,
 };
 use compat_harness::{extract_manifest, UpstreamPaths};
 use dialoguer::{FuzzySelect, Select};
@@ -3199,11 +3200,18 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
         observer: &mut runtime::acp_sdk_server::SdkSessionObserver,
     ) -> Result<(), runtime::AcpError> {
         use runtime::RuntimeObserver as _;
-        let Ok(Some(command)) = SlashCommand::parse(input) else {
-            observer.on_text_delta(&format!(
-                "Unknown slash command: `{input}`. Type `/help` for available commands."
-            ));
-            return Ok(());
+        let command = match SlashCommand::parse(input) {
+            Ok(Some(command)) => command,
+            Ok(None) => {
+                observer.on_text_delta(&format_acp_unsupported_slash_command(input));
+                return Ok(());
+            }
+            Err(error) => {
+                observer.on_text_delta(&format!(
+                    "{error}\n  Help             /help lists the commands available in ACP mode"
+                ));
+                return Ok(());
+            }
         };
 
         let response = match &command {
@@ -3213,7 +3221,7 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 self.inner
                     .handle_acp_model_switch(&mut session, model.clone())?
             }
-            SlashCommand::Help => render_repl_help(),
+            SlashCommand::Help => render_acp_slash_command_help(),
             SlashCommand::Status => {
                 let locked = self.lock_session(session_id)?;
                 let session = locked.get();
@@ -3237,8 +3245,8 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
             SlashCommand::Cost => {
                 let locked = self.lock_session(session_id)?;
                 let session = locked.get();
-                let usage = UsageTracker::from_session(session.runtime.session())
-                    .cumulative_usage();
+                let usage =
+                    UsageTracker::from_session(session.runtime.session()).cumulative_usage();
                 format!(
                     "Token usage: {} input, {} output, {} cache-create, {} cache-read",
                     usage.input_tokens,
@@ -3293,14 +3301,15 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                     .map(|report| report.render())
                     .map_err(|e| runtime::AcpError::internal(e.to_string()))?
             }
-            _ => format!(
-                "`{}` is not supported in ACP mode. Available: /model, /status, /cost, /config, /diff, /doctor, /help",
-                input.split_whitespace().next().unwrap_or(input)
-            ),
+            _ => format_acp_unsupported_slash_command(input),
         };
 
         observer.on_text_delta(&response);
         Ok(())
+    }
+
+    fn available_commands(&self) -> &'static [runtime::acp_sdk_server::AcpSlashCommandSpec] {
+        acp_slash_commands()
     }
 
     fn list_sessions(&self) -> Vec<(String, PathBuf)> {
@@ -3584,6 +3593,8 @@ impl AcpSdkDelegate {
         // Estimate current session tokens
         let estimated_tokens = estimate_session_tokens(session.runtime.session());
         let threshold = (context_limit as f64 * 0.85) as usize; // 85% threshold
+                                                                // Surfaced to the client as `_meta.sudocode.autoCompacted`.
+        let mut auto_compacted = false;
 
         // If approaching limit, try auto-compact
         if estimated_tokens > threshold {
@@ -3620,6 +3631,7 @@ impl AcpSdkDelegate {
                 };
                 let result = compact_session_sync(session.runtime.session(), compaction_config);
                 if result.removed_message_count > 0 {
+                    auto_compacted = true;
                     // Update session with compacted version
                     *session.runtime.session_mut() = result.compacted_session.clone();
                     // Persist the compacted state immediately. The end-of-turn save_to_path is
@@ -3696,6 +3708,7 @@ impl AcpSdkDelegate {
                 }
                 runtime::AcpError::internal(e.to_string())
             })?;
+        auto_compacted |= turn_summary.auto_compaction.is_some();
         // Use turn_usage for PromptUsage, session_usage for cumulative
         let per_turn_usage =
             (turn_summary.turn_usage.total_tokens() > 0).then_some(turn_summary.turn_usage);
@@ -3720,6 +3733,7 @@ impl AcpSdkDelegate {
                 cached_read_tokens: Some(u64::from(cumulative_usage.cache_read_input_tokens)),
                 cached_write_tokens: Some(u64::from(cumulative_usage.cache_creation_input_tokens)),
             }),
+            auto_compacted,
         });
         // Record token usage to telemetry log
         if let Some(tracer) = session.runtime.session_tracer() {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -61,15 +61,15 @@ use cli::export::{
     PromptHistoryEntry,
 };
 use cli::format::{
-    describe_tool_progress, first_visible_line, format_acp_clear_report, format_acp_compact_report,
-    format_auth_report, format_auth_switch_report, format_auto_compaction_notice,
-    format_bughunter_report, format_commit_preflight_report, format_commit_skipped_report,
-    format_compact_report, format_cost_report, format_internal_prompt_progress_line,
-    format_issue_report, format_model_report, format_model_switch_report,
-    format_permission_prompt_box, format_permissions_report, format_permissions_switch_report,
-    format_pr_report, format_resume_report, format_sandbox_report, format_tool_call_start,
-    format_tool_result, format_turn_status_line_with_branch, format_ultraplan_report,
-    render_messages, render_resume_usage, render_version_report, truncate_for_summary,
+    describe_tool_progress, first_visible_line, format_acp_compact_report, format_auth_report,
+    format_auth_switch_report, format_auto_compaction_notice, format_bughunter_report,
+    format_commit_preflight_report, format_commit_skipped_report, format_compact_report,
+    format_cost_report, format_internal_prompt_progress_line, format_issue_report,
+    format_model_report, format_model_switch_report, format_permission_prompt_box,
+    format_permissions_report, format_permissions_switch_report, format_pr_report,
+    format_resume_report, format_sandbox_report, format_tool_call_start, format_tool_result,
+    format_turn_status_line_with_branch, format_ultraplan_report, render_messages,
+    render_resume_usage, render_version_report, truncate_for_summary,
 };
 use cli::git::{
     enforce_broad_cwd_policy, git_output, parse_git_status_branch, parse_git_status_metadata,
@@ -2877,9 +2877,8 @@ impl AcpCliAgent {
     /// injected MCP servers, prompt overrides, abort signal and the *active*
     /// permission mode (a `session/setPermissionMode` must survive the
     /// rebuild). The caller installs it with `session.runtime = …` once any
-    /// step that may still fail (e.g. persisting) has succeeded. Shared by
-    /// `/model` (new model, same transcript) and `/clear` (same model, fresh
-    /// transcript). The caller holds the session lock.
+    /// step that may still fail has succeeded. Used by `/model`; the caller
+    /// holds the session lock.
     fn build_replacement_session_runtime(
         &self,
         session: &mut AcpCliSession,
@@ -3010,45 +3009,6 @@ impl AcpCliAgent {
             AcpStopReason::EndTurn,
         ))
     }
-
-    /// `/clear` under ACP: reset the session **in place**. The session id,
-    /// file, cwd, model and permission mode are kept; the transcript is
-    /// archived under a new session id (still resumable / `session/load`-able)
-    /// and replaced by an empty one. No `--confirm` needed — the client's UI
-    /// owns that decision. The caller holds the session lock.
-    fn handle_acp_clear(&self, session: &mut AcpCliSession) -> Result<String, AcpError> {
-        let _scope = runtime::WorkspaceRootScope::enter(&session.cwd);
-        let model = session
-            .runtime
-            .session()
-            .model
-            .clone()
-            .unwrap_or_else(|| self.current_model());
-        let cleared = clear_session_state(
-            &session.cwd,
-            session.runtime.session(),
-            &session.handle,
-            ClearMode::InPlace,
-        )
-        .map_err(|e| AcpError::internal(format!("failed to clear session: {e}")))?;
-        let mut runtime = self.build_replacement_session_runtime(session, cleared.fresh, &model)?;
-        // Persist the empty transcript *before* installing the new runtime:
-        // if the write fails, memory and disk both still hold the old
-        // transcript (plus the archive), instead of a cleared session that
-        // reloads its old history.
-        runtime
-            .session()
-            .save_to_path(&session.handle.path)
-            .map_err(|e| AcpError::internal(format!("failed to persist cleared session: {e}")))?;
-        let permission_mode = runtime.permission_policy_mut().active_mode();
-        session.runtime = runtime;
-        Ok(format_acp_clear_report(
-            &session.handle.id,
-            &cleared.previous.id,
-            &model,
-            permission_mode.as_str(),
-        ))
-    }
 }
 
 /// Resolve once `signal` is aborted. Polls as well as awaiting the signal's
@@ -3066,17 +3026,6 @@ async fn wait_for_abort(signal: &runtime::HookAbortSignal) {
     }
 }
 
-/// How `/clear` replaces the live transcript.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClearMode {
-    /// REPL: the fresh transcript gets a new session id and file; the previous
-    /// transcript stays on disk under its own id.
-    NewSessionId,
-    /// ACP: the session id and file are kept for the fresh transcript, and the
-    /// previous transcript is archived under a new id first.
-    InPlace,
-}
-
 /// Outcome of [`clear_session_state`].
 struct ClearedSession {
     /// Empty transcript to rebuild the runtime around (persistence path set).
@@ -3084,46 +3033,25 @@ struct ClearedSession {
     /// Where `fresh` lives.
     handle: SessionHandle,
     /// Where the previous transcript lives — a managed session, so it stays
-    /// resumable (`/resume <id>`, `session/load`).
+    /// resumable (`/resume <id>`).
     previous: SessionHandle,
 }
 
-/// `/clear` core shared by the REPL and ACP: keep the previous transcript on
-/// disk as its own managed session and hand back a fresh one that keeps the
-/// workspace root. The caller rebuilds its runtime around `fresh` (model and
-/// permission mode live in the runtime config, so they carry over).
+/// REPL `/clear` core: the previous transcript stays on disk under its own
+/// id, and a fresh one with a new id and file keeps the workspace root. The
+/// caller rebuilds its runtime around `fresh` (model and permission mode
+/// live in the runtime config, so they carry over).
 fn clear_session_state(
     cwd: &Path,
-    current: &Session,
     current_handle: &SessionHandle,
-    mode: ClearMode,
 ) -> Result<ClearedSession, Box<dyn std::error::Error>> {
-    match mode {
-        ClearMode::NewSessionId => {
-            let fresh = new_cli_session_for(cwd)?;
-            let handle = create_managed_session_handle_for(cwd, &fresh.session_id)?;
-            Ok(ClearedSession {
-                fresh: fresh.with_persistence_path(handle.path.clone()),
-                handle,
-                previous: current_handle.clone(),
-            })
-        }
-        ClearMode::InPlace => {
-            // Archive as a fork branch named "cleared": a new id with the full
-            // transcript, compaction state and lineage back to the live id.
-            let archived = current.fork(Some("cleared".to_string()));
-            let previous = create_managed_session_handle_for(cwd, &archived.session_id)?;
-            archived.save_to_path(&previous.path)?;
-            let mut fresh = new_cli_session_for(cwd)?;
-            fresh.session_id.clone_from(&current_handle.id);
-            fresh.model.clone_from(&current.model);
-            Ok(ClearedSession {
-                fresh: fresh.with_persistence_path(current_handle.path.clone()),
-                handle: current_handle.clone(),
-                previous,
-            })
-        }
-    }
+    let fresh = new_cli_session_for(cwd)?;
+    let handle = create_managed_session_handle_for(cwd, &fresh.session_id)?;
+    Ok(ClearedSession {
+        fresh: fresh.with_persistence_path(handle.path.clone()),
+        handle,
+        previous: current_handle.clone(),
+    })
 }
 
 fn canonical_session_cwd(cwd: &Path) -> Result<PathBuf, AcpError> {
@@ -3447,13 +3375,6 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
                 let (report, compact_stop) = self.inner.handle_acp_compact(&mut session)?;
                 stop = compact_stop;
                 report
-            }
-            // `--confirm` is accepted but not required: an ACP client confirms
-            // in its own UI before sending the command.
-            SlashCommand::Clear { .. } => {
-                let locked = self.lock_session(session_id)?;
-                let mut session = locked.get();
-                self.inner.handle_acp_clear(&mut session)?
             }
             SlashCommand::Status => {
                 let locked = self.lock_session(session_id)?;
@@ -5347,12 +5268,7 @@ impl LiveCli {
         }
 
         let cwd = runtime::current_workspace_root()?;
-        let cleared = clear_session_state(
-            &cwd,
-            self.runtime.session(),
-            &self.session,
-            ClearMode::NewSessionId,
-        )?;
+        let cleared = clear_session_state(&cwd, &self.session)?;
         let runtime = self.build_replacement_runtime(
             cleared.fresh,
             cleared.handle.id.clone(),

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -592,12 +592,16 @@ fn assert_available_commands_update(update: &Value, session_id: &str) {
         .iter()
         .map(|c| c["name"].as_str().expect("command name is a string"))
         .collect();
-    for expected in ["compact", "clear", "help", "model", "status"] {
+    for expected in ["compact", "help", "model", "status"] {
         assert!(
             names.contains(&expected),
             "available commands should include `{expected}`, got {names:?}"
         );
     }
+    assert!(
+        !names.contains(&"clear"),
+        "/clear is not offered in ACP mode, got {names:?}"
+    );
     for command in commands {
         assert!(
             !command["name"].as_str().unwrap_or("").starts_with('/'),
@@ -1084,76 +1088,6 @@ async fn scenario_slash_compact(
     );
 }
 
-/// `/clear` without `--confirm`: the session id keeps working, the model no
-/// longer sees the earlier turn, and the old transcript is archived under a
-/// new session id that `session/load` can reopen.
-async fn scenario_slash_clear(
-    client: &mut AcpTestClient,
-    server: &MockAnthropicService,
-    workspace: &TestWorkspace,
-) {
-    let session_id = scenario_session_new(client, &workspace.root).await;
-    run_marked_turn(client, &session_id, "ACP_CLEAR_ONE").await;
-
-    let (text, _resp) = run_slash_command(client, &session_id, "/clear").await;
-    assert!(
-        text.contains("Session cleared") && text.contains(&session_id),
-        "/clear should confirm the in-place reset for this session: {text}"
-    );
-    let archived_id = text
-        .lines()
-        .find_map(|l| l.trim().strip_prefix("Archived as"))
-        .and_then(|v| v.split_whitespace().next())
-        .unwrap_or_else(|| panic!("report should name the archived session: {text}"))
-        .to_string();
-    assert_ne!(archived_id, session_id, "the archive gets its own id");
-
-    // Same session id, fresh context.
-    let body = last_model_request_after_prompt(client, server, &session_id, "ACP_CLEAR_TWO").await;
-    assert!(
-        !body.contains("ACP_CLEAR_ONE"),
-        "cleared turn must not reach the model: {body}"
-    );
-    assert!(body.contains("ACP_CLEAR_TWO"), "new turn reaches the model");
-
-    // The old transcript survives on disk and is loadable.
-    let archived = read_session_transcript(&workspace.root, &archived_id);
-    assert!(
-        archived.contains("ACP_CLEAR_ONE"),
-        "archived transcript keeps the cleared turn"
-    );
-    let live = read_session_transcript(&workspace.root, &session_id);
-    assert!(
-        !live.contains("ACP_CLEAR_ONE"),
-        "live transcript no longer holds the cleared turn"
-    );
-    let (_n, load_resp) = client
-        .send_request(
-            "session/load",
-            json!({
-                "sessionId": archived_id,
-                "cwd": workspace.root.to_string_lossy().to_string(),
-                "mcpServers": []
-            }),
-        )
-        .await;
-    assert!(
-        load_resp.get("error").is_none(),
-        "session/load of the archived transcript should succeed: {load_resp}"
-    );
-    // …and continues with the pre-clear history.
-    let archived_body =
-        last_model_request_after_prompt(client, server, &archived_id, "ACP_CLEAR_ARCHIVE").await;
-    assert!(
-        archived_body.contains("ACP_CLEAR_ONE"),
-        "a turn on the archived session must carry the cleared history to the model"
-    );
-
-    // `--confirm` is accepted too.
-    let (text, _resp) = run_slash_command(client, &session_id, "/clear --confirm").await;
-    assert!(text.contains("Session cleared"), "got: {text}");
-}
-
 /// `session/cancel` during `/compact`: the turn ends with `cancelled`, and
 /// neither the in-memory nor the on-disk transcript is touched.
 ///
@@ -1250,13 +1184,13 @@ async fn scenario_slash_compact_cancel(
 /// `/help` renders only the ACP table; an unknown command names the table.
 async fn scenario_slash_help_and_unknown(client: &mut AcpTestClient, session_id: &str) {
     let (help, _resp) = run_slash_command(client, session_id, "/help").await;
-    for expected in ["/compact", "/clear", "/model <model-id>", "/status"] {
+    for expected in ["/compact", "/model <model-id>", "/status"] {
         assert!(
             help.contains(expected),
             "/help should list {expected}: {help}"
         );
     }
-    for repl_only in ["/exit", "/resume", "Ctrl-R"] {
+    for repl_only in ["/exit", "/resume", "/clear", "Ctrl-R"] {
         assert!(
             !help.contains(repl_only),
             "/help under ACP must not advertise REPL-only `{repl_only}`: {help}"
@@ -1268,12 +1202,23 @@ async fn scenario_slash_help_and_unknown(client: &mut AcpTestClient, session_id:
         unknown.contains("`/nonexistent` is not supported in ACP mode"),
         "got: {unknown}"
     );
-    for expected in ["/compact", "/clear", "/help"] {
+    for expected in ["/compact", "/help"] {
         assert!(
             unknown.contains(expected),
             "unknown-command hint should list {expected}: {unknown}"
         );
     }
+    assert!(
+        !unknown.contains("/clear"),
+        "unknown-command hint must not offer /clear: {unknown}"
+    );
+
+    // `/clear` itself is a REPL-only command under ACP.
+    let (clear, _resp) = run_slash_command(client, session_id, "/clear").await;
+    assert!(
+        clear.contains("`/clear` is not supported in ACP mode"),
+        "got: {clear}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1296,7 +1241,6 @@ async fn run_all_scenarios(
     scenario_slash_help_and_unknown(client, &session_id).await;
     scenario_slash_compact(client, server, workspace).await;
     scenario_slash_compact_cancel(client, server, workspace).await;
-    scenario_slash_clear(client, server, workspace).await;
     // Run per-turn usage test last with a fresh session
     scenario_session_prompt_per_turn_usage(client, workspace).await;
 }

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -44,6 +44,10 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// the ACP response. 30s was cutting it exactly at the VLM timeout and
 /// the test recv panicked before scode's push_images could finish.
 const RECV_TIMEOUT: Duration = Duration::from_secs(90);
+/// The `available_commands_update` follows a `session/new` / `session/load`
+/// response on the same queue, so it is either there at once or the
+/// broadcast regressed — fail fast instead of waiting out `RECV_TIMEOUT`.
+const AVAILABLE_COMMANDS_TIMEOUT: Duration = Duration::from_secs(10);
 const SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
@@ -196,7 +200,13 @@ impl AcpTestClient {
         // it here so every session-creating test verifies the broadcast and
         // no test sees it as a stray notification on its next request.
         if matches!(method, "session/new" | "session/load") && response.get("error").is_none() {
-            let update = self.recv().await;
+            let update = timeout(AVAILABLE_COMMANDS_TIMEOUT, self.recv_inner())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "{method} succeeded but no available_commands_update arrived within {AVAILABLE_COMMANDS_TIMEOUT:?}"
+                    )
+                });
             assert_eq!(
                 update["method"].as_str(),
                 Some("session/update"),
@@ -1131,29 +1141,19 @@ async fn scenario_slash_clear(
         load_resp.get("error").is_none(),
         "session/load of the archived transcript should succeed: {load_resp}"
     );
+    // …and continues with the pre-clear history.
+    let archived_body =
+        last_model_request_after_prompt(client, server, &archived_id, "ACP_CLEAR_ARCHIVE").await;
+    assert!(
+        archived_body.contains("ACP_CLEAR_ONE"),
+        "a turn on the archived session must carry the cleared history to the model"
+    );
 
     // `--confirm` is accepted too.
     let (text, _resp) = run_slash_command(client, &session_id, "/clear --confirm").await;
     assert!(text.contains("Session cleared"), "got: {text}");
 }
 
-/// `/help` renders only the ACP table; an unknown command names the table.
-async fn scenario_slash_help_and_unknown(client: &mut AcpTestClient, session_id: &str) {
-    let (help, _resp) = run_slash_command(client, session_id, "/help").await;
-    for expected in ["/compact", "/clear", "/model <model-id>", "/status"] {
-        assert!(
-            help.contains(expected),
-            "/help should list {expected}: {help}"
-        );
-    }
-    for repl_only in ["/exit", "/resume", "Ctrl-R"] {
-        assert!(
-            !help.contains(repl_only),
-            "/help under ACP must not advertise REPL-only `{repl_only}`: {help}"
-        );
-    }
-
-    let (unknown, _resp) = run_slash_command(client, session_id, "/nonexistent").await;
 /// `session/cancel` during `/compact`: the turn ends with `cancelled`, and
 /// neither the in-memory nor the on-disk transcript is touched.
 ///
@@ -1247,6 +1247,23 @@ async fn scenario_slash_compact_cancel(
     );
 }
 
+/// `/help` renders only the ACP table; an unknown command names the table.
+async fn scenario_slash_help_and_unknown(client: &mut AcpTestClient, session_id: &str) {
+    let (help, _resp) = run_slash_command(client, session_id, "/help").await;
+    for expected in ["/compact", "/clear", "/model <model-id>", "/status"] {
+        assert!(
+            help.contains(expected),
+            "/help should list {expected}: {help}"
+        );
+    }
+    for repl_only in ["/exit", "/resume", "Ctrl-R"] {
+        assert!(
+            !help.contains(repl_only),
+            "/help under ACP must not advertise REPL-only `{repl_only}`: {help}"
+        );
+    }
+
+    let (unknown, _resp) = run_slash_command(client, session_id, "/nonexistent").await;
     assert!(
         unknown.contains("`/nonexistent` is not supported in ACP mode"),
         "got: {unknown}"
@@ -1278,6 +1295,7 @@ async fn run_all_scenarios(
     scenario_slash_command_model(client, &session_id).await;
     scenario_slash_help_and_unknown(client, &session_id).await;
     scenario_slash_compact(client, server, workspace).await;
+    scenario_slash_compact_cancel(client, server, workspace).await;
     scenario_slash_clear(client, server, workspace).await;
     // Run per-turn usage test last with a fresh session
     scenario_session_prompt_per_turn_usage(client, workspace).await;
@@ -1295,7 +1313,6 @@ async fn acp_stdio_integration() {
     let workspace = TestWorkspace::new("stdio");
     workspace.create();
     workspace.write_sudocode_json(&server.base_url());
-    scenario_slash_compact_cancel(client, server, workspace).await;
 
     let mut client = spawn_stdio_client(&workspace);
     run_all_scenarios(&mut client, &server, &workspace).await;

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -160,6 +160,11 @@ enum Transport {
 struct AcpTestClient {
     transport: Transport,
     next_id: u64,
+    /// The `available_commands_update` the agent sent after the most recent
+    /// successful `session/new` / `session/load` (consumed by
+    /// [`AcpTestClient::send_request`] so it never leaks into the next
+    /// request's notifications).
+    last_available_commands: Option<Value>,
 }
 
 impl AcpTestClient {
@@ -178,14 +183,40 @@ impl AcpTestClient {
         self.send_raw(&request).await;
 
         let mut notifications = Vec::new();
-        loop {
+        let response = loop {
             let msg = self.recv().await;
             // A response has a matching numeric id.
             if msg.get("id").and_then(Value::as_u64) == Some(id) {
-                return (notifications, msg);
+                break msg;
             }
             notifications.push(msg);
+        };
+        // A successful session/new or session/load is followed by exactly one
+        // `available_commands_update` for the new session. Consume and check
+        // it here so every session-creating test verifies the broadcast and
+        // no test sees it as a stray notification on its next request.
+        if matches!(method, "session/new" | "session/load") && response.get("error").is_none() {
+            let update = self.recv().await;
+            assert_eq!(
+                update["method"].as_str(),
+                Some("session/update"),
+                "{method} must be followed by a session/update, got: {update}"
+            );
+            assert_eq!(
+                update["params"]["update"]["sessionUpdate"].as_str(),
+                Some("available_commands_update"),
+                "{method} must be followed by available_commands_update, got: {update}"
+            );
+            if let Some(expected) = params["sessionId"].as_str() {
+                assert_eq!(
+                    update["params"]["sessionId"].as_str(),
+                    Some(expected),
+                    "available_commands_update must target the loaded session"
+                );
+            }
+            self.last_available_commands = Some(update);
         }
+        (notifications, response)
     }
 
     /// Send a JSON-RPC request WITHOUT waiting for its response. Returns the
@@ -360,6 +391,7 @@ fn spawn_stdio_client_with_args(workspace: &TestWorkspace, extra: &[&str]) -> Ac
             stdout: BufReader::new(stdout),
         },
         next_id: 1,
+        last_available_commands: None,
     }
 }
 
@@ -422,6 +454,7 @@ async fn spawn_ws_client(workspace: &TestWorkspace) -> AcpTestClient {
             ws_stream: Box::new(ws_stream),
         },
         next_id: 1,
+        last_available_commands: None,
     }
 }
 
@@ -527,7 +560,60 @@ async fn scenario_session_new(client: &mut AcpTestClient, cwd: &std::path::Path)
         .as_str()
         .expect("sessionId should be a string");
     assert!(!session_id.is_empty(), "sessionId should not be empty");
+    assert_available_commands_update(
+        client
+            .last_available_commands
+            .as_ref()
+            .expect("session/new should be followed by available_commands_update"),
+        session_id,
+    );
     session_id.to_string()
+}
+
+/// The `available_commands_update` broadcast: addressed to `session_id`,
+/// shaped per the ACP schema (`availableCommands: [{name, description,
+/// input?: {hint}}]`), and listing the commands apeiron needs.
+fn assert_available_commands_update(update: &Value, session_id: &str) {
+    assert_eq!(update["params"]["sessionId"].as_str(), Some(session_id));
+    let commands = update["params"]["update"]["availableCommands"]
+        .as_array()
+        .unwrap_or_else(|| panic!("availableCommands should be an array: {update}"));
+    let names: Vec<&str> = commands
+        .iter()
+        .map(|c| c["name"].as_str().expect("command name is a string"))
+        .collect();
+    for expected in ["compact", "clear", "help", "model", "status"] {
+        assert!(
+            names.contains(&expected),
+            "available commands should include `{expected}`, got {names:?}"
+        );
+    }
+    for command in commands {
+        assert!(
+            !command["name"].as_str().unwrap_or("").starts_with('/'),
+            "command names carry no leading slash: {command}"
+        );
+        assert!(
+            command["description"]
+                .as_str()
+                .is_some_and(|d| !d.is_empty()),
+            "every command has a description: {command}"
+        );
+        if let Some(input) = command.get("input") {
+            assert!(
+                input["hint"].as_str().is_some(),
+                "input, when present, is {{hint}}: {command}"
+            );
+        }
+    }
+    let model = commands
+        .iter()
+        .find(|c| c["name"] == "model")
+        .expect("model command");
+    assert!(
+        model["input"]["hint"].as_str().is_some(),
+        "/model advertises an input hint: {model}"
+    );
 }
 
 async fn scenario_session_prompt_streaming(client: &mut AcpTestClient, session_id: &str) {
@@ -834,11 +920,261 @@ async fn scenario_session_prompt_with_image_attachment(
     );
 }
 
+/// Send one slash command and return the concatenated agent text it produced
+/// plus the response.
+async fn run_slash_command(
+    client: &mut AcpTestClient,
+    session_id: &str,
+    command: &str,
+) -> (String, Value) {
+    let (notifs, resp) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": command }]
+            }),
+        )
+        .await;
+    assert_eq!(
+        resp["result"]["stopReason"].as_str(),
+        Some("end_turn"),
+        "{command} should end the turn normally: {resp}"
+    );
+    let text = notifs
+        .iter()
+        .filter(|m| {
+            m["params"]["sessionId"].as_str() == Some(session_id)
+                && m["params"]["update"]["sessionUpdate"].as_str() == Some("agent_message_chunk")
+        })
+        .filter_map(|m| m["params"]["update"]["content"]["text"].as_str())
+        .collect::<String>();
+    assert!(
+        !text.is_empty(),
+        "{command} should produce text: {notifs:?}"
+    );
+    (text, resp)
+}
+
+/// Run one `streaming_text` turn tagged with `marker` and return the
+/// response (for `_meta`) — the marker later identifies the turn in the
+/// model's request bodies and in the transcript on disk.
+async fn run_marked_turn(client: &mut AcpTestClient, session_id: &str, marker: &str) -> Value {
+    let (_notifs, resp) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text {marker}") }]
+            }),
+        )
+        .await;
+    assert!(
+        resp["result"].get("stopReason").is_some(),
+        "turn {marker} should complete: {resp}"
+    );
+    resp
+}
+
+/// The persisted transcript of `session_id` under `root`'s session store
+/// (`.scode/sessions/<workspace-fingerprint>/<session-id>/...`).
+fn read_session_transcript(root: &std::path::Path, session_id: &str) -> String {
+    fn walk(dir: &std::path::Path, session_id: &str, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().and_then(|n| n.to_str()) == Some(session_id) {
+                    for file in fs::read_dir(&path).into_iter().flatten().flatten() {
+                        if file.path().is_file() {
+                            out.push(file.path());
+                        }
+                    }
+                } else {
+                    walk(&path, session_id, out);
+                }
+            }
+        }
+    }
+    let mut files = Vec::new();
+    walk(
+        &root.join(".scode").join("sessions"),
+        session_id,
+        &mut files,
+    );
+    assert!(
+        !files.is_empty(),
+        "session {session_id} should be persisted under {}",
+        root.display()
+    );
+    files
+        .iter()
+        .map(|f| fs::read_to_string(f).expect("read transcript"))
+        .collect()
+}
+
+/// `/compact`: after three turns the two oldest messages are summarised (the
+/// mock answers compaction requests with its canned summary, so the LLM path
+/// is taken), the compaction is on disk immediately, and the next model
+/// request no longer carries the summarised turn.
+async fn scenario_slash_compact(
+    client: &mut AcpTestClient,
+    server: &MockAnthropicService,
+    workspace: &TestWorkspace,
+) {
+    let session_id = scenario_session_new(client, &workspace.root).await;
+    for marker in ["ACP_COMPACT_ONE", "ACP_COMPACT_TWO", "ACP_COMPACT_THREE"] {
+        run_marked_turn(client, &session_id, marker).await;
+    }
+    let before = read_session_transcript(&workspace.root, &session_id);
+    assert!(
+        !before.contains("\"type\":\"compaction\""),
+        "no compaction record before /compact"
+    );
+
+    let (text, _resp) = run_slash_command(client, &session_id, "/compact").await;
+    assert!(
+        text.contains("Result           compacted"),
+        "/compact should report a compaction, got: {text}"
+    );
+    assert!(
+        text.contains("Method           llm summary"),
+        "/compact should take the LLM path against the mock, got: {text}"
+    );
+    let removed: usize = text
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Messages removed"))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or_else(|| panic!("report should carry the removed count: {text}"));
+    assert!(removed >= 1, "/compact should remove messages: {text}");
+    assert!(
+        text.contains("Estimated tokens"),
+        "/compact should report the token estimate: {text}"
+    );
+
+    // Persisted right away, not at the end of the next turn.
+    let after = read_session_transcript(&workspace.root, &session_id);
+    assert!(
+        after.contains("\"type\":\"compaction\""),
+        "compaction metadata should be on disk right after /compact"
+    );
+
+    // The model now sees the summary instead of the oldest turn.
+    let body =
+        last_model_request_after_prompt(client, server, &session_id, "ACP_COMPACT_FOUR").await;
+    assert!(
+        !body.contains("ACP_COMPACT_ONE"),
+        "summarised turn must not reach the model after /compact"
+    );
+    assert!(
+        body.contains("ACP_COMPACT_THREE"),
+        "preserved recent turn must still reach the model"
+    );
+}
+
+/// `/clear` without `--confirm`: the session id keeps working, the model no
+/// longer sees the earlier turn, and the old transcript is archived under a
+/// new session id that `session/load` can reopen.
+async fn scenario_slash_clear(
+    client: &mut AcpTestClient,
+    server: &MockAnthropicService,
+    workspace: &TestWorkspace,
+) {
+    let session_id = scenario_session_new(client, &workspace.root).await;
+    run_marked_turn(client, &session_id, "ACP_CLEAR_ONE").await;
+
+    let (text, _resp) = run_slash_command(client, &session_id, "/clear").await;
+    assert!(
+        text.contains("Session cleared") && text.contains(&session_id),
+        "/clear should confirm the in-place reset for this session: {text}"
+    );
+    let archived_id = text
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Archived as"))
+        .and_then(|v| v.split_whitespace().next())
+        .unwrap_or_else(|| panic!("report should name the archived session: {text}"))
+        .to_string();
+    assert_ne!(archived_id, session_id, "the archive gets its own id");
+
+    // Same session id, fresh context.
+    let body = last_model_request_after_prompt(client, server, &session_id, "ACP_CLEAR_TWO").await;
+    assert!(
+        !body.contains("ACP_CLEAR_ONE"),
+        "cleared turn must not reach the model: {body}"
+    );
+    assert!(body.contains("ACP_CLEAR_TWO"), "new turn reaches the model");
+
+    // The old transcript survives on disk and is loadable.
+    let archived = read_session_transcript(&workspace.root, &archived_id);
+    assert!(
+        archived.contains("ACP_CLEAR_ONE"),
+        "archived transcript keeps the cleared turn"
+    );
+    let live = read_session_transcript(&workspace.root, &session_id);
+    assert!(
+        !live.contains("ACP_CLEAR_ONE"),
+        "live transcript no longer holds the cleared turn"
+    );
+    let (_n, load_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": archived_id,
+                "cwd": workspace.root.to_string_lossy().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        load_resp.get("error").is_none(),
+        "session/load of the archived transcript should succeed: {load_resp}"
+    );
+
+    // `--confirm` is accepted too.
+    let (text, _resp) = run_slash_command(client, &session_id, "/clear --confirm").await;
+    assert!(text.contains("Session cleared"), "got: {text}");
+}
+
+/// `/help` renders only the ACP table; an unknown command names the table.
+async fn scenario_slash_help_and_unknown(client: &mut AcpTestClient, session_id: &str) {
+    let (help, _resp) = run_slash_command(client, session_id, "/help").await;
+    for expected in ["/compact", "/clear", "/model <model-id>", "/status"] {
+        assert!(
+            help.contains(expected),
+            "/help should list {expected}: {help}"
+        );
+    }
+    for repl_only in ["/exit", "/resume", "Ctrl-R"] {
+        assert!(
+            !help.contains(repl_only),
+            "/help under ACP must not advertise REPL-only `{repl_only}`: {help}"
+        );
+    }
+
+    let (unknown, _resp) = run_slash_command(client, session_id, "/nonexistent").await;
+    assert!(
+        unknown.contains("`/nonexistent` is not supported in ACP mode"),
+        "got: {unknown}"
+    );
+    for expected in ["/compact", "/clear", "/help"] {
+        assert!(
+            unknown.contains(expected),
+            "unknown-command hint should list {expected}: {unknown}"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Scenario runner
 // ---------------------------------------------------------------------------
 
-async fn run_all_scenarios(client: &mut AcpTestClient, workspace: &TestWorkspace) {
+async fn run_all_scenarios(
+    client: &mut AcpTestClient,
+    server: &MockAnthropicService,
+    workspace: &TestWorkspace,
+) {
     scenario_initialize(client).await;
     let session_id = scenario_session_new(client, &workspace.root).await;
     scenario_session_prompt_streaming(client, &session_id).await;
@@ -847,6 +1183,9 @@ async fn run_all_scenarios(client: &mut AcpTestClient, workspace: &TestWorkspace
     scenario_session_load_unknown_session_errors(client).await;
     scenario_unknown_method(client).await;
     scenario_slash_command_model(client, &session_id).await;
+    scenario_slash_help_and_unknown(client, &session_id).await;
+    scenario_slash_compact(client, server, workspace).await;
+    scenario_slash_clear(client, server, workspace).await;
     // Run per-turn usage test last with a fresh session
     scenario_session_prompt_per_turn_usage(client, workspace).await;
 }
@@ -865,7 +1204,7 @@ async fn acp_stdio_integration() {
     workspace.write_sudocode_json(&server.base_url());
 
     let mut client = spawn_stdio_client(&workspace);
-    run_all_scenarios(&mut client, &workspace).await;
+    run_all_scenarios(&mut client, &server, &workspace).await;
     client.shutdown().await;
     workspace.cleanup();
 }
@@ -1863,6 +2202,7 @@ async fn acp_wrong_model_vlm_full_roundtrip() {
             stdout: BufReader::new(stdout),
         },
         next_id: 1,
+        last_available_commands: None,
     };
 
     // 1×1 transparent PNG.
@@ -1972,7 +2312,7 @@ async fn acp_ws_integration() {
     workspace.write_sudocode_json(&server.base_url());
 
     let mut client = spawn_ws_client(&workspace).await;
-    run_all_scenarios(&mut client, &workspace).await;
+    run_all_scenarios(&mut client, &server, &workspace).await;
     client.shutdown().await;
     workspace.cleanup();
 }
@@ -2062,6 +2402,7 @@ fn spawn_stdio_client_danger(workspace: &TestWorkspace) -> AcpTestClient {
             stdout: BufReader::new(stdout),
         },
         next_id: 1,
+        last_available_commands: None,
     }
 }
 
@@ -2105,6 +2446,7 @@ fn spawn_stdio_client_danger_with_allowed(
             stdout: BufReader::new(stdout),
         },
         next_id: 1,
+        last_available_commands: None,
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -1154,6 +1154,99 @@ async fn scenario_slash_help_and_unknown(client: &mut AcpTestClient, session_id:
     }
 
     let (unknown, _resp) = run_slash_command(client, session_id, "/nonexistent").await;
+/// `session/cancel` during `/compact`: the turn ends with `cancelled`, and
+/// neither the in-memory nor the on-disk transcript is touched.
+///
+/// The first turn uses the mock's `delayed_text` scenario. Compaction
+/// requests are classified by the markers of the messages being summarised,
+/// and with three turns the first one is what gets summarised — so the
+/// compaction request itself is held for `DELAYED_TEXT_LATENCY`, which is the
+/// window in which the cancel lands.
+async fn scenario_slash_compact_cancel(
+    client: &mut AcpTestClient,
+    server: &MockAnthropicService,
+    workspace: &TestWorkspace,
+) {
+    let session_id = scenario_session_new(client, &workspace.root).await;
+    let (_n, first) = client
+        .send_request(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}delayed_text ACP_CANCEL_ONE") }]
+            }),
+        )
+        .await;
+    assert!(first["result"].get("stopReason").is_some(), "{first}");
+    for marker in ["ACP_CANCEL_TWO", "ACP_CANCEL_THREE"] {
+        run_marked_turn(client, &session_id, marker).await;
+    }
+    let transcript_before = read_session_transcript(&workspace.root, &session_id);
+    let requests_before = server.captured_requests().await.len();
+
+    let compact_id = client
+        .send_request_no_wait(
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{ "type": "text", "text": "/compact" }]
+            }),
+        )
+        .await;
+    // Wait until the compaction request is in flight at the mock.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let requests = server.captured_requests().await;
+        if requests[requests_before..]
+            .iter()
+            .any(|r| r.scenario == "delayed_text")
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "/compact never issued its compaction request"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    client
+        .send_raw(&json!({
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": { "sessionId": session_id }
+        }))
+        .await;
+    let (notifs, resp) = client
+        .recv_until(Duration::from_secs(20), |m| is_response_to(m, compact_id))
+        .await
+        .unwrap_or_else(|seen| panic!("/compact never answered after cancel; seen: {seen:?}"));
+    assert_eq!(
+        resp["result"]["stopReason"].as_str(),
+        Some("cancelled"),
+        "cancelled /compact must end with stopReason cancelled: {resp}"
+    );
+    let text = notifs
+        .iter()
+        .filter(|m| m["params"]["update"]["sessionUpdate"].as_str() == Some("agent_message_chunk"))
+        .filter_map(|m| m["params"]["update"]["content"]["text"].as_str())
+        .collect::<String>();
+    assert!(text.contains("cancelled"), "got: {text}");
+
+    // Nothing changed on disk…
+    let transcript_after = read_session_transcript(&workspace.root, &session_id);
+    assert_eq!(
+        transcript_before, transcript_after,
+        "a cancelled /compact must leave the persisted transcript untouched"
+    );
+    // …or in memory: the next turn still carries the would-be-summarised turn.
+    let body =
+        last_model_request_after_prompt(client, server, &session_id, "ACP_CANCEL_FOUR").await;
+    assert!(
+        body.contains("ACP_CANCEL_ONE"),
+        "a cancelled /compact must not replace the in-memory transcript"
+    );
+}
+
     assert!(
         unknown.contains("`/nonexistent` is not supported in ACP mode"),
         "got: {unknown}"
@@ -1202,6 +1295,7 @@ async fn acp_stdio_integration() {
     let workspace = TestWorkspace::new("stdio");
     workspace.create();
     workspace.write_sudocode_json(&server.base_url());
+    scenario_slash_compact_cancel(client, server, workspace).await;
 
     let mut client = spawn_stdio_client(&workspace);
     run_all_scenarios(&mut client, &server, &workspace).await;


### PR DESCRIPTION
## What

ACP mode gains a proper slash-command surface, driven by one table:

- **`/compact`** in ACP: LLM summary first, local heuristic fallback, threshold 0, persisted immediately. Runs **outside** the process-wide cwd lease (only `/model` holds it now), and honours `session/cancel`: the compaction future races the abort signal; a late cancel discards the result. Memory and disk stay untouched and the prompt ends with `stopReason: "cancelled"`.
- **`available_commands_update`** broadcast right after `session/new` and `session/load` (typed structs from `agent-client-protocol-schema`, no feature gate). Table: help, status, cost, model, compact, config, diff, doctor.
- **`/help`** in ACP now renders only the ACP table (previously the full REPL help, listing commands ACP rejects).
- **`_meta.sudocode.autoCompacted: true`** on `session/prompt` responses when the pre-turn overflow guard or the in-turn threshold compacted.
- `/model` rebuild factored into `rebuild_session_runtime`, which now carries the session's active permission mode across the rebuild (previously `session/setPermissionMode` was silently reset by `/model`).
- `docs/acp.md`: new "Slash commands" section (broadcast timing, cancel semantics, `autoCompacted` caveats).

`/clear` was implemented and then removed by product decision (`/compact` only); the with-`/clear` state is kept on a local `keep/` branch, not pushed.

## Verification

- `cargo fmt --all -- --check`; `cargo test -p rusty-sudocode-cli --test acp_integration` 19 passed; `cargo test -p runtime --lib` 717 passed; `cargo test -p commands` 65 passed.
- Independent review pass (lease scope, cancel race, clear persistence ordering) — all must-fix items addressed in follow-up commits.
- End-to-end against a real DeepSeek model over ACP/NDJSON: broadcast arrives in the same millisecond as the `session/new` response; `/compact` summarised 13 messages (est. 2751 → 1725 tokens, ~13 s) and the summary kept user-pinned facts; `/compact` + `session/cancel` after 203 ms returned `cancelled` in 1 ms with the transcript md5 unchanged; `/model` switch to `deepseek-v4-pro` and back kept history, cumulative usage and the `workspace-write` permission mode.

## Found while testing (not addressed here)

- **Auto-compaction compares *cumulative* `input_tokens` against the threshold** (`conversation.rs` `maybe_auto_compact`). The cumulative value only grows, so once a session crosses ~98k it re-summarises on **every** turn (+10–30 s each), collapses the transcript to "summary + 4 messages", and manual `/compact` reports `skipped`. Should compare the latest turn's input tokens. Workaround used in testing: `CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS=<large>`.
- `/status` prints the process default permission mode, not the session's active mode.
- `clippy -D warnings` fails on `main` in the telemetry/runtime/commands crates on the current toolchain; none of the reported locations are in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PssZgUyJ1ZrgZRWZBMpSbg
