### PR TITLE
chore(release): bump version to 0.2.4

### DIFF
--- a/RELEASE_NOTES_v0.2.4.md
+++ b/RELEASE_NOTES_v0.2.4.md
@@ -1,0 +1,58 @@
+# Sudo Code v0.2.4
+
+## What's New
+
+Internally this release finishes the engine/renderer split: `EngineEvent` /
+`EngineCommand` are now the only types crossing between the engine and anything
+that renders it, the ACP server consumes that seam rather than its own delegate,
+and CI enforces the boundary. That work is invisible from the outside — but
+getting the Windows test suite to run against it uncovered a run of real bugs,
+and those are what this release is worth installing for.
+
+## Fixed
+
+**`--allowedTools` refused the tool names models actually use.** The allow-list
+is stored canonicalised and tool dispatch canonicalises before matching, but the
+gate compared the raw name — so a model calling `Bash` was rejected under
+`--allowedTools bash`. Every tool call in an allow-listed run was refused, and
+because the model then explained itself politely instead of failing, it read as
+the model declining to work. Affects every platform.
+
+**Streaming bash captured no output on Windows.** The two pipe readers were
+`tokio::select!` branches, and `read_line` is not cancellation-safe: each time
+one resolved, the other's in-flight read was dropped. On Unix the bytes stay in
+the pipe; on Windows `tokio::process` reads through the blocking pool, so they
+were lost. `printf 'hi'` returned exit 0 and empty stdout — silently, on the
+path the REPL uses.
+
+**ACP answered `session/prompt` before sending that turn's updates.** A client
+renders `session/update`s as they arrive and finalises on the response, so an
+update behind it is one the client has stopped listening for. Slash commands
+lost their output entirely over WebSocket.
+
+**ACP could hang after a turn.** A per-turn hook-progress reporter was installed
+from the observer and never cleared, pinning the renderer's event channel open
+after the turn had returned.
+
+**`scode acp` never exited on Windows when its host disconnected.** The
+stdin-EOF watchdog was a `poll(2)` probe and therefore Unix-only, leaving one
+orphaned process per session. Replaced on all platforms by an EOF-aware stdin
+wrapper around the transport's own reader.
+
+**One-shot turns could not be cancelled from a new process group.** Windows
+disables Ctrl-C for a group created with `CREATE_NEW_PROCESS_GROUP` — the
+standard way a job runner isolates cancellation — leaving Ctrl-Break as the only
+signal that reaches the child. It is now handled as the same cancel.
+
+**Memory entries were dropped over frontmatter case.** A file that fails to
+parse is skipped silently, and a model writing `TYPE: FEEDBACK` for
+`type: feedback` produced exactly that. Field names and type values are now read
+case-insensitively.
+
+## Testing
+
+Every `cfg(unix)` gate and Windows-only skip is gone from the CLI test suite:
+the full PTY suite, ACP integration included, now runs on Windows in both mock
+and live modes. The suite also no longer reads or writes the developer's real
+`~/.nexus/sudocode` — each test gets a throwaway config home, and the live
+account is chosen per run via `SCODE_LIVE_AUTH_PROFILE`.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "api",
  "plugins",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "commands",
  "runtime",
@@ -1370,7 +1370,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-acp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "engine-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "api",
  "async-trait",
@@ -1408,14 +1408,14 @@ dependencies = [
 
 [[package]]
 name = "engine-events"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "runtime",
 ]
 
 [[package]]
 name = "engine-host"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "commands",
  "engine-core",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "api",
  "serde_json",
@@ -2666,7 +2666,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c1
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3961,7 +3961,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arboard",
  "async-trait",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Bumps `rust/Cargo.toml` to 0.2.4 and adds `RELEASE_NOTES_v0.2.4.md`.

The engine/renderer seam (#534) is the bulk of what landed since 0.2.3, and it
is invisible from the outside. What makes this worth releasing is the run of
real bugs that surfaced while getting the Windows PTY suite to run against it —
one of which (`--allowedTools` rejecting the tool names models actually use)
affects every platform and silently refuses every tool call in an allow-listed
run.

Release notes have the full list.