### PR TITLE
fix(runtime): interruptible tool execution + repair orphan tool_use on load

### DIFF
--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -1402,23 +1402,65 @@ where
                     // Phase 2 (concurrent, &self): overlap the executes of the
                     // permitted tools — only `&self.tool_executor` and the owned
                     // inputs enter the futures, never `&mut self`.
-                    let exec_results: Vec<Option<Result<String, ToolError>>> =
-                        futures::future::join_all(prepared.iter().map(|p| async {
-                            if p.deny_reason.is_some() {
-                                None
-                            } else {
-                                Some(
-                                    self.tool_executor
-                                        .execute_with_context(
-                                            &p.tool_name,
-                                            &p.effective_input,
-                                            &dispatch_context,
-                                        )
-                                        .await,
-                                )
-                            }
-                        }))
-                        .await;
+                    // Race the concurrent batch against the abort signal so a
+                    // hung tool cannot pin the turn open with committed tool_use
+                    // blocks that never receive a tool_result. The push happens
+                    // *after* the select! so the batch future (which borrows
+                    // `&self.tool_executor`) is already dropped and `&mut self`
+                    // is free.
+                    let abort_signal = self.hook_abort_signal.clone();
+                    let batch_exec = futures::future::join_all(prepared.iter().map(|p| async {
+                        if p.deny_reason.is_some() {
+                            None
+                        } else {
+                            Some(
+                                self.tool_executor
+                                    .execute_with_context(
+                                        &p.tool_name,
+                                        &p.effective_input,
+                                        &dispatch_context,
+                                    )
+                                    .await,
+                            )
+                        }
+                    }));
+                    let maybe_results: Option<Vec<Option<Result<String, ToolError>>>> = tokio::select! {
+                        biased;
+                        () = abort_signal.cancelled() => None,
+                        results = batch_exec => Some(results),
+                    };
+                    let Some(exec_results) = maybe_results else {
+                        // Aborted mid-batch: answer every tool_use in this batch
+                        // and any still-pending ones with a synthetic interrupted
+                        // tool_result, then finish the turn.
+                        for p in &prepared {
+                            let result_message = ConversationMessage::tool_result(
+                                p.tool_use_id.clone(),
+                                p.tool_name.clone(),
+                                INTERRUPT_MESSAGE,
+                                true,
+                            );
+                            self.push_tool_result_message(
+                                &mut observer,
+                                iterations,
+                                &mut tool_results,
+                                result_message,
+                            )?;
+                        }
+                        self.push_interrupted_tool_results(
+                            &mut observer,
+                            iterations,
+                            &mut tool_results,
+                            &pending_tool_uses,
+                            batch_end,
+                        )?;
+                        return Ok(self.cancelled_summary(
+                            assistant_messages,
+                            tool_results,
+                            prompt_cache_events,
+                            iterations,
+                        ));
+                    };
 
                     // Phase 3 (serial, &mut self): post-hook + push, in order.
                     for (offset, p) in prepared.into_iter().enumerate() {
@@ -1599,11 +1641,58 @@ where
                 let result_message = match permission_outcome {
                     PermissionOutcome::Allow => {
                         self.record_tool_started(iterations, &tool_name);
-                        let (mut output, mut is_error) = match self
-                            .tool_executor
-                            .execute_with_context(&tool_name, &effective_input, &dispatch_context)
-                            .await
-                        {
+                        // Race tool execution against the abort signal. A naked
+                        // `.await` only observes the abort *after* the tool
+                        // returns; a tool that hangs (e.g. a sub-agent stuck
+                        // retrying a bad endpoint) would never yield, so ESC could
+                        // not interrupt it and the already-committed `tool_use`
+                        // would be left without a matching `tool_result` —
+                        // producing a session the API rejects on resume.
+                        let abort_signal = self.hook_abort_signal.clone();
+                        let exec_outcome = {
+                            let exec = self.tool_executor.execute_with_context(
+                                &tool_name,
+                                &effective_input,
+                                &dispatch_context,
+                            );
+                            tokio::select! {
+                                biased;
+                                () = abort_signal.cancelled() => None,
+                                res = exec => Some(res),
+                            }
+                        };
+                        let Some(exec_result) = exec_outcome else {
+                            // Aborted mid-execution: answer this tool_use (and any
+                            // still-pending ones) with a synthetic interrupted
+                            // tool_result so the persisted transcript keeps the
+                            // "every tool_use has a tool_result" invariant.
+                            let result_message = ConversationMessage::tool_result(
+                                tool_use_id,
+                                tool_name,
+                                INTERRUPT_MESSAGE,
+                                true,
+                            );
+                            self.push_tool_result_message(
+                                &mut observer,
+                                iterations,
+                                &mut tool_results,
+                                result_message,
+                            )?;
+                            self.push_interrupted_tool_results(
+                                &mut observer,
+                                iterations,
+                                &mut tool_results,
+                                &pending_tool_uses,
+                                tool_index + 1,
+                            )?;
+                            return Ok(self.cancelled_summary(
+                                assistant_messages,
+                                tool_results,
+                                prompt_cache_events,
+                                iterations,
+                            ));
+                        };
+                        let (mut output, mut is_error) = match exec_result {
                             Ok(output) => (output, false),
                             Err(error) => (error.to_string(), true),
                         };

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -379,7 +379,7 @@ impl Session {
     ) -> Result<Self, SessionError> {
         let path = path.as_ref();
         let contents = fs.read_to_string(&path.to_string_lossy())?;
-        let session = match JsonValue::parse(&contents) {
+        let mut session = match JsonValue::parse(&contents) {
             Ok(value)
                 if value
                     .as_object()
@@ -389,7 +389,63 @@ impl Session {
             }
             Err(_) | Ok(_) => Self::from_jsonl(&contents)?,
         };
+        // Defensive repair: a session persisted mid-tool-call (e.g. the process
+        // was killed, or crashed, while a tool was still running) can contain a
+        // `tool_use` with no following `tool_result`. The Anthropic API rejects
+        // such a history on resume ("`tool_use` ids were found without
+        // `tool_result` blocks immediately after"). Backfill a synthetic error
+        // result for any orphan so the transcript is always resumable, no matter
+        // how it was persisted. Applied in-memory on every load (idempotent).
+        session.sanitize_orphan_tool_uses();
         Ok(session.with_persistence_path(path.to_path_buf()))
+    }
+
+    /// Backfill a synthetic `tool_result` immediately after any `tool_use` that
+    /// has no matching `tool_result` anywhere in the transcript. Returns the
+    /// number of synthetic results inserted (0 when the history is already
+    /// well-formed). See [`Self::load_from_path_with`] for why this is needed.
+    fn sanitize_orphan_tool_uses(&mut self) -> usize {
+        const ORPHAN_TOOL_RESULT_MESSAGE: &str =
+            "[Tool call was interrupted before it returned — no result was produced. Treated as cancelled.]";
+
+        // Every tool_use id that is already answered somewhere in the history.
+        let mut answered: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for message in &self.messages {
+            for block in &message.blocks {
+                if let ContentBlock::ToolResult { tool_use_id, .. } = block {
+                    answered.insert(tool_use_id.clone());
+                }
+            }
+        }
+
+        let mut repaired: Vec<ConversationMessage> = Vec::with_capacity(self.messages.len());
+        let mut inserted = 0usize;
+        for message in std::mem::take(&mut self.messages) {
+            let orphans: Vec<(String, String)> = message
+                .blocks
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::ToolUse { id, name, .. } if !answered.contains(id) => {
+                        Some((id.clone(), name.clone()))
+                    }
+                    _ => None,
+                })
+                .collect();
+            repaired.push(message);
+            for (tool_use_id, tool_name) in orphans {
+                // Mark answered so a later duplicate id is not filled twice.
+                answered.insert(tool_use_id.clone());
+                repaired.push(ConversationMessage::tool_result(
+                    tool_use_id,
+                    tool_name,
+                    ORPHAN_TOOL_RESULT_MESSAGE,
+                    true,
+                ));
+                inserted += 1;
+            }
+        }
+        self.messages = repaired;
+        inserted
     }
 
     pub fn push_message(&mut self, message: ConversationMessage) -> Result<(), SessionError> {
@@ -1632,6 +1688,78 @@ mod tests {
             Some(43_700)
         );
         assert_eq!(restored.session_id, session.session_id);
+    }
+
+    #[test]
+    fn sanitizes_orphan_tool_use_on_load() {
+        // Assistant emits a tool_use; the tool call is interrupted so the very
+        // next message is plain user text with no tool_result. The Anthropic API
+        // rejects this on resume — load must backfill a synthetic tool_result.
+        let mut session = Session::new();
+        session.push_user_text("go").expect("user append");
+        session
+            .push_message(ConversationMessage::assistant(vec![
+                ContentBlock::ToolUse {
+                    id: "tool-x".to_string(),
+                    name: "Agent".to_string(),
+                    input: "{}".to_string(),
+                    thought_signature: None,
+                },
+            ]))
+            .expect("assistant append");
+        session.push_user_text("stop").expect("user append");
+
+        let path = temp_session_path("orphan");
+        session.save_to_path(&path).expect("session should save");
+        let restored = Session::load_from_path(&path).expect("session should load");
+        fs::remove_file(&path).expect("temp file should be removable");
+
+        let pos = restored
+            .messages
+            .iter()
+            .position(|m| {
+                m.blocks
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "tool-x"))
+            })
+            .expect("tool_use present");
+        let next = restored
+            .messages
+            .get(pos + 1)
+            .expect("message after tool_use");
+        assert!(
+            next.blocks.iter().any(|b| matches!(
+                b,
+                ContentBlock::ToolResult { tool_use_id, is_error, .. }
+                    if tool_use_id == "tool-x" && *is_error
+            )),
+            "a synthetic error tool_result must immediately follow the orphan tool_use"
+        );
+    }
+
+    #[test]
+    fn sanitize_leaves_well_formed_history_unchanged() {
+        // A complete tool_use → tool_result pair must not gain a duplicate.
+        let mut session = Session::new();
+        session.push_user_text("hi").expect("user append");
+        session
+            .push_message(ConversationMessage::assistant(vec![
+                ContentBlock::ToolUse {
+                    id: "t1".to_string(),
+                    name: "bash".to_string(),
+                    input: "{}".to_string(),
+                    thought_signature: None,
+                },
+            ]))
+            .expect("assistant append");
+        session
+            .push_message(ConversationMessage::tool_result("t1", "bash", "ok", false))
+            .expect("tool result append");
+
+        let before = session.messages.len();
+        let inserted = session.sanitize_orphan_tool_uses();
+        assert_eq!(inserted, 0, "well-formed history needs no repair");
+        assert_eq!(session.messages.len(), before);
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -1127,13 +1127,27 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             // Update spinner.  When a new turn starts (spinner becomes
             // active), clear the previous turn's result — the spinner
             // takes priority in the StatusSlot and the old result is stale.
+            //
+            // Only mutate state when it actually changes. `render_frame`
+            // returns "" whenever the spinner is inactive (idle), so the old
+            // unconditional `frame.set(idx+1)` + `spinner_text.set("")` churned
+            // identical state on every 80ms idle tick. Per iocraft's render
+            // model an unconditional `State::set` — even to the same value —
+            // resolves `component.wait()` and can starve `term.wait()`, dropping
+            // keyboard events (the failure mode guarded by
+            // `iocraft_repl_keyboard_input_not_frozen`). Leaving idle ticks
+            // untouched keeps key-event distribution alive between renders.
             let idx = frame.get();
-            frame.set(idx.wrapping_add(1));
             let text = spinner_for_future.render_frame(idx);
-            if !text.is_empty() && turn_result.read().is_some() {
-                turn_result.set(None);
+            if !text.is_empty() {
+                frame.set(idx.wrapping_add(1));
+                if turn_result.read().is_some() {
+                    turn_result.set(None);
+                }
             }
-            spinner_text.set(text);
+            if *spinner_text.read() != text {
+                spinner_text.set(text);
+            }
         }
     });
 


