### PR TITLE
fix: model identity + SSE truncation

### DIFF
--- a/rust/crates/api/src/error.rs
+++ b/rust/crates/api/src/error.rs
@@ -71,6 +71,18 @@ pub enum ApiError {
         last_error: Box<ApiError>,
     },
     InvalidSseFrame(&'static str),
+    /// The response stream ended in the middle of an SSE frame — the trailing
+    /// bytes are a partial `data:` payload that cannot be parsed. This is a
+    /// transport truncation (dropped connection, a proxy cutting the stream),
+    /// not a malformed payload from the model, so it is retryable and must not
+    /// be reported as a JSON parse failure "for model X" (which misleads the
+    /// user into blaming the model). `body_snippet` carries the leading bytes
+    /// of the unparseable tail for diagnosis.
+    IncompleteStream {
+        provider: String,
+        model: String,
+        body_snippet: String,
+    },
     BackoffOverflow {
         attempt: u32,
         base_delay: Duration,
@@ -83,6 +95,27 @@ pub enum ApiError {
     /// Config-driven provider resolution error (e.g. missing model alias,
     /// unavailable auth mode, missing credential in sudocode.json).
     Configuration(String),
+}
+
+/// Internal classification used by [`ApiError::categorize`] to share
+/// exhaustive match arms across predicate methods without repeating every
+/// variant in every method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorCategory {
+    /// `Http`, `Api`, or `RetriesExhausted` — callers inspect these directly.
+    Structured,
+    /// `IncompleteStream`, `InvalidSseFrame`, `BackoffOverflow`.
+    Transport,
+    /// `MissingCredentials`, `ExpiredOAuthToken`, `Auth`.
+    Auth,
+    /// `ContextWindowExceeded`.
+    ContextWindow,
+    /// `RequestBodySizeExceeded`.
+    RequestSize,
+    /// `InvalidApiKeyEnv`, `Io`, `Json`.
+    RuntimeIo,
+    /// `Configuration`.
+    Configuration,
 }
 
 impl ApiError {
@@ -135,23 +168,66 @@ impl ApiError {
         }
     }
 
+    /// Build an [`ApiError::IncompleteStream`] from the unparseable trailing
+    /// bytes of a truncated SSE stream.
+    #[must_use]
+    pub fn incomplete_stream(
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        body: &str,
+    ) -> Self {
+        Self::IncompleteStream {
+            provider: provider.into(),
+            model: model.into(),
+            body_snippet: truncate_body_snippet(body, 200),
+        }
+    }
+
+    /// Internal classification used to share exhaustive match arms across the
+    /// several boolean/option predicate methods below. Each method still has
+    /// its own `match self` at the top for variants that carry data (e.g.
+    /// `Api` for retryability and failure class, `Http` for retryability) —
+    /// those branches return before `categorize()` is ever called. The helper
+    /// is #[inline] so the compiler can constant-fold it into each call site.
+    #[inline]
+    fn categorize(&self) -> ErrorCategory {
+        match self {
+            // These carry data needed by each predicate method; callers
+            // short-circuit before reaching categorize().
+            Self::Http(_) | Self::Api { .. } | Self::RetriesExhausted { .. } => {
+                ErrorCategory::Structured
+            }
+            // Transport failures: retryable, safe_failure_class = "provider_transport".
+            Self::IncompleteStream { .. }
+            | Self::InvalidSseFrame(_)
+            | Self::BackoffOverflow { .. } => ErrorCategory::Transport,
+            // Credential / auth errors: safe_failure_class = "provider_auth".
+            Self::MissingCredentials { .. } | Self::ExpiredOAuthToken | Self::Auth(_) => {
+                ErrorCategory::Auth
+            }
+            // Context-window hard stop.
+            Self::ContextWindowExceeded { .. } => ErrorCategory::ContextWindow,
+            // Request too large.
+            Self::RequestBodySizeExceeded { .. } => ErrorCategory::RequestSize,
+            // Local I/O or JSON parse failures.
+            Self::InvalidApiKeyEnv(_) | Self::Io(_) | Self::Json { .. } => ErrorCategory::RuntimeIo,
+            // Config-driven resolution errors.
+            Self::Configuration(_) => ErrorCategory::Configuration,
+        }
+    }
+
     #[must_use]
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::Http(error) => error.is_connect() || error.is_timeout() || error.is_request(),
             Self::Api { retryable, .. } => *retryable,
+            // A stream truncated mid-frame is a transport failure: retry the
+            // whole request rather than surfacing the partial tail as fatal.
+            Self::IncompleteStream { .. } => true,
             Self::RetriesExhausted { last_error, .. } => last_error.is_retryable(),
-            Self::MissingCredentials { .. }
-            | Self::ContextWindowExceeded { .. }
-            | Self::ExpiredOAuthToken
-            | Self::Auth(_)
-            | Self::InvalidApiKeyEnv(_)
-            | Self::Io(_)
-            | Self::Json { .. }
-            | Self::InvalidSseFrame(_)
-            | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. }
-            | Self::Configuration(_) => false,
+            // All remaining variants — auth, context-window, I/O, config, etc.
+            // — are not retryable.
+            _ => false,
         }
     }
 
