### PR TITLE
feat(cli): show which account a session is billed to, and let /account change it

### DIFF
--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -40,9 +40,9 @@ pub use providers::registry::{
     estimate_request_overhead_tokens, max_tokens_for_model, max_tokens_for_model_from_config,
     max_tokens_for_model_with_override, model_token_limit, model_token_limit_from_config,
     preflight_message_request, proxy_account_for_model, resolve_model,
-    resolve_model_alias_from_config, resolve_provider_from_config, select_proxy_account, ApiFormat,
-    Credential, ModelConfigEntry, ModelProviderMapping, ModelTokenLimit, ProviderConnectionConfig,
-    ResolvedProvider, SudoCodeConfig,
+    resolve_model_alias_from_config, resolve_provider_from_config, select_proxy_account,
+    AccountSource, ApiFormat, Credential, ModelConfigEntry, ModelProviderMapping, ModelTokenLimit,
+    ProviderConnectionConfig, ResolvedProvider, SelectedAccount, SudoCodeConfig,
 };
 pub use providers::{detect_provider_kind, AuthMode, ProviderKind};
 pub use sse::{parse_frame, SseParser};

--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -268,6 +268,48 @@ fn connection_for<'a>(
     config.auth_modes.get(auth_mode)?.get(provider_name)
 }
 
+/// Which rule in [`select_proxy_account`]'s precedence chose the account.
+///
+/// Reported alongside the account because "who pays" is only actionable next
+/// to "and why". An account reached by `AuthProfile` is a choice someone made
+/// and can change; one reached by `FirstConfigured` is a default nobody chose,
+/// and it is the case where a surprising name on the bill has no visible
+/// cause. Telling them apart is what makes an unexpected account fixable
+/// instead of merely alarming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountSource {
+    /// The layered settings' `auth_profile` — an explicit per-project choice.
+    AuthProfile,
+    /// The `provider` named by `models.<alias>.providers.proxy`.
+    ModelMapping,
+    /// The first account configured under `auth_modes.proxy`, because nothing
+    /// selected one.
+    FirstConfigured,
+}
+
+impl AccountSource {
+    /// A phrase for reports, naming the setting a user would edit.
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::AuthProfile => "auth_profile",
+            Self::ModelMapping => "model mapping",
+            Self::FirstConfigured => "first configured",
+        }
+    }
+}
+
+/// The proxy account a request is billed to, plus the rule that chose it.
+#[derive(Debug, Clone, Copy)]
+pub struct SelectedAccount<'a> {
+    /// The account's name under `auth_modes.proxy`.
+    pub name: &'a str,
+    /// Its connection config (base URL, credentials).
+    pub connection: &'a ProviderConnectionConfig,
+    /// Which precedence rule selected it.
+    pub source: AccountSource,
+}
+
 /// Single source of truth for **which proxy account a request is billed to**.
 ///
 /// Every path that can put a request on a proxy account resolves through this
@@ -287,7 +329,7 @@ fn connection_for<'a>(
 pub fn select_proxy_account<'a>(
     config: &'a SudoCodeConfig,
     mapping_provider: Option<&str>,
-) -> Result<(&'a str, &'a ProviderConnectionConfig), ApiError> {
+) -> Result<SelectedAccount<'a>, ApiError> {
     let accounts = config
         .auth_modes
         .get("proxy")
