### PR TITLE
fix: context-window status line shows real occupancy, not cumulative total

### DIFF
--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -1135,9 +1135,9 @@ mod tests {
         let large = super::autocompact_buffer_tokens("claude-opus-4-8");
         assert_eq!(large, 50_000);
 
-        // Unknown model falls back to SSOT default (200K) → 13K
+        // Unknown model falls back to SSOT default (1M) → 50K (large tier)
         let unknown = super::autocompact_buffer_tokens("unknown-model-xyz");
-        assert_eq!(unknown, 13_000);
+        assert_eq!(unknown, 50_000);
     }
 
     #[test]

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -4532,9 +4532,10 @@ mod tests {
         let threshold = auto_compact_threshold_for_model("claude-sonnet-4-6");
         assert_eq!(threshold, 167_000);
 
-        // Unknown model falls back to SSOT default (200K context, 64K output)
+        // Unknown model falls back to SSOT default (1M context, 64K output):
+        //   buffer = 50K (1M >= 800K), threshold = 1M - 20K - 50K = 930K
         let unknown = auto_compact_threshold_for_model("some-unknown-model");
-        assert_eq!(unknown, 167_000);
+        assert_eq!(unknown, 930_000);
     }
 
     // Circuit-breaker for consecutive auto-compact no-ops (PR #249) is

--- a/rust/crates/runtime/src/model-capabilities.bundled.json
+++ b/rust/crates/runtime/src/model-capabilities.bundled.json
@@ -5,6 +5,7 @@
     "claude-opus-4-6": { "context_window": 200000, "max_output_tokens": 32000 },
     "claude-opus-4-7": { "context_window": 200000, "max_output_tokens": 32000 },
     "claude-opus-4-8": { "context_window": 1000000, "max_output_tokens": 32000 },
+    "claude-opus-5": { "context_window": 1000000, "max_output_tokens": 64000 },
     "claude-sonnet-4-6": { "context_window": 200000, "max_output_tokens": 64000 },
     "claude-haiku-4-5-20251213": { "context_window": 200000, "max_output_tokens": 64000 },
     "grok-3": { "context_window": 131072, "max_output_tokens": 64000 },

