### PR TITLE
runtime: compact before Anthropic's "exceed context limit" rejection

### DIFF
--- a/rust/crates/api/src/error.rs
+++ b/rust/crates/api/src/error.rs
@@ -21,6 +21,11 @@ const CONTEXT_WINDOW_ERROR_MARKERS: &[&str] = &[
     "completion tokens",
     "prompt tokens",
     "request is too large",
+    // Anthropic, when `input + max_tokens` overflows the window: "input
+    // length and `max_tokens` exceed context limit: N + M > W". This fires
+    // long before "prompt is too long" (input alone over the window), so it
+    // is the overflow a long agentic session actually sees.
+    "context limit",
 ];
 
 #[derive(Debug)]

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -107,22 +107,10 @@ pub fn model_token_limit_from_config(
 /// while keeping sensible defaults for unknown models.
 #[must_use]
 pub fn max_tokens_for_model(model_id: &str) -> u32 {
-    // An explicit `models.<alias>.maxOutputTokens` is the user's own number
-    // for a model the compiled-in table may not know — take it as written,
-    // above or below the heuristic.
-    if let Some(configured) = runtime::model_capabilities::config_max_output_tokens(model_id) {
-        return configured;
-    }
-
-    let heuristic = if model_id.contains("opus") {
-        32_000
-    } else {
-        64_000
-    };
-
-    model_token_limit(model_id)
-        .map(|limit| heuristic.min(limit.max_output_tokens))
-        .unwrap_or(heuristic)
+    // Single source of truth shared with the runtime's auto-compaction
+    // threshold, so "when to compact" and "how much output the request
+    // reserves" can never disagree.
+    runtime::model_capabilities::request_max_output_tokens(model_id)
 }
 
 /// Return the effective max output tokens by resolving an alias through

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -160,6 +160,17 @@ enum Scenario {
     ForkSubagentRecursionGuardRoundtrip,
     LlmCompactionRoundtrip,
     AskUserQuestionRoundtrip,
+    /// Streaming request without a compaction summary in its history is
+    /// rejected with Anthropic's real `input length and max_tokens exceed
+    /// context limit` 400; once the history carries a summary the request is
+    /// answered. Exercises the runtime's compact-and-retry on the overflow
+    /// error a long session actually gets.
+    ContextLimitThenText,
+    /// First request answers with a `read_file` tool use whose reported
+    /// context is far above the auto-compact threshold; the follow-up
+    /// request (carrying the tool result) is answered with text that says
+    /// whether a compaction summary was in its history.
+    ToolLoopContextGrowth,
     /// `streaming_text`, answered after [`DELAYED_TEXT_LATENCY`]. Gives a
     /// test a window to cancel a request in flight — including an LLM
     /// compaction request, since compaction requests are classified by the
@@ -205,6 +216,8 @@ impl Scenario {
             }
             "llm_compaction_roundtrip" => Some(Self::LlmCompactionRoundtrip),
             "delayed_text" => Some(Self::DelayedText),
+            "context_limit_then_text" => Some(Self::ContextLimitThenText),
+            "tool_loop_context_growth" => Some(Self::ToolLoopContextGrowth),
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             _ => None,
         }
@@ -243,6 +256,8 @@ impl Scenario {
             Self::LlmCompactionRoundtrip => "llm_compaction_roundtrip",
             Self::DelayedText => "delayed_text",
             Self::AskUserQuestionRoundtrip => "ask_user_question_roundtrip",
+            Self::ContextLimitThenText => "context_limit_then_text",
+            Self::ToolLoopContextGrowth => "tool_loop_context_growth",
         }
     }
 }
@@ -456,7 +471,33 @@ fn flatten_tool_result_content(content: &[api::ToolResultContentBlock]) -> Strin
 }
 
 #[allow(clippy::too_many_lines)]
