### PR TITLE
feat(acp): session/new forkFrom — fork a conversation into a new cwd

### DIFF
--- a/docs/acp.md
+++ b/docs/acp.md
@@ -190,7 +190,50 @@ the `session/load` request.
 `cwd` must be the directory the session was created in — a session's store
 is keyed by its workspace and the persisted `workspace_root` is validated on
 load, so loading a session id from another directory is rejected. Continuing
-a conversation in a new directory is a fork, not a load. `session/load` does
-not currently replay the history to the client as `session/update`
-notifications; the client is expected to keep its own copy of the
-conversation.
+a conversation in a new directory is a fork, not a load — see `forkFrom`
+below. `session/load` does not currently replay the history to the client as
+`session/update` notifications; the client is expected to keep its own copy
+of the conversation.
+
+### Forking a conversation (`session/new` + `_meta.sudocode.forkFrom`)
+
+A client that branches a conversation — "continue from here in a new
+session" — creates the branch with `session/new` and names the source under
+`_meta.sudocode.forkFrom`. The new session starts as a **copy of the source's
+transcript** (messages, compaction state, model, prompt history), gets a
+fresh id, records the source as its parent, and is persisted under the new
+`cwd`'s own session store, so it is a first-class session there (later
+`session/load {cwd}` of it works). The source is read, never modified.
+
+```json
+{
+  "cwd": "/home/user/session-b",
+  "mcpServers": [],
+  "_meta": {
+    "sudocode": {
+      "forkFrom": { "sessionId": "session-1788512053256-0", "cwd": "/home/user/session-a" }
+    }
+  }
+}
+```
+
+`forkFrom` takes `sessionId` and/or `cwd`:
+
+| Given | Source |
+|---|---|
+| `sessionId` only | A session **open in this process**. Rejected (`invalid_params`) if it is not — after a restart pass `cwd` as well. |
+| `sessionId` + `cwd` | The session persisted under `cwd`'s store, validated against its recorded workspace root exactly like `session/load`; an open session of that id must live in `cwd`. |
+| `cwd` only | The most recently updated session persisted under `cwd`. Useful for a client that keeps one directory per conversation and does not track scode's session ids. |
+
+An open source is copied from memory when it is idle; mid-turn (a turn holds
+the session for its duration) the persisted transcript is copied instead,
+which carries every completed message. Offloaded tool results referenced from
+the transcript are copied alongside it. The copy is the whole transcript —
+there is no point-in-time cut yet.
+
+`forkFrom` composes with `systemPrompt` / `appendSystemPrompt` on the same
+request; a present-but-malformed `forkFrom` (not an object, neither field,
+empty strings) is `invalid_params`. The `initialize` response advertises
+`_meta.sudocode.sessionFork: true` so clients can feature-detect. Older
+agents ignore the key and start an empty session, which is the behaviour
+the flag lets a client avoid relying on.

--- a/rust/crates/runtime/src/acp_sdk_server.rs
+++ b/rust/crates/runtime/src/acp_sdk_server.rs
@@ -246,6 +246,24 @@ pub trait SdkAcpDelegate: Send + Sync + 'static {
         prompt_overrides: SystemPromptOverrides,
     ) -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
 
