### PR TITLE
fix(engine): resume reads the model from config SSOT, not the session pin

### DIFF
--- a/rust/crates/engine-host/src/session_engine.rs
+++ b/rust/crates/engine-host/src/session_engine.rs
@@ -30,6 +30,33 @@ use crate::session::{
     load_session_reference, new_cli_session_for, SessionHandle,
 };
 
+/// Resolve which model a resumed session runs on — the Claude Code rule, where
+/// the config is the single source of truth for the model.
+///
+/// - An explicit `--model` flag always wins (`model_flag_raw` is `Some`).
+/// - Otherwise the current config default is used (`resolve_repl_model`), so
+///   changing the global model applies to resumed sessions too.
+///
+/// The persisted transcript's `session.model` is deliberately NOT consulted: it
+/// is only a descriptive record of the model the transcript last ran on (shown
+/// in the resume list / `/status`), never the selector. `/model` switches within
+/// a session are runtime-only and do not survive resume. Auto-compaction sizes
+/// the context window from the runtime's active model (this same config SSOT),
+/// so it stays correct regardless of what the transcript records.
+///
+/// `already_resolved_default` is the model the caller already computed for the
+/// no-flag case (the config default); when a flag was passed it is the resolved
+/// flag value. Kept as one helper so every resume path resolves identically.
+fn resume_model_from_config_ssot(
+    model_flag_raw: Option<&str>,
+    already_resolved_default: &str,
+) -> String {
+    match model_flag_raw {
+        Some(_) => already_resolved_default.to_string(),
+        None => resolve_repl_model(already_resolved_default.to_string()),
+    }
+}
+
 // === moved from rusty-sudocode-cli/src/main.rs (CORE cluster extraction) ===
 
 pub struct AcpCliSession {
@@ -56,8 +83,9 @@ pub struct AcpCliSession {
 /// returning the seam's neutral `TurnComplete`. Every renderer shares this one
 /// core — nothing renders here.
 ///
-/// The active model is the session's own (`session.model`); this type keeps no
-/// separate copy.
+/// The active model is the model the runtime was built with from the config
+/// SSOT (see [`resume_model_from_config_ssot`] and `ConversationRuntime`'s
+/// `running_model`); `session.model` is only a descriptive record.
 /// Outcome of a model switch, returned by [`SessionEngine::set_model_impl`] so
 /// each seam consumer formats it its own way: the REPL renders a
 /// `format_model_switch_report` / `format_model_report`; the pump/ACP path takes
@@ -222,18 +250,9 @@ impl SessionEngine {
     ) -> Result<Self, String> {
         let cwd = canonical_session_cwd(cwd)?;
         let _scope = runtime::WorkspaceRootScope::enter(&cwd);
-        // A persisted transcript carries the model it was last run with
-        // (`build_runtime_with_plugin_state` records it). Prefer that over the
-        // directory's default: resuming a session that had been switched to
-        // another model must not silently drop back to the config model, which
-        // would run the rest of the conversation on the wrong model and
-        // mis-size the context window for auto-compaction. An explicit
-        // `--model` flag still wins.
-        let resolved_model = match (&model_flag_raw, &session.model) {
-            (Some(_), _) => model.clone(),
-            (None, Some(persisted)) => persisted.clone(),
-            (None, None) => resolve_repl_model(model.clone()),
-        };
+        // Model resolution on resume follows Claude Code: the config is the
+        // single source of truth. See [`resume_model_from_config_ssot`].
+        let resolved_model = resume_model_from_config_ssot(model_flag_raw.as_deref(), &model);
         let permission_mode = permission_mode_override.unwrap_or_else(default_permission_mode);
         let sudocode_config = require_sudocode_config_for_cwd(&cwd)?;
         let resolved_auth = resolve_auth_mode(&resolved_model, auth_mode, &sudocode_config)
@@ -1149,5 +1168,30 @@ impl SessionLifecycle for SessionEngine {
             .save_to_path(&path)
             .map_err(|e| e.to_string())?;
         Ok((removed, kept, skipped, summary_source))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resume_model_from_config_ssot;
+
+    #[test]
+    fn resume_model_flag_wins_and_is_used_verbatim() {
+        // An explicit --model flag (already alias-resolved by the caller) is
+        // used as-is on resume, regardless of what the transcript recorded.
+        let resolved = resume_model_from_config_ssot(Some("claude-opus-4-8"), "claude-opus-4-8");
+        assert_eq!(resolved, "claude-opus-4-8");
+    }
+
+    #[test]
+    fn resume_never_consults_the_session_pin() {
+        // Structural guarantee: the resolver takes only the flag and the
+        // config-resolved default — it has no parameter for the persisted
+        // `session.model`, so a stale transcript model can never drive
+        // selection. This test documents that contract at the type level; if
+        // someone re-adds a `session.model` argument, it will fail to compile
+        // against this call and force a review of the SSOT rule.
+        let with_flag = resume_model_from_config_ssot(Some("m"), "m");
+        assert_eq!(with_flag, "m");
     }
 }

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -930,6 +930,21 @@ where
             .unwrap_or_default()
     }
 
+    /// The model the runtime is actually running on — the config SSOT model it
+    /// was built with (`prompt_known_model`, set from `RuntimeConfig.model` and
+    /// re-set on every `/model` rebuild). Used to size the auto-compaction
+    /// context window and to tag assistant messages. Unlike [`Self::active_model`]
+    /// this prefers `prompt_known_model` over the persisted `session.model`,
+    /// because on resume `session.model` still records the transcript's old
+    /// model while the runtime already runs on the current config default.
+    /// Empty only when a unit test builds a runtime without announcing a model.
+    fn running_model(&self) -> &str {
+        self.prompt_known_model
+            .as_deref()
+            .or(self.session.model.as_deref())
+            .unwrap_or_default()
+    }
+
     /// `true` when some message already announced the active model to the
     /// assistant, via either the first-turn announcement or a change reminder.
     /// Scanning the session self-heals after compaction removes the carrier.
@@ -1586,7 +1601,10 @@ where
                     }
                 };
             response_model = iter_response_model;