### PR DESCRIPTION
## Problem

Resuming a session can fail with:

```
api returned 400 Bad Request: messages.N: `tool_use` ids were found without
`tool_result` blocks immediately after: <id>. Each `tool_use` block must have
a corresponding `tool_result` block in the next message.
```

The persisted transcript contains a `tool_use` with no matching `tool_result`, so the Anthropic API rejects it on **every** resume.

## Root cause

A tool call is only checked against the abort signal **after** it returns. In `conversation.rs`, both the serial-singleton (`:1602`) and concurrent-batch (`:1411`) paths call `tool_executor.execute_with_context(...).await` as a **naked `.await`** — unlike the streaming path (`:1154`), which races stream events against the abort signal with `tokio::select!`.

So when a tool **hangs** (the observed case: a sub-agent stuck retrying an unavailable model/endpoint, backing off 8×), ESC/abort cannot interrupt the `.await` — it only fires the abort check once the tool returns, which never happens. The assistant message carrying the `tool_use` was already committed + persisted, so a forced kill leaves a dangling `tool_use`. The existing cancellation compensator (`finalize_cancelled_turn` / `push_interrupted_tool_results`) is correct but is **never reached** because the `.await` is stuck.

## Fix

**A — interruptible tool execution (root cause).** Race both tool-execution paths against the abort signal via `tokio::select!` (mirroring the streaming path). On abort during execution, synthesize an interrupted `tool_result` for the running tool + any still-pending ones (reusing `push_interrupted_tool_results` / `cancelled_summary`), then finish the turn. A hung tool can now be interrupted, and the transcript always preserves the *every `tool_use` has a matching `tool_result`* invariant.

**B — defensive load-time sanitizer (belt & suspenders).** `Session::load_from_path_with` now backfills a synthetic error `tool_result` for any unanswered `tool_use`. This covers crashes / hard kills where the turn finalizer never ran, and **repairs already-corrupted sessions** so they resume. Idempotent; applied in-memory on every load.

## Tests

- `sanitizes_orphan_tool_use_on_load` — orphan `tool_use` → synthetic `tool_result` inserted immediately after on load.
- `sanitize_leaves_well_formed_history_unchanged` — complete pairs are untouched (no duplicate results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)