--- a/rust/crates/runtime/src/model-capabilities.bundled.json
+++ b/rust/crates/runtime/src/model-capabilities.bundled.json
@@ -1,6 +1,6 @@
 {
   "updated_at": 0,
-  "default": { "context_window": 200000, "max_output_tokens": 64000 },
+  "default": { "context_window": 1000000, "max_output_tokens": 64000 },
   "models": {
     "claude-opus-4-6": { "context_window": 200000, "max_output_tokens": 32000 },
     "claude-opus-4-7": { "context_window": 200000, "max_output_tokens": 32000 },

--- a/rust/crates/runtime/tests/integration_tests.rs
+++ b/rust/crates/runtime/tests/integration_tests.rs
@@ -404,8 +404,10 @@ fn context_window_resolves_from_ssot_with_default_fallback() {
         file_default
     );
 
-    // known model → its own value; 1M for opus-4-8, distinct from the default
-    let opus = context_window_or_default("claude-opus-4-8");
-    assert_eq!(opus, 1_000_000);
-    assert_ne!(opus, file_default);
+    // known model → its own seeded value, distinct from the default. Use a
+    // model whose window differs from the default (sonnet-4-6 is 200K) so the
+    // assertion is meaningful even when the default itself is 1M.
+    let sonnet = context_window_or_default("claude-sonnet-4-6");
+    assert_eq!(sonnet, 200_000);
+    assert_ne!(sonnet, file_default);
 }

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -1772,6 +1772,53 @@ pub(crate) fn format_turn_status_line(
     format_turn_status_line_with_branch(model, turn, usage, None, None, elapsed, None)
 }
 
+/// Format the `ctx <used>/<window> (<pct>%)` status segment, or `None` when
+/// the window is unknown/zero.
+///
+/// `context_tokens` is the CURRENT context-window occupancy — the size of the
+/// prompt the provider actually processed on the latest response (uncached
+/// input + cache reads + cache writes), i.e. `TokenUsage::context_tokens()`.
+/// It is NOT the session-cumulative token total: cumulative grows every turn
+/// and never shrinks, so it overshoots the window (and rockets past 100%)
+/// while telling the user nothing about how full the context actually is.
+/// This is the same occupancy metric auto-compaction compares against the
+/// window, so the indicator and the compaction trigger stay in agreement.
+#[inline]
+pub(crate) fn format_context_usage_segment(context_tokens: u32, window: u32) -> Option<String> {
+    if window == 0 {
+        return None;
+    }
+    let pct = (f64::from(context_tokens) / f64::from(window) * 100.0).min(100.0);
+    let used_display = format_token_count(context_tokens);
+    let win_display = format_token_count_round(window);
+    Some(format!("ctx {used_display}/{win_display} ({pct:.0}%)"))
+}
+
+/// Compact token count with one decimal (`1.2k`, `3.4M`).
+#[inline]
+fn format_token_count(n: u32) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", f64::from(n) / 1_000_000.0)
+    } else if n >= 1000 {
+        format!("{:.1}k", f64::from(n) / 1000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Compact token count with no decimals (`1M`, `200k`) — used for the window
+/// denominator, which is a round capacity figure.
+#[inline]
+fn format_token_count_round(n: u32) -> String {
+    if n >= 1_000_000 {
+        format!("{:.0}M", f64::from(n) / 1_000_000.0)
+    } else if n >= 1000 {
+        format!("{:.0}k", f64::from(n) / 1000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 /// Render the dim per-turn status line shown after each interactive turn.
 ///
 /// Contains, in order: model name, turn number, cumulative token count,
@@ -1783,7 +1830,10 @@ pub(crate) fn format_turn_status_line_with_branch(
     model: &str,
     turn: u32,
     usage: &TokenUsage,
-    cumulative_usage: Option<&TokenUsage>,
+    // Current context-window occupancy (TokenUsage::context_tokens of the
+    // latest turn), NOT the session-cumulative total. See
+    // format_context_usage_segment.
+    context_tokens: Option<u32>,
     context_window: Option<u32>,
     elapsed: Duration,
     branch: Option<&str>,
@@ -1810,26 +1860,11 @@ pub(crate) fn format_turn_status_line_with_branch(
         segments.push(cost);
     }
     segments.push(format!("{secs:.1}s"));
-    // Context window usage: cumulative tokens / model context window
-    if let (Some(cumulative), Some(window)) = (cumulative_usage, context_window) {
-        if window > 0 {
-            let cum_total = cumulative.total_tokens();
-            let pct = (f64::from(cum_total) / f64::from(window) * 100.0).min(100.0);
-            let cum_display = if cum_total >= 1_000_000 {
-                format!("{:.1}M", f64::from(cum_total) / 1_000_000.0)
-            } else if cum_total >= 1000 {
-                format!("{:.1}k", f64::from(cum_total) / 1000.0)
-            } else {
-                cum_total.to_string()
-            };
-            let win_display = if window >= 1_000_000 {
-                format!("{:.0}M", f64::from(window) / 1_000_000.0)
-            } else if window >= 1000 {
-                format!("{:.0}k", f64::from(window) / 1000.0)
-            } else {
-                window.to_string()
-            };
-            segments.push(format!("ctx {cum_display}/{win_display} ({pct:.0}%)"));
+    // Context-window usage: current occupancy / model window. Uses the same
+    // occupancy metric as auto-compaction (see format_context_usage_segment).
+    if let (Some(used), Some(window)) = (context_tokens, context_window) {
+        if let Some(segment) = format_context_usage_segment(used, window) {
+            segments.push(segment);
         }
     }
     if let Some(branch) = branch.filter(|b| !b.is_empty()) {
@@ -2258,6 +2293,44 @@ mod tests {
         let plain = strip_ansi(&rendered);
         // Trailing segment should be the duration, not an empty " · ".
         assert!(plain.ends_with("0.8s"), "{plain}");
+    }
+
+    #[test]
+    fn context_usage_segment_reports_occupancy_over_window() {
+        // 150k occupancy in a 1M window => 15%.
+        let seg = format_context_usage_segment(150_000, 1_000_000)
+            .expect("segment present for non-zero window");
+        assert_eq!(seg, "ctx 150.0k/1M (15%)", "{seg}");
+    }
+
+    #[test]
+    fn context_usage_segment_never_exceeds_100_percent() {
+        // Occupancy above the window is clamped to 100% rather than showing a
+        // nonsensical >100% figure (the old cumulative-total bug rendered
+        // things like 7740%).
+        let seg = format_context_usage_segment(2_000_000, 1_000_000).expect("segment present");
+        assert!(seg.ends_with("(100%)"), "{seg}");
+    }
+
+    #[test]
+    fn context_usage_segment_absent_for_zero_window() {
+        assert!(format_context_usage_segment(1234, 0).is_none());
+    }
+
+    #[test]
+    fn turn_status_line_renders_context_segment() {
+        let usage = TokenUsage::default();
+        let rendered = format_turn_status_line_with_branch(
+            "claude-sonnet-4-6",
+            2,
+            &usage,
+            Some(150_000),
+            Some(1_000_000),
+            Duration::from_secs_f64(0.5),
+            None,
+        );
+        let plain = strip_ansi(&rendered);
+        assert!(plain.contains("ctx 150.0k/1M (15%)"), "{plain}");
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -4791,14 +4791,15 @@ impl LiveCli {
                     }
                     let elapsed = turn_start.elapsed();
                     let usage = self.runtime.usage().current_turn_usage();
-                    let cumulative = self.runtime.usage().cumulative_usage();
                     let turns = self.runtime.usage().turns();
-                    let model_for_caps = summary
-                        .response_model
-                        .as_deref()
-                        .unwrap_or(&self.config.model);
+                    // Current context-window occupancy (what the provider just
+                    // processed), the same metric auto-compaction uses — not the
+                    // session-cumulative total, which never shrinks and overshoots
+                    // the window. Window is sized off the session model so the
+                    // percentage and the compaction trigger share one denominator.
+                    let context_tokens = self.runtime.usage().current_turn_usage().context_tokens();
                     let context_window =
-                        runtime::model_capabilities::context_window_or_default(model_for_caps);
+                        runtime::model_capabilities::context_window_or_default(&self.config.model);
                     let branch = env::current_dir()
                         .ok()
                         .and_then(|cwd| resolve_git_branch_for(&cwd));
@@ -4806,7 +4807,7 @@ impl LiveCli {
                         &self.config.model,
                         turns,
                         &usage,
-                        Some(&cumulative),
+                        Some(context_tokens),
                         Some(context_window),
                         elapsed,
                         branch.as_deref(),
@@ -4900,14 +4901,15 @@ impl LiveCli {
                     }
                     let elapsed = turn_start.elapsed();
                     let usage = self.runtime.usage().current_turn_usage();
-                    let cumulative = self.runtime.usage().cumulative_usage();
                     let turns = self.runtime.usage().turns();
-                    let model_for_caps = summary
-                        .response_model
-                        .as_deref()
-                        .unwrap_or(&self.config.model);
+                    // Current context-window occupancy (what the provider just
+                    // processed), the same metric auto-compaction uses — not the
+                    // session-cumulative total, which never shrinks and overshoots
+                    // the window. Window is sized off the session model so the
+                    // percentage and the compaction trigger share one denominator.
+                    let context_tokens = self.runtime.usage().current_turn_usage().context_tokens();
                     let context_window =
-                        runtime::model_capabilities::context_window_or_default(model_for_caps);
+                        runtime::model_capabilities::context_window_or_default(&self.config.model);
                     let branch = env::current_dir()
                         .ok()
                         .and_then(|cwd| resolve_git_branch_for(&cwd));
@@ -4919,7 +4921,7 @@ impl LiveCli {
                         &self.config.model,
                         turns,
                         &usage,
-                        Some(&cumulative),
+                        Some(context_tokens),
                         Some(context_window),
                         elapsed,
                         branch.as_deref(),


### PR DESCRIPTION
## Summary

Fixes the `ctx 77.4M/1M (100%)` nonsense in the per-turn status line, plus the two data-layer causes behind it. Three commits.

### 1. `fix(runtime): default unknown-model context window 200k -> 1M`

`sudorouter /v1/models` never returns `context_window`/`max_output_tokens` (only `supported_endpoint_types`), so any model missing from the bundled seed silently falls back to the `default` entry. With the old 200k default a current flagship like `claude-opus-5` was handled as a 200k window — wrong indicator, and auto-compaction fired far too early. Most current frontier models are ≥1M, so 1M is the safer floor; a real seed value or a sudorouter refresh still overrides it, and the context-overflow retry path self-heals if 1M ever overshoots a smaller model.

### 2. `fix(cli): status line shows current context occupancy, not cumulative total` (core fix)

The status line computed `ctx` from `cumulative_usage().total_tokens()` — the session-wide running total of every turn's input+output+cache. It only grows, so after ~320 turns it read `77.4M/1M (100%)`, where 77.4M is total tokens ever billed, not context occupancy.

Switched to `TokenUsage::context_tokens()` (uncached input + cache reads + cache writes on the latest response) — the same occupancy metric auto-compaction already compares against the window, so the indicator and the compaction trigger now agree.

DRY/SSOT:
- Extracted `format_context_usage_segment(context_tokens, window)` + two `#[inline]` number formatters so the segment/percentage/clamp logic is in one place with tests.
- `format_turn_status_line_with_branch` now takes `context_tokens: Option<u32>` (occupancy) instead of `Option<&TokenUsage>` (which invited `.total_tokens()`).
- Both call sites pass `current_turn_usage().context_tokens()` and size the window off `self.config.model` (the session model auto-compaction uses) rather than the wire `response_model`, so numerator, denominator, and compaction threshold share one basis.

### 3. `fix(runtime): seed claude-opus-5 capabilities (1M context window)`

Explicit 1M seed for `claude-opus-5` so it's correct regardless of the default and doesn't depend on the fallback.

## Root cause note (sudorouter)

`/v1/models` omits capacity metadata for **all** models (even `claude-opus-4-8`; those are only correct today because they're in the bundled seed). Filed a separate bug report for the sudorouter team to populate `context_window`/`max_output_tokens` in the API response — once they do, the client picks it up automatically via the dynamic cache and these seed values become just a fallback.

## Test Plan

- `cargo test -p rusty-sudocode-cli --bin scode`: 155 pass (incl. 4 new: occupancy→percent, >100% clamp = the reported bug, zero-window→absent, rendered segment).
- `cargo test -p runtime --lib model_capabilities`: 4 pass.
- `cargo fmt --check`: clean.
- `cargo clippy -p rusty-sudocode-cli -p runtime`: no new warnings in touched code.