+/// Text every compaction continuation message starts with (see
+/// `runtime::compact::COMPACT_CONTINUATION_PREAMBLE`).
+const COMPACTION_SUMMARY_MARKER: &str = "continued from a previous conversation";
+
+/// Anthropic's verbatim rejection when `input + max_tokens` overflows the
+/// window — the overflow a long agentic session sees first, well before
+/// "prompt is too long".
+const CONTEXT_LIMIT_ERROR_BODY: &str = r#"{"type":"error","error":{"type":"invalid_request_error","message":"input length and `max_tokens` exceed context limit: 150000 + 64000 > 200000, decrease input length or `max_tokens` and try again"},"request_id":"req_context_limit_then_text"}"#;
+
+fn history_carries_compaction_summary(request: &MessageRequest) -> bool {
+    request.messages.iter().any(|message| {
+        message.content.iter().any(|block| match block {
+            InputContentBlock::Text { text } => text.contains(COMPACTION_SUMMARY_MARKER),
+            _ => false,
+        })
+    })
+}
+
 fn build_http_response(request: &MessageRequest, scenario: Scenario) -> String {
+    if scenario == Scenario::ContextLimitThenText && !history_carries_compaction_summary(request) {
+        return http_response(
+            "400 Bad Request",
+            "application/json",
+            CONTEXT_LIMIT_ERROR_BODY,
+            &[("request-id", request_id_for(scenario))],
+        );
+    }
     let response = if request.stream {
         let body = build_stream_body(request, scenario);
         return http_response(
@@ -633,6 +674,19 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
         Scenario::AutoCompactTriggered => {
             final_text_sse_with_usage("auto compact parity complete.", 50_000, 200)
         }
+        Scenario::ContextLimitThenText => final_text_sse("context limit recovery complete."),
+        Scenario::ToolLoopContextGrowth => match latest_tool_result(request) {
+            Some(_) if history_carries_compaction_summary(request) => {
+                final_text_sse("tool loop compacted before the next request.")
+            }
+            Some(_) => final_text_sse("tool loop continued without compaction."),
+            None => tool_use_sse_with_context(
+                "toolu_tool_loop_growth",
+                "read_file",
+                &[r#"{"path":"fixture.txt"}"#],
+                TOOL_LOOP_GROWTH_CONTEXT_TOKENS,
+            ),
+        },
         Scenario::TokenCostReporting => {
             final_text_sse_with_usage("token cost reporting parity complete.", 1_000, 500)
         }
@@ -982,6 +1036,26 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
             50_000,
             200,
         ),
+        Scenario::ContextLimitThenText => text_message_response(
+            "msg_context_limit_then_text",
+            "context limit recovery complete.",
+        ),
+        Scenario::ToolLoopContextGrowth => match latest_tool_result(request) {
+            Some(_) if history_carries_compaction_summary(request) => text_message_response(
+                "msg_tool_loop_growth_final",
+                "tool loop compacted before the next request.",
+            ),
+            Some(_) => text_message_response(
+                "msg_tool_loop_growth_final",
+                "tool loop continued without compaction.",
+            ),
+            None => tool_message_response(
+                "msg_tool_loop_growth_tool",
+                "toolu_tool_loop_growth",
+                "read_file",
+                json!({"path": "fixture.txt"}),
+            ),
+        },
         Scenario::TokenCostReporting => text_message_response_with_usage(
             "msg_token_cost_reporting",
             "token cost reporting parity complete.",
@@ -1214,6 +1288,8 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         }
         Scenario::LlmCompactionRoundtrip => "req_llm_compaction_roundtrip",
         Scenario::AskUserQuestionRoundtrip => "req_ask_user_question_roundtrip",
+        Scenario::ContextLimitThenText => "req_context_limit_then_text",
+        Scenario::ToolLoopContextGrowth => "req_tool_loop_context_growth",
     }
 }
 
@@ -1475,11 +1551,37 @@ fn streaming_text_sse() -> String {
 }
 
 fn tool_use_sse(tool_id: &str, tool_name: &str, partial_json_chunks: &[&str]) -> String {
-    tool_uses_sse(&[ToolUseSse {
-        tool_id,
-        tool_name,
-        partial_json_chunks,
-    }])
+    tool_uses_sse_with_context(
+        &[ToolUseSse {
+            tool_id,
+            tool_name,
+            partial_json_chunks,
+        }],
+        12,
+    )
+}
+
+/// Context (`input_tokens`) reported by the [`Scenario::ToolLoopContextGrowth`]
+/// tool-use response: above the runtime's auto-compact threshold for the
+/// mock's 200K / 64K model (`200K - 64K - 13K = 123K`), below the window.
+pub const TOOL_LOOP_GROWTH_CONTEXT_TOKENS: u32 = 150_000;
+
+/// [`tool_use_sse`] with an explicit reported context size, for scenarios
+/// that drive the runtime's usage-based auto-compaction.
+fn tool_use_sse_with_context(
+    tool_id: &str,
+    tool_name: &str,
+    partial_json_chunks: &[&str],
+    input_tokens: u32,
+) -> String {
+    tool_uses_sse_with_context(
+        &[ToolUseSse {
+            tool_id,
+            tool_name,
+            partial_json_chunks,
+        }],
+        input_tokens,
+    )
 }
 
 struct ToolUseSse<'a> {
@@ -1489,6 +1591,10 @@ struct ToolUseSse<'a> {
 }
 
 fn tool_uses_sse(tool_uses: &[ToolUseSse<'_>]) -> String {
+    tool_uses_sse_with_context(tool_uses, 12)
+}
+
+fn tool_uses_sse_with_context(tool_uses: &[ToolUseSse<'_>], input_tokens: u32) -> String {
     let mut body = String::new();
     let message_id = tool_uses.first().map_or_else(
         || "msg_tool_use".to_string(),
@@ -1507,7 +1613,7 @@ fn tool_uses_sse(tool_uses: &[ToolUseSse<'_>]) -> String {
                 "model": DEFAULT_MODEL,
                 "stop_reason": null,
                 "stop_sequence": null,
-                "usage": usage_json(12, 0)
+                "usage": usage_json(input_tokens, 0)
             }
         }),
     );
@@ -1552,7 +1658,7 @@ fn tool_uses_sse(tool_uses: &[ToolUseSse<'_>]) -> String {
         json!({
             "type": "message_delta",
             "delta": {"stop_reason": "tool_use", "stop_sequence": null},
-            "usage": usage_json(12, 4)
+            "usage": usage_json(input_tokens, 4)
         }),
     );
     append_sse(&mut body, "message_stop", json!({"type": "message_stop"}));

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -599,6 +599,8 @@ fn is_prompt_too_long(error_msg: &str) -> bool {
         // own prompt-too-long so the head-truncation retry still applies.
         || lower.contains("context_window_blocked")
         || lower.contains("context window")
+        // Anthropic: "input length and `max_tokens` exceed context limit".
+        || lower.contains("context limit")
 }
 
 /// Drop the oldest ~20% of message groups from compaction input to make

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -10,8 +10,8 @@ use telemetry::SessionTracer;
 
 use crate::compact::{
     autocompact_buffer_tokens, compact_session, compact_session_sync,
-    compact_session_sync_after_llm_failure, estimate_session_tokens, CompactionConfig,
-    CompactionError, CompactionResult, ReadFileTracker,
+    compact_session_sync_after_llm_failure, estimate_block_tokens, estimate_session_tokens,
+    CompactionConfig, CompactionError, CompactionResult, ReadFileTracker,
 };
 use crate::config::RuntimeFeatureConfig;
 use crate::hooks::{HookAbortSignal, HookProgressReporter, HookRunResult, HookRunner};
@@ -1883,6 +1883,14 @@ where
                     result_message,
                 )?;
             }
+
+            // A tool loop grows the context without ever returning to the
+            // caller, so the end-of-turn check alone lets a long turn sail
+            // from "under the threshold" straight into a provider rejection.
+            // Check here, with the tool results just pushed, before the next
+            // request is built.
+            overflow_compaction =
+                merge_auto_compaction(overflow_compaction, self.maybe_auto_compact().await);
         }
 
         let auto_compaction =
