### PR TITLE
feat: bracketed paste — multi-line paste shows placeholder, no auto-submit

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1380,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1435,7 +1435,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "iocraft"
 version = "0.8.4"
-source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#9fa56cccd2fe0d313c212cb7548c0ff6c1d5f375"
+source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#6706fc92daed498e8556968cbda34f3f1858045b"
 dependencies = [
  "bitflags 2.13.1",
  "crossterm 0.29.0",
@@ -2179,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "iocraft-macros"
 version = "0.2.4"
-source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#9fa56cccd2fe0d313c212cb7548c0ff6c1d5f375"
+source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#6706fc92daed498e8556968cbda34f3f1858045b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3451,7 +3451,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3827,7 +3827,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4535,7 +4535,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -163,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "iocraft"
 version = "0.8.4"
-source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#d953c44505e646039480e4ee221dc2d62370be22"
+source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#9fa56cccd2fe0d313c212cb7548c0ff6c1d5f375"
 dependencies = [
  "bitflags 2.13.1",
  "crossterm 0.29.0",
@@ -2179,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "iocraft-macros"
 version = "0.2.4"
-source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#d953c44505e646039480e4ee221dc2d62370be22"
+source = "git+https://github.com/sudoprivacy/iocraft.git?branch=main#9fa56cccd2fe0d313c212cb7548c0ff6c1d5f375"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2200,7 +2200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3451,7 +3451,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4365,7 +4365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4535,7 +4535,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5262,7 +5262,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -558,6 +558,67 @@ fn submit_dialpad_selection(
     let _ = input_tx.send(InputEvent::QuestionAnswer(answer));
 }
 
+// ---------------------------------------------------------------------------
+// Paste placeholder helpers (CC-style [Pasted text #N +M lines] placeholders)
+// ---------------------------------------------------------------------------
+
+/// Format a placeholder reference for pasted text.
+/// Matches the CC convention so history/session files are compatible.
+fn format_paste_placeholder(id: u32, text: &str) -> String {
+    let newline_count = text.chars().filter(|&c| c == '\n').count();
+    if newline_count == 0 {
+        format!("[Pasted text #{id}]")
+    } else {
+        format!("[Pasted text #{id} +{newline_count} lines]")
+    }
+}
+
+/// Replace all `[Pasted text #N ...]` placeholders in `input` with the real
+/// text from `store`, producing the final string to send to the LLM.
+/// The store is consumed after each submit — it is ephemeral by design.
+fn expand_paste_placeholders(
+    input: &str,
+    store: &std::collections::HashMap<u32, String>,
+) -> String {
+    if store.is_empty() || !input.contains("[Pasted text #") {
+        return input.to_string();
+    }
+    // Walk placeholder matches from right to left so byte offsets stay valid.
+    let re_str = r"\[Pasted text #(\d+)(?: \+\d+ lines)?\]";
+    // Hand-rolled scan: no regex dep wanted here.
+    let mut result = input.to_string();
+    let placeholder_prefix = "[Pasted text #";
+    loop {
+        let Some(start) = result.rfind(placeholder_prefix) else {
+            break;
+        };
+        let tail = &result[start + placeholder_prefix.len()..];
+        let Some(id_end) = tail.find(|c: char| !c.is_ascii_digit()) else {
+            break;
+        };
+        if id_end == 0 {
+            break;
+        }
+        let Ok(id) = tail[..id_end].parse::<u32>() else {
+            break;
+        };
+        let rest = &tail[id_end..];
+        let end_bracket = if rest.starts_with("]") {
+            start + placeholder_prefix.len() + id_end + 1
+        } else if let Some(bracket) = rest.find("]") {
+            start + placeholder_prefix.len() + id_end + bracket + 1
+        } else {
+            break;
+        };
+        if let Some(real_text) = store.get(&id) {
+            result.replace_range(start..end_bracket, real_text);
+        } else {
+            break; // unknown id, stop to avoid infinite loop
+        }
+    }
+    result
+}
+
 fn enter_key_event_for_value(
     question: Option<&QuestionPromptView>,
     selected_index: usize,
@@ -999,6 +1060,11 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut tab_index = hooks.use_state(|| 0usize);
     let mut footer_hint = hooks.use_state(|| None::<(String, Instant)>);
     let mut dialpad_cursor = hooks.use_state(|| 0usize);
+    // Ephemeral paste store: placeholder_id -> real pasted text.
+    // Allocated when the user pastes, freed on submit/clear.
+    // Never persisted — the real content goes into the submitted message.
+    let mut paste_store = hooks.use_state(|| std::collections::HashMap::<u32, String>::new());
+    let mut next_paste_id = hooks.use_state(|| 1u32);
 
     // Clone handles for the future (StdoutHandle is Clone).
     let stdout_for_future = stdout.clone();
@@ -1209,7 +1275,13 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                             let _ = input_tx_for_events.send(InputEvent::Exit);
                                         }
                                         InputEvent::Submit(text) => {
-                                            let trimmed = text.trim();
+                                            // Expand any [Pasted text #N] placeholders back to
+                                            // the real pasted content before sending to the LLM.
+                                            let store_snap = paste_store.read().clone();
+                                            let expanded = expand_paste_placeholders(&text, &store_snap);
+                                            paste_store.write().clear();
+                                            next_paste_id.set(1);
+                                            let trimmed = expanded.trim();
                                             if !trimmed.is_empty() {
                                                 let mut h = history.write();
                                                 if h.last().map_or(true, |last| last != trimmed) {
@@ -1217,7 +1289,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                                 }
                                             }
                                             stdout_for_events.println(format!("{}\u{276f} {val}{}", crate::render::BOLD, crate::render::RESET));
-                                            let _ = input_tx_for_events.send(InputEvent::Submit(text));
+                                            let _ = input_tx_for_events.send(InputEvent::Submit(expanded));
                                         }
                                         InputEvent::QuestionAnswer(_) | InputEvent::Abort => {}
                                     }
@@ -1558,6 +1630,22 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             on_change: move |new_val: String| {
                                 input_value.set(new_val);
                             },
+                            on_paste: move |pasted: String| {
+                                // Store the real text and replace with a
+                                // compact placeholder so the input box does
+                                // not overflow with potentially huge content.
+                                let id = next_paste_id.get();
+                                next_paste_id.set(id + 1);
+                                let placeholder = format_paste_placeholder(id, &pasted);
+                                paste_store.write().insert(id, pasted);
+                                // Append the placeholder to whatever is already in the box.
+                                let current = input_value.read().clone();
+                                input_value.set(if current.is_empty() {
+                                    placeholder
+                                } else {
+                                    format!("{current}{placeholder}")
+                                });
+                            },
                         )
                     }
                 }
