### PR TITLE
fix(test): give the mock bash scenarios a timeout a cold runner can meet

### DIFF
--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -566,7 +566,7 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             None => tool_use_sse(
                 "toolu_bash_stdout",
                 "bash",
-                &[r#"{"command":"printf 'alpha from bash'","timeout":1000}"#],
+                &[r#"{"command":"printf 'alpha from bash'","timeout":30000}"#],
             ),
         },
         Scenario::BashInterruptLongRunning => match latest_tool_result(request) {
@@ -595,7 +595,7 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             None => tool_use_sse(
                 "toolu_bash_prompt_allow",
                 "bash",
-                &[r#"{"command":"printf 'approved via prompt'","timeout":1000}"#],
+                &[r#"{"command":"printf 'approved via prompt'","timeout":30000}"#],
             ),
         },
         Scenario::BashPermissionPromptDenied => match latest_tool_result(request) {
@@ -605,7 +605,7 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             None => tool_use_sse(
                 "toolu_bash_prompt_deny",
                 "bash",
-                &[r#"{"command":"printf 'should not run'","timeout":1000}"#],
+                &[r#"{"command":"printf 'should not run'","timeout":30000}"#],
             ),
         },
         Scenario::PluginToolRoundtrip => match latest_tool_result(request) {
@@ -892,7 +892,7 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 "msg_bash_stdout_tool",
                 "toolu_bash_stdout",
                 "bash",
-                json!({"command": "printf 'alpha from bash'", "timeout": 1000}),
+                json!({"command": "printf 'alpha from bash'", "timeout": 30000}),
             ),
         },
         Scenario::BashInterruptLongRunning => match latest_tool_result(request) {
@@ -931,7 +931,7 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 "msg_bash_prompt_allow_tool",
                 "toolu_bash_prompt_allow",
                 "bash",
-                json!({"command": "printf 'approved via prompt'", "timeout": 1000}),
+                json!({"command": "printf 'approved via prompt'", "timeout": 30000}),
             ),
         },
         Scenario::BashPermissionPromptDenied => match latest_tool_result(request) {
@@ -943,7 +943,7 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 "msg_bash_prompt_deny_tool",
                 "toolu_bash_prompt_deny",
                 "bash",
-                json!({"command": "printf 'should not run'", "timeout": 1000}),
+                json!({"command": "printf 'should not run'", "timeout": 30000}),
             ),
         },
         Scenario::PluginToolRoundtrip => match latest_tool_result(request) {


### PR DESCRIPTION
`main` went red on `cargo test --workspace (windows-latest)` after #534:

```
content text should be the bash stdout the model saw, got: {
  "stdout": "",
  "stderr": "Command exceeded timeout of 1000 ms",
  "interrupted": true,
```

The scripted bash scenarios passed `timeout: 1000`. That is not a budget for
`printf` — it is a budget for *starting a shell*. `sh -lc` takes ~270ms on a warm
box, and more than a second on a cold Windows runner where the MSYS runtime
initialises on first use.

It surfaced now because these ACP tests were `#![cfg(unix)]` until #534 un-gated
them, so the tight budget had never met a Windows runner.

Raised to 30s across the scripted scenarios. None of them tests timeout
behaviour — `bash_interrupt_long_running` is the scenario for that, untouched.

Locally on Windows: `acp_integration` 23/23, `mock_parity_harness` 1/1,
`pty_bash_execution` 5/5.