@@ -313,7 +355,11 @@ pub fn select_proxy_account<'a>(
     {
         return accounts
             .get_key_value(name)
-            .map(|(name, connection)| (name.as_str(), connection))
+            .map(|(name, connection)| SelectedAccount {
+                name: name.as_str(),
+                connection,
+                source: AccountSource::AuthProfile,
+            })
             .ok_or_else(|| {
                 ApiError::Configuration(format!(
                     "auth_profile '{name}' is not present in auth_modes.proxy (configured: {}). \
@@ -327,7 +373,11 @@ pub fn select_proxy_account<'a>(
     if let Some(name) = mapping_provider {
         return accounts
             .get_key_value(name)
-            .map(|(name, connection)| (name.as_str(), connection))
+            .map(|(name, connection)| SelectedAccount {
+                name: name.as_str(),
+                connection,
+                source: AccountSource::ModelMapping,
+            })
             .ok_or_else(|| {
                 ApiError::Configuration(format!(
                     "provider '{name}' not found under auth_modes.proxy in sudocode.json \
@@ -340,7 +390,11 @@ pub fn select_proxy_account<'a>(
     accounts
         .iter()
         .next()
-        .map(|(name, connection)| (name.as_str(), connection))
+        .map(|(name, connection)| SelectedAccount {
+            name: name.as_str(),
+            connection,
+            source: AccountSource::FirstConfigured,
+        })
         .ok_or_else(|| {
             ApiError::Configuration(
                 "no accounts configured under auth_modes.proxy in sudocode.json".to_string(),
@@ -358,7 +412,7 @@ pub fn select_proxy_account<'a>(
 pub fn proxy_account_for_model<'a>(
     config: &'a SudoCodeConfig,
     model_alias: &str,
-) -> Result<(&'a str, &'a ProviderConnectionConfig), ApiError> {
+) -> Result<SelectedAccount<'a>, ApiError> {
     let alias_lower = model_alias.trim().to_ascii_lowercase();
     let mapping_provider = resolve_model_for_mode(config, &alias_lower, Some("proxy"))
         .and_then(|entry| entry.providers.get("proxy"))
@@ -455,7 +509,8 @@ pub fn resolve_provider_from_config(
     //    selector, so an explicit per-project `auth_profile` decides who pays
     //    here exactly as it does on the passthrough path and in `doctor`.
     let (provider_name, connection) = if auth_mode_str == "proxy" {
-        select_proxy_account(config, Some(mapping.provider.as_str()))?
+        let selected = select_proxy_account(config, Some(mapping.provider.as_str()))?;
+        (selected.name, selected.connection)
     } else {
         let connection =
             connection_for(config, &auth_mode_str, &mapping.provider).ok_or_else(|| {
@@ -518,7 +573,8 @@ fn try_proxy_passthrough(
     // Who pays: the shared selector (SSOT with the model-config path and
     // `doctor`). There is no `models.<alias>` entry here, so no mapping
     // provider to offer it.
-    let (provider_name, connection) = select_proxy_account(config, None)?;
+    let selected = select_proxy_account(config, None)?;
+    let (provider_name, connection) = (selected.name, selected.connection);
 
     // Wire format: the shared resolver (SSOT with the model-config path) —
     // no explicit `api` here, so it consults the model_capabilities SSOT.
@@ -1026,8 +1082,9 @@ mod tests {
             let mut config = config_with_second_proxy_account();
             config.selected_account = selected.clone();
 
-            let (reported, connection) =
+            let selected =
                 proxy_account_for_model(&config, "opus").expect("should resolve an account");
+            let (reported, connection) = (selected.name, selected.connection);
             let resolved = resolve_provider_from_config("opus", Some(AuthMode::Proxy), &config)
                 .expect("should resolve");
 
@@ -1051,8 +1108,9 @@ mod tests {
         let config = config_with_second_proxy_account();
         assert!(config.selected_account.is_none());
 
-        let (name, _) = proxy_account_for_model(&config, "opus").expect("should resolve");
-        assert_eq!(name, "sudorouter");
+        let selected = proxy_account_for_model(&config, "opus").expect("should resolve");
+        assert_eq!(selected.name, "sudorouter");
+        assert_eq!(selected.source, AccountSource::ModelMapping);
 
         let resolved = resolve_provider_from_config("opus", Some(AuthMode::Proxy), &config)
             .expect("should resolve");

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -245,6 +245,13 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: false,
     },
     SlashCommandSpec {
+        name: "account",
+        aliases: &[],
+        summary: "Show or switch which proxy account this project is billed to",
+        argument_hint: Some("[name]"),
+        resume_supported: false,
+    },
+    SlashCommandSpec {
         name: "clear",
         aliases: &[],
         summary: "Start a fresh local session",
@@ -1220,6 +1227,11 @@ pub enum SlashCommand {
     Auth {
         mode: Option<String>,
     },
+    /// `/account [name]` — show which proxy account pays for this project's
+    /// requests, or point it at a different configured one.
+    Account {
+        account: Option<String>,
+    },
     Clear {
         confirm: bool,
     },
@@ -1512,6 +1524,9 @@ pub fn validate_slash_command_input(
         },
         "auth" => SlashCommand::Auth {
             mode: parse_auth_mode(&args)?,
+        },
+        "account" => SlashCommand::Account {
+            account: optional_single_arg("account", &args, "[name]")?,
         },
         "clear" => SlashCommand::Clear {
             confirm: parse_clear_args(&args)?,
@@ -2180,8 +2195,8 @@ fn slash_command_category(name: &str) -> &'static str {
         | "bookmarks" | "context" | "files" | "focus" | "unfocus" | "retry" | "stop" | "undo" => {
             "Session"
         }
-        "model" | "permissions" | "auth" | "config" | "memory" | "theme" | "vim" | "voice"
-        | "color" | "effort" | "fast" | "brief" | "output-style" | "keybindings"
+        "model" | "permissions" | "auth" | "account" | "config" | "memory" | "theme" | "vim"
+        | "voice" | "color" | "effort" | "fast" | "brief" | "output-style" | "keybindings"
         | "privacy-settings" | "stickers" | "language" | "profile" | "max-tokens"
         | "temperature" | "system-prompt" | "api-key" | "terminal-setup" | "notifications"
         | "telemetry" | "providers" | "env" | "project" | "reasoning" | "budget" | "rate-limit"
@@ -4910,6 +4925,7 @@ pub fn handle_slash_command(
         | SlashCommand::Model { .. }
         | SlashCommand::Permissions { .. }
         | SlashCommand::Auth { .. }
+        | SlashCommand::Account { .. }
         | SlashCommand::Clear { .. }
         | SlashCommand::Cost
         | SlashCommand::Resume { .. }
@@ -5553,7 +5569,8 @@ mod tests {
         assert!(help.contains("aliases: /skill"));
         assert!(!help.contains("/login"));
         assert!(!help.contains("/logout"));
-        assert_eq!(slash_command_specs().len(), 141);
+        assert!(help.contains("/account [name]"));
+        assert_eq!(slash_command_specs().len(), 142);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/commands/src/reports.rs
+++ b/rust/crates/commands/src/reports.rs
@@ -493,6 +493,13 @@ pub fn status_context(
     })
 }
 
+/// Render the `/status` report.
+///
+/// `account` is the already-resolved billing line (`engine_host::BillingAccount::describe`).
+/// It arrives pre-rendered because resolving it needs the engine-side config
+/// SSOT, and this crate is a pure formatter that `engine-host` depends on —
+/// reaching back for the answer here would be a dependency cycle and a second
+/// copy of the precedence rules.
 #[must_use]
 pub fn format_status_report(
     model: &str,
@@ -500,6 +507,7 @@ pub fn format_status_report(
     permission_mode: &str,
     context: &StatusContext,
     provenance: Option<&ProvenanceView>,
+    account: &str,
 ) -> String {
     let status_line = if context.config_load_error.is_some() {
         "Status (degraded)"
@@ -524,6 +532,7 @@ pub fn format_status_report(
         format!(
             "{status_line}
   Model            {model}{model_source_line}
+  Account          {account}
   Permission mode  {permission_mode}
   Messages         {}
   Turns            {}
@@ -1060,14 +1069,14 @@ fn check_account_health(config_loader: &ConfigLoader, resolved_model: &str) -> D
             "no proxy accounts configured",
         );
     }
-    let selected = config.selected_account.as_deref();
     match api::proxy_account_for_model(&config, resolved_model) {
-        Ok((name, connection)) => {
+        Ok(selected) => {
             DiagnosticCheck::new("Account", DiagnosticLevel::Ok, "resolved proxy account")
                 .with_details(vec![format!(
-                    "account={name} base_url={} auth_profile={} model={}",
-                    connection.base_url,
-                    selected.unwrap_or("<default>"),
+                    "account={} base_url={} chosen_by={} model={}",
+                    selected.name,
+                    selected.connection.base_url,
+                    selected.source.describe(),
                     if resolved_model.is_empty() {
                         "<none>"
                     } else {

--- a/rust/crates/engine-acp/src/session_ops.rs
+++ b/rust/crates/engine-acp/src/session_ops.rs
@@ -563,6 +563,7 @@ pub(crate) fn handle_slash_command(
             let snapshot = engine.session_snapshot();
             let tracker = UsageTracker::from_session(&snapshot);
             let handle = engine.session_handle();
+            let account = engine.current_billing_account();
             format_status_report(
                 &engine.current_model(),
                 StatusUsage {
@@ -576,6 +577,7 @@ pub(crate) fn handle_slash_command(
                 &status_context(Some(&handle.path))
                     .map_err(|e| crate::AcpError::internal(e.to_string()))?,
                 None,
+                &account.describe(),
             )
         }
         SlashCommand::Cost => {

--- a/rust/crates/engine-core/src/lib.rs
+++ b/rust/crates/engine-core/src/lib.rs
@@ -97,10 +97,13 @@ pub use api::{
     // Error surface (raw type + the human-facing formatter the CLI renders).
     format_user_visible_api_error,
     max_tokens_for_model,
+    // Which proxy account a request is billed to, and the rule that chose it.
+    proxy_account_for_model,
     read_base_url,
     resolve_model,
     resolve_provider_from_config,
     resolve_startup_auth_source,
+    AccountSource,
     ApiError,
     // Auth / provider enums + sources.
     AuthMode,

--- a/rust/crates/engine-host/src/session_engine.rs
+++ b/rust/crates/engine-host/src/session_engine.rs
@@ -755,6 +755,96 @@ impl engine_core::EngineDelegate for SessionEngine {
     }
 }
 
+/// Who a session's requests are billed to.
+///
+/// A session spends someone's money, and until this crossed the seam nothing on
+/// screen said whose. The account is resolved per request from layered config,
+/// so it can be one the user never chose — an `auth_profile` inherited from a
+/// parent directory, or simply the first account in the file. That is fine
+/// right up until the bill arrives on the wrong account, which is why the rule
+/// that chose it travels with the name rather than being left to be inferred.
+#[derive(Debug, Clone)]
+pub enum BillingAccount {
+    /// A named account under `auth_modes.proxy`, and the rule that chose it.
+    Proxy {
+        name: String,
+        source: engine_core::AccountSource,
+    },
+    /// The session is not on a proxy account — its auth mode bills no named
+    /// account, so there is nothing to show.
+    NotProxied,
+    /// The selector refused to resolve one. Carries its message: this is the
+    /// case worth showing, because the same refusal is what a request will hit.
+    Unresolved(String),
+}
+
+impl BillingAccount {
+    /// The account name, when one resolved — for the per-turn status line,
+    /// which has room for the answer but not the reasoning.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Proxy { name, .. } => Some(name.as_str()),
+            Self::NotProxied | Self::Unresolved(_) => None,
+        }
+    }
+
+    /// A stable token for the deciding rule, for machine-readable reports.
+    #[must_use]
+    pub fn source_label(&self) -> &'static str {
+        match self {
+            Self::Proxy { source, .. } => source.describe(),
+            Self::NotProxied => "not proxied",
+            Self::Unresolved(_) => "unresolved",
+        }
+    }
+
+    /// One line for `/status`: who pays, and what made it them.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Proxy { name, source } => format!("{name} (chosen by {})", source.describe()),
+            Self::NotProxied => "none (this auth mode bills no named account)".to_string(),
+            Self::Unresolved(err) => format!("unresolved — {err}"),
+        }
+    }
+}
+
+/// Every account configured under `auth_modes.proxy`, in config order.
+#[must_use]
+pub fn configured_proxy_accounts(config: &engine_core::SudoCodeConfig) -> Vec<String> {
+    config
+        .auth_modes
+        .get("proxy")
+        .map(|accounts| accounts.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Who a request for `model` from the current directory would be billed to.
+///
+/// The engine-side entry point for the question, so `/status` in a live REPL,
+/// `scode status` with no engine at all, and the ACP `/status` all get the
+/// answer from the one selector the request path uses. A report that re-derives
+/// the decision can disagree with the code that spends the money — which is
+/// exactly how an unhonored `auth_profile` stayed invisible while every request
+/// billed a different account.
+#[must_use]
+pub fn billing_account_for_model(model: &str, auth_override: Option<AuthMode>) -> BillingAccount {
+    let config = load_sudocode_config_for_current_dir();
+    if resolve_auth_mode(model, auth_override, &config).unwrap_or(AuthMode::ApiKey)
+        != AuthMode::Proxy
+    {
+        return BillingAccount::NotProxied;
+    }
+    match engine_core::proxy_account_for_model(&config, model) {
+        Ok(selected) => BillingAccount::Proxy {
+            name: selected.name.to_string(),
+            source: selected.source,
+        },
+        Err(err) => BillingAccount::Unresolved(err.to_string()),
+    }
+}
+
 /// The non-turn session-lifecycle contract the composition root (`LiveCli`) uses
 /// to manage a live engine session **without being able to drive turns** — turns
 /// go only through `EngineHandle`. Split from [`engine_core::EngineDelegate`]
@@ -800,6 +890,20 @@ pub trait SessionLifecycle: Send + Sync + 'static {
     fn current_permission_mode(&self) -> PermissionMode;
     /// The resolved auth mode in effect.
     fn current_auth_mode(&self) -> AuthMode;
+    /// Who this session's requests are billed to, and why that account.
+    fn current_billing_account(&self) -> BillingAccount;
+    /// Every account configured under `auth_modes.proxy`, in config order —
+    /// the set `set_billing_account` will accept.
+    fn billing_accounts(&self) -> Vec<String>;
+    /// Point this project at a named proxy account: persist the selection and
+    /// rebuild so the live session bills it from the next turn on. Returns the
+    /// account now in effect.
+    ///
+    /// The rebuild is the point. Persisting alone would leave the session
+    /// spending the old account while every report named the new one — the
+    /// same invisible divergence between what is reported and what is billed
+    /// that [`BillingAccount`] exists to close.
+    fn set_billing_account(&self, name: &str) -> Result<BillingAccount, String>;
 
     // --- semantic session ops (engine owns the rebuild; renderer only formats)-
     /// Switch the model. Returns report DATA (`previous` / `resolved` /
@@ -898,6 +1002,47 @@ impl SessionLifecycle for SessionEngine {
 
     fn current_auth_mode(&self) -> AuthMode {
         self.resolved_auth_mode()
+    }
+
+    fn current_billing_account(&self) -> BillingAccount {
+        billing_account_for_model(&self.session_model(), self.auth_override())
+    }
+
+    fn billing_accounts(&self) -> Vec<String> {
+        configured_proxy_accounts(&load_sudocode_config_for_current_dir())
+    }
+
+    fn set_billing_account(&self, name: &str) -> Result<BillingAccount, String> {
+        let name = name.trim();
+        // Refuse an account that is not configured rather than writing it and
+        // letting the next request fail: the selector treats an unhonored
+        // selection as fatal precisely so it never quietly bills another
+        // account, and a `/account` that accepted a typo would just move that
+        // failure to a place the user has stopped looking.
+        let available = configured_proxy_accounts(&load_sudocode_config_for_current_dir());
+        if !available.iter().any(|candidate| candidate == name) {
+            return Err(if available.is_empty() {
+                "no accounts are configured under auth_modes.proxy in sudocode.json".to_string()
+            } else {
+                format!(
+                    "no account named '{name}' under auth_modes.proxy (configured: {})",
+                    available.join(", ")
+                )
+            });
+        }
+
+        // The one scope-aware config writer `/config set` uses, so the
+        // selection lands in the project's `settings.local.json` exactly as it
+        // would by hand.
+        tools::set_config_setting("auth_profile", name)?;
+
+        {
+            let mut session = self.lock_session();
+            let new_session = session.runtime.session().clone();
+            let handle = session.handle.clone();
+            self.rebuild_locked(&mut session, new_session, handle)?;
+        }
+        Ok(self.current_billing_account())
     }
 
     fn set_model(&self, new_model: &str) -> Result<ModelSwitchReport, String> {

--- a/rust/crates/rusty-sudocode-cli/src/cli/format.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/format.rs
@@ -414,6 +414,61 @@ pub(crate) fn format_auth_switch_report(previous: &str, next: &str) -> String {
     )
 }
 
+/// Render `/account`: who pays, what chose them, and what else is on offer.
+///
+/// `current` is the rendered [`engine_host::BillingAccount`] line, so the
+/// deciding rule travels with the name — an account nobody selected reads very
+/// differently from one this project asked for, and that difference is the
+/// whole reason to look.
+pub(crate) fn format_account_report(
+    current: &str,
+    current_name: Option<&str>,
+    available: &[String],
+) -> String {
+    let accounts = if available.is_empty() {
+        "  (none configured under auth_modes.proxy in sudocode.json)".to_string()
+    } else {
+        available
+            .iter()
+            .map(|name| {
+                let marker = if Some(name.as_str()) == current_name {
+                    "● current"
+                } else {
+                    "○ available"
+                };
+                format!("  {name:<18} {marker}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        "Account
+  Billed to        {current}
+  Defined in       auth_modes.proxy in sudocode.json
+  Selection scope  this project (.nexus/sudocode/settings.local.json)
+
+Accounts
+{accounts}
+
+Usage
+  Inspect current account with /account
+  Switch accounts with /account <name>"
+    )
+}
+
+pub(crate) fn format_account_switch_report(previous: &str, next: &str) -> String {
+    format!(
+        "Account updated
+  Result           account switched
+  Previous account {previous}
+  Billed to        {next}
+  Applies to       subsequent API calls
+  Persisted to     this project's settings.local.json
+  Usage            /account to inspect current account"
+    )
+}
+
 pub(crate) fn format_cost_report(usage: TokenUsage) -> String {
     format!(
         "Cost
@@ -1546,15 +1601,6 @@ pub(crate) fn truncate_for_summary(value: &str, limit: usize) -> String {
     }
 }
 
-pub(crate) fn format_turn_status_line(
-    model: &str,
-    turn: u32,
-    usage: &TokenUsage,
-    elapsed: Duration,
-) -> String {
-    format_turn_status_line_with_branch(model, turn, usage, None, None, elapsed, None)
-}
-
 /// Format the `ctx <used>/<window> (<pct>%)` status segment, or `None` when
 /// the window is unknown/zero.
 ///
@@ -1602,25 +1648,53 @@ fn format_token_count_round(n: u32) -> String {
     }
 }
 
+/// What one finished turn cost, for [`format_turn_status_line`].
+///
+/// Grouped rather than passed positionally: the line summarises a single turn,
+/// and a call site with three `Option`s in a row is one transposition away from
+/// reporting the window as the occupancy with nothing to catch it.
+pub(crate) struct TurnStatus<'a> {
+    /// The model that answered.
+    pub model: &'a str,
+    /// 1-based turn number within the session.
+    pub turn: u32,
+    /// The turn's usage — token counts and the cost estimate.
+    pub usage: &'a TokenUsage,
+    /// Current context-window occupancy (`TokenUsage::context_tokens` of the
+    /// latest turn), NOT the session-cumulative total. See
+    /// [`format_context_usage_segment`].
+    pub context_tokens: Option<u32>,
+    /// The model's context window, the denominator for the occupancy segment.
+    pub context_window: Option<u32>,
+    /// Wall-clock time the turn took.
+    pub elapsed: Duration,
+    /// Current git branch, when the workspace is a repository.
+    pub branch: Option<&'a str>,
+    /// The proxy account the turn was billed to, when one resolved. Shown
+    /// because a session spends someone's money and the name is otherwise
+    /// invisible until the bill arrives; `/status` carries which rule chose it.
+    pub account: Option<&'a str>,
+}
+
 /// Render the dim per-turn status line shown after each interactive turn.
 ///
-/// Contains, in order: model name, turn number, cumulative token count,
-/// estimated cost (when pricing for the model is known), elapsed wall-clock
-/// time for the turn, and the current git branch (when one is available).
-/// All fields are dimmed; turn and tokens are kept compact (`turn 3`,
-/// `3.2k tokens`) so the line stays single-row even at narrow widths.
-pub(crate) fn format_turn_status_line_with_branch(
-    model: &str,
-    turn: u32,
-    usage: &TokenUsage,
-    // Current context-window occupancy (TokenUsage::context_tokens of the
-    // latest turn), NOT the session-cumulative total. See
-    // format_context_usage_segment.
-    context_tokens: Option<u32>,
-    context_window: Option<u32>,
-    elapsed: Duration,
-    branch: Option<&str>,
-) -> String {
+/// Contains, in order: model name, billing account, turn number, cumulative
+/// token count, estimated cost (when pricing for the model is known), elapsed
+/// wall-clock time for the turn, context-window occupancy, and the current git
+/// branch (when one is available). All fields are dimmed; turn and tokens are
+/// kept compact (`turn 3`, `3.2k tokens`) so the line stays single-row even at
+/// narrow widths.
+pub(crate) fn format_turn_status_line(status: &TurnStatus<'_>) -> String {
+    let &TurnStatus {
+        model,
+        turn,
+        usage,
+        context_tokens,
+        context_window,
+        elapsed,
+        branch,
+        account,
+    } = status;
     let total = usage.total_tokens();
     let tokens_display = if total >= 1000 {
         format!("{:.1}k", f64::from(total) / 1000.0)
@@ -1637,6 +1711,11 @@ pub(crate) fn format_turn_status_line_with_branch(
 
     let mut segments: Vec<String> = Vec::with_capacity(8);
     segments.push(format!("[{model}]"));
+    // Next to the model: together they answer "who served this turn, and on
+    // whose account".
+    if let Some(account) = account.filter(|a| !a.is_empty()) {
+        segments.push(format!("acct {account}"));
+    }
     segments.push(format!("turn {turn}"));
     segments.push(format!("{tokens_display} tokens"));
     if let Some(cost) = cost_display {
@@ -2012,15 +2091,16 @@ mod tests {
             cache_read_input_tokens: 0,
             ..TokenUsage::default()
         };
-        let rendered = format_turn_status_line_with_branch(
-            "claude-opus-4-6",
-            3,
-            &usage,
-            None,
-            None,
-            Duration::from_secs_f64(1.2),
-            None,
-        );
+        let rendered = format_turn_status_line(&TurnStatus {
+            model: "claude-opus-4-6",
+            turn: 3,
+            usage: &usage,
+            context_tokens: None,
+            context_window: None,
+            elapsed: Duration::from_secs_f64(1.2),
+            branch: None,
+            account: None,
+        });
         let plain = strip_ansi(&rendered);
         assert!(plain.contains("[claude-opus-4-6]"), "{plain}");
         assert!(plain.contains("turn 3"), "{plain}");
@@ -2032,15 +2112,16 @@ mod tests {
     #[test]
     fn turn_status_line_omits_cost_when_zero() {
         let usage = TokenUsage::default();
-        let rendered = format_turn_status_line_with_branch(
-            "claude-opus-4-6",
-            1,
-            &usage,
-            None,
-            None,
-            Duration::from_secs_f64(0.3),
-            None,
-        );
+        let rendered = format_turn_status_line(&TurnStatus {
+            model: "claude-opus-4-6",
+            turn: 1,
+            usage: &usage,
+            context_tokens: None,
+            context_window: None,
+            elapsed: Duration::from_secs_f64(0.3),
+            branch: None,
+            account: None,
+        });
         let plain = strip_ansi(&rendered);
         assert!(!plain.contains("$"), "{plain}");
     }
@@ -2048,15 +2129,16 @@ mod tests {
     #[test]
     fn turn_status_line_appends_branch_when_present() {
         let usage = TokenUsage::default();
-        let rendered = format_turn_status_line_with_branch(
-            "claude-opus-4-6",
-            1,
-            &usage,
-            None,
-            None,
-            Duration::from_millis(800),
-            Some("feat/tui-backlog-179"),
-        );
+        let rendered = format_turn_status_line(&TurnStatus {
+            model: "claude-opus-4-6",
+            turn: 1,
+            usage: &usage,
+            context_tokens: None,
+            context_window: None,
+            elapsed: Duration::from_millis(800),
+            branch: Some("feat/tui-backlog-179"),
+            account: None,
+        });
         let plain = strip_ansi(&rendered);
         assert!(plain.ends_with("feat/tui-backlog-179"), "{plain}");
     }
@@ -2064,15 +2146,16 @@ mod tests {
     #[test]
     fn turn_status_line_omits_branch_when_empty() {
         let usage = TokenUsage::default();
-        let rendered = format_turn_status_line_with_branch(
-            "claude-opus-4-6",
-            1,
-            &usage,
-            None,
-            None,
-            Duration::from_millis(800),
-            Some(""),
-        );
+        let rendered = format_turn_status_line(&TurnStatus {
+            model: "claude-opus-4-6",
+            turn: 1,
+            usage: &usage,
+            context_tokens: None,
+            context_window: None,
+            elapsed: Duration::from_millis(800),
+            branch: Some(""),
+            account: None,
+        });
         let plain = strip_ansi(&rendered);
         // Trailing segment should be the duration, not an empty " · ".
         assert!(plain.ends_with("0.8s"), "{plain}");
@@ -2103,17 +2186,35 @@ mod tests {
     #[test]
     fn turn_status_line_renders_context_segment() {
         let usage = TokenUsage::default();
-        let rendered = format_turn_status_line_with_branch(
-            "claude-sonnet-4-6",
-            2,
-            &usage,
-            Some(150_000),
-            Some(1_000_000),
-            Duration::from_secs_f64(0.5),
-            None,
-        );
+        let rendered = format_turn_status_line(&TurnStatus {
+            model: "claude-sonnet-4-6",
+            turn: 2,
+            usage: &usage,
+            context_tokens: Some(150_000),
+            context_window: Some(1_000_000),
+            elapsed: Duration::from_secs_f64(0.5),
+            branch: None,
+            account: None,
+        });
         let plain = strip_ansi(&rendered);
         assert!(plain.contains("ctx 150.0k/1M (15%)"), "{plain}");
+    }
+
+    #[test]
+    fn turn_status_line_names_the_billing_account() {
+        let usage = TokenUsage::default();
+        let rendered = format_turn_status_line(&TurnStatus {
+            model: "claude-sonnet-4-6",
+            turn: 1,
+            usage: &usage,
+            context_tokens: None,
+            context_window: None,
+            elapsed: Duration::from_millis(500),
+            branch: None,
+            account: Some("fujitoken"),
+        });
+        let plain = strip_ansi(&rendered);
+        assert!(plain.contains("acct fujitoken"), "{plain}");
     }
 
     #[test]

--- a/rust/crates/rusty-sudocode-cli/src/cli/status.rs
+++ b/rust/crates/rusty-sudocode-cli/src/cli/status.rs
@@ -1,3 +1,4 @@
+use engine_host::{billing_account_for_model, BillingAccount};
 use runtime::{resolve_sandbox_status, ConfigLoader};
 use serde_json::json;
 
@@ -36,6 +37,9 @@ pub(crate) fn print_status_snapshot(
         },
         None => ModelProvenance::from_default_lookup(),
     };
+    // No engine is running on this path, so the account comes from the same
+    // engine-side selector a request would use, asked directly.
+    let account = billing_account_for_model(&provenance.resolved, None);
     match output_format {
         CliOutputFormat::Text => println!(
             "{}",
@@ -44,7 +48,8 @@ pub(crate) fn print_status_snapshot(
                 usage,
                 permission_mode.as_str(),
                 &context,
-                Some(&provenance.view())
+                Some(&provenance.view()),
+                &account.describe(),
             )
         ),
         CliOutputFormat::Json => println!(
@@ -55,6 +60,7 @@ pub(crate) fn print_status_snapshot(
                 permission_mode.as_str(),
                 &context,
                 Some(&provenance),
+                &account,
             ))?
         ),
     }
@@ -72,6 +78,11 @@ pub(crate) fn status_json_value(
     // that don't have provenance (legacy resume paths) pass None, in which
     // case both new fields are omitted.
     provenance: Option<&ModelProvenance>,
+    // Who the session's requests are billed to. Reported next to the model
+    // because both answer "who served this and on whose account", and because
+    // the text report shows it — a JSON consumer that could not see the account
+    // would be reading a different `/status` than the terminal does.
+    account: &BillingAccount,
 ) -> serde_json::Value {
     // #143: top-level `status` marker so consumers can distinguish
     // a clean run from a degraded run (config parse failed but other fields
@@ -87,6 +98,8 @@ pub(crate) fn status_json_value(
         "model": model,
         "model_source": model_source,
         "model_raw": model_raw,
+        "account": account.name(),
+        "account_source": account.source_label(),
         "permission_mode": permission_mode,
         "usage": {
             "messages": usage.message_count,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -61,15 +61,16 @@ use cli::export::{
     PromptHistoryEntry,
 };
 use cli::format::{
-    describe_tool_progress, first_visible_line, format_acp_compact_report, format_auth_report,
+    describe_tool_progress, first_visible_line, format_account_report,
+    format_account_switch_report, format_acp_compact_report, format_auth_report,
     format_auth_switch_report, format_auto_compaction_notice, format_bughunter_report,
     format_commit_preflight_report, format_commit_skipped_report, format_compact_report,
     format_cost_report, format_internal_prompt_progress_line, format_issue_report,
     format_model_report, format_model_switch_report, format_permission_prompt_box,
     format_permissions_report, format_permissions_switch_report, format_pr_report,
     format_resume_report, format_sandbox_report, format_tool_call_start, format_tool_result,
-    format_turn_status_line_with_branch, format_ultraplan_report, render_messages,
-    render_resume_usage, render_version_report, truncate_for_summary,
+    format_turn_status_line, format_ultraplan_report, render_messages, render_resume_usage,
+    render_version_report, truncate_for_summary, TurnStatus,
 };
 use cli::git::{
     enforce_broad_cwd_policy, git_output, parse_git_status_branch, parse_git_status_metadata,
@@ -1204,10 +1205,15 @@ fn run_resume_command(
             let tracker = UsageTracker::from_session(session);
             let usage = tracker.cumulative_usage();
             let context = status_context(Some(session_path))?;
+            let model = session.model.as_deref().unwrap_or("restored-session");
+            // Resolved for the model the session was restored with: a resumed
+            // session bills whoever the current config says, which need not be
+            // whoever paid for the turns already in the transcript.
+            let account = engine_host::billing_account_for_model(model, None);
             Ok(ResumeCommandOutcome {
                 session: session.clone(),
                 message: Some(format_status_report(
-                    session.model.as_deref().unwrap_or("restored-session"),
+                    model,
                     StatusUsage {
                         message_count: session.messages.len(),
                         turns: tracker.turns(),
@@ -1218,6 +1224,7 @@ fn run_resume_command(
                     default_permission_mode().as_str(),
                     &context,
                     None, // #148: resumed sessions don't have flag provenance
+                    &account.describe(),
                 )),
                 json: Some(status_json_value(
                     session.model.as_deref(),
@@ -1231,6 +1238,7 @@ fn run_resume_command(
                     default_permission_mode().as_str(),
                     &context,
                     None, // #148: resumed sessions don't have flag provenance
+                    &account,
                 )),
             })
         }
@@ -1502,6 +1510,7 @@ fn run_resume_command(
         | SlashCommand::Model { .. }
         | SlashCommand::Permissions { .. }
         | SlashCommand::Auth { .. }
+        | SlashCommand::Account { .. }
         | SlashCommand::Session { .. }
         | SlashCommand::Plugins { .. }
         | SlashCommand::Login
@@ -3576,15 +3585,20 @@ impl LiveCli {
         let branch = env::current_dir()
             .ok()
             .and_then(|cwd| resolve_git_branch_for(&cwd));
-        let line = format_turn_status_line_with_branch(
+        // Read once per turn, from the engine's own selector rather than a
+        // second copy of the precedence rules. A turn takes seconds; the config
+        // read behind this does not register next to it.
+        let account = self.lifecycle.current_billing_account();
+        let line = format_turn_status_line(&TurnStatus {
             model,
-            turns,
-            &usage,
-            Some(context_tokens),
-            Some(context_window),
+            turn: turns,
+            usage: &usage,
+            context_tokens: Some(context_tokens),
+            context_window: Some(context_window),
             elapsed,
-            branch.as_deref(),
-        );
+            branch: branch.as_deref(),
+            account: account.name(),
+        });
         match (ui, output) {
             // Persist in ChromeSlot (visible until next turn) AND scrollback
             // (survives scroll, visible in session replay).
@@ -3845,6 +3859,7 @@ impl LiveCli {
             SlashCommand::Model { model } => self.set_model(model)?,
             SlashCommand::Permissions { mode } => self.set_permissions(mode)?,
             SlashCommand::Auth { mode } => self.set_auth(mode)?,
+            SlashCommand::Account { account } => self.set_billing_account(account)?,
             SlashCommand::Clear { confirm } => self.clear_session(confirm)?,
             SlashCommand::Cost => {
                 self.print_cost();
@@ -4048,6 +4063,7 @@ impl LiveCli {
             self.lifecycle.current_permission_mode().as_str(),
             &status_context(Some(&handle.path)).expect("status context should load"),
             None, // #148: REPL /status doesn't carry flag provenance
+            &self.lifecycle.current_billing_account().describe(),
         );
         self.out_suspend(|| print_with_pager(&report));
     }
@@ -4189,6 +4205,41 @@ impl LiveCli {
         self.lifecycle
             .set_permission_mode(permission_mode_from_label(normalized))?;
         self.out_println(format_permissions_switch_report(&previous, normalized));
+        Ok(true)
+    }
+
+    /// `/account [name]` — report who pays, or switch to another configured
+    /// account. Returns whether the session was rebuilt.
+    fn set_billing_account(
+        &mut self,
+        account: Option<String>,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let current = self.lifecycle.current_billing_account();
+
+        let Some(account) = account else {
+            self.out_println(format_account_report(
+                &current.describe(),
+                current.name(),
+                &self.lifecycle.billing_accounts(),
+            ));
+            return Ok(false);
+        };
+
+        if current.name() == Some(account.trim()) {
+            self.out_println(format_account_report(
+                &current.describe(),
+                current.name(),
+                &self.lifecycle.billing_accounts(),
+            ));
+            return Ok(false);
+        }
+
+        let previous = current.describe();
+        let switched = self.lifecycle.set_billing_account(&account)?;
+        self.out_println(format_account_switch_report(
+            &previous,
+            &switched.describe(),
+        ));
         Ok(true)
     }
 

--- a/rust/crates/rusty-sudocode-cli/tests/cli_flags_and_config_defaults.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/cli_flags_and_config_defaults.rs
@@ -33,6 +33,10 @@ fn status_command_applies_model_and_permission_mode_flags() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     assert!(stdout.contains("Status"));
     assert!(stdout.contains("Model            claude-sonnet-4-6"));
+    // Who the session's requests are billed to. Present on every status
+    // report, including the modes that bill no named account — "none" is an
+    // answer; a missing line is not.
+    assert!(stdout.contains("Account          "), "{stdout}");
     assert!(stdout.contains("Permission mode  read-only"));
 
     fs::remove_dir_all(temp_dir).expect("cleanup temp dir");
@@ -60,6 +64,7 @@ fn resume_flag_loads_a_saved_session_and_dispatches_status() {
     assert_success(&output);
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     assert!(stdout.contains("Status"));
+    assert!(stdout.contains("Account          "), "{stdout}");
     assert!(stdout.contains("Messages         1"));
     assert!(stdout.contains("Session          "));
     assert!(stdout.contains(session_path.to_str().expect("utf8 path")));

--- a/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
@@ -167,3 +167,143 @@ fn write_auth_profile(env: &TestEnv, profile: &str) {
     )
     .expect("write settings.local.json");
 }
+
+/// `/account` names who pays and lists what else is configured.
+///
+/// The account is resolved per request from layered config, so it can be one
+/// nobody in this project chose. This is the command that makes it visible
+/// without reading three files.
+#[test]
+fn account_lists_configured_accounts_and_marks_current() {
+    let env = TestEnv::new("account-list");
+    write_two_account_config(&env);
+
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+    sess.set_default_timeout(Duration::from_secs(20));
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send("/account\r").expect("send /account");
+    for expected in ["Accounts", "sudorouter", "team-b"] {
+        sess.expect(expected).unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!("/account should list {expected}: {e}\nPTY screen:\n{screen}");
+        });
+    }
+
+    sess.send("/exit\r").expect("send exit");
+    assert_eq!(sess.expect_eof().expect("exit"), 0);
+}
+
+/// `/account <name>` switches the project to another configured account and
+/// persists the selection through the same writer `/config set` uses, so the
+/// choice survives the session and a later `/account` reports it as chosen by
+/// `auth_profile` rather than by a default.
+#[test]
+fn account_switch_persists_the_selection() {
+    let env = TestEnv::new("account-switch");
+    write_two_account_config(&env);
+
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+    sess.set_default_timeout(Duration::from_secs(20));
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send("/account team-b\r")
+        .expect("send /account team-b");
+    sess.expect("Account updated").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("/account <name> should report the switch: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send exit");
+    assert_eq!(sess.expect_eof().expect("exit"), 0);
+
+    // On disk, in the scope-appropriate file — the same one `/config set
+    // auth_profile` writes, not a session-only toggle.
+    let settings_local = env
+        .workspace_root()
+        .join(".nexus")
+        .join("sudocode")
+        .join("settings.local.json");
+    let content = fs::read_to_string(&settings_local).unwrap_or_else(|e| {
+        panic!(
+            "settings.local.json should exist at {}: {e}",
+            settings_local.display()
+        )
+    });
+    assert!(
+        content.contains("auth_profile") && content.contains("team-b"),
+        "/account must persist the selection; settings.local.json:\n{content}"
+    );
+}
+
+/// An account that is not configured is refused, naming the ones that are.
+///
+/// Writing it instead would move the failure to the next request, where the
+/// selector refuses rather than billing someone else — correct, but by then
+/// the user has stopped looking at the command that caused it.
+#[test]
+fn account_refuses_a_name_that_is_not_configured() {
+    let env = TestEnv::new("account-unknown");
+    write_two_account_config(&env);
+
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+    sess.set_default_timeout(Duration::from_secs(20));
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send("/account no-such-account\r")
+        .expect("send /account no-such-account");
+    sess.expect("no account named").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("/account should refuse an unconfigured name: {e}\nPTY screen:\n{screen}");
+    });
+    sess.expect("team-b").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("the refusal should name what is configured: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send exit");
+    assert_eq!(sess.expect_eof().expect("exit"), 0);
+
+    // Nothing was written: a refused selection must not land on disk.
+    let settings_local = env
+        .workspace_root()
+        .join(".nexus")
+        .join("sudocode")
+        .join("settings.local.json");
+    let content = fs::read_to_string(&settings_local).unwrap_or_default();
+    assert!(
+        !content.contains("no-such-account"),
+        "a refused account must not be persisted; settings.local.json:\n{content}"
+    );
+}
+
+/// The per-turn status line names the account the turn was billed to.
+///
+/// Live-only for the same reason as `status_reports_the_billing_account_and_why`.
+#[test]
+fn turn_status_line_names_the_billing_account() {
+    let env = TestEnv::new("account-status-line");
+    if env.is_mock() {
+        eprintln!(
+            "skipping turn_status_line_names_the_billing_account: mock mode \
+             runs under --auth api-key (run with SCODE_TEST_BACKEND=live)"
+        );
+        return;
+    }
+
+    let mut sess = env.spawn(&["--permission-mode", "read-only"]);
+    sess.set_default_timeout(Duration::from_secs(120));
+    sess.expect("❯").expect("async REPL prompt");
+
+    sess.send("Reply with the single word: ok\r")
+        .expect("send prompt");
+    // `acct ` is emitted only by the status-line renderer, so unlike the model
+    // name it cannot be matched against the echo of the prompt.
+    sess.expect("acct ").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("turn status line should name the account: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("/exit\r").expect("send exit");
+    assert_eq!(sess.expect_eof().expect("exit"), 0);
+}

--- a/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_auth_profile.rs
@@ -168,6 +168,29 @@ fn write_auth_profile(env: &TestEnv, profile: &str) {
     .expect("write settings.local.json");
 }
 
+/// Wait for the REPL to be ready for input again, then exit and assert a clean
+/// shutdown.
+///
+/// The `expect("❯")` is the load-bearing half. A slash command's output can
+/// match while the REPL is still finishing the command, and keys sent into that
+/// window are not read as a submitted line — the session then never exits, and
+/// the failure surfaces as a timeout on the exit rather than on the command
+/// that caused it. The exit then gets its own budget, because teardown is a
+/// different cost from the command under test.
+fn exit_cleanly(sess: &mut pty_expect::PtySession) {
+    sess.expect("❯").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("REPL should return to the prompt: {e}\nPTY screen:\n{screen}");
+    });
+    sess.send("/exit\r").expect("send /exit");
+    sess.set_default_timeout(Duration::from_secs(60));
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
+}
+
 /// `/account` names who pays and lists what else is configured.
 ///
 /// The account is resolved per request from layered config, so it can be one
@@ -190,8 +213,7 @@ fn account_lists_configured_accounts_and_marks_current() {
         });
     }
 
-    sess.send("/exit\r").expect("send exit");
-    assert_eq!(sess.expect_eof().expect("exit"), 0);
+    exit_cleanly(&mut sess);
 }
 
 /// `/account <name>` switches the project to another configured account and
@@ -214,8 +236,7 @@ fn account_switch_persists_the_selection() {
         panic!("/account <name> should report the switch: {e}\nPTY screen:\n{screen}");
     });
 
-    sess.send("/exit\r").expect("send exit");
-    assert_eq!(sess.expect_eof().expect("exit"), 0);
+    exit_cleanly(&mut sess);
 
     // On disk, in the scope-appropriate file — the same one `/config set
     // auth_profile` writes, not a session-only toggle.
@@ -261,8 +282,7 @@ fn account_refuses_a_name_that_is_not_configured() {
         panic!("the refusal should name what is configured: {e}\nPTY screen:\n{screen}");
     });
 
-    sess.send("/exit\r").expect("send exit");
-    assert_eq!(sess.expect_eof().expect("exit"), 0);
+    exit_cleanly(&mut sess);
 
     // Nothing was written: a refused selection must not land on disk.
     let settings_local = env
@@ -279,7 +299,8 @@ fn account_refuses_a_name_that_is_not_configured() {
 
 /// The per-turn status line names the account the turn was billed to.
 ///
-/// Live-only for the same reason as `status_reports_the_billing_account_and_why`.
+/// Live-only: mock mode runs under `--auth api-key`, which bills no named
+/// account, so there is nothing for the line to name there.
 #[test]
 fn turn_status_line_names_the_billing_account() {
     let env = TestEnv::new("account-status-line");
@@ -304,6 +325,5 @@ fn turn_status_line_names_the_billing_account() {
         panic!("turn status line should name the account: {e}\nPTY screen:\n{screen}");
     });
 
-    sess.send("/exit\r").expect("send exit");
-    assert_eq!(sess.expect_eof().expect("exit"), 0);
+    exit_cleanly(&mut sess);
 }


### PR DESCRIPTION
## Why

A sudocode session spends someone's money, and nothing on screen said whose. The account is resolved per request from layered config, so it can easily be one nobody in this project chose — an `auth_profile` inherited from a parent directory, or simply the first entry in `auth_modes.proxy`. That stays invisible right up until the bill lands on the wrong account, which is exactly how an unhonored `auth_profile` went unnoticed while every request billed someone else.

## What changed

The selector reports the **rule** that chose the account, not just the name. `AccountSource` distinguishes an explicit `auth_profile` from a model mapping from the first-configured default — those read very differently, and only the second half of "billed to X because Y" makes a surprising X actionable.

Surfaced in three places, all from that one selector rather than a second copy of the precedence rules:

- **per-turn status line** gains `acct <name>`, next to the model:
  ```
  [claude-sonnet-4-6] · acct fujitoken · turn 3 · 12.6k tokens · $0.03 · 16.2s · ctx 12.6k/1M (1%) · main
  ```
- **`/status`** gains an `Account` line carrying the deciding rule, in the text report and the JSON alike (a JSON consumer that could not see the account would be reading a different `/status` than the terminal does).
- **`doctor`**'s Account check reports `chosen_by=<rule>` instead of echoing the raw `auth_profile` setting and leaving the decision to be inferred.

## `/account`

`/account` shows the same thing and lists what else is configured; `/account <name>` switches.

It **refuses a name that is not configured** — writing it would move the failure to the next request, where the selector refuses rather than billing someone else, by which point the user has stopped looking at the command that caused it.

A successful switch persists through the same scope-aware writer `/config set auth_profile` uses (project `settings.local.json`) **and rebuilds the session**. Persisting alone would leave the session spending the old account while every report named the new one — the same reported-vs-billed divergence this change exists to close.

## Incidental

`format_turn_status_line` now takes a `TurnStatus` struct. Eight positional arguments with three `Option`s in a row is one transposition away from silently reporting the window as the occupancy. The dead four-argument wrapper is deleted rather than carried.

## Verification

- `cargo test --workspace` green on Windows; `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean.
- Live on Windows (`SCODE_TEST_BACKEND=live`): the status line names the account through a real turn (`turn_status_line_names_the_billing_account`), and the `/account` list / switch / persist / refuse paths pass in both mock and live mode.