### PR TITLE
fix(prompt): a direct request to delete is the confirmation for deleting

### DIFF
--- a/rust/crates/runtime/src/memory/mod.rs
+++ b/rust/crates/runtime/src/memory/mod.rs
@@ -238,7 +238,7 @@ A file that fails to parse is skipped silently. Bodies render up to 2,000 chars;
 
 After writing a file, add one line to `MEMORY.md`: `- [Title](file.md) — one-line hook`. That file is only an index.
 
-Save immediately when asked to remember (remove when asked to forget); otherwise save anything durable you learn. Update an existing memory instead of duplicating; remove ones that turn out wrong. Don't save what the repo already records (code structure, git history, fixes, AGENTS.md) — if asked to, save what was non-obvious instead. Memories are past observations: verify a file, function, or flag a memory names still exists before relying on it, and trust the current state over the memory."
+Save immediately when asked to remember. When asked to forget, delete that entry's file and its `MEMORY.md` line in the same turn — the request is the confirmation. Otherwise save anything durable you learn. Update an existing memory instead of duplicating; remove ones that turn out wrong. Don't save what the repo already records (code structure, git history, fixes, AGENTS.md) — if asked to, save what was non-obvious instead. Memories are past observations: verify a file, function, or flag a memory names still exists before relying on it, and trust the current state over the memory."
     )
 }
 
@@ -260,7 +260,7 @@ You have a persistent, file-based memory system at `{dir_display}`. This directo
 
 You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
 
-If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find the relevant entry, delete its file, and remove its `MEMORY.md` line — the request is the confirmation, so do it in that turn rather than asking them to confirm it.
 
 ## Types of memory
 

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -685,9 +685,20 @@ fn get_working_section() -> String {
         .to_string()
 }
 
+/// The confirmation rule governs actions the assistant *chooses* to take.
+///
+/// Without the "the request is the confirmation" clause it also reads as
+/// covering actions the user just asked for, and the two readings collide with
+/// any instruction to perform one of the listed actions — most visibly the
+/// memory contract's "delete the entry when asked to forget"
+/// (`memory::build_compact_memory_instructions`). A model resolving that
+/// collision conservatively answers "I'll delete X — confirm?" and leaves the
+/// entry on disk, which is a re-ask of a question the user already answered,
+/// not a safety check. The clause states the intent that was always implicit;
+/// unrequested destructive actions still need confirmation.
 fn get_actions_section() -> String {
     "# Risky actions\n\
-     Local, reversible actions (editing files, running tests) need no confirmation. Confirm first for anything hard to reverse or visible to others: deleting files or branches, rm -rf, git reset --hard, force-push, amending published commits, dropping tables, killing processes, changing CI, pushing, creating or commenting on PRs or issues, sending messages, calling external services. One approval does not carry over to other contexts. \
+     Local, reversible actions (editing files, running tests) need no confirmation. Confirm first for anything hard to reverse or visible to others: deleting files or branches, rm -rf, git reset --hard, force-push, amending published commits, dropping tables, killing processes, changing CI, pushing, creating or commenting on PRs or issues, sending messages, calling external services. When the user asks for one of these directly, that request is the confirmation — carry it out in the same turn rather than asking them to confirm what they just told you to do. One approval does not carry over to other contexts. \
      Never bypass safety checks (--no-verify) or delete unfamiliar files, branches, or config to get unblocked — investigate; it may be the user's in-progress work."
         .to_string()
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_memory.rs
@@ -561,19 +561,20 @@ fn memory_write_read_forget_workflow() {
         panic!("prompt after forget: {e}\nPTY screen:\n{screen}");
     });
 
-    // ── Step 4: the forget outcome is NOT asserted, deliberately ─────
+    // ── Step 4: the fact is gone from disk ───────────────────────────
     //
-    // It should be, and this step used to say so in a comment with no code
-    // behind it. Asserting it — that no remaining entry still records the fact,
-    // via `memory_entry_text` below — was tried and fails about two runs in
-    // three: the model acknowledges the request and leaves the entry on disk.
-    // The compact memory instructions do say "remove when asked to forget", so
-    // that is a gap in how reliably the instruction lands, not in this test.
-    //
-    // Asserting it here would make this suite fail for a reason it cannot fix.
-    // Left un-asserted, with the helper kept, so whoever fixes the memory
-    // behaviour can turn this back on as the regression guard for it.
-    let _ = memory_entry_text(&projects_dir);
+    // Asserted on the entries themselves, not on what the model said: "done,
+    // that memory is gone" is exactly the answer that used to accompany the
+    // entry still sitting on disk. The index (`MEMORY.md`) is excluded by the
+    // helper, so this is about the memory the next session would actually be
+    // reminded of.
+    let remaining = memory_entry_text(&projects_dir);
+    assert!(
+        !remaining.to_lowercase().contains("rust"),
+        "forget must remove the entry, not just acknowledge the request; \
+         still on disk:\n{remaining}\nPTY screen:\n{}",
+        sess.render(|s| s.contents())
+    );
 
     // Clean exit.
     sess.send("/exit\r").expect("send /exit");
@@ -616,9 +617,8 @@ fn memory_dedup_does_not_create_duplicate() {
 
     // Pre-seed a memory entry about the user's role.
     let workspace_home = root.join("home");
-    let projects_dir = workspace_home.join(".scode").join("projects");
-    // We need to figure out the slug — just create a well-known memory dir.
-    // Use SUDOCODE_MEMORY_DIR to control the path deterministically.
+    // SUDOCODE_MEMORY_DIR pins the memory path, so this test never has to
+    // derive the per-workspace slug under `.scode/projects/`.
     let memory_dir = workspace_home.join("test-memory");
     fs::create_dir_all(&memory_dir).expect("create memory dir");
 


### PR DESCRIPTION
## The bug

Asked to forget a memory, scode acknowledged and left the entry on disk about two runs in three. The PTY screen from a failing run says what is happening:

```
❯ Forget my favorite programming language. Remove that memory entry.
⏺ I'll delete the following:
    • `memory/favorite-language.md`
    • Remove its entry from `MEMORY.md`
  Confirm?
```

The model is not being unreliable. It is obeying the prompt.

## Root cause

Two sections of the system prompt contradict each other:

- `# Risky actions`: *"Confirm first for anything hard to reverse … deleting files …"*
- the memory contract: *"remove when asked to forget"*

The confirmation rule was written for actions the model **chooses** to take, but nothing in it says so, so it also reads as covering the ones the user just asked for. Asking the user to confirm what they just instructed is a re-ask of a question already answered, not a safety check — and a model resolving the collision conservatively leaves the entry on disk.

## Fix

State the rule's intended scope in the rule: a direct request for one of the listed actions **is** that confirmation. Unrequested destructive actions still require one, and the "never delete unfamiliar files to get unblocked" clause is untouched.

The memory instructions now also state the removal in full — the entry file **and** its `MEMORY.md` line — so a partial forget cannot leave the index dangling.

## Verification

The forget assertion in `pty_memory` is no longer parked. It asserts the fact is gone from the entries on disk rather than trusting the model's "done, that memory is gone" — which is exactly the sentence that accompanied the entry that was still there.

Live on Windows, `SCODE_TEST_BACKEND=live`: **4/4 with the assertion enabled**, against roughly 1 in 3 before the change.