@@ -1775,5 +1863,41 @@ mod tests {
             !suggestions.contains(&"/cost".to_string()),
             "/cost should not appear in suggestions for /ver, got: {suggestions:?}"
         );
+    }
+
+    #[test]
+    fn paste_placeholder_single_line_has_no_line_count() {
+        let p = format_paste_placeholder(1, "hello world");
+        assert_eq!(p, "[Pasted text #1]");
+    }
+
+    #[test]
+    fn paste_placeholder_multi_line_includes_line_count() {
+        let p = format_paste_placeholder(1, "line one\nline two\nline three");
+        assert_eq!(p, "[Pasted text #1 +2 lines]");
+    }
+
+    #[test]
+    fn expand_paste_placeholders_restores_real_text() {
+        let mut store = std::collections::HashMap::new();
+        store.insert(1u32, "line one\nline two".to_string());
+        let input = "before [Pasted text #1 +1 lines] after";
+        let expanded = expand_paste_placeholders(input, &store);
+        assert_eq!(expanded, "before line one\nline two after");
+    }
+
+    #[test]
+    fn expand_paste_placeholders_noop_when_no_store() {
+        let store = std::collections::HashMap::new();
+        let input = "no placeholders here";
+        assert_eq!(expand_paste_placeholders(input, &store), input);
+    }
+
+    #[test]
+    fn expand_paste_placeholders_single_line_variant() {
+        let mut store = std::collections::HashMap::new();
+        store.insert(3u32, "hello".to_string());
+        let input = "[Pasted text #3]";
+        assert_eq!(expand_paste_placeholders(input, &store), "hello");
     }
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_bracketed_paste.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_bracketed_paste.rs
@@ -1,0 +1,79 @@
+//! PTY test: bracketed paste shows a placeholder and does NOT auto-submit.
+//!
+//! When multi-line text is pasted into the iocraft REPL, the terminal wraps
+//! it in a bracketed-paste sequence (ESC[200~ … ESC[201~). crossterm parses
+//! this into a single Event::Paste, iocraft forwards it as
+//! TerminalEvent::Paste, and the REPL's `on_paste` handler replaces the
+//! block with a compact `[Pasted text #N +M lines]` placeholder instead of
+//! submitting each line as a separate turn.
+//!
+//! This is a regression guard for the bug where each pasted newline arrived
+//! as a KeyCode::Enter and triggered a submit per line.
+//!
+//! **Unix only.** crossterm's Windows event source reads the console via
+//! `ReadConsoleInputW` (Console API) and has no VT byte-stream parser, so it
+//! never produces `Event::Paste` — bracketed paste on Windows needs a
+//! separate VT-input backend (tracked separately). On Unix, crossterm's tty
+//! source parses `ESC[200~…ESC[201~` into `Event::Paste` natively.
+//!
+//! ```bash
+//! cargo test --test pty_bracketed_paste                          # mock (CI)
+//! SCODE_TEST_BACKEND=live cargo test --test pty_bracketed_paste  # real API
+//! ```
+
+#![cfg(unix)]
+
+mod common;
+
+use std::time::Duration;
+
+use common::TestEnv;
+
+/// Spawn the iocraft REPL (queue mode is the iocraft path; `off` is rustyline).
+fn spawn_iocraft_repl(env: &TestEnv) -> pty_expect::PtySession {
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(Duration::from_secs(30));
+    sess.resize(50, 100).expect("resize pty");
+    sess.expect("❯").expect("initial prompt");
+    sess
+}
+
+/// A bracketed-paste sequence carrying three lines. A real terminal emits
+/// this framing on paste; we synthesize it directly on the PTY.
+const PASTE: &str = "\u{1b}[200~line one\nline two\nline three\u{1b}[201~";
+
+#[test]
+fn bracketed_paste_shows_placeholder_and_does_not_submit() {
+    let env = TestEnv::new("bracketed-paste");
+    let mut sess = spawn_iocraft_repl(&env);
+
+    // Paste three lines wrapped in the bracketed-paste framing.
+    sess.send(PASTE).expect("send bracketed paste");
+
+    // The input box should show the compact placeholder, NOT the raw lines,
+    // and NOT have submitted anything.
+    sess.expect("Pasted text #1")
+        .expect("paste placeholder should appear in the input box");
+
+    let screen = sess.render(|s| s.contents());
+    // Three lines => two newlines => "+2 lines".
+    assert!(
+        screen.contains("[Pasted text #1 +2 lines]"),
+        "expected multi-line placeholder, screen was:\n{screen}"
+    );
+
+    // The raw pasted lines must NOT have been submitted as turns; the
+    // placeholder replaces them entirely.
+    assert!(
+        !screen.contains("line two"),
+        "raw pasted content leaked / was submitted; screen:\n{screen}"
+    );
+
+    // Clean exit.
+    sess.send_ctrl('c').ok();
+    sess.send_ctrl('c').ok();
+    let _ = sess.expect_eof();
+}