@@ -2093,7 +2101,7 @@ where
         // hundred tokens per turn and never reaches the threshold; without
         // caching it grows quadratically, never decreases, and re-compacts
         // after every turn once crossed.
-        if self.usage_tracker.current_turn_usage().context_tokens() < threshold {
+        if self.projected_context_tokens() < threshold {
             return None;
         }
 
@@ -2119,6 +2127,27 @@ where
                 self.consecutive_auto_compact_noops.saturating_add(1);
         }
         event
+    }
+
+    /// Best estimate of the context the next request will carry: the context
+    /// the provider reported for the latest response, plus everything pushed
+    /// since that response (tool results, injected reminders) that no usage
+    /// report has counted yet. At the end of a turn the trailing part is
+    /// empty and this is exactly the latest response's context; between
+    /// iterations of a tool loop it is what lets auto-compaction run before
+    /// the next request instead of after the provider rejects it.
+    fn projected_context_tokens(&self) -> u32 {
+        let reported = self.usage_tracker.current_turn_usage().context_tokens();
+        let unreported: usize = self
+            .session
+            .messages
+            .iter()
+            .rev()
+            .take_while(|message| message.role != MessageRole::Assistant)
+            .flat_map(|message| message.blocks.iter())
+            .map(estimate_block_tokens)
+            .sum();
+        reported.saturating_add(u32::try_from(unreported).unwrap_or(u32::MAX))
     }
 
     /// Compact the live session and install the result.
