### PR TITLE
fix(api): treat a truncated message_stop frame as a complete message, not a retryable error

### DIFF
--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -376,6 +376,7 @@ impl AnthropicClient {
             parser: SseParser::new().with_context("Anthropic", request.model.clone()),
             pending: VecDeque::new(),
             done: false,
+            logically_complete: false,
             request: request.clone(),
             prompt_cache: self.prompt_cache.clone(),
             latest_usage: None,
@@ -855,6 +856,12 @@ pub struct MessageStream {
     parser: SseParser,
     pending: VecDeque<StreamEvent>,
     done: bool,
+    /// Set once we observe a logical end-of-message (a `message_delta` with a
+    /// `stop_reason`, or a `message_stop`). After this the response is
+    /// semantically complete, so a truncated trailing frame (e.g. a proxy
+    /// cutting the connection right after `message_stop`) is harmless noise
+    /// and must not be surfaced as an `IncompleteStream` error.
+    logically_complete: bool,
     request: MessageRequest,
     prompt_cache: Option<PromptCache>,
     latest_usage: Option<Usage>,
@@ -877,7 +884,17 @@ impl MessageStream {
             }
 
             if self.done {
-                let remaining = self.parser.finish()?;
+                // The turn already ended (stop_reason or message_stop). If a
+                // trailing frame was truncated by a proxy dropping the
+                // connection after the logical end, that leftover is noise:
+                // ignore the parse error rather than turning a completed
+                // message into a spurious IncompleteStream. Only surface the
+                // error when the stream stopped WITHOUT a logical end.
+                let remaining = match self.parser.finish() {
+                    Ok(remaining) => remaining,
+                    Err(_) if self.logically_complete => Vec::new(),
+                    Err(error) => return Err(error),
+                };
                 self.pending.extend(remaining);
                 if let Some(event) = self.pending.pop_front() {
                     return Ok(Some(event));
@@ -906,10 +923,12 @@ impl MessageStream {
                 // connection alive after the logical stream has ended.
                 if delta.stop_reason.is_some() {
                     self.done = true;
+                    self.logically_complete = true;
                 }
             }
             StreamEvent::MessageStop(_) => {
                 self.done = true;
+                self.logically_complete = true;
                 if !self.usage_recorded {
                     if let Some(usage) = self.latest_usage.as_ref() {
                         if let Some(prompt_cache) = &self.prompt_cache {

--- a/rust/crates/api/src/sse.rs
+++ b/rust/crates/api/src/sse.rs
@@ -54,6 +54,14 @@ impl SseParser {
         match self.parse_frame_with_context(&tail) {
             Ok(Some(event)) => Ok(vec![event]),
             Ok(None) => Ok(Vec::new()),
+            // The tail did not parse. If it is the *start* of a terminal frame
+            // (a `message_stop` — the last event Anthropic emits), the stream
+            // reached its logical end and only the closing `}\n\n` bytes were
+            // dropped by a proxy cutting the connection. That is a complete
+            // message, not a truncated one: swallow it rather than forcing a
+            // wasteful whole-turn retry (or a retry loop against a proxy that
+            // keeps truncating the same terminal frame).
+            Err(_) if tail_began_terminal_frame(&tail) => Ok(Vec::new()),
             Err(_) => Err(ApiError::incomplete_stream(
                 self.provider.as_deref().unwrap_or("unknown"),
                 self.model.as_deref().unwrap_or("unknown"),
@@ -93,6 +101,35 @@ impl SseParser {
 
 pub fn parse_frame(frame: &str) -> Result<Option<StreamEvent>, ApiError> {
     parse_frame_with_provider(frame, "unknown", "unknown")
+}
+
+/// Whether an unparseable trailing frame is the *beginning* of a terminal
+/// event — the last frame Anthropic emits (`message_stop`). Used by
+/// [`SseParser::finish`] to distinguish a proxy dropping the closing bytes of
+/// the final frame (the message is complete) from a mid-content truncation
+/// (retryable). Matches on the SSE `event:` line and, as a fallback, the
+/// leading `"type":"message_stop"` of the partial `data:` JSON, so it works
+/// whether the cut landed before or after the event line.
+fn tail_began_terminal_frame(tail: &str) -> bool {
+    for line in tail.trim().lines() {
+        let line = line.trim();
+        if let Some(name) = line.strip_prefix("event:") {
+            if name.trim() == "message_stop" {
+                return true;
+            }
+        }
+        if let Some(data) = line.strip_prefix("data:") {
+            let data = data.trim_start();
+            // The JSON may be cut anywhere after the type; a prefix match is
+            // enough to recognize the terminal event.
+            if data.starts_with("{\"type\":\"message_stop\"")
+                || data.starts_with("{ \"type\": \"message_stop\"")
+            {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 pub(crate) fn parse_frame_with_provider(
@@ -444,5 +481,54 @@ mod tests {
             .finish()
             .expect("unterminated final frame still parses");
         assert_eq!(events.len(), 1, "the final frame should yield its event");
+    }
+
+    #[test]
+    fn finish_swallows_a_truncated_message_stop_frame() {
+        // Real incident: a proxy cut the connection right after the terminal
+        // `message_stop` event, leaving `event: message_stop\ndata: {"type":"m`
+        // in the buffer. The message is logically complete — only the closing
+        // bytes were dropped — so finish() must NOT surface a retryable
+        // IncompleteStream (which forces a wasteful whole-turn retry, or loops
+        // against a proxy that keeps truncating the same terminal frame).
+        let mut parser = SseParser::new().with_context("anthropic", "claude-opus-5");
+        let partial = b"event: message_stop\ndata: {\"type\":\"m";
+        assert!(parser.push(partial).expect("partial buffers").is_empty());
+
+        let events = parser
+            .finish()
+            .expect("a truncated terminal frame is a complete message, not an error");
+        assert!(
+            events.is_empty(),
+            "no event is emitted from the dropped closing bytes"
+        );
+    }
+
+    #[test]
+    fn finish_swallows_truncated_message_stop_even_before_the_event_line() {
+        // Same completion signal, but the cut landed inside the data JSON with
+        // no preceding event line survived — the `"type":"message_stop"` prefix
+        // alone must still be recognized as the terminal frame.
+        let mut parser = SseParser::new().with_context("anthropic", "claude-opus-5");
+        let partial = b"data: {\"type\":\"message_stop\"";
+        assert!(parser.push(partial).expect("partial buffers").is_empty());
+
+        let events = parser.finish().expect("terminal frame is complete");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn finish_still_errors_on_a_truncated_content_frame() {
+        // A mid-content truncation (not a terminal frame) is a real transport
+        // failure and must remain a retryable IncompleteStream.
+        let mut parser = SseParser::new().with_context("anthropic", "claude-opus-5");
+        let partial = b"event: content_block_delta\ndata: {\"type\":\"content_block_del";
+        assert!(parser.push(partial).expect("partial buffers").is_empty());
+
+        let err = parser
+            .finish()
+            .expect_err("a truncated content frame must still error");
+        assert!(matches!(err, ApiError::IncompleteStream { .. }));
+        assert!(err.is_retryable());
     }
 }


### PR DESCRIPTION
## Summary

A proxy can cut the connection right after Anthropic's terminal `message_stop` event, dropping only the closing bytes of the final SSE frame. The buffer is then left holding a partial `event: message_stop\ndata: {"type":"m` frame, which `finish()` surfaced as a retryable `IncompleteStream` — forcing a wasteful whole-turn retry, or an infinite retry loop against a proxy that keeps truncating the same terminal frame. (This is the "Anthropic stream ended mid-frame … `event: message_stop`" failure.)

The message is **logically complete** at that point — only the closing bytes were dropped — so it should be treated as a finished turn, not an error.

Two complementary guards:

- **`sse.rs` (stateless parse layer).** When the unparseable trailing frame is the *start* of a terminal `message_stop` frame, `finish()` swallows it instead of erroring. Matches on the SSE `event:` line and, as a fallback, the leading `"type":"message_stop"` of the partial `data:` JSON, so it works whether the cut landed before or after the event line.
- **`anthropic.rs` (stateful stream layer).** `MessageStream` tracks `logically_complete`, set on a `message_delta` carrying a `stop_reason` or a `message_stop`. Once set, a trailing `finish()` parse error is ignored rather than turned into a spurious `IncompleteStream`. This catches the case where the whole terminal frame never arrived but the logical end was already signalled.

**Safety boundary preserved:** a mid-content truncation (no logical end reached) still errors and stays retryable — covered by a test.

## Test plan

- `cargo test -p api` — 199 pass, including:
  - `finish_swallows_a_truncated_message_stop_frame`
  - `finish_swallows_truncated_message_stop_even_before_the_event_line`
  - `finish_still_errors_on_a_truncated_content_frame` (boundary: mid-content truncation stays a retryable `IncompleteStream`)
  - `finish_on_truncated_frame_reports_incomplete_stream_not_json_error`
- `cargo fmt -p api --check` clean; `cargo clippy -p api` clean for the changed files.
