### PR TITLE
fix(nexus-vfs-client): resync the vendored vfs.proto with upstream

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -100,6 +100,32 @@ jobs:
             exit 1
           fi
 
+      - name: Vendored vfs.proto must match what nexus-vfs publishes
+        shell: bash
+        # rust/crates/nexus-vfs-client vendors a copy of the VFS service
+        # definition. nexus-vfs owns it, and the copy has drifted before --
+        # it kept sending WriteRequest.content_id after upstream reserved the
+        # field (their issue #5, where the documented If-Match contract was a
+        # no-op that masked concurrent-writer data loss). Diff against the
+        # definition shipped in the published Node client, which nexus-vfs
+        # generates from that same proto. Public bucket, no credentials.
+        run: |
+          set -euo pipefail
+          url='https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/latest/nexus-ai-fs-vfs-client.tgz'
+          work="$(mktemp -d)"
+          if ! curl -fsSL --retry 3 --max-time 60 "$url" -o "$work/client.tgz"; then
+            echo "::warning::could not reach the published client; skipping the proto drift check"
+            exit 0
+          fi
+          tar xzf "$work/client.tgz" -C "$work"
+          upstream="$work/package/proto/nexus/grpc/vfs/vfs.proto"
+          vendored='rust/crates/nexus-vfs-client/proto/nexus/grpc/vfs/vfs.proto'
+          if ! diff -u --strip-trailing-cr "$upstream" "$vendored"; then
+            echo "::error::$vendored has drifted from the definition nexus-vfs publishes; copy the upstream file over it and fix the fallout"
+            exit 1
+          fi
+          echo "vendored vfs.proto matches upstream"
+
   test-workspace:
     name: cargo test --workspace (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/rust/crates/nexus-vfs-client/proto/nexus/grpc/vfs/vfs.proto
+++ b/rust/crates/nexus-vfs-client/proto/nexus/grpc/vfs/vfs.proto
@@ -127,7 +127,18 @@ message WriteRequest {
   string path = 1;
   bytes content = 2;       // Raw file bytes — no base64
   string auth_token = 3;
-  string content_id = 4;   // Optional: opaque content identifier for conditional write (If-Match)
+  // Field 4 (`content_id` — documented as "If-Match" conditional
+  // write) removed for issue #5.  The server never enforced it, so
+  // the documented optimistic-concurrency contract was a silent
+  // no-op that would mask concurrent-writer data loss in any
+  // client that trusted it.  Dropped rather than half-implemented
+  // per YAGNI: the `content_id` at rest is a hash (CAS backends)
+  // or a path (PAS backends), neither of which is the right shape
+  // for a versioning token.  If optimistic-write semantics come
+  // back later, key off `WriteResponse.gen` (monotonic version)
+  // via an explicit `expected_gen` field, not `content_id`.
+  reserved 4;
+  reserved "content_id";
 }
 
 message WriteResponse {
@@ -145,7 +156,18 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-  bool success = 1;
+  // `success` is `optional bool` so the wire distinguishes
+  // "success=false transmitted explicitly" (idempotent no-op —
+  // target did not exist) from "field unset" (issue #8).  Under
+  // proto3's default-omit rule a bare `bool success = 1` on a
+  // not-found delete serialized as `{}`, indistinguishable from
+  // "field never populated" — a footgun for any client that
+  // relies on `success` to gate follow-up work.  With the
+  // optional marker: `Some(true)` = target existed and was
+  // deleted; `Some(false)` = target did not exist (idempotent);
+  // `None` should never occur post-fix, but a defensive client
+  // should treat it as "server does not understand the request".
+  optional bool success = 1;
   bool is_error = 2;
   bytes error_payload = 3;
   // Richer per-result fields — added so the typed Delete subsumes the
@@ -280,6 +302,29 @@ message ReaddirRequest {
   string zone_id = 3;        // empty → caller's context zone
   // `is_admin` is intentionally NOT a request field — the handler reads
   // it from the auth-resolved OperationContext so a client can't spoof.
+
+  // Set to `true` by peer-side fan-out dispatch (see
+  // `try_remote_readdir` / `FederationGrpcOps::list_dir`) so the
+  // receiving node's handler runs its local metastore + backend scan
+  // only, skipping its own fan-out.  Loop-guard: prevents ping-pong
+  // in 3+ node topologies where every hop's local search comes up
+  // empty.  Kernel-level: routes to `sys_readdir_peer_dispatch`
+  // instead of `sys_readdir`.
+  bool from_peer = 4;
+
+  // Recursive whole-subtree enumeration (default `false` = classic
+  // single-level `readdir(3)`). When set, the handler asks the kernel for
+  // the entire subtree under `path` in ONE call (the metastore's native
+  // `list(prefix)` range-scan) instead of forcing the client to compose N
+  // single-level reads — the round-trip collapse that lets a remote
+  // client's glob/grep ride this RPC rather than walk the tree client-side.
+  // Maps to `ReaddirOpts::recursive`.
+  bool recursive = 5;
+
+  // Cap the number of returned entries (`0` = unbounded). Entries are
+  // path-sorted, so a limit takes the lexicographically-first N
+  // deterministically. Maps to `ReaddirOpts::limit`.
+  uint32 limit = 6;
 }
 
 message ReaddirEntry {
@@ -348,6 +393,25 @@ message SetattrRequest {
   string io_profile = 12;
   bool is_external = 13;
   uint64 capacity = 14;
+
+  // ── DT_MOUNT backend-construction params (entry_type == 2) ──────────
+  //
+  // `backend_type` is the dispatch key (matches DRIVER_* values:
+  // "s3", "gcs", "remote", …). Empty ⇒ metadata-only / local re-mount.
+  // `backend_params` carries all app-layer constructor params as an
+  // opaque string map — each backend arm in the provider parses its
+  // own required keys (e.g. "s3_bucket", "aws_region"). This keeps the
+  // proto extensible: adding a new backend or param requires zero
+  // proto changes.
+  string backend_type = 15;
+
+  // Old flat backend fields (16-30) replaced by the opaque map.
+  reserved 16 to 30;
+
+  // Opaque app-layer backend-construction params. Keys match the
+  // provider arm's expected param names (e.g. "s3_bucket", "aws_region",
+  // "server_address"). Binary data (PEM certs) is stored as UTF-8 text.
+  map<string, string> backend_params = 31;
 }
 
 message SetattrResponse {
@@ -542,6 +606,12 @@ message StreamReadAtResponse {
   bool eof = 3;               // non-blocking: true → no data available
   bool is_error = 4;
   bytes error_payload = 5;
+  // Set true ONLY when a blocking read (blocking=true) reaches timeout_ms with
+  // no frame — a normal long-poll expiry. `eof` also stays true (backward-compat:
+  // a follower that only checks `eof` still re-polls) and `is_error` stays false.
+  // Lets a blocking long-poll reader tell "idle timeout → re-read same offset"
+  // apart from a real disconnect (`is_error=true`) without overloading `eof`.
+  bool timed_out = 6;
 }
 
 message StreamCollectAllResponse {

--- a/rust/crates/nexus-vfs-client/src/lib.rs
+++ b/rust/crates/nexus-vfs-client/src/lib.rs
@@ -210,7 +210,6 @@ impl NexusVfsClient {
                                             path,
                                             content,
                                             auth_token,
-                                            content_id: String::new(),
                                         })
                                         .await;
                                     let _ = resp.send(grpc_result(r, |r| {


### PR DESCRIPTION
`rust/crates/nexus-vfs-client` vendors a copy of the VFS service definition that nexus-vfs owns. It had fallen 12 lines behind, and **both gaps were upstream bug fixes**:

- **`WriteRequest.content_id`** was reserved upstream ([their issue #5](https://github.com/nexi-lab/nexus-vfs)). The documented If-Match contract was a no-op the server never enforced, so a client trusting it would **mask concurrent-writer data loss**. We were still sending the field.
- **`DeleteResponse.success`** gained proto3 explicit presence (their issue #8), so an idempotent not-found delete is distinguishable from an unpopulated field.

The copy also lacked `StreamReadAtResponse.timed_out` and the newer `Delete`/backend fields, so this client could not express them at all.

Neither gap was doing active damage today — the server ignores a reserved field, and nothing here reads `success` — but the copy was diverging with nothing to stop it.

## The guard

CI now diffs the vendored file against the definition nexus-vfs **publishes**, inside its Node client tarball, which is generated from that same proto. Public COS bucket, no credentials. It skips with a warning if the bucket is unreachable, so a network blip does not fail a build.

Verified both directions locally: identical after the resync, and a one-line deliberate edit makes it fail.

## Context

This is the last copy of that proto in the fleet. moss and sudowork each carried one too, behind hand-written clients; both are gone as of sudoprivacy/moss#220 and sudoprivacy/sudowork#1108, which now consume the client nexus-vfs publishes.

## Verified

`cargo check` passes for the crate and for all three consumers — `engine-host`, `runtime`, `rusty-sudocode-cli`.
