### PR TITLE
chore(release): bump version to 0.2.3

### DIFF
--- a/RELEASE_NOTES_v0.2.3.md
+++ b/RELEASE_NOTES_v0.2.3.md
@@ -1,0 +1,20 @@
+# Sudo Code v0.2.3
+
+## What's New
+
+### Features
+- **ACP `session/new` forkFrom — fork a conversation into a new cwd** (#549) — `session/new` accepts `_meta.sudocode.forkFrom { sessionId?, cwd? }` and starts the new session with the source session's transcript instead of empty. Until now a client that branched a conversation into a new working directory (apeiron's run fork does exactly that) had the whole history in its UI and none of it model-side; `session/load` could not help because it is bound to the cwd the session was created in. `Session::fork()` existed only for the REPL; ACP now has the same entry point.
+- **`scode --resume` resumes the latest session directly** (#553) — bare `scode --resume` no longer needs a session id copied from the browser; `scode --resume list` / `ls` / `sessions` opens the browser as before.
+
+### Fixes
+- **Interruptible tool execution + repair of orphan `tool_use` on load** (#550) — a tool call was only checked against the abort signal *after* it returned, so ESC could not interrupt a hanging tool (a sub-agent stuck retrying an unavailable endpoint) and a forced kill left a `tool_use` with no `tool_result`. The Anthropic API then rejected the persisted history on **every** resume (`tool_use ids were found without tool_result blocks immediately after`). Tool execution in the serial and concurrent paths now races the abort signal like the streaming path already did, and loading a transcript repairs an orphan `tool_use` with a synthetic error `tool_result` so the session resumes.
+- **Session browser: no duplicate entries, no empty `(latest)`** (#553) — rotation snapshots `<id>.rot-<ts>.jsonl` carry their parent's session id and were listed as separate sessions, so one session appeared N times; a freshly created empty shell could sort first and be picked as `(latest)`. Snapshots are excluded from the managed-session listing and empty (0-message) shells sink below real sessions.
+- **REPL: idle spinner ticks no longer churn identical state** (4b98030) — the 80 ms tick called `State::set` unconditionally even when the spinner was inactive; under iocraft's render model that resolves `component.wait()` every tick and can starve `term.wait()`, dropping keyboard events. State is only mutated when the value changes. Targets the intermittent macOS PTY flakiness in `iocraft_repl_ctrlc_hint_in_footer`.
+- **TaskUpdate tool description states that the task must already exist** (5eb5a6c).
+
+### Internal
+- **nexus-vfs pin b5b969a0 → 5806c39d** (#552) — `ServiceBootCtx.api_key_secret` widened upstream; additive only.
+
+## Upgrade
+
+`scode update`, or download `scode-<platform>.tar.gz` from this release. No config or transcript format changes; the orphan-`tool_use` repair runs automatically on load.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "plugins",
  "runtime",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "commands",
  "runtime",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "api",
  "serde_json",
@@ -2604,7 +2604,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c1
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3899,7 +3899,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "api",
  "arboard",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Patch release: bump workspace version 0.2.2 -> 0.2.3, refresh Cargo.lock (workspace crates only; `cargo update --workspace`), add `RELEASE_NOTES_v0.2.3.md`.

Ships everything on `main` since v0.2.2:
- #549 ACP `session/new` `forkFrom` (fork a conversation into a new cwd)
- #550 interruptible tool execution + orphan `tool_use` repair on load
- #553 session browser dedup / no empty `(latest)`, bare `--resume` resumes latest
- #552 nexus-vfs pin bump
- 4b98030 REPL idle spinner tick fix, 5eb5a6c TaskUpdate description

Same shape as #548 (v0.2.2). Tag `v0.2.3` goes on the merge commit after this lands; `release.yml` builds and publishes on the tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)