-            assistant_message.model.clone_from(&self.session.model);
+            assistant_message.model = {
+                let running = self.running_model();
+                (!running.is_empty()).then(|| running.to_string())
+            };
             if let Some(usage) = usage {
                 self.usage_tracker.record(usage);
             }
@@ -2303,7 +2321,12 @@ where
     }
 
     async fn maybe_auto_compact(&mut self) -> Option<AutoCompactionEvent> {
-        let model = self.session.model.as_deref().unwrap_or("claude-sonnet-4-6");
+        let running = self.running_model();
+        let model = if running.is_empty() {
+            "claude-sonnet-4-6"
+        } else {
+            running
+        };
         let threshold = auto_compact_threshold_for_model(model);
         // Compare the context the provider actually processed on the latest
         // response (uncached input + cache reads + cache writes) against the


### PR DESCRIPTION
## Summary

Align model resolution with Claude Code: **the config is the single source of truth for which model a session runs on.** Previously a resumed session was pinned to the model recorded in its transcript (`session.model`), so changing the global default model did **not** apply on `--resume` — you had to `/model` back every time.

### Behavior change

- `--resume` (no `--model`) now runs on the **current config default**, not the transcript's recorded model. Change the global model once and every resumed session follows.
- An explicit `--model` flag still wins.
- `/model` switches within a session are runtime-only and do not survive resume (matches CC — `mainLoopModelOverride` is runtime state, never persisted as the selector).
- `session.model` stays as a **descriptive record** for the resume list / `/status` display — it is simply no longer a *selector*.

### Why this is safe (auto-compaction)

CC sizes the auto-compact context window from the *currently active* model every turn, not a persisted one — so "read config SSOT" keeps window sizing correct by construction. This PR does the same: auto-compaction and message tagging now read `ConversationRuntime::running_model()` (the model the runtime was built with from the config SSOT, re-set on every `/model` rebuild), replacing the old `session.model` read and its hardcoded `"claude-sonnet-4-6"` fallback path.

### DRY / no-leak design

- One `resume_model_from_config_ssot(flag, config_default)` helper is the sole resume resolver. Its signature has **no `session.model` parameter**, so the pin cannot leak back into selection — a compile-time guard: re-adding the arg breaks the call and forces review.
- `running_model()` (compaction/tagging, config SSOT) and `active_model()` (the `/model`-change announcement detector, which intentionally reads `session.model` to answer "what will the next request use") are kept as two distinct, documented concepts rather than conflated.

## Test plan

- `cargo test -p runtime` — 667 pass, incl. `model_change_is_announced_mid_session`, `first_turn_announces_active_model_after_user_content`, auto-compact, `per_message_model_round_trips_through_jsonl`.
- `cargo test -p engine-host` — 11 pass, incl. new `resume_model_flag_wins_and_is_used_verbatim` / `resume_never_consults_the_session_pin`.
- `resume_slash_commands` (12) pass — `resumed_status_surfaces_persisted_model` confirms the descriptive record still round-trips to `/status`.
- `cargo fmt --all --check` clean; changed files clippy-clean.
