### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/RELEASE_NOTES_v0.2.2.md
+++ b/RELEASE_NOTES_v0.2.2.md
@@ -1,0 +1,11 @@
+# Sudo Code v0.2.2
+
+## What's New
+
+### Features
+- **ACP slash commands: `/compact`, `/clear`, `/help`, `available_commands_update`** (#547) — `scode acp` now owns a single slash-command table shared by `/help`, the unknown-command hint, and a `session/update { sessionUpdate: "available_commands_update" }` broadcast sent right after every `session/new` / `session/load`. `/compact` mirrors the REPL command (LLM summary first, local heuristic fallback, persisted immediately). `/clear` resets the session in place — same session id, cwd, model and permission mode — and archives the old transcript as a loadable `cleared` fork. `session/prompt` responses carry `_meta.sudocode.autoCompacted: true` when a turn compacted automatically. `/compact` runs outside the cwd lease and honours `session/cancel`.
+
+### Fixes
+- **Compact before a context-window rejection wedges the session** (#545) — long ACP sessions used to hit `context_window_blocked` with no compaction ever running: the pre-send check compacted at 85% of the window while the API preflight rejects at roughly 65% (history + system + tools + `max_tokens`). The ACP pre-send check now budgets the way the preflight does, auto-compaction triggers on the latest response's actual context size (works with prompt caching), `run_turn` compacts and resends once on a context-window rejection and drops the unanswered prompt if it still fails, and `compact_in_place` rewrites the persisted transcript so a resume no longer reloads pre-compaction history. Context-window errors are now classified as `history_context_too_large` vs `single_request_too_large`.
+- **Keep tool role in compaction messages so `tool_result`s stay paired** (#546) — LLM compaction silently fell back to the lossy local summary whenever the summarised conversation contained a parallel tool call, because `build_compaction_messages` remapped `Tool` messages to `User` and broke the `tool_use` / `tool_result` pairing Anthropic requires. Only `System -> User` is remapped now. `CompactionResult` carries a `summary_source`, and the `/compact` report prints a `Summary` line (`llm`, `local`, or `local (LLM compaction failed: ...)`) so any degradation is visible.
+- **PTY test deflake** (#544) — `iocraft_repl_ctrlc_hint` settles before sending Ctrl-C.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "plugins",
  "runtime",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "commands",
  "runtime",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "api",
  "serde_json",
@@ -2604,7 +2604,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3899,7 +3899,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "api",
  "arboard",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Patch release: bump workspace version 0.2.1 -> 0.2.2, refresh Cargo.lock, add `RELEASE_NOTES_v0.2.2.md`.

Ships #544, #545, #546, #547 (ACP `/compact` + `/clear` + `available_commands_update`, context-window compaction fixes, tool-role pairing fix in LLM compaction). See the release notes file for the full summary.

Same shape as #543 (v0.2.1). Tag `v0.2.2` goes on the merge commit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PssZgUyJ1ZrgZRWZBMpSbg