@@ -160,18 +236,7 @@ impl ApiError {
         match self {
             Self::Api { request_id, .. } => request_id.as_deref(),
             Self::RetriesExhausted { last_error, .. } => last_error.request_id(),
-            Self::MissingCredentials { .. }
-            | Self::ContextWindowExceeded { .. }
-            | Self::ExpiredOAuthToken
-            | Self::Auth(_)
-            | Self::InvalidApiKeyEnv(_)
-            | Self::Http(_)
-            | Self::Io(_)
-            | Self::Json { .. }
-            | Self::InvalidSseFrame(_)
-            | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. }
-            | Self::Configuration(_) => None,
+            _ => None,
         }
     }
 
@@ -185,18 +250,7 @@ impl ApiError {
                 retry_after.map(|secs| Duration::from_secs(u64::from(secs.get())))
             }
             Self::RetriesExhausted { last_error, .. } => last_error.retry_after(),
-            Self::MissingCredentials { .. }
-            | Self::ContextWindowExceeded { .. }
-            | Self::ExpiredOAuthToken
-            | Self::Auth(_)
-            | Self::InvalidApiKeyEnv(_)
-            | Self::Http(_)
-            | Self::Io(_)
-            | Self::Json { .. }
-            | Self::InvalidSseFrame(_)
-            | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. }
-            | Self::Configuration(_) => None,
+            _ => None,
         }
     }
 
@@ -218,11 +272,18 @@ impl ApiError {
             Self::Api { status, .. } if status.as_u16() == 429 => "provider_rate_limit",
             Self::Api { .. } if self.is_generic_fatal_wrapper() => "provider_internal",
             Self::Api { .. } => "provider_error",
-            Self::Http(_) | Self::InvalidSseFrame(_) | Self::BackoffOverflow { .. } => {
-                "provider_transport"
-            }
-            Self::InvalidApiKeyEnv(_) | Self::Io(_) | Self::Json { .. } => "runtime_io",
-            Self::RequestBodySizeExceeded { .. } => "request_size",
+            // Collapse remaining variants through categorize() so adding a new
+            // ApiError variant only requires updating categorize().
+            _ => match self.categorize() {
+                ErrorCategory::Transport => "provider_transport",
+                ErrorCategory::Auth => "provider_auth",
+                ErrorCategory::ContextWindow => "context_window",
+                ErrorCategory::RequestSize => "request_size",
+                ErrorCategory::RuntimeIo => "runtime_io",
+                ErrorCategory::Configuration => "provider_auth",
+                // Structured (Http/Api/RetriesExhausted) already handled above.
+                ErrorCategory::Structured => "provider_error",
+            },
         }
     }
 
@@ -236,18 +297,7 @@ impl ApiError {
                     || looks_like_generic_fatal_wrapper(body)
             }
             Self::RetriesExhausted { last_error, .. } => last_error.is_generic_fatal_wrapper(),
-            Self::MissingCredentials { .. }
-            | Self::ContextWindowExceeded { .. }
-            | Self::ExpiredOAuthToken
-            | Self::Auth(_)
-            | Self::InvalidApiKeyEnv(_)
-            | Self::Http(_)
-            | Self::Io(_)
-            | Self::Json { .. }
-            | Self::InvalidSseFrame(_)
-            | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. }
-            | Self::Configuration(_) => false,
+            _ => false,
         }
     }
 
@@ -268,17 +318,7 @@ impl ApiError {
                         || looks_like_context_window_error(body))
             }
             Self::RetriesExhausted { last_error, .. } => last_error.is_context_window_failure(),