+    /// Create a new session in `cwd` whose transcript starts as a copy of
+    /// another session's (`session/new` with `_meta.sudocode.forkFrom`).
+    ///
+    /// The source is resolved per [`SessionForkSource`]: a session open in
+    /// this process, or one persisted under `source.cwd`'s session store.
+    /// The fork gets a fresh session id, records the source as its parent
+    /// (`fork.parent_session_id`) and is persisted under `cwd`'s own store —
+    /// the source session is left untouched. Everything else (`mcp_servers`,
+    /// `prompt_overrides`, the returned tuple) is as for
+    /// [`Self::new_session`].
+    fn fork_session(
+        &self,
+        source: SessionForkSource,
+        cwd: PathBuf,
+        mcp_servers: BTreeMap<String, ScopedMcpServerConfig>,
+        prompt_overrides: SystemPromptOverrides,
+    ) -> Result<(String, PathBuf, HookAbortSignal), AcpError>;
+
     /// Run a prompt turn. The implementation should call observer methods
     /// to stream session updates.
     fn run_prompt(
@@ -603,6 +621,10 @@ fn initialize_meta() -> Map<String, serde_json::Value> {
     // (see `system_prompt_overrides_from_meta`).
     sudocode_ns.insert("systemPromptOverride".to_string(), json!(true));
     sudocode_ns.insert("systemPromptAppend".to_string(), json!(true));
+    // `session/new` accepts `_meta.sudocode.forkFrom` (see
+    // `fork_source_from_meta`): a client that forks a conversation into a
+    // new directory gates on this instead of probing.
+    sudocode_ns.insert("sessionFork".to_string(), json!(true));
     let mut meta = Map::new();
     meta.insert("sudocode".to_string(), json!(sudocode_ns));
     meta
@@ -630,6 +652,65 @@ fn system_prompt_overrides_from_meta(
         system_prompt: non_empty_string_meta(ns, SYSTEM_PROMPT_META_KEY)?,
         append_system_prompt: non_empty_string_meta(ns, APPEND_SYSTEM_PROMPT_META_KEY)?,
     })
+}
+
+/// `_meta.sudocode` key on `session/new`: start the new session from a copy
+/// of another session's transcript.
+pub const FORK_FROM_META_KEY: &str = "forkFrom";
+
+/// Where a forked session's transcript comes from
+/// (`_meta.sudocode.forkFrom` on `session/new`).
+///
+/// At least one of the two fields is present:
+///
+/// * `session_id` alone — the source must be open in this process;
+/// * `cwd` alone — the most recently updated session persisted under that
+///   directory's session store;
+/// * both — the persisted session `session_id` under `cwd`'s store (or the
+///   open session of that id, which must live in `cwd`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionForkSource {
+    pub session_id: Option<String>,
+    pub cwd: Option<PathBuf>,
+}
+
+/// Parse `_meta.sudocode.forkFrom` from a `session/new` request. Absent →
+/// `None`; present but malformed → `invalid_params` (never silently ignored,
+/// like the system-prompt keys).
+fn fork_source_from_meta(
+    meta: Option<&agent_client_protocol_schema::Meta>,
+) -> Result<Option<SessionForkSource>, AcpError> {
+    let ns = meta.and_then(|m| m.get("sudocode"));
+    let Some(value) = ns.and_then(|ns| ns.get(FORK_FROM_META_KEY)) else {
+        return Ok(None);
+    };
+    let Some(object) = value.as_object() else {
+        return Err(AcpError::invalid_params(format!(
+            "_meta.sudocode.{FORK_FROM_META_KEY} must be an object"
+        )));
+    };
+    let field = |key: &str| -> Result<Option<String>, AcpError> {
+        match object.get(key) {
+            None => Ok(None),
+            Some(v) => match v.as_str() {
+                Some(text) if !text.trim().is_empty() => Ok(Some(text.to_string())),
+                Some(_) => Err(AcpError::invalid_params(format!(
+                    "_meta.sudocode.{FORK_FROM_META_KEY}.{key} must not be empty"
+                ))),
+                None => Err(AcpError::invalid_params(format!(
+                    "_meta.sudocode.{FORK_FROM_META_KEY}.{key} must be a string"
+                ))),
+            },
+        }
+    };
+    let session_id = field("sessionId")?;
+    let cwd = field("cwd")?.map(PathBuf::from);
+    if session_id.is_none() && cwd.is_none() {
+        return Err(AcpError::invalid_params(format!(
+            "_meta.sudocode.{FORK_FROM_META_KEY} needs sessionId and/or cwd"
+        )));
+    }
+    Ok(Some(SessionForkSource { session_id, cwd }))
 }
 
 fn non_empty_string_meta(
@@ -1288,6 +1369,13 @@ pub(crate) async fn run_acp_on_transport(
                                 return Ok(());
                             }
                         };
