### PR TITLE
runtime: honour autoMemoryEnabled so memory can be switched off

### DIFF
--- a/docs/acp.md
+++ b/docs/acp.md
@@ -85,7 +85,11 @@ The two compose: set both and the static blocks are replaced *and* the
 extra block is appended after the replacement, still inside the static
 prefix. Workspace-derived dynamic blocks (environment,
 `AGENTS.md`, memory) are always kept, so an overridden prompt still knows
-which directory it is operating in.
+which directory it is operating in. The one dynamic block with its own
+switch is auto-memory: `"autoMemoryEnabled": false` in the session
+`cwd`'s `.nexus/sudocode/settings.local.json` (or the process-wide
+`~/.nexus/sudocode/settings.json`) drops it for that session — see
+[`usage.md`](./usage.md#memory).
 
 Rules:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,6 +81,31 @@ default that ACP sessions can further adjust per session via
 `_meta.sudocode.systemPrompt` / `appendSystemPrompt` — see
 [`acp.md`](./acp.md#per-session-system-prompt-_metasudocode).
 
+## Memory
+
+Every session gets a `# auto memory` block in the system prompt: the
+entries under the workspace's memory directory (`~/.scode/projects/<slug>/memory/`
+by default, `SUDOCODE_MEMORY_DIR` to relocate) plus the instructions that
+tell the model how to write new ones. `/memory` in the REPL opens the
+files.
+
+To turn memory off, set `autoMemoryEnabled` to `false` in settings —
+globally in `~/.nexus/sudocode/settings.json`, or per project in
+`<cwd>/.nexus/sudocode/settings.local.json` (the scope
+`/config set autoMemoryEnabled false` writes to):
+
+```json
+{ "autoMemoryEnabled": false }
+```
+
+With the key off the block is dropped entirely — no remembered entries,
+no write instructions — and the memory directory is left untouched.
+`scode system-prompt` shows the result. The key is read at session start
+(and on `scode acp` per session `cwd`), so a running REPL needs a restart
+to pick up a change. Note that `SUDOCODE_MEMORY_DIR` pointed at an empty
+directory is *not* an off switch: the write instructions still go in and
+the model still writes there.
+
 ## Models
 
 Select a model with `--model`. See [`models.md`](./models.md) for aliases

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -182,6 +182,10 @@ pub struct RuntimeFeatureConfig {
     trusted_roots: Vec<String>,
     /// Enable extended thinking for models that support it (default: true).
     thinking: bool,
+    /// Load the auto-memory directory and inject the `# auto memory` block
+    /// (entries + write instructions) into the system prompt (default:
+    /// true). Settings key: `autoMemoryEnabled`.
+    auto_memory: bool,
     /// `experimental` section: feature-flag key -> enabled. Keys are
     /// validated against `crate::experiments::Experiment` at parse time.
     experiments: BTreeMap<String, bool>,
@@ -457,6 +461,7 @@ impl ConfigLoader {
             provider_fallbacks: parse_optional_provider_fallbacks(&merged_value)?,
             trusted_roots: parse_optional_trusted_roots(&merged_value)?,
             thinking: parse_optional_thinking(&merged_value),
+            auto_memory: parse_optional_auto_memory(&merged_value),
             experiments: parse_optional_experiments(&merged_value)?,
         };
 
@@ -612,6 +617,13 @@ impl RuntimeConfig {
         self.feature_config.thinking
     }
 
+    /// Whether the auto-memory block is injected into the system prompt
+    /// (`autoMemoryEnabled`, default: true).
+    #[must_use]
+    pub fn auto_memory_enabled(&self) -> bool {
+        self.feature_config.auto_memory
+    }
+
     #[must_use]
     pub fn aliases(&self) -> &BTreeMap<String, String> {
         &self.feature_config.aliases
@@ -684,6 +696,11 @@ impl RuntimeFeatureConfig {
     #[must_use]
     pub fn thinking(&self) -> bool {
         self.thinking
+    }
+
+    #[must_use]
+    pub fn auto_memory_enabled(&self) -> bool {
+        self.auto_memory
     }
 
     #[must_use]
@@ -1158,6 +1175,16 @@ fn parse_optional_experiments(root: &JsonValue) -> Result<BTreeMap<String, bool>
 fn parse_optional_thinking(root: &JsonValue) -> bool {
     root.as_object()
         .and_then(|object| object.get("thinking"))
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(true)
+}
+
+/// Parse `autoMemoryEnabled` from settings. Default is `true` (enabled);
+/// `false` keeps the memory directory untouched and drops the
+/// `# auto memory` block from the system prompt.
+fn parse_optional_auto_memory(root: &JsonValue) -> bool {
+    root.as_object()
+        .and_then(|object| object.get("autoMemoryEnabled"))
         .and_then(JsonValue::as_bool)
         .unwrap_or(true)
 }

--- a/rust/crates/runtime/src/config_schema.rs
+++ b/rust/crates/runtime/src/config_schema.rs
@@ -258,6 +258,11 @@ pub const SETTINGS_SCHEMA: &[FieldSchema] = &[
         "Enable extended thinking for supported models (default: true)",
     ),
     FieldSchema::leaf(
+        "autoMemoryEnabled",
+        FieldType::Bool,
+        "Inject the auto-memory block (entries + write instructions) into the system prompt (default: true)",
+    ),
+    FieldSchema::leaf(
         "providerFallbacks",
         FieldType::Object,
         "Provider fallback chain",

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -617,10 +617,17 @@ fn load_system_prompt_impl(
     let cwd = cwd.into();
     let project_context = ProjectContext::discover_with_git_fs(&cwd, current_date.into(), fs)?;
     let config = ConfigLoader::default_for(&cwd).load()?;
+    let auto_memory_enabled = config.auto_memory_enabled();
     let builder_base = SystemPromptBuilder::new()
         .with_os(os_name, os_version)
         .with_project_context(project_context)
         .with_runtime_config(config);
+    // `autoMemoryEnabled: false` drops the whole `# auto memory` block —
+    // both the remembered entries and the instructions telling the model
+    // where to write — and leaves the memory directory untouched.
+    if !auto_memory_enabled {
+        return Ok(builder_base.build());
+    }
     // Preserves the previous per-branch choice exactly: sub-agent spawns ask
     // the agent definition, the main loop always takes the compact edition.
     let variant = match agent_type {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -9,6 +9,10 @@
 //! 3. Budget enforcement: when total rendered memory exceeds the
 //!    16 000-char cap, excess entries are dropped with a notice.
 //!
+//! 4. Opt-out: `autoMemoryEnabled: false` in settings drops the whole
+//!    `# auto memory` block (entries and write instructions) and leaves
+//!    the memory directory untouched.
+//!
 //! All tests set `SUDOCODE_MEMORY_DIR` to a temp directory, avoiding
 //! any interaction with the user's real `~/.scode/memory/`.
 
@@ -350,6 +354,87 @@ fn memory_project_scoped_path() {
     );
 
     fs::remove_dir_all(root).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 4b. Opt-out via `autoMemoryEnabled: false`
+// ──────────────────────────────────────────────────────────────────────
+
+/// `autoMemoryEnabled: false` in the project's `settings.local.json` must
+/// remove the `# auto memory` block entirely: no remembered entries, no
+/// write instructions, and the memory directory is not created. The same
+/// workspace with the key absent keeps the block, proving the toggle (not
+/// the fixture) is what removes it.
+#[test]
+fn memory_disabled_by_setting() {
+    let root = unique_temp_dir("disabled");
+    let memory_dir = unique_temp_dir("disabled-memory");
+    let config_home = unique_temp_dir("disabled-config-home");
+    fs::create_dir_all(&root).expect("create root");
+    fs::create_dir_all(&memory_dir).expect("create memory dir");
+    fs::create_dir_all(&config_home).expect("create config home");
+    write_entry(
+        &memory_dir,
+        "secret_preference",
+        "user",
+        "Preference that must not leak",
+        "The user prefers tabs over spaces.",
+    );
+    let memory_dir_str = memory_dir.to_str().expect("utf8");
+    let config_home_str = config_home.to_str().expect("utf8");
+    // Isolate the config home so the developer's real settings.json
+    // cannot flip the toggle either way.
+    let envs = [
+        ("SUDOCODE_MEMORY_DIR", memory_dir_str),
+        ("SUDO_CODE_CONFIG_HOME", config_home_str),
+    ];
+
+    // Control: key absent → block present, entry rendered.
+    let output = run_system_prompt(&root, &envs);
+    assert!(output.status.success(), "control run should exit 0");
+    let control = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        control.contains("# auto memory") && control.contains("tabs over spaces"),
+        "control run should render the memory block; got:\n{control}"
+    );
+
+    // Opt out at project scope (the scope `/config set autoMemoryEnabled`
+    // writes to).
+    let settings_dir = root.join(".nexus").join("sudocode");
+    fs::create_dir_all(&settings_dir).expect("create settings dir");
+    fs::write(
+        settings_dir.join("settings.local.json"),
+        "{\"autoMemoryEnabled\": false}\n",
+    )
+    .expect("write settings.local.json");
+    fs::remove_dir_all(&memory_dir).expect("drop memory dir for the opt-out run");
+
+    let output = run_system_prompt(&root, &envs);
+    assert!(
+        output.status.success(),
+        "opt-out run should exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !text.contains("# auto memory"),
+        "auto-memory block should be absent when autoMemoryEnabled=false; got:\n{text}"
+    );
+    assert!(
+        !text.contains("tabs over spaces") && !text.contains("secret_preference"),
+        "memory entries must not leak when autoMemoryEnabled=false"
+    );
+    assert!(
+        !text.contains("MEMORY.md"),
+        "memory write instructions must not be injected when autoMemoryEnabled=false"
+    );
+    assert!(
+        !memory_dir.exists(),
+        "memory directory must not be created when autoMemoryEnabled=false"
+    );
+
+    fs::remove_dir_all(root).ok();
+    fs::remove_dir_all(config_home).ok();
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`/config set autoMemoryEnabled false` already existed and wrote the key to `settings.local.json`, but nothing ever read it: every system-prompt build loaded the memory directory and appended the `# auto memory` block unconditionally. `--system-prompt` and the ACP `_meta.sudocode.systemPrompt` override deliberately keep workspace blocks, and pointing `SUDOCODE_MEMORY_DIR` at an empty directory still injects the ~2k-char write instructions, so there was no way to actually run without memory.

This PR wires the existing key through:

- `runtime/config.rs`: parse `autoMemoryEnabled` (default `true`) into `RuntimeFeatureConfig`, with `auto_memory_enabled()` accessors.
- `runtime/config_schema.rs`: declare the key so `scode config validate` accepts it.
- `runtime/prompt.rs`: when off, `load_system_prompt_impl` skips the memory provider entirely — no remembered entries, no write instructions, and the memory directory is not created.
- `docs/usage.md`: new **Memory** section (default location, the key at global / project scope, what off means, why an empty `SUDOCODE_MEMORY_DIR` is not an off switch). `docs/acp.md` points its dynamic-block note at it.

The key is read per prompt build, so under `scode acp` it applies per session `cwd` via `<cwd>/.nexus/sudocode/settings.local.json` (or process-wide via `~/.nexus/sudocode/settings.json`). No new CLI flag or ACP `_meta` key — the existing settings surface is enough for the ask.

## Testing

- `cargo test -p rusty-sudocode-cli --test pty_memory` (isolated `HOME` / `SUDO_CODE_CONFIG_HOME`): 12 passed, including the new `memory_disabled_by_setting` — a control run with the key absent renders the block and an entry, then the opt-out run asserts the header, the entry, the `MEMORY.md` instructions and the memory directory are all absent.
- `cargo test -p runtime --lib -- config_schema config:: prompt::tests memory::`: 101 passed.
- `cargo fmt --all --check` clean; `cargo clippy -p runtime --no-deps --all-targets` reports nothing on the touched lines (the crate's pre-existing pedantic baseline is unchanged).
- No unit tests added.
