### PR TITLE
fix(cli): report provider retries again, through the seam

### DIFF
--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -190,7 +190,7 @@ impl ProviderClient {
 
     pub fn set_retry_notifier(
         &mut self,
-        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+        notifier: Option<std::sync::Arc<dyn crate::http_transport::RetryNotifier>>,
     ) {
         match self {
             Self::Anthropic(client) => client.set_retry_notifier(notifier),

--- a/rust/crates/api/src/http_transport.rs
+++ b/rust/crates/api/src/http_transport.rs
@@ -140,8 +140,8 @@ impl HttpTransport {
         }
     }
 
-    pub fn set_retry_notifier(&mut self, notifier: std::sync::Arc<dyn RetryNotifier>) {
-        self.retry_notifier = Some(notifier);
+    pub fn set_retry_notifier(&mut self, notifier: Option<std::sync::Arc<dyn RetryNotifier>>) {
+        self.retry_notifier = notifier;
     }
 
     #[must_use]
@@ -352,16 +352,15 @@ impl HttpTransport {
                     }
                     other => format!("{other}"),
                 };
+                // Reported only through the notifier. A transport writing to
+                // the terminal itself is the boundary leak the engine/renderer
+                // split exists to remove: it lands wherever the cursor happens
+                // to be, no renderer can style or suppress it, and — the reason
+                // this comment exists — it silently stood in for the real
+                // indicator once the notifier stopped being installed, which is
+                // what let that regression go unnoticed.
                 if let Some(ref notifier) = self.retry_notifier {
                     notifier.on_retry(attempts, retry_policy.max_retries, &reason);
-                } else {
-                    eprintln!(
-                        "  \u{27f3} retry {}/{} in {:.0}s \u{2014} {}",
-                        attempts,
-                        retry_policy.max_retries,
-                        delay.as_secs_f64(),
-                        reason,
-                    );
                 }
             }
             tokio::time::sleep(delay).await;

--- a/rust/crates/api/src/providers/anthropic.rs
+++ b/rust/crates/api/src/providers/anthropic.rs
@@ -276,7 +276,7 @@ impl AnthropicClient {
 
     pub fn set_retry_notifier(
         &mut self,
-        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+        notifier: Option<std::sync::Arc<dyn crate::http_transport::RetryNotifier>>,
     ) {
         self.http.set_retry_notifier(notifier);
     }

--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -118,7 +118,7 @@ impl CodexClient {
 
     pub fn set_retry_notifier(
         &mut self,
-        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+        notifier: Option<std::sync::Arc<dyn crate::http_transport::RetryNotifier>>,
     ) {
         self.http.set_retry_notifier(notifier);
     }

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -133,7 +133,7 @@ impl GeminiClient {
 
     pub fn set_retry_notifier(
         &mut self,
-        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+        notifier: Option<std::sync::Arc<dyn crate::http_transport::RetryNotifier>>,
     ) {
         self.http.set_retry_notifier(notifier);
     }

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -172,7 +172,7 @@ impl OpenAiCompatClient {
 
     pub fn set_retry_notifier(
         &mut self,
-        notifier: std::sync::Arc<dyn crate::http_transport::RetryNotifier>,
+        notifier: Option<std::sync::Arc<dyn crate::http_transport::RetryNotifier>>,
     ) {
         self.http.set_retry_notifier(notifier);
     }

--- a/rust/crates/engine-core/src/engine_client.rs
+++ b/rust/crates/engine-core/src/engine_client.rs
@@ -277,8 +277,36 @@ impl EngineApiClient {
     }
 }
 
+/// Carries a [`runtime::RetrySink`] across the one boundary where the
+/// transport's own callback shape and the seam's meet.
+///
+/// `api` cannot name a runtime sink and the renderer cannot name an `api`
+/// notifier — the compiler gate exists precisely to keep it that way — so the
+/// translation happens here, in the crate that legitimately sees both.
+struct RetrySinkNotifier(runtime::RetrySink);
+
+impl api::RetryNotifier for RetrySinkNotifier {
+    fn on_retry(&self, attempt: u32, max_retries: u32, reason: &str) {
+        self.0.emit(runtime::RetryEvent::Waiting {
+            attempt,
+            max_retries,
+            reason: reason.to_string(),
+        });
+    }
+
+    fn on_retry_end(&self) {
+        self.0.emit(runtime::RetryEvent::Resumed);
+    }
+}
+
 #[async_trait]
 impl ApiClient for EngineApiClient {
+    fn set_retry_sink(&mut self, sink: Option<runtime::RetrySink>) {
+        self.client.set_retry_notifier(sink.map(|sink| {
+            std::sync::Arc::new(RetrySinkNotifier(sink)) as std::sync::Arc<dyn api::RetryNotifier>
+        }));
+    }
+
     async fn send_compaction(
         &mut self,
         model: &str,

--- a/rust/crates/engine-core/src/session.rs
+++ b/rust/crates/engine-core/src/session.rs
@@ -467,6 +467,20 @@ impl RuntimeObserver for ObserverAdapter {
                 .send(EngineEvent::HookProgress(event));
         }))
     }
+
+    fn retry_sink(&self) -> Option<runtime::RetrySink> {
+        // Same shape and same reason as `hook_progress_sink`: the emitter is
+        // the HTTP transport on its own task, so the channel is wrapped to be
+        // `Send + Sync`. Reporting retries through the seam is what stops the
+        // transport writing to the terminal behind the renderer's back.
+        let tx = Arc::new(Mutex::new(self.tx.clone()));
+        Some(runtime::RetrySink::new(move |event| {
+            let _ = tx
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .send(EngineEvent::Retry(event));
+        }))
+    }
 }
 
 /// `PermissionPrompter::decide` → emit [`EngineEvent::PermissionRequest`], park

--- a/rust/crates/engine-events/src/lib.rs
+++ b/rust/crates/engine-events/src/lib.rs
@@ -57,6 +57,8 @@ pub use runtime::{
     QuestionOption,
     QuestionPromptAnswer,
     QuestionPromptRequest,
+    // What the HTTP transport is doing while it retries a failed request.
+    RetryEvent,
     // Incremental + cumulative token usage (AssistantEvent::Usage,
     // TurnSummary::{turn_usage,session_usage}).
     TokenUsage,
@@ -166,6 +168,10 @@ pub enum EngineEvent {
     /// `CliHookProgressReporter` stderr sink in the REPL, now surfaced through
     /// the seam. Structured; the renderer formats it.
     HookProgress(HookProgressEvent),
+    /// The HTTP transport is retrying a failed request (provider 429/5xx).
+    /// Without it a backoff is indistinguishable from a slow model: seconds of
+    /// nothing, repeatedly. Structured; the renderer formats it.
+    Retry(RetryEvent),
     /// Incremental token usage for the in-flight assistant message (was
     /// `AssistantEvent::Usage`, previously only reaching `TurnSummary`).
     Usage(TokenUsage),

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -165,6 +165,10 @@ enum Scenario {
     /// compaction request, since compaction requests are classified by the
     /// markers of the messages being summarised.
     DelayedText,
+    /// First request answers 429, the next succeeds — the only way to exercise
+    /// the transport's retry loop, and therefore the retry indicator, without
+    /// waiting on a real provider to rate-limit us.
+    RetryThenSucceed,
 }
 
 /// How long [`Scenario::DelayedText`] holds a request before answering.
@@ -206,6 +210,7 @@ impl Scenario {
             "llm_compaction_roundtrip" => Some(Self::LlmCompactionRoundtrip),
             "delayed_text" => Some(Self::DelayedText),
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
+            "retry_then_succeed" => Some(Self::RetryThenSucceed),
             _ => None,
         }
     }
@@ -243,6 +248,7 @@ impl Scenario {
             Self::LlmCompactionRoundtrip => "llm_compaction_roundtrip",
             Self::DelayedText => "delayed_text",
             Self::AskUserQuestionRoundtrip => "ask_user_question_roundtrip",
+            Self::RetryThenSucceed => "retry_then_succeed",
         }
     }
 }
@@ -261,6 +267,7 @@ async fn handle_connection(
     let scenario = detect_scenario(&request)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing parity scenario"))?;
 
+    let path_for_count = path.clone();
     requests.lock().await.push(CapturedRequest {
         method,
         path,
@@ -273,7 +280,19 @@ async fn handle_connection(
     if scenario == Scenario::DelayedText {
         tokio::time::sleep(DELAYED_TEXT_LATENCY).await;
     }
-    let response = build_http_response(&request, scenario);
+    // How many times this scenario has already been served AT THIS PATH, so a
+    // scenario can answer differently on a retry. Per-path because a turn is
+    // not one request: the Anthropic provider also asks `/v1/messages/count_tokens`
+    // to refine its preflight, best-effort, and swallows the failure. Counting
+    // scenario-wide would let that call absorb the answer meant for the turn.
+    let attempt = requests
+        .lock()
+        .await
+        .iter()
+        .filter(|captured| captured.scenario == scenario.name() && captured.path == path_for_count)
+        .count()
+        .saturating_sub(1);
+    let response = build_http_response(&request, scenario, attempt);
     socket.write_all(response.as_bytes()).await?;
     Ok(())
 }
@@ -456,7 +475,15 @@ fn flatten_tool_result_content(content: &[api::ToolResultContentBlock]) -> Strin
 }
 
 #[allow(clippy::too_many_lines)]
-fn build_http_response(request: &MessageRequest, scenario: Scenario) -> String {
+fn build_http_response(request: &MessageRequest, scenario: Scenario, attempt: usize) -> String {
+    if scenario == Scenario::RetryThenSucceed && attempt == 0 {
+        return http_response(
+            "429 Too Many Requests",
+            "application/json",
+            r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#,
+            &[("request-id", request_id_for(scenario))],
+        );
+    }
     let response = if request.stream {
         let body = build_stream_body(request, scenario);
         return http_response(
@@ -480,7 +507,9 @@ fn build_http_response(request: &MessageRequest, scenario: Scenario) -> String {
 #[allow(clippy::too_many_lines)]
 fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
     match scenario {
-        Scenario::StreamingText | Scenario::DelayedText => streaming_text_sse(),
+        Scenario::StreamingText | Scenario::DelayedText | Scenario::RetryThenSucceed => {
+            streaming_text_sse()
+        }
         Scenario::MarkdownRenderingShowcase => markdown_showcase_sse(),
         Scenario::ReadFileRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => final_text_sse(&format!(
@@ -794,10 +823,12 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
         Scenario::MarkdownRenderingShowcase => {
             text_message_response("msg_markdown_showcase", MARKDOWN_SHOWCASE_DOC)
         }
-        Scenario::StreamingText | Scenario::DelayedText => text_message_response(
-            "msg_streaming_text",
-            "Mock streaming says hello from the parity harness.",
-        ),
+        Scenario::StreamingText | Scenario::DelayedText | Scenario::RetryThenSucceed => {
+            text_message_response(
+                "msg_streaming_text",
+                "Mock streaming says hello from the parity harness.",
+            )
+        }
         Scenario::ReadFileRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => text_message_response(
                 "msg_read_file_final",
@@ -1214,6 +1245,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         }
         Scenario::LlmCompactionRoundtrip => "req_llm_compaction_roundtrip",
         Scenario::AskUserQuestionRoundtrip => "req_ask_user_question_roundtrip",
+        Scenario::RetryThenSucceed => "req_retry_then_succeed",
     }
 }
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -147,6 +147,13 @@ pub trait ApiClient: Send {
             "compaction not supported by this API client",
         ))
     }
+
+    /// Install (or clear) the sink the transport reports retries to.
+    ///
+    /// Called once per turn with the current observer's sink, because the
+    /// renderer a turn belongs to changes while the client does not. Clients
+    /// whose transport has no retry loop ignore it.
+    fn set_retry_sink(&mut self, _sink: Option<crate::conversation::RetrySink>) {}
 }
 
 /// Optional observer for runtime events emitted while processing a turn.
@@ -217,6 +224,16 @@ pub trait RuntimeObserver {
     /// self` hooks above: the reporter is invoked from the (synchronous) hook
     /// runner, so it needs a `Send + Sync` value, not a borrow of the observer.
     fn hook_progress_sink(&self) -> Option<HookProgressSink> {
+        None
+    }
+
+    /// Sink for the HTTP transport's retry loop, installed into the API client
+    /// at the start of each turn (see `run_turn_with_blocks`). Same reason as
+    /// `hook_progress_sink` for not being a `&mut self` hook: the transport
+    /// reports from its own async task, so it needs an owned `Send + Sync`
+    /// value. A renderer that returns `None` leaves the client's own default
+    /// behaviour in place.
+    fn retry_sink(&self) -> Option<RetrySink> {
         None
     }
 }
@@ -300,6 +317,56 @@ impl HookProgressSink {
 impl std::fmt::Debug for HookProgressSink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("HookProgressSink(..)")
+    }
+}
+
+/// What the HTTP transport is doing while it retries a failed request.
+///
+/// A provider 429 or 5xx is retried with backoff, and from the outside that is
+/// indistinguishable from the model being slow — several seconds of nothing,
+/// repeatedly. The transport therefore reports what it is doing, and this is
+/// the shape that report takes on its way to a renderer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryEvent {
+    /// A request failed and the transport is waiting before trying again.
+    /// `attempt` is 1-based.
+    Waiting {
+        attempt: u32,
+        max_retries: u32,
+        reason: String,
+    },
+    /// The wait is over and the request is going back out.
+    Resumed,
+}
+
+/// A `Send + Sync` sink a renderer installs (via
+/// [`RuntimeObserver::retry_sink`]) to receive [`RetryEvent`]s from the HTTP
+/// transport's retry loop.
+///
+/// The seam analogue of [`HookProgressSink`], and it exists for the same
+/// reason: the emitter is neither the observer nor on the observer's thread —
+/// here it is the transport, below the runtime — so it needs an owned
+/// `Send + Sync` value rather than a borrow. The runtime hands it to the API
+/// client for the turn; the client adapts it to whatever notifier its
+/// transport wants.
+#[derive(Clone)]
+pub struct RetrySink(std::sync::Arc<dyn Fn(RetryEvent) + Send + Sync>);
+
+impl RetrySink {
+    /// Wrap a retry handler.
+    pub fn new(f: impl Fn(RetryEvent) + Send + Sync + 'static) -> Self {
+        Self(std::sync::Arc::new(f))
+    }
+
+    /// Report one retry event to the renderer.
+    pub fn emit(&self, event: RetryEvent) {
+        (self.0)(event);
+    }
+}
+
+impl std::fmt::Debug for RetrySink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RetrySink(..)")
     }
 }
 
@@ -699,15 +766,6 @@ where
         self.tool_executor
             .set_abort_signal(hook_abort_signal.clone());
         self.hook_abort_signal = hook_abort_signal;
-        self
-    }
-
-    #[must_use]
-    pub fn with_hook_progress_reporter(
-        mut self,
-        hook_progress_reporter: Box<dyn HookProgressReporter + Send>,
-    ) -> Self {
-        self.hook_progress_reporter = Some(hook_progress_reporter);
         self
     }
 
@@ -1273,16 +1331,17 @@ where
     #[allow(clippy::too_many_lines)]
     /// Run a turn, then tear down what was installed *for* that turn.
     ///
-    /// The hook-progress reporter is the one such thing. It is rebuilt from the
-    /// observer at the start of every turn, so it must not survive the turn
-    /// either — and it used to, because nothing cleared it. That pins the
-    /// renderer's live event channel open after the turn has already returned.
-    /// The REPL never noticed; the ACP server waits for exactly that channel to
-    /// close before answering `session/prompt`, and so waited forever.
+    /// Two such things: the hook-progress reporter and the API client's retry
+    /// sink. Both are rebuilt from the observer at the start of every turn, so
+    /// neither may survive it — and the reporter used to, because nothing
+    /// cleared it. Anything holding a clone of the renderer's event channel
+    /// pins that channel open after the turn has already returned. The REPL
+    /// never notices; the ACP server waits for exactly that channel to close
+    /// before answering `session/prompt`, and so waits forever.
     ///
-    /// Only cleared when this turn installed it: a reporter supplied at build
-    /// time through [`with_hook_progress_reporter`](Self::with_hook_progress_reporter)
-    /// is not per-turn and stays.
+    /// The reporter is only cleared when this turn installed it, since one can
+    /// also be supplied at build time. The retry sink has no build-time form,
+    /// so it is always cleared.
     pub async fn run_turn_with_blocks(
         &mut self,
         blocks: Vec<ContentBlock>,
@@ -1299,6 +1358,7 @@ where
         if installs_hook_reporter {
             self.hook_progress_reporter = None;
         }
+        self.api_client.set_retry_sink(None);
         summary
     }
 
@@ -1376,6 +1436,12 @@ where
         {
             self.hook_progress_reporter = Some(Box::new(SinkHookReporter(sink)));
         }
+
+        // Retry reporting follows the observer, so it is set unconditionally —
+        // passing `None` when this observer wants none is what stops a previous
+        // turn's renderer from still receiving events.
+        self.api_client
+            .set_retry_sink(observer.as_deref().and_then(RuntimeObserver::retry_sink));
 
         let mut assistant_messages = Vec::new();
         let mut tool_results = Vec::new();

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -112,8 +112,9 @@ pub use config_validate::{
 pub use conversation::{
     auto_compact_threshold_for_model, ApiClient, ApiRequest, AssistantEvent, AssistantEventStream,
     AutoCompactionEvent, CompactionMethod, ConversationRuntime, HookProgressSink, ProgressSink,
-    PromptCacheEvent, RuntimeError, RuntimeObserver, StaticToolExecutor, ToolDispatchContext,
-    ToolError, ToolExecutor, ToolProgressEvent, TurnSummary, FORK_BOILERPLATE_TAG,
+    PromptCacheEvent, RetryEvent, RetrySink, RuntimeError, RuntimeObserver, StaticToolExecutor,
+    ToolDispatchContext, ToolError, ToolExecutor, ToolProgressEvent, TurnSummary,
+    FORK_BOILERPLATE_TAG,
 };
 pub use file_intent::{detect_file_intent, FileIntent, FileOpKind, UserRequestIntent};
 pub use file_ops::{

--- a/rust/crates/rusty-sudocode-cli/src/render_engine.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render_engine.rs
@@ -13,7 +13,7 @@ use std::io::{self, Write};
 
 use engine_events::{
     EngineEvent, HookProgressEvent, PermissionRequest, QuestionPromptRequest, RequestId,
-    ToolProgressEvent,
+    RetryEvent, ToolProgressEvent,
 };
 
 use crate::cli::format::{format_tool_call_start, format_tool_result};
@@ -85,6 +85,43 @@ impl EngineEventRenderer {
     fn resume_spinner(&self) {
         if let Some(s) = &self.spinner {
             s.resume();
+        }
+    }
+
+    /// Show that the transport is retrying a failed request.
+    ///
+    /// The line is unconditional. A status-line phase alone would be invisible
+    /// on the paths that have no phase to set — the rustyline REPL and
+    /// `--print` both hold a spinner whose `phase` is `None` — and "the
+    /// indicator exists but not where you are looking" is how this stopped
+    /// being visible in the first place. Where a phase IS available (iocraft)
+    /// it is set too, so a long backoff also reads on the live status line
+    /// rather than only in scrollback.
+    fn render_retry(&mut self, event: &RetryEvent) {
+        {
+            use std::io::Write as _;
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("C:/Users/songym/AppData/Local/Temp/claude/C--Users-songym-cursor-projects-nexus/98991364-6741-4069-89d2-900c0379fb58/scratchpad/retry_dbg.log") { let _ = writeln!(f, "renderer render_retry {:?}", event); }
+        }
+        match event {
+            RetryEvent::Waiting {
+                attempt,
+                max_retries,
+                reason,
+            } => {
+                self.pause_spinner();
+                self.write_out(&format!(
+                    "{DIM}  \u{27f3} retry {attempt}/{max_retries} \u{2014} {reason}{RESET}\n"
+                ));
+                self.resume_spinner();
+                if let Some(spinner) = &self.spinner {
+                    spinner.set_retry(*attempt, *max_retries, reason.clone());
+                }
+            }
+            RetryEvent::Resumed => {
+                if let Some(spinner) = &self.spinner {
+                    spinner.set_thinking(true);
+                }
+            }
         }
     }
 
@@ -164,6 +201,10 @@ impl EngineEventRenderer {
             }
             EngineEvent::HookProgress(ev) => {
                 render_hook_progress(&ev);
+                RenderOutcome::Continue
+            }
+            EngineEvent::Retry(ev) => {
+                self.render_retry(&ev);
                 RenderOutcome::Continue
             }
             EngineEvent::Notice { text } => {

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -162,11 +162,6 @@ impl SpinnerState {
         self.active.store(false, Ordering::SeqCst);
     }
 
-    /// Set the current turn phase.
-    pub fn set_phase(&self, phase: TurnPhase) {
-        *self.phase.lock().unwrap() = phase;
-    }
-
     /// Read the current turn phase.
     pub fn phase(&self) -> TurnPhase {
         self.phase.lock().unwrap().clone()

--- a/rust/crates/rusty-sudocode-cli/tests/pty_retry_visibility.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_retry_visibility.rs
@@ -1,0 +1,101 @@
+//! PTY test: a provider retry is visible while it is happening.
+//!
+//! When the provider answers 429 or 5xx the transport backs off and tries
+//! again. From the outside that is indistinguishable from a slow model —
+//! several seconds of nothing, possibly repeatedly — so the retry has to say
+//! so. `⟳ retry 1/8 — 429: slow down` is the whole feature.
+//!
+//! **Why this test exists.** This regressed once already and nothing caught
+//! it. Before the engine/renderer split, the CLI owned its own `ApiClient` and
+//! implemented the transport's `RetryNotifier` directly, driving the spinner.
+//! The split deleted that client — correctly, the renderer must not name `api`
+//! — but the replacement was never wired: `RetryNotifier` had no implementor
+//! anywhere and `SpinnerRef::set_retry` had no callers. The feature had been
+//! documented as "cannot be reliably triggered in automated tests — requires a
+//! specific proxy error", so nothing was watching. The mock can produce that
+//! specific proxy error, which is what makes this testable at all.
+//!
+//! ```bash
+//! cargo test --test pty_retry_visibility
+//! ```
+
+mod common;
+
+use std::time::Duration;
+
+use common::TestEnv;
+
+/// The transport retries a 429 and says so on the terminal, then the turn
+/// completes normally.
+///
+/// The mock answers the first request 429 and the second normally, so this
+/// exercises the real retry loop in `HttpTransport` — backoff included — not a
+/// synthesised event.
+#[test]
+fn provider_retry_is_reported_then_the_turn_completes() {
+    let env = TestEnv::new("retry-visibility");
+    if !env.is_mock() {
+        eprintln!(
+            "skipping provider_retry_is_reported_then_the_turn_completes: \
+             needs the mock's scripted 429 (a live provider will not \
+             rate-limit on cue)"
+        );
+        return;
+    }
+
+    let prompt = env.prompt("Say hello", "retry_then_succeed");
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
+    // The first backoff is a second plus jitter, and the turn still has to
+    // finish after it.
+    sess.set_default_timeout(Duration::from_secs(60));
+
+    // Named as the user sees it: which attempt, out of how many, and why.
+    // Matched as one line so a report that lost the reason — the only part
+    // that says whether to wait or to go fix something — fails here.
+    sess.expect(r"retry 1/8 .* 429").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("the retry should be reported: {e}\nPTY screen:\n{screen}");
+    });
+
+    // And the retry actually retried: the turn produces its answer.
+    sess.expect("(?i)hello").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("the turn should complete after the retry: {e}\nPTY screen:\n{screen}");
+    });
+
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "a retried turn should still exit 0; got {exit}");
+}
+
+/// A turn that never hits a retry says nothing about retries.
+///
+/// Without this the test above would pass against a build that printed the
+/// line unconditionally, which would be its own bug — every turn in every
+/// session gaining a line about a retry that did not happen.
+#[test]
+fn a_turn_without_retries_reports_none() {
+    let env = TestEnv::new("retry-visibility-absent");
+    if !env.is_mock() {
+        eprintln!("skipping a_turn_without_retries_reports_none: mock-only");
+        return;
+    }
+
+    let prompt = env.prompt("Say hello", "streaming_text");
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
+    sess.set_default_timeout(Duration::from_secs(60));
+
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0);
+
+    let screen = sess.render(|s| s.contents());
+    assert!(
+        !screen.contains("retry"),
+        "nothing was retried, so nothing should mention a retry; PTY screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
## The regression

When the provider answers 429 or 5xx the transport backs off and tries again. From outside that is indistinguishable from a slow model — several seconds of nothing, repeatedly — so saying so is the whole feature. It had stopped working.

Before the engine/renderer split the CLI owned its own `ApiClient`, which implemented the transport's `RetryNotifier` and drove the spinner. The split deleted that client — correctly; the renderer must not be able to name `api` — and nothing replaced the wiring. On main:

- `RetryNotifier` had **no implementor anywhere**
- `StderrRetryNotifier` was **never constructed** (the compiler has been saying so on every build)
- `SpinnerRef::set_retry` had **no callers**

Found by an audit for this exact shape — a callee kept, its caller deleted — after the same pattern had already cost this repo the iocraft task panel and plugin-hook progress. Script at `scratchpad/orphan_audit.py`; this was the one real hit out of 81 candidates.

## The fix

Retries cross the seam like every other progress signal, mirroring the hook-progress path: `RuntimeObserver::retry_sink` (default `None`) → a `RetrySink` the runtime installs into its API client at the start of each turn → `ObserverAdapter` → `EngineEvent::Retry` → the renderer formats it.

`runtime` cannot name an `api` notifier and must not, so `engine-core` — the crate that legitimately sees both — carries the single adapter between the two callback shapes. `api`'s setters take `Option` so a sink can be cleared, not only replaced.

## Three things this turned up

**The transport's stderr fallback is gone.** `send_json` had an `else { eprintln!(…) }` that printed the retry line when no notifier was installed. It is a boundary leak — a transport writing to the user's terminal from below the seam, landing wherever the cursor happens to be, unstylable and unsuppressable — and it is *why nobody noticed*: it silently stood in for the real indicator. My first version of the new test passed against it; only a mutation run exposed that.

**The retry sink is cleared after every turn**, next to the hook reporter and for the same reason. A sink installed and not cleared leaves a clone of the renderer's event channel inside the API client, pinning the channel open past the end of the turn. The REPL does not notice; the ACP server waits for exactly that channel to close before answering `session/prompt`. The `acp_integration` suite hung indefinitely until this line existed — the same bug the seam work already had to fix once for hook progress.

**`repl_ui::set_phase` is deleted** — no callers, and none before the split either.

## Verification

New PTY test `pty_retry_visibility`, mock-driven: the mock answers the first `/v1/messages` request 429 and the next normally, so the real `HttpTransport` retry loop runs, backoff included. A second test asserts a turn without retries says nothing about retries, so the first cannot pass against a build that printed the line unconditionally.

| mutation | result |
|---|---|
| `ObserverAdapter::retry_sink` returns `None` | FAILED ✅ |
| restored | passes |

`cargo test --workspace` — **121 binaries, 0 failures** on Windows; `clippy --workspace --all-targets` and `fmt --all --check` clean. Rebased onto `2b38a9c5` (#570) and re-verified: `acp_integration` 23/23, `pty_auth_profile` 7/7, `pty_retry_visibility` 2/2.