+                    let fork_source = match fork_source_from_meta(req.meta.as_ref()) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            responder.respond_with_error(acp_error_to_sdk(&e))?;
+                            return Ok(());
+                        }
+                    };
                     let d = Arc::clone(&delegate);
                     let registry = Arc::clone(&registry);
                     let commands = delegate.available_commands();
@@ -1306,7 +1394,16 @@ pub(crate) async fn run_acp_on_transport(
                                 .map_err(|e| AcpError::internal(format!("failed to enter cwd: {e}")))?;
                             let _scope = WorkspaceRootScope::enter(cwd);
                             let mcp_servers = acp_mcp_servers_to_scoped(&req.mcp_servers, &req.cwd);
-                            d.new_session(req.cwd, mcp_servers, prompt_overrides)
+                            match fork_source {
+                                // `forkFrom`: the new session starts from a
+                                // copy of another session's transcript. The
+                                // source is read, never written, so only the
+                                // new cwd needs the lease.
+                                Some(source) => {
+                                    d.fork_session(source, req.cwd, mcp_servers, prompt_overrides)
+                                }
+                                None => d.new_session(req.cwd, mcp_servers, prompt_overrides),
+                            }
                         })
                         .await
                         .unwrap_or_else(|e| Err(AcpError::internal(e.to_string())));

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3060,6 +3060,38 @@ fn clear_session_state(
     })
 }
 