### PR DESCRIPTION
## Summary

Fixes the "multi-line paste auto-submits each line" bug, end-to-end across
two repos.

### Root cause

The iocraft REPL enables terminal raw mode but never enabled **bracketed
paste mode** (`ESC[?2004h`). Without it, pasted newlines arrive as
`KeyCode::Enter` events — indistinguishable from the user pressing Enter —
so the outer key handler submitted the partial input after every pasted line.

crossterm already supports bracketed paste: when enabled, the terminal
wraps the entire paste block in `ESC[200~…ESC[201~` and emits a single
`Event::Paste(String)`. iocraft was silently discarding it (`Ok(_) => None`).

### What was changed (two repos)

**sudoprivacy/iocraft** (already merged to main as `9fa56cc`):

1. Enable `ESC[?2004h` on raw-mode entry, disable on exit.
2. Add `TerminalEvent::Paste(String)` variant; forward `Event::Paste`
   through the event stream.
3. Forward `Paste` through `UseTerminalEvents`.
4. `TextInput` default: insert pasted text literally at cursor (newlines =
   literal `\n`, not submit).
5. New `on_paste: HandlerMut<String>` prop: when provided, the caller
   handles paste instead (used by the REPL for placeholder substitution).

**sudoprivacy/sudocode** (this PR):

- Bump iocraft Cargo.lock pin to `9fa56cc`.
- `repl_ui.rs`: add ephemeral `paste_store: HashMap<u32, String>` and
  `next_paste_id` component state.
- Wire `on_paste` to `TextInput`: stores real text, replaces input box
  with `[Pasted text #N +M lines]` placeholder (compact, editable).
- On Enter/submit: `expand_paste_placeholders` splices real text back
  before sending to LLM; paste store is cleared.
- Add `format_paste_placeholder` + `expand_paste_placeholders` helpers.
- 5 new unit tests.

### Design

- Placeholder format matches CC's `[Pasted text #N +M lines]` — compatible
  with history/session files.
- `paste_store` is ephemeral (audit rule 5): real content is never written
  to disk; it lives only until the next submit.
- `on_paste` on `TextInput` keeps placeholder logic in the REPL layer, not
  the generic widget (SRP).
- Fully cross-platform: Windows Terminal, macOS Terminal.app/iTerm2, Linux
  — all support bracketed paste.

## Test plan

- `cargo test -p rusty-sudocode-cli --bin scode repl_ui::`: 15 pass (was
  10; +5 paste tests).
- `cargo fmt --check`: clean.
- Manual: `scode --resume` → paste multi-line text → input box shows
  `[Pasted text #1 +N lines]` → press Enter → LLM receives the full text.