@@ -2376,10 +2405,16 @@ fn merge_auto_compaction(
     }
 }
 
-/// Per-model auto-compact threshold: `context_window - max_output - buffer`.
+/// Per-model auto-compact threshold:
+/// `context_window - request max_tokens - buffer`.
 ///
-/// Matches CC's dynamic threshold calculation instead of a flat 100K default.
-/// Falls back to the env-var or built-in default when the model is unknown.
+/// The provider rejects a request once `input + max_tokens` exceeds the
+/// window, and the API client's preflight mirrors that sum. The output
+/// reservation subtracted here is therefore the `max_tokens` chat requests
+/// are actually sent with ([`crate::model_capabilities::request_max_output_tokens`]),
+/// not the compaction summary's smaller cap: with a 200K window and 64K
+/// `max_tokens` the provider rejects at 136K, so a threshold above that can
+/// never fire in time. Falls back to the env-var override when set.
 #[must_use]
 pub fn auto_compact_threshold_for_model(model: &str) -> u32 {
     // Env-var override takes precedence (explicit user intent).
@@ -2392,11 +2427,9 @@ pub fn auto_compact_threshold_for_model(model: &str) -> u32 {
     }
 
     let context_window = crate::model_capabilities::context_window_or_default(model);
-    let max_output = crate::model_capabilities::max_output_tokens_or_default(model);
-    // Clamp max_output to avoid overflow on small context windows
-    let effective_max_output = std::cmp::min(max_output, crate::compact::COMPACT_MAX_OUTPUT_TOKENS);
+    let max_output = crate::model_capabilities::request_max_output_tokens(model);
     let buffer = autocompact_buffer_tokens(model);
-    context_window.saturating_sub(effective_max_output + buffer)
+    context_window.saturating_sub(max_output.saturating_add(buffer))
 }
 
 fn build_assistant_message(
@@ -4526,16 +4559,16 @@ mod tests {
         let _g = env_guard();
         // Ensure no env-var override is active.
         std::env::remove_var("CLAUDE_CODE_AUTO_COMPACT_INPUT_TOKENS");
-        // The threshold is context_window - min(max_output, 20K) - buffer.
-        // For claude-sonnet-4-6 (200K context, 64K output):
-        //   buffer = 13K (200K < 400K), threshold = 200K - 20K - 13K = 167K
+        // The threshold is context_window - request max_tokens - buffer.
+        // For claude-sonnet-4-6 (200K context, 64K request max_tokens):
+        //   buffer = 13K (200K < 400K), threshold = 200K - 64K - 13K = 123K
         let threshold = auto_compact_threshold_for_model("claude-sonnet-4-6");
-        assert_eq!(threshold, 167_000);
+        assert_eq!(threshold, 123_000);
 
-        // Unknown model falls back to SSOT default (1M context, 64K output):
-        //   buffer = 50K (1M >= 800K), threshold = 1M - 20K - 50K = 930K
+        // Unknown model: SSOT default window (1M) and the 64K request heuristic:
+        //   buffer = 50K (1M >= 800K), threshold = 1M - 64K - 50K = 886K
         let unknown = auto_compact_threshold_for_model("some-unknown-model");
-        assert_eq!(unknown, 930_000);
+        assert_eq!(unknown, 886_000);
     }
 
     // Circuit-breaker for consecutive auto-compact no-ops (PR #249) is

--- a/rust/crates/runtime/src/model_capabilities.rs
+++ b/rust/crates/runtime/src/model_capabilities.rs
@@ -152,6 +152,31 @@ pub fn config_max_output_tokens(model_id: &str) -> Option<u32> {
     config_limit_for(base).and_then(|over| over.max_output_tokens)
 }
 
+/// The `max_tokens` a chat request for this model is sent with.
+///
+/// An explicit `models.<alias>.maxOutputTokens` is the user's own number and
+/// is taken as written. Otherwise a heuristic default (32K for opus, 64K
+/// for everything else) capped by the model's registered `max_output_tokens`
+/// when the model is known.
+///
+/// This is the number the provider (and the API client's local preflight)
+/// adds to the input when deciding whether a request fits the context
+/// window, so anything that budgets history against the window — the
+/// auto-compaction threshold, the ACP pre-send check — must subtract this
+/// value, not the compaction summary's smaller output reservation.
+#[must_use]
+pub fn request_max_output_tokens(model_id: &str) -> u32 {
+    if let Some(configured) = config_max_output_tokens(model_id) {
+        return configured;
+    }
+    let heuristic = if model_id.contains("opus") {
+        32_000
+    } else {
+        64_000
+    };
+    lookup(model_id).map_or(heuristic, |cap| heuristic.min(cap.max_output_tokens))
+}
+
 /// Look up the configured override for a wire model ID, if any.
 fn config_limit_for(base: &str) -> Option<ModelLimitOverride> {
     let guard = CONFIG_LIMITS.read().ok()?;

--- a/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_integration.rs
@@ -1618,6 +1618,273 @@ async fn acp_stdio_long_history_is_compacted_instead_of_rejected() {
     workspace.cleanup();
 }
 
+/// Create a session, run one seed turn so its transcript exists, then
+/// replace the transcript with `pairs` small user/assistant exchanges of
+/// plain text (no parity markers, so a compaction request over them falls
+/// through to the mock's `llm_compaction_roundtrip` detection). Small enough
+/// that the ACP pre-send budget check never compacts on its own; what the
+/// history provides is enough compactable messages (more than the four
+/// preserved verbatim) for an in-turn compaction to have something to remove.
+async fn seed_filler_history(
+    server: &MockAnthropicService,
+    workspace: &TestWorkspace,
+    pairs: usize,
+) -> (String, PathBuf) {
+    let session_id = {
+        let mut client = spawn_stdio_client(workspace);
+        scenario_initialize(&mut client).await;
+        let session_id = scenario_session_new(&mut client, &workspace.root).await;
+        let (_notifs, resp) = client
+            .send_request(
+                "session/prompt",
+                json!({
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": format!("{SCENARIO_PREFIX}streaming_text") }]
+                }),
+            )
+            .await;
+        assert!(
+            resp["result"].get("stopReason").is_some(),
+            "seed turn should complete: {resp}"
+        );
+        client.shutdown().await;
+        session_id
+    };
+    // The seed turn's requests are not part of what the test inspects.
+    let _ = server.captured_requests().await;
+
+    let transcript_path = find_session_transcript(&workspace.root, &session_id);
+    let mut session =
+        runtime::Session::load_from_path(&transcript_path).expect("seed transcript should load");
+    session.messages.clear();
+    for turn in 0..pairs {
+        session
+            .push_user_text(format!(
+                "user turn {turn}: earlier discussion about the migration plan."
+            ))
+            .expect("seed user message");
+        session
+            .push_message(runtime::ConversationMessage::assistant(vec![
+                runtime::ContentBlock::Text {
+                    text: format!("assistant turn {turn}: acknowledged, continuing the plan."),
+                },
+            ]))
+            .expect("seed assistant message");
+    }
+    session
+        .save_to_path(&transcript_path)
+        .expect("seeded transcript should persist");
+    (session_id, transcript_path)
+}
+
+/// Regression: the overflow error a long Anthropic session actually gets is
+/// `400 input length and max_tokens exceed context limit` — raised as soon
+/// as `input + max_tokens` passes the window, long before the input alone
+/// does ("prompt is too long"). That text matched none of the API client's
+/// context-window markers, so the runtime never classified it: no
+/// compaction, no retry, the rejected prompt stayed in the transcript, and
+/// ACP surfaced the raw provider text. The mock rejects until the history
+/// carries a compaction summary; the turn must be answered from a compacted
+/// request.
+#[tokio::test]
+async fn acp_stdio_context_limit_rejection_is_compacted_and_retried() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-context-limit");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    let (session_id, transcript_path) = seed_filler_history(&server, &workspace, 3).await;
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let (_load_notifs, load_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": session_id,
+                "cwd": workspace.root.to_string_lossy().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        load_resp.get("error").is_none(),
+        "session/load should succeed, got: {load_resp}"
+    );
+
+    let before = server.captured_requests().await.len();
+    let (text, _tools) = run_scenario_collect_text(
+        &mut client,
+        &session_id,
+        "context_limit_then_text",
+        Duration::from_secs(30),
+        "prompt rejected with `exceed context limit` must be compacted and retried",
+    )
+    .await;
+    assert!(
+        text.contains("context limit recovery complete."),
+        "turn should be answered after compaction, got: {text:?}"
+    );
+
+    let requests = server.captured_requests().await;
+    let scenarios = requests[before..]
+        .iter()
+        .map(|request| request.scenario.as_str())
+        .collect::<Vec<_>>();
+    let rejected = requests[before..]
+        .iter()
+        .position(|request| {
+            request.stream
+                && request.scenario == "context_limit_then_text"
+                && !request
+                    .raw_body
+                    .contains("continued from a previous conversation")
+        })
+        .unwrap_or_else(|| {
+            panic!("the first attempt should have been rejected; saw {scenarios:?}")
+        });
+    let compacted = requests[before..]
+        .iter()
+        .position(|request| request.scenario == "llm_compaction_roundtrip")
+        .unwrap_or_else(|| {
+            panic!("the rejection should trigger LLM compaction; saw {scenarios:?}")
+        });
+    let answered = requests[before..]
+        .iter()
+        .rposition(|request| {
+            request.stream
+                && request.scenario == "context_limit_then_text"
+                && request
+                    .raw_body
+                    .contains("continued from a previous conversation")
+        })
+        .unwrap_or_else(|| panic!("the retry should carry the summary; saw {scenarios:?}"));
+    assert!(
+        rejected < compacted && compacted < answered,
+        "expected reject -> compact -> retry, saw {scenarios:?}"
+    );
+
+    let reloaded =
+        runtime::Session::load_from_path(&transcript_path).expect("compacted transcript loads");
+    assert!(
+        reloaded.compaction.is_some(),
+        "transcript on disk should record the compaction"
+    );
+    assert!(
+        reloaded
+            .messages
+            .last()
+            .is_some_and(|message| message.role == runtime::MessageRole::Assistant),
+        "the answered turn should be persisted after the compacted history: {:?}",
+        reloaded
+            .messages
+            .iter()
+            .map(|message| message.role)
+            .collect::<Vec<_>>()
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
+/// Regression: auto-compaction only ran at the end of a turn, so a tool loop
+/// could grow the context from "under the threshold" straight into a
+/// provider rejection with no compaction in between. The mock's tool-use
+/// response reports a context far above the threshold; the runtime must
+/// compact before building the next request of the same turn, and the
+/// follow-up request must carry the summary alongside the tool result.
+#[tokio::test]
+async fn acp_stdio_tool_loop_compacts_before_next_request() {
+    let server = MockAnthropicService::spawn()
+        .await
+        .expect("mock service should start");
+    let workspace = TestWorkspace::new("stdio-tool-loop-growth");
+    workspace.create();
+    workspace.write_sudocode_json(&server.base_url());
+    fs::write(
+        workspace.root.join("fixture.txt"),
+        "tool loop fixture line\n",
+    )
+    .expect("fixture should be written");
+    let (session_id, _transcript_path) = seed_filler_history(&server, &workspace, 2).await;
+
+    let mut client = spawn_stdio_client(&workspace);
+    scenario_initialize(&mut client).await;
+    let (_load_notifs, load_resp) = client
+        .send_request(
+            "session/load",
+            json!({
+                "sessionId": session_id,
+                "cwd": workspace.root.to_string_lossy().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await;
+    assert!(
+        load_resp.get("error").is_none(),
+        "session/load should succeed, got: {load_resp}"
+    );
+
+    let before = server.captured_requests().await.len();
+    let (text, tools) = run_scenario_collect_text(
+        &mut client,
+        &session_id,
+        "tool_loop_context_growth",
+        Duration::from_secs(30),
+        "tool loop whose context passes the threshold mid-turn",
+    )
+    .await;
+    assert!(
+        text.contains("tool loop compacted before the next request."),
+        "the request after the tool result should carry a compaction summary; got: {text:?} \
+         (tool outputs: {tools:?})"
+    );
+
+    let requests = server.captured_requests().await;
+    let scenarios = requests[before..]
+        .iter()
+        .map(|request| request.scenario.as_str())
+        .collect::<Vec<_>>();
+    let tool_use = requests[before..]
+        .iter()
+        .position(|request| {
+            request.stream
+                && request.scenario == "tool_loop_context_growth"
+                && !request.raw_body.contains("tool_result")
+        })
+        .unwrap_or_else(|| panic!("the first request should ask for the tool; saw {scenarios:?}"));
+    let compacted = requests[before..]
+        .iter()
+        .position(|request| request.scenario == "llm_compaction_roundtrip")
+        .unwrap_or_else(|| {
+            panic!("the reported context should trigger LLM compaction; saw {scenarios:?}")
+        });
+    let follow_up = requests[before..]
+        .iter()
+        .rposition(|request| {
+            request.stream
+                && request.scenario == "tool_loop_context_growth"
+                && request.raw_body.contains("tool_result")
+        })
+        .unwrap_or_else(|| panic!("the tool result should be sent back; saw {scenarios:?}"));
+    assert!(
+        tool_use < compacted && compacted < follow_up,
+        "expected tool use -> compact -> follow-up, saw {scenarios:?}"
+    );
+    assert!(
+        requests[before + follow_up]
+            .raw_body
+            .contains("continued from a previous conversation"),
+        "follow-up request should carry the compaction summary; body head: {}",
+        &requests[before + follow_up].raw_body
+            [..requests[before + follow_up].raw_body.len().min(400)]
+    );
+
+    client.shutdown().await;
+    workspace.cleanup();
+}
+
 /// Locate `<root>/.scode/sessions/<fingerprint>/<id>/transcript.jsonl`.
 fn find_session_transcript(root: &std::path::Path, session_id: &str) -> PathBuf {
     let sessions = root.join(".scode").join("sessions");


### PR DESCRIPTION
## Summary

Long ACP sessions (apeiron) hit a context-window error with no compaction ever running, even after #545. Three gaps on `main`, all in the path between "the context is getting full" and "the provider rejects":

1. **The overflow error Anthropic actually sends was not recognised.** Once `input + max_tokens > window` Anthropic answers `400 input length and max_tokens exceed context limit: N + M > W`. With a 200K model and 64K `max_tokens` that fires at 136K input tokens, long before `prompt is too long` (input alone over 200K). That text matched none of `CONTEXT_WINDOW_ERROR_MARKERS`, so `is_context_window_failure` was false: the compact-and-retry from #545 never ran, the rejected prompt stayed in the transcript, and ACP surfaced the raw provider text.

2. **The end-of-turn threshold sat above the provider's rejection point.** `auto_compact_threshold_for_model` was `window - min(max_output, 20K) - 13K` = 167K for a 200K model, but requests go out with `max_tokens` 64K and the provider (and our preflight) reject at 136K. The threshold now subtracts the `max_tokens` requests are actually sent with (123K for sonnet). That number has one home, `model_capabilities::request_max_output_tokens`; `api::max_tokens_for_model` delegates to it so "when to compact" and "how much output the request reserves" cannot disagree.

3. **No check inside a tool loop.** Auto-compaction ran only when a turn ended, so one long agentic turn could grow from under the threshold straight into a rejection. The check now also runs after each batch of tool results is pushed, projecting the next request's context as the latest response's reported context plus the estimate of everything pushed since.

Not changed: the ACP pre-send budget check in `run_prompt_impl`, the `preserve_recent_messages: 4` tail policy, and the local `bytes/4` estimator.

## Testing

```
cargo fmt --all --check
cargo clippy -p api -p runtime -p mock-anthropic-service --no-deps --all-targets   # 0 findings on changed lines (baseline is red)
cargo test -p runtime -p api -p mock-anthropic-service
cargo test -p rusty-sudocode-cli --test acp_integration --test mock_parity_harness --test compact_output
HOME=<tmp> SUDO_CODE_CONFIG_HOME=<tmp> cargo test --workspace --no-fail-fast      # 110 suites, 0 failures
```

New ACP integration tests, each verified to fail with its fix reverted:

- `acp_stdio_context_limit_rejection_is_compacted_and_retried` — mock rejects with Anthropic's verbatim 400 until the history carries a compaction summary; asserts reject → compact → retry within one turn and that the transcript on disk records the compaction.
- `acp_stdio_tool_loop_compacts_before_next_request` — mock's tool-use response reports 150K context; asserts tool use → compact → follow-up, with the follow-up request carrying the summary alongside the tool result.