+/// Read the persisted session `session_id` from `cwd`'s session store
+/// (workspace-root validated, like `session/load`). Errors are phrased for
+/// the `forkFrom` caller.
+fn load_persisted_session(cwd: &Path, session_id: &str) -> Result<runtime::Session, String> {
+    let store = runtime::SessionStore::from_cwd(cwd)
+        .map_err(|e| format!("forkFrom.cwd {}: {e}", cwd.display()))?;
+    store
+        .load_session(session_id)
+        .map(|loaded| loaded.session)
+        .map_err(|e| {
+            format!(
+                "forkFrom.sessionId {session_id} not found under {}: {e}",
+                cwd.display()
+            )
+        })
+}
+
+/// Copy a directory tree (files and sub-directories; symlinks are followed).
+fn copy_dir_recursive(from: &Path, to: &Path) -> io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let target = to.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
 fn canonical_session_cwd(cwd: &Path) -> Result<PathBuf, AcpError> {
     let canonical = fs::canonicalize(cwd).map_err(|error| {
         AcpError::invalid_params(format!("params.cwd is not accessible: {error}"))
@@ -3647,7 +3679,129 @@ impl runtime::acp_sdk_server::SdkAcpDelegate for AcpSdkDelegate {
 
         let (handle, session) = load_session_reference(session_id)
             .map_err(|e| runtime::AcpError::internal(format!("failed to load session: {e}")))?;
+        self.open_persisted_session(handle, session, cwd, mcp_servers, prompt_overrides)
+    }
 
+    fn fork_session(
+        &self,
+        source: runtime::acp_sdk_server::SessionForkSource,
+        cwd: PathBuf,
+        mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
+        prompt_overrides: runtime::SystemPromptOverrides,
+    ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
+        let cwd = canonical_session_cwd(&cwd)?;
+        // Read the source before entering the new cwd's scope: a persisted
+        // source resolves through *its* directory's session store.
+        let parent = self.resolve_fork_source(&source)?;
+        let parent_tool_results = parent.tool_results_dir();
+
+        let _scope = runtime::WorkspaceRootScope::enter(&cwd);
+        // `Session::fork` keeps the transcript, compaction state, model and
+        // prompt history, mints a fresh id and records the parent; the
+        // workspace root is re-homed to the new cwd so the fork is a
+        // first-class session there (loadable with `session/load {cwd}`).
+        let forked = parent.fork(None).with_workspace_root(cwd.clone());
+        let handle =
+            create_managed_session_handle_for(&cwd, &forked.session_id).map_err(|error| {
+                runtime::AcpError::internal(format!("failed to create session handle: {error}"))
+            })?;
+        let forked = forked.with_persistence_path(handle.path.clone());
+        forked.save_to_path(&handle.path).map_err(|error| {
+            runtime::AcpError::internal(format!("failed to persist fork: {error}"))
+        })?;
+        // Offloaded tool results live beside the transcript and are
+        // referenced from it by id; carry them over so the fork's
+        // "read more" paths keep resolving. Best-effort: a source without
+        // any is the common case.
+        if let (Some(from), Some(to)) = (parent_tool_results, forked.tool_results_dir()) {
+            if from.is_dir() {
+                if let Err(error) = copy_dir_recursive(&from, &to) {
+                    eprintln!(
+                        "warning: fork of {} could not copy offloaded tool results: {error}",
+                        parent.session_id
+                    );
+                }
+            }
+        }
+        self.open_persisted_session(handle, forked, cwd, mcp_servers, prompt_overrides)
+    }
+}
+
+impl AcpSdkDelegate {
+    /// The transcript a `session/new { _meta.sudocode.forkFrom }` copies.
+    ///
+    /// An open session is read from memory (its freshest state) when its
+    /// lock is free; mid-turn — the turn holds the lock for its duration —
+    /// the persisted transcript is read instead, which carries every
+    /// completed message. A session that is not open resolves through the
+    /// session store of `source.cwd`, which validates the persisted
+    /// workspace root exactly like `session/load`.
+    fn resolve_fork_source(
+        &self,
+        source: &runtime::acp_sdk_server::SessionForkSource,
+    ) -> Result<runtime::Session, runtime::AcpError> {
+        let invalid = |message: String| runtime::AcpError::invalid_params(message);
+        let source_cwd = source
+            .cwd
+            .as_deref()
+            .map(canonical_session_cwd)
+            .transpose()
+            .map_err(|e| invalid(format!("forkFrom.cwd: {e}")))?;
+
+        if let Some(session_id) = &source.session_id {
+            let live = self
+                .inner
+                .lock_sessions()
+                .get(session_id)
+                .map(|slot| (slot.cwd.clone(), Arc::clone(&slot.session)));
+            if let Some((live_cwd, slot)) = live {
+                if let Some(expected) = &source_cwd {
+                    // Both sides are canonical (`canonical_session_cwd`).
+                    if live_cwd != *expected {
+                        return Err(invalid(format!(
+                            "forkFrom.sessionId {session_id} is open in {} not {}",
+                            live_cwd.display(),
+                            expected.display()
+                        )));
+                    }
+                }
+                if let Ok(guard) = slot.try_lock() {
+                    return Ok(guard.runtime.session().clone());
+                }
+                // Mid-turn: fall through to the persisted transcript.
+                return load_persisted_session(&live_cwd, session_id).map_err(invalid);
+            }
+            let Some(store_cwd) = &source_cwd else {
+                return Err(invalid(format!(
+                    "forkFrom.sessionId {session_id} is not open in this process; pass forkFrom.cwd to fork a persisted session"
+                )));
+            };
+            return load_persisted_session(store_cwd, session_id).map_err(invalid);
+        }
+
+        let store_cwd =
+            source_cwd.ok_or_else(|| invalid("forkFrom needs sessionId and/or cwd".to_string()))?;
+        let store = runtime::SessionStore::from_cwd(&store_cwd)
+            .map_err(|e| invalid(format!("forkFrom.cwd: {e}")))?;
+        let latest = store.latest_session().map_err(|e| {
+            invalid(format!(
+                "forkFrom.cwd {}: no persisted session to fork ({e})",
+                store_cwd.display()
+            ))
+        })?;
+        load_persisted_session(&store_cwd, &latest.id).map_err(invalid)
+    }
+
+    /// Build the runtime for an already-persisted transcript (a
+    /// `session/load` or a fresh fork) and register it as a live session.
+    fn open_persisted_session(
+        &self,
+        handle: SessionHandle,
+        session: runtime::Session,
+        cwd: PathBuf,
+        mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
+        prompt_overrides: runtime::SystemPromptOverrides,
+    ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
         let model = self.inner.resolve_model_for_cwd(&cwd)?;
         let permission_mode = self.inner.resolve_permission_mode_for_cwd(&cwd)?;
         let system_prompt = build_acp_system_prompt(&cwd, &prompt_overrides)?;

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -3662,3 +3662,253 @@ async fn acp_stdio_llm_compaction_keeps_parallel_tool_results_paired() {
     client.shutdown().await;
     workspace.cleanup();
 }
+
+// ---------------------------------------------------------------------------
+// `session/new` + `_meta.sudocode.forkFrom`: fork a conversation into a new cwd
+// ---------------------------------------------------------------------------
+
+/// `session/new` carrying `forkFrom` for the given source, into `cwd`.
+async fn fork_session(
+    client: &mut AcpTestClient,
+    cwd: &std::path::Path,
+    fork_from: Value,
+) -> Value {
+    fs::create_dir_all(cwd).expect("fork cwd should exist");
+    session_new_with_meta(client, cwd, json!({ "forkFrom": fork_from })).await
+}
+
+fn assert_invalid_params(resp: &Value, what: &str) {
+    assert_eq!(
+        resp["error"]["code"].as_i64(),
+        Some(-32602),
+        "{what} must be rejected with invalid_params, got: {resp}"
+    );
+}
+
+/// The apeiron shape: the parent conversation lives in one directory, a
+/// "branch from here" creates a NEW session in a NEW directory. Before
+/// `forkFrom` the only option was a plain `session/new`, which starts empty
+/// (`session/load` refuses another cwd) — the model on the branch had no
+/// memory of the conversation. With `forkFrom {sessionId}` on an open
+/// session the branch's first model request carries the parent's history,
+/// the transcript persisted under the new cwd records the lineage, and the
+/// parent goes on unaffected.
+#[tokio::test]
+async fn acp_stdio_fork_copies_open_session_history_into_new_cwd() {
+    const MARKER: &str = "fork-marker-live-5b1e9c7d";
+    const BRANCH_TURN: &str = "branch-turn-2e0f4a";
+    const PARENT_TURN: &str = "parent-turn-9c3d1b";
+
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-fork-live");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    let mut client = spawn_stdio_client(&workspace);
+
+    let (_, init) = client
+        .send_request("initialize", json!({ "protocolVersion": 1 }))
+        .await;
+    assert_eq!(
+        init["result"]["_meta"]["sudocode"]["sessionFork"].as_bool(),
+        Some(true),
+        "initialize must advertise _meta.sudocode.sessionFork: {init}"
+    );
+
+    let parent = scenario_session_new(&mut client, &workspace.root).await;
+    run_marked_turn(&mut client, &parent, MARKER).await;
+
+    let fork_cwd = workspace.root.join("branch");
+    let resp = fork_session(&mut client, &fork_cwd, json!({ "sessionId": parent })).await;
+    assert!(
+        resp.get("error").is_none(),
+        "forkFrom an open session should succeed: {resp}"
+    );
+    let forked = session_id_of(&resp);
+    assert_ne!(forked, parent, "a fork is a new session");
+    assert_available_commands_update(
+        client
+            .last_available_commands
+            .as_ref()
+            .expect("a forked session/new is followed by available_commands_update"),
+        &forked,
+    );
+
+    // The branch's first model request carries the parent's turn — user
+    // message and assistant reply — not just the new prompt.
+    let body = last_model_request_after_prompt(&mut client, &server, &forked, BRANCH_TURN).await;
+    assert!(
+        body.contains(MARKER),
+        "forked session's model request must include the parent's message ({MARKER}); \
+         a plain session/new would omit it. body: {body}"
+    );
+    assert!(
+        body.contains("\"role\":\"assistant\""),
+        "forked session's model request must carry the parent's assistant turn; body: {body}"
+    );
+
+    // Persisted under the NEW cwd's store, with the lineage recorded.
+    let transcript = read_session_transcript(&fork_cwd, &forked);
+    assert!(
+        transcript.contains(&parent),
+        "forked transcript must record parent_session_id={parent}; got: {transcript}"
+    );
+    assert!(
+        transcript.contains(MARKER),
+        "forked transcript must contain the copied history; got: {transcript}"
+    );
+
+    // The parent is untouched: its next turn does not see the branch's turn.
+    let parent_body =
+        last_model_request_after_prompt(&mut client, &server, &parent, PARENT_TURN).await;
+    assert!(
+        !parent_body.contains(BRANCH_TURN),
+        "parent must not see the branch's turn; body: {parent_body}"
+    );
+    let parent_transcript = read_session_transcript(&workspace.root, &parent);
+    assert!(
+        !parent_transcript.contains(BRANCH_TURN),
+        "parent transcript must not contain the branch's turn"
+    );
+
+    // The fork is a first-class session of this process — and of the new
+    // cwd: `session/load {cwd: branch}` accepts it after a restart.
+    client.shutdown().await;
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let (_, load) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": forked,
+                "cwd": fork_cwd.to_string_lossy(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        load.get("error").is_none(),
+        "the fork must be loadable from its own cwd: {load}"
+    );
+    let body = last_model_request_after_prompt(&mut client, &server, &forked, "after-reload").await;
+    assert!(
+        body.contains(MARKER) && body.contains(BRANCH_TURN),
+        "reloaded fork must carry both the parent history and its own turn; body: {body}"
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// `forkFrom` against a session that is NOT open in this process (the
+/// parent was created by an earlier process — apeiron after a restart):
+/// `sessionId` alone cannot be resolved and is rejected, `cwd` points the
+/// lookup at that directory's session store (validated like `session/load`),
+/// and `cwd` alone forks the most recent session persisted there.
+#[tokio::test]
+async fn acp_stdio_fork_from_persisted_session_across_processes() {
+    const MARKER: &str = "fork-marker-persisted-a71c04e2";
+
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-fork-persisted");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+
+    // --- Process A: the parent conversation, then exit ---
+    let parent = {
+        let mut client = spawn_stdio_client(&workspace);
+        scenario_initialize(&mut client).await;
+        let parent = scenario_session_new(&mut client, &workspace.root).await;
+        run_marked_turn(&mut client, &parent, MARKER).await;
+        client.shutdown().await;
+        parent
+    };
+
+    // --- Process B: fork it ---
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let branch_a = workspace.root.join("branch-a");
+    let branch_b = workspace.root.join("branch-b");
+    let elsewhere = workspace.root.join("elsewhere");
+
+    // Malformed `forkFrom` is rejected, never silently ignored.
+    for (label, meta) in [
+        ("non-object", json!("nope")),
+        ("empty object", json!({})),
+        ("empty sessionId", json!({ "sessionId": "  " })),
+        ("non-string cwd", json!({ "cwd": 7 })),
+    ] {
+        let resp = fork_session(&mut client, &branch_a, meta).await;
+        assert_invalid_params(&resp, &format!("forkFrom {label}"));
+    }
+
+    // Not open here and no cwd to look it up under.
+    let resp = fork_session(&mut client, &branch_a, json!({ "sessionId": parent })).await;
+    assert_invalid_params(&resp, "forkFrom.sessionId of a session that is not open");
+
+    // Wrong directory: the persisted workspace root does not match.
+    fs::create_dir_all(&elsewhere).expect("create elsewhere");
+    let resp = fork_session(
+        &mut client,
+        &branch_a,
+        json!({ "sessionId": parent, "cwd": elsewhere.to_string_lossy() }),
+    )
+    .await;
+    assert_invalid_params(&resp, "forkFrom with a cwd the session was not created in");
+
+    // sessionId + cwd: the persisted transcript is the source.
+    let resp = fork_session(
+        &mut client,
+        &branch_a,
+        json!({ "sessionId": parent, "cwd": workspace.root.to_string_lossy() }),
+    )
+    .await;
+    assert!(
+        resp.get("error").is_none(),
+        "forkFrom persisted session: {resp}"
+    );
+    let forked_a = session_id_of(&resp);
+    let body = last_model_request_after_prompt(&mut client, &server, &forked_a, "branch-a").await;
+    assert!(
+        body.contains(MARKER),
+        "fork of a persisted session must carry its history; body: {body}"
+    );
+
+    // cwd only: the latest session persisted under that directory (the
+    // parent — the fork above lives under branch-a, not here).
+    let resp = fork_session(
+        &mut client,
+        &branch_b,
+        json!({ "cwd": workspace.root.to_string_lossy() }),
+    )
+    .await;
+    assert!(resp.get("error").is_none(), "forkFrom.cwd only: {resp}");
+    let forked_b = session_id_of(&resp);
+    assert_ne!(forked_b, forked_a);
+    let body = last_model_request_after_prompt(&mut client, &server, &forked_b, "branch-b").await;
+    assert!(
+        body.contains(MARKER) && !body.contains("branch-a"),
+        "cwd-only fork must start from the parent, not from the sibling branch; body: {body}"
+    );
+    assert!(
+        read_session_transcript(&branch_b, &forked_b).contains(&parent),
+        "cwd-only fork must record the parent as its lineage"
+    );
+
+    // A directory with no sessions at all cannot be forked from.
+    let empty = workspace.root.join("empty");
+    fs::create_dir_all(&empty).expect("create empty");
+    let resp = fork_session(
+        &mut client,
+        &branch_a,
+        json!({ "cwd": empty.to_string_lossy() }),
+    )
+    .await;
+    assert_invalid_params(&resp, "forkFrom.cwd with no persisted session");
+
+    client.shutdown().await;
+    workspace.cleanup();
+}


### PR DESCRIPTION
## Problem

apeiron's session fork (`POST /sessions/{sid}/runs/{rid}/fork`) copies the run history into a new apeiron session, whose first prompt does a plain `session/new` in a **new cwd**. scode starts that session empty: the branch has the whole conversation in the UI and none of it model-side. Reproduced against real scode 0.2.2 + a real model:

```
parent  : "请记住暗号：pineapple-42" → "好的"
branch  : "我刚才让你记住的暗号是什么？" → "我没有记住任何暗号。记忆目录是空的…"
```

`session/load` cannot be used — it is bound to the cwd the session was created in — and `Session::fork()` existed only for the REPL; ACP had no fork entry point.

## Change

`session/new` accepts `_meta.sudocode.forkFrom { sessionId?, cwd? }`:

| given | source |
|---|---|
| `sessionId` | a session open in this process (`invalid_params` otherwise) |
| `sessionId` + `cwd` | the persisted session under `cwd`'s store, workspace-root validated like `session/load` |
| `cwd` | the most recently updated session persisted under `cwd` |

The new session is `Session::fork()` of the source (messages, compaction state, model, prompt history), re-homed to the new cwd and persisted under its store with `fork.parent_session_id`, so it is a first-class session there (`session/load {cwd}` works after a restart). The source is never written: an idle open session is copied from memory, a mid-turn one from its persisted transcript. Offloaded tool results are copied alongside. `initialize` advertises `_meta.sudocode.sessionFork: true`; malformed `forkFrom` is `invalid_params`.

Delegate: new `SdkAcpDelegate::fork_session`; the CLI shares runtime construction with `session/load` via `open_persisted_session`.

Same repro with this branch: branch answers `"pineapple-42"`.

## Tests

- `acp_stdio_fork_copies_open_session_history_into_new_cwd` — open source; the branch's first model request carries the parent's user+assistant turns; lineage in the new store; parent unaffected; fork loadable from its own cwd in a fresh process.
- `acp_stdio_fork_from_persisted_session_across_processes` — persisted source by id+cwd and by cwd only; unknown id, wrong cwd, empty dir and malformed meta rejected.

Full `acp_integration` suite: 23/23. Docs: `docs/acp.md` § Forking a conversation.

## Not in this PR

Point-in-time forks (cut at an earlier turn) need per-turn identity in the transcript; `session/prompt`'s `_meta.traceId` is the natural key. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PssZgUyJ1ZrgZRWZBMpSbg