### PR TITLE
test(pty): un-ignore the queue-during-turn tests — the gate they blamed is gone

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_batched_flush.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_batched_flush.rs
@@ -51,7 +51,6 @@ use std::time::Duration;
 /// downstream requests. Regression guard for the batched-flush → sequential
 /// replay regression (would show as `after == before + 4`, not `+ 2`).
 #[test]
-#[ignore = "prompt_ready gating blocks input during turns — queue-during-turn needs redesign"]
 fn three_queued_inputs_flush_as_one_combined_downstream_request() {
     let env = TestEnv::new("batched-flush-request-count");
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_interrupt.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_interrupt.rs
@@ -49,7 +49,6 @@ const INTERRUPT_MARKER: &str = "INTERRUPT_TRIGGER_MARKER";
 /// guard for any change that breaks the `TurnDriver::abort_current_turn`
 /// → runtime abort → tool SIGTERM chain.
 #[test]
-#[ignore = "prompt_ready gating blocks input during turns — queue-during-turn needs redesign"]
 fn submit_during_turn_in_interrupt_mode_aborts_running_turn() {
     let env = TestEnv::new("repl-async-interrupt");
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_async_up_dequeue.rs
@@ -54,7 +54,6 @@ const MARKER: &str = "MARKER_QUEUED_INPUT";
 /// the hook wasn't installed, the coordinator wasn't shared, or the empty-
 /// buffer guard is inverted.
 #[test]
-#[ignore = "prompt_ready gating blocks input during turns — queue-during-turn needs redesign"]
 fn up_arrow_on_empty_buffer_dequeues_last_queued_input() {
     let env = TestEnv::new("repl-async-up-dequeue");
 


### PR DESCRIPTION
Three PTY tests have been skipped since 2026-08-02 (`06ee283e`) with the reason:

> `prompt_ready gating blocks input during turns — queue-during-turn needs redesign`

That gate is real, but it lives in `repl_async`'s **rustyline** coordinator, which parks its input thread on `prompt_ready` after every submit and therefore cannot take a second line mid-turn.

**Queue mode no longer reaches it.** Both REPL entry points (`main.rs:1006` and `main.rs:1595`) route any non-`off` `SUDOCODE_INTERRUPT_QUEUE_MODE` to `run_repl_iocraft_dispatch`, and all three tests set `queue` — so what they exercise today is the iocraft REPL, which delivers keys through its own render loop with no such gate. The reason on the attribute has been describing a path these tests do not take.

All three pass unmodified, and they are the regression guards for the **default** REPL's queue-during-turn behaviour:

| test | guards |
|---|---|
| `three_queued_inputs_flush_as_one_combined_downstream_request` | 3 queued inputs flush as ONE request, not replayed sequentially |
| `submit_during_turn_in_interrupt_mode_aborts_running_turn` | a mid-turn submit aborts the running turn and its tool |
| `up_arrow_on_empty_buffer_dequeues_last_queued_input` | `↑` pops the newest queued input back into the buffer |

Leaving them skipped left all of that unguarded on the path every user is actually on.

Verified on Windows: 3/3 runs each, green.

Follow-up, not in this PR: `run_repl_async_dispatch` (main.rs) has no callers at all, and `repl_async::run_coordinator_loop` is called only from it — the whole rustyline coordinator REPL is unreachable. That is a separate deletion.