-            Self::MissingCredentials { .. }
-            | Self::ExpiredOAuthToken
-            | Self::Auth(_)
-            | Self::InvalidApiKeyEnv(_)
-            | Self::Http(_)
-            | Self::Io(_)
-            | Self::Json { .. }
-            | Self::InvalidSseFrame(_)
-            | Self::BackoffOverflow { .. }
-            | Self::RequestBodySizeExceeded { .. }
-            | Self::Configuration(_) => false,
+            _ => false,
         }
     }
 }
@@ -345,6 +385,14 @@ impl Display for ApiError {
             } => write!(
                 f,
                 "failed to parse {provider} response for model {model}: {source}; first 200 chars of body: {body_snippet}"
+            ),
+            Self::IncompleteStream {
+                provider,
+                model,
+                body_snippet,
+            } => write!(
+                f,
+                "{provider} stream for model {model} ended mid-frame (truncated response, likely a dropped connection or a proxy cutting the stream); first 200 chars of the incomplete tail: {body_snippet}"
             ),
             Self::Api {
                 status,

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -636,13 +636,18 @@ impl OpenAiSseParser {
             return Ok(Vec::new());
         }
         let trailing = std::mem::take(&mut self.buffer);
-        match parse_sse_frame(
-            &String::from_utf8_lossy(&trailing),
-            &self.provider,
-            &self.model,
-        )? {
-            Some(event) => Ok(vec![event]),
-            None => Ok(Vec::new()),
+        let tail = String::from_utf8_lossy(&trailing);
+        // A leftover frame at end-of-stream that fails to parse is a
+        // truncation, not a malformed model payload: surface it as a retryable
+        // IncompleteStream instead of a JSON error that blames the model.
+        match parse_sse_frame(&tail, &self.provider, &self.model) {
+            Ok(Some(event)) => Ok(vec![event]),
+            Ok(None) => Ok(Vec::new()),
+            Err(_) => Err(ApiError::incomplete_stream(
+                &self.provider,
+                &self.model,
+                &tail,
+            )),
         }
     }
 }

--- a/rust/crates/api/src/sse.rs
+++ b/rust/crates/api/src/sse.rs
@@ -44,9 +44,21 @@ impl SseParser {
         }
 
         let trailing = std::mem::take(&mut self.buffer);
-        match self.parse_frame_with_context(&String::from_utf8_lossy(&trailing))? {
-            Some(event) => Ok(vec![event]),
-            None => Ok(Vec::new()),
+        let tail = String::from_utf8_lossy(&trailing);
+        // A non-empty buffer at end-of-stream is a frame that never got its
+        // `\n\n` terminator. Some servers legitimately omit the final blank
+        // line, so a clean parse must still succeed. But when the tail cannot
+        // be parsed it is a truncation, not a malformed model payload: report
+        // it as a retryable IncompleteStream carrying the tail, never as a
+        // JSON "failed to parse ... for model X" error that blames the model.
+        match self.parse_frame_with_context(&tail) {
+            Ok(Some(event)) => Ok(vec![event]),
+            Ok(None) => Ok(Vec::new()),
+            Err(_) => Err(ApiError::incomplete_stream(
+                self.provider.as_deref().unwrap_or("unknown"),
+                self.model.as_deref().unwrap_or("unknown"),
+                &tail,
+            )),
         }
     }
 
@@ -190,6 +202,7 @@ pub(crate) fn detect_non_sse_error(trimmed: &str) -> Option<ApiError> {
 #[cfg(test)]
 mod tests {
     use super::{parse_frame, SseParser};
+    use crate::error::ApiError;
     use crate::types::{ContentBlockDelta, MessageDelta, OutputContentBlock, StreamEvent, Usage};
 
     #[test]
@@ -387,5 +400,49 @@ mod tests {
                 usage: Usage::default(),
             }))
         );
+    }
+
+    #[test]
+    fn finish_on_truncated_frame_reports_incomplete_stream_not_json_error() {
+        // A stream that ends mid-frame (no terminating blank line, partial
+        // JSON) is a transport truncation. finish() must surface it as a
+        // retryable IncompleteStream naming the truncation — never as a JSON
+        // parse error "for model X" that blames the model.
+        let mut parser = SseParser::new().with_context("anthropic", "claude-opus-5");
+        let partial = b"event: content_block_delta\ndata: {\"type\":\"content_block_del";
+        assert!(parser.push(partial).expect("partial buffers").is_empty());
+
+        let err = parser.finish().expect_err("truncated tail must error");
+        assert!(
+            matches!(err, ApiError::IncompleteStream { .. }),
+            "expected IncompleteStream, got: {err:?}"
+        );
+        assert!(err.is_retryable(), "a truncated stream must be retryable");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("ended mid-frame") && rendered.contains("claude-opus-5"),
+            "message should name the truncation and model: {rendered}"
+        );
+        assert!(
+            !rendered.contains("failed to parse"),
+            "must not render as a JSON parse failure: {rendered}"
+        );
+    }
+
+    #[test]
+    fn finish_parses_a_final_frame_missing_its_trailing_blank_line() {
+        // Some servers omit the final `\n\n`. A complete-but-unterminated last
+        // frame must still parse cleanly (not be misclassified as truncated).
+        let mut parser = SseParser::new().with_context("anthropic", "claude-opus-5");
+        let whole = b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{}}";
+        assert!(parser
+            .push(whole)
+            .expect("buffers, no terminator yet")
+            .is_empty());
+
+        let events = parser
+            .finish()
+            .expect("unterminated final frame still parses");
+        assert_eq!(events.len(), 1, "the final frame should yield its event");
     }
 }

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -62,6 +62,17 @@ const DATE_CONTEXT_REMINDER_PREFIX: &str = "<system-reminder>Today's date is ";
 /// also counts as a valid date announcement when scanning the session.
 const DATE_ROLLOVER_REMINDER_MARKER: &str = "The local calendar date has changed";
 
+/// Prefix of the user-side model announcement injected on the first turn.
+/// The active model deliberately lives in a content block instead of the
+/// system prompt so the system blocks stay byte-stable across a `/model`
+/// switch (the dynamic system block would otherwise miss its prompt cache
+/// every switch). Also used as the marker when scanning the session for an
+/// existing announcement.
+const MODEL_CONTEXT_REMINDER_PREFIX: &str = "<system-reminder>You are running as ";
+/// Marker present in the model-change reminder text; a change reminder also
+/// counts as a valid model announcement when scanning the session.
+const MODEL_CHANGE_REMINDER_MARKER: &str = "The active model has changed";
+
 /// Fully assembled request payload sent to the upstream model client.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiRequest {
@@ -385,6 +396,13 @@ pub struct ConversationRuntime<C, T> {
     /// a `<system-reminder>` content block on the first user turn and
     /// prepends a rollover reminder when the local date changes mid-session.
     prompt_known_date: Option<String>,
+    /// The model this session last announced to the assistant. Mirrors
+    /// `prompt_known_date`: `run_turn_with_blocks` announces the active model
+    /// via a `<system-reminder>` content block on the first user turn and
+    /// prepends a change reminder when the active model differs mid-session
+    /// (e.g. after `/model`). Keeps model identity out of the cached system
+    /// prompt entirely.
+    prompt_known_model: Option<String>,
     /// Override for "today" used in tests. Always `None` outside tests.
     #[cfg(test)]
     today_override: Option<String>,
@@ -456,6 +474,7 @@ where
             permission_policy,
             system_prompt,
             prompt_known_date: None,
+            prompt_known_model: None,
             #[cfg(test)]
             today_override: None,
             max_iterations: usize::MAX,
@@ -494,6 +513,24 @@ where
     #[must_use]
     pub fn prompt_known_date(&self) -> Option<&str> {
         self.prompt_known_date.as_deref()
+    }
+
+    /// Announce the model this session starts on. Mirrors
+    /// [`Self::with_session_known_date`]: the model is carried in a first-turn
+    /// `<system-reminder>` content block, never in the cached system prompt.
+    #[must_use]
+    pub fn with_session_known_model(mut self, model: impl Into<String>) -> Self {
+        self.prompt_known_model = Some(model.into());
+        self
+    }
+
+    /// Model this session last announced to the assistant. Exposed so the CLI
+    /// can carry the state across runtime rebuilds (a `/model` switch rebuilds
+    /// the runtime); without it a rebuild would re-announce or, worse, announce
+    /// a stale model.
+    #[must_use]
+    pub fn prompt_known_model(&self) -> Option<&str> {
+        self.prompt_known_model.as_deref()
     }
 
     #[must_use]
@@ -676,6 +713,79 @@ where
                     ContentBlock::Text { text }
                         if text.contains(DATE_CONTEXT_REMINDER_PREFIX)
                             || text.contains(DATE_ROLLOVER_REMINDER_MARKER)
+                )
+            })
+        })
+    }
+
+    /// Keep the assistant informed of which model it is WITHOUT ever putting
+    /// the model into the (cache-prefix) system prompt, mirroring
+    /// [`Self::inject_date_context`]. Both shapes live in user-side content
+    /// blocks, leaving the system prompt byte-stable across a `/model` switch
+    /// so its prompt-cache prefix stays warm.
+    fn inject_model_context(&mut self, blocks: Vec<ContentBlock>) -> Vec<ContentBlock> {
+        let Some(known) = self.prompt_known_model.clone() else {
+            return blocks;
+        };
+        let active = self.active_model();
+        if active.is_empty() {
+            return blocks;
+        }
+        if active != known {
+            let reminder = ContentBlock::Text {
+                text: format!(
+                    "<system-reminder>The active model has changed since this session started. \
+                     You were {known}; you are now running as {active}. \
+                     Any earlier text in this conversation that named a different model is stale. \
+                     When asked which model you are, answer {active}.</system-reminder>"
+                ),
+            };
+            self.prompt_known_model = Some(active);
+            let mut combined = Vec::with_capacity(blocks.len() + 1);
+            combined.push(reminder);
+            combined.extend(blocks);
+            return combined;
+        }
+        if self.session_has_model_context() {
+            return blocks;
+        }
+        let mut combined = blocks;
+        combined.push(ContentBlock::Text {
+            text: format!(
+                "{MODEL_CONTEXT_REMINDER_PREFIX}{active}. \
+                 Your built-in identity text may name a different model or vendor; \
+                 the model named here is the one actually serving this session, so \
+                 when asked which model you are, answer {active}.</system-reminder>"
+            ),
+        });
+        combined
+    }
+
+    /// Model the session should treat as the one currently answering. Reads
+    /// the session's requested model (`session.model`) — the one the next
+    /// request will actually use, kept in sync by `/model` and runtime
+    /// rebuilds — and falls back to the announced model when the session
+    /// carries none. This is compared against `prompt_known_model` (what was
+    /// last announced) so a switch is detected exactly once.
+    fn active_model(&self) -> String {
+        self.session
+            .model
+            .clone()
+            .or_else(|| self.prompt_known_model.clone())
+            .unwrap_or_default()
+    }
+
+    /// `true` when some message already announced the active model to the
+    /// assistant, via either the first-turn announcement or a change reminder.
+    /// Scanning the session self-heals after compaction removes the carrier.
+    fn session_has_model_context(&self) -> bool {
+        self.session.messages.iter().any(|message| {
+            message.blocks.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::Text { text }
+                        if text.contains(MODEL_CONTEXT_REMINDER_PREFIX)
+                            || text.contains(MODEL_CHANGE_REMINDER_MARKER)
                 )
             })
         })
@@ -998,6 +1108,7 @@ where
         mut observer: Option<&mut dyn RuntimeObserver>,
     ) -> Result<TurnSummary, RuntimeError> {
         let blocks = self.inject_date_context(blocks);
+        let blocks = self.inject_model_context(blocks);
         // Coordinator-mode push: drain any `<task-notification>` XML
         // blocks that background sub-agents deposited into the
         // coordinator's inbox since the previous turn, and prepend
@@ -4685,6 +4796,127 @@ mod tests {
             &second_turn_user_blocks[0],
             ContentBlock::Text { text } if text == "second"
         ));
+    }
+
+    #[tokio::test]
+    async fn first_turn_announces_active_model_after_user_content() {
+        // The system prompt carries no model, so the first turn must announce
+        // it via a user-side system-reminder block appended AFTER the user's
+        // content (mirrors the date announcement).
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_model("claude-opus-5");
+
+        runtime
+            .run_turn("hello", None, None)
+            .await
+            .expect("turn should succeed");
+
+        let requests = captured.lock().expect("captured mutex");
+        let user_blocks = &requests[0].messages[0].blocks;
+        assert_eq!(
+            user_blocks.len(),
+            2,
+            "first turn should carry user text + model announcement"
+        );
+        assert!(matches!(
+            &user_blocks[0],
+            ContentBlock::Text { text } if text == "hello"
+        ));
+        let ContentBlock::Text { text: announcement } = &user_blocks[1] else {
+            panic!("second block should be the model announcement");
+        };
+        assert!(
+            announcement.contains("<system-reminder>")
+                && announcement.contains("You are running as claude-opus-5"),
+            "model announcement malformed: {announcement}"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_announcement_is_not_repeated_on_later_turns() {
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_model("claude-opus-5");
+
+        runtime.run_turn("first", None, None).await.expect("turn 1");
+        runtime
+            .run_turn("second", None, None)
+            .await
+            .expect("turn 2");
+
+        let requests = captured.lock().expect("captured mutex");
+        let second_turn_user_blocks = requests[1]
+            .messages
+            .iter()
+            .rfind(|m| m.role == MessageRole::User)
+            .expect("user message")
+            .blocks
+            .clone();
+        assert_eq!(
+            second_turn_user_blocks.len(),
+            1,
+            "model announcement must not repeat while the session carries it"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_change_is_announced_mid_session() {
+        // Switching the requested model mid-session (as `/model` does by
+        // rebuilding the runtime with a new session.model) must inject a
+        // change reminder naming the new model, prepended BEFORE the user
+        // content.
+        let captured: Arc<std::sync::Mutex<Vec<ApiRequest>>> = Arc::default();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            CapturingApi {
+                requests: captured.clone(),
+            },
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_session_known_model("claude-opus-5");
+
+        runtime.run_turn("first", None, None).await.expect("turn 1");
+        runtime.session_mut().model = Some("claude-sonnet-4-6".to_string());
+        runtime
+            .run_turn("second", None, None)
+            .await
+            .expect("turn 2");
+
+        let requests = captured.lock().expect("captured mutex");
+        let second_turn_user_blocks = requests[1]
+            .messages
+            .iter()
+            .rfind(|m| m.role == MessageRole::User)
+            .expect("user message")
+            .blocks
+            .clone();
+        let ContentBlock::Text { text: reminder } = &second_turn_user_blocks[0] else {
+            panic!("first block of the switched turn should be the change reminder");
+        };
+        assert!(
+            reminder.contains("The active model has changed")
+                && reminder.contains("claude-sonnet-4-6"),
+            "model change reminder malformed: {reminder}"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2555,6 +2555,15 @@ impl BuiltRuntime {
         self
     }
 
+    fn with_session_known_model(mut self, model: impl Into<String>) -> Self {
+        let runtime = self
+            .runtime
+            .take()
+            .expect("runtime should exist before overriding session known model");
+        self.runtime = Some(runtime.with_session_known_model(model));
+        self
+    }
+
     /// Set the trace ID for the next request.
     fn set_trace_id(&mut self, trace_id: impl Into<String>) {
         if let Some(ref mut runtime) = self.runtime {
@@ -3802,7 +3811,17 @@ impl AcpSdkDelegate {
         mcp_servers: std::collections::BTreeMap<String, runtime::ScopedMcpServerConfig>,
         prompt_overrides: runtime::SystemPromptOverrides,
     ) -> Result<(String, PathBuf, runtime::HookAbortSignal), runtime::AcpError> {
-        let model = self.inner.resolve_model_for_cwd(&cwd)?;
+        // A persisted transcript carries the model it was last run with
+        // (`build_runtime_with_plugin_state` records it). Prefer that over the
+        // directory's default: resuming a session that had been switched to
+        // another model must not silently drop back to the config model, which
+        // would run the rest of the conversation on the wrong model and
+        // mis-size the context window for auto-compaction. An explicit
+        // `--model` flag still wins.
+        let model = match (&self.inner.model_flag_raw, &session.model) {
+            (None, Some(persisted)) => persisted.clone(),
+            _ => self.inner.resolve_model_for_cwd(&cwd)?,
+        };
         let permission_mode = self.inner.resolve_permission_mode_for_cwd(&cwd)?;
         let system_prompt = build_acp_system_prompt(&cwd, &prompt_overrides)?;
         let sudocode_config =
@@ -4675,6 +4694,7 @@ impl LiveCli {
         // known date silently advanced to today on every turn — suppressing
         // the date-rollover reminder added in #128 (see issue #135).
         let inherited_known_date = self.runtime.prompt_known_date().map(str::to_string);
+        let inherited_known_model = self.runtime.prompt_known_model().map(str::to_string);
         let session = self.runtime.session().clone();
         let session_id = self.session.id.clone();
         self.shutdown_runtime_resources()?;
@@ -4689,6 +4709,9 @@ impl LiveCli {
         .with_hook_abort_signal(hook_abort_signal.clone());
         if let Some(known) = inherited_known_date {
             runtime = runtime.with_session_known_date(known);
+        }
+        if let Some(known) = inherited_known_model {
+            runtime = runtime.with_session_known_model(known);
         }
         let hook_abort_monitor = if self.esc_monitor_enabled {
             HookAbortMonitor::spawn(hook_abort_signal)
@@ -6759,7 +6782,8 @@ fn build_runtime_with_plugin_state(
         system_prompt,
         &feature_config,
     )
-    .with_session_known_date(runtime::today_local());
+    .with_session_known_date(runtime::today_local())
+    .with_session_known_model(config.model.clone());
     // nexus A2A: give the CLI executor the send half so `send_message` routes
     // to the peer's replicated DT_STREAM inbox (the shared handler the co-host
     // uses). Set only when configured; absent it the tool is never advertised.


### PR DESCRIPTION
## Summary

Two bugs fixed, two commits.

### Commit 1 — `fix(api): truncated SSE stream reported as retryable IncompleteStream`

**Bug:** When the SSE stream ended mid-frame (proxy dropped the connection), `SseParser::finish()` passed the partial JSON bytes to serde, producing `ApiError::Json: failed to parse <provider> response for model X: EOF while parsing a string`. This implicated the model for a transport failure, and `ApiError::Json` is non-retryable, so the session died instead of retrying.

**Fix:**
- New `ApiError::IncompleteStream` variant — transport-truncation semantic, `is_retryable() = true`, display names the cause ("stream ended mid-frame") without blaming the model.
- `SseParser::finish()` (Anthropic) and the openai_compat chat `finish()` now convert a trailing-buffer parse failure into `IncompleteStream` instead of propagating the `Json` error. A cleanly-parseable final frame without `\n\n` (lenient servers) still works.
- `ErrorCategory` enum + `#[inline] categorize()` helper extracted so predicate methods share one exhaustive match. Adding a future variant only requires updating `categorize()`, not every predicate.
- Two new unit tests in `sse::tests`.

### Commit 2 — `fix(runtime,cli): model identity announced per-turn, resume uses correct model`

**Bug 1 (identity):** After `bbd92823` removed the `Model:` line from the system prompt (cache-prefix reason), the model had to guess its own identity from weights alone — unreliable, especially through a proxy with aliases. After `/model`, the stale identity persisted until the next session.

**Bug 2 (resume):** `open_persisted_session` (`session/load`, `session/new forkFrom`) resolved the model from the cwd config default (`settings.local.json`, etc.) rather than the model the session was actually using. In a fresh process the user's `/model` switch was silently lost.

**Fix:**
- Mirror `inject_date_context`: `inject_model_context()` injects a user-side `<system-reminder>You are running as X</system-reminder>` on the first turn, and a change reminder when `session.model` differs from `prompt_known_model`. Zero cache impact — the system prompt prefix stays byte-stable.
- `open_persisted_session` now prefers `session.model` (the persisted model) over `resolve_model_for_cwd()`; `--model` CLI flag still wins.
- `BuiltRuntime::with_session_known_model()` wrapper added (parallel to `with_session_known_date`) so the REPL runtime-rebuild path carries state correctly.
- Three new unit tests (first-turn announce, no-repeat, mid-session change).
- **Verified live** against real API (fujitoken): `pty_model_switch_iocraft` passes.

## Test Plan

- `cargo test -p api --lib`: 192 pass (includes 2 new SSE tests).
- `cargo test -p runtime --lib`: 671 pass (includes 3 new model-identity tests). 2 pre-existing prompt-test failures unrelated to this PR (local `settings.json` deprecation warning leaks into temp dir during test — fails on clean HEAD too).
- Live PTY: `SCODE_TEST_BACKEND=live cargo test -p rusty-sudocode-cli --test pty_model_switch_iocraft` — switched to `claude-sonnet-4-6`, asked "what model are you?", correctly answered sonnet.
- `pty_model_compat` (1 test) and `pty_subcommands` (10 tests): all pass.
