### PR TITLE
fix(runtime): compact inside a turn, before the provider rejects

### DIFF
--- a/rust/crates/engine-core/src/engine_client.rs
+++ b/rust/crates/engine-core/src/engine_client.rs
@@ -307,6 +307,31 @@ impl ApiClient for EngineApiClient {
         }));
     }
 
+    /// The runtime's default derives these from the capabilities table and
+    /// the system prompt alone. This client knows better on both counts: the
+    /// output reservation it will actually request and the tool definitions
+    /// it attaches to every request. Overriding keeps the in-turn guard and
+    /// the engine host's preflight working off the same numbers.
+    fn context_budget(
+        &self,
+        _model: &str,
+        system_prompt: &runtime::SystemPrompt,
+    ) -> runtime::ContextBudget {
+        // Keyed on `self.model`, not the caller's model name, because that is
+        // provably what the request will carry (`stream` below builds its
+        // `MessageRequest` with `self.model` and
+        // `api::max_tokens_for_model(&self.model)`). Budgeting against
+        // anything else would let the guard and the provider's rejection
+        // disagree.
+        runtime::ContextBudget {
+            context_limit: runtime::model_capabilities::context_window_or_default(&self.model)
+                as usize,
+            max_output_tokens: api::max_tokens_for_model(&self.model) as usize,
+            overhead_tokens: self.fixed_request_overhead_tokens(system_prompt),
+            buffer_tokens: runtime::autocompact_buffer_tokens(&self.model) as usize,
+        }
+    }
+
     async fn send_compaction(
         &mut self,
         model: &str,

--- a/rust/crates/engine-host/src/session_engine.rs
+++ b/rust/crates/engine-host/src/session_engine.rs
@@ -641,15 +641,19 @@ impl engine_core::EngineDelegate for SessionEngine {
         // persisted transcript; the runtime also compacts-and-resends once
         // reactively inside run_turn if the provider still rejects.
         let model = session.runtime.session().model.clone().unwrap_or_default();
-        let context_limit = runtime::model_capabilities::context_window_or_default(&model) as usize;
-        let max_output_tokens = engine_core::max_tokens_for_model(&model) as usize;
-        let overhead_tokens = session
-            .runtime
-            .api_client()
-            .fixed_request_overhead_tokens(session.runtime.system_prompt());
-        let buffer_tokens = runtime::autocompact_buffer_tokens(&model) as usize;
-        let history_budget =
-            context_limit.saturating_sub(max_output_tokens + overhead_tokens + buffer_tokens);
+        let budget = runtime::ContextBudget {
+            context_limit: runtime::model_capabilities::context_window_or_default(&model) as usize,
+            max_output_tokens: engine_core::max_tokens_for_model(&model) as usize,
+            overhead_tokens: session
+                .runtime
+                .api_client()
+                .fixed_request_overhead_tokens(session.runtime.system_prompt()),
+            buffer_tokens: runtime::autocompact_buffer_tokens(&model) as usize,
+        };
+        let context_limit = budget.context_limit;
+        let max_output_tokens = budget.max_output_tokens;
+        let overhead_tokens = budget.overhead_tokens;
+        let history_budget = budget.history_budget();
         let prompt_tokens: usize = blocks.iter().map(estimate_block_tokens).sum();
         let estimated_tokens = estimate_session_tokens(session.runtime.session());
         let mut pre_send_compaction = None;
@@ -676,18 +680,17 @@ impl engine_core::EngineDelegate for SessionEngine {
                     attrs
                 });
             }
-            pre_send_compaction =
-                self.rt()
-                    .block_on(session.runtime.compact_in_place(CompactionConfig {
-                        max_estimated_tokens: 0, // force compaction
-                        ..CompactionConfig::default()
-                    }));
+            pre_send_compaction = self.rt().block_on(session.runtime.compact_in_place(
+                CompactionConfig {
+                    max_estimated_tokens: 0, // force compaction
+                    ..CompactionConfig::default()
+                },
+                runtime::CompactionTrigger::Preflight,
+            ));
             // Re-estimate against the hard limit the preflight enforces. Still
             // over → classified error instead of a request that will be rejected.
             let new_estimated_tokens = estimate_session_tokens(session.runtime.session());
-            if new_estimated_tokens + prompt_tokens + overhead_tokens + max_output_tokens
-                > context_limit
-            {
+            if !budget.fits(new_estimated_tokens + prompt_tokens) {
                 return Err(context_overflow_user_message(
                     session.runtime.session(),
                     new_estimated_tokens + prompt_tokens + overhead_tokens + max_output_tokens,

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -137,6 +137,46 @@ pub fn autocompact_buffer_tokens(model: &str) -> u32 {
     }
 }
 
+/// The numbers the context-window guard subtracts from the model's window,
+/// and the arithmetic that turns them into a history budget.
+///
+/// Two callers need this and they sit in different crates: the per-turn
+/// preflight in the engine host (which knows the provider's output
+/// reservation and the rendered tool definitions) and the in-turn check in
+/// the runtime tool loop (which does not). Sharing the struct keeps one
+/// formula while each layer supplies the inputs it actually has — see
+/// [`ApiClient::context_budget`](crate::conversation::ApiClient::context_budget).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextBudget {
+    /// The model's full context window.
+    pub context_limit: usize,
+    /// Output space reserved for the response that has not been generated yet.
+    pub max_output_tokens: usize,
+    /// Rendered system prompt + tool definitions: present on every request and
+    /// not something compaction can shrink.
+    pub overhead_tokens: usize,
+    /// Headroom so a turn that grows while it runs does not land exactly on
+    /// the limit. Zero when checking the hard limit rather than the trigger.
+    pub buffer_tokens: usize,
+}
+
+impl ContextBudget {
+    /// Tokens of history that still fit, buffer included.
+    #[must_use]
+    pub fn history_budget(&self) -> usize {
+        self.context_limit
+            .saturating_sub(self.max_output_tokens + self.overhead_tokens + self.buffer_tokens)
+    }
+
+    /// Whether `estimated_tokens` of history fits under the hard limit. The
+    /// buffer is deliberately not applied here: this is the question "would
+    /// the provider accept this request", not "should we compact first".
+    #[must_use]
+    pub fn fits(&self, estimated_tokens: usize) -> bool {
+        estimated_tokens + self.overhead_tokens + self.max_output_tokens <= self.context_limit
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Post-compact file restore (CC parity)
 // ---------------------------------------------------------------------------
@@ -392,7 +432,7 @@ fn estimate_single_block_tokens(block: &ContentBlock) -> usize {
     }
 }
 
-fn estimate_message_tokens(message: &ConversationMessage) -> usize {
+pub(crate) fn estimate_message_tokens(message: &ConversationMessage) -> usize {
     message
         .blocks
         .iter()

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -10,8 +10,9 @@ use telemetry::SessionTracer;
 
 use crate::compact::{
     autocompact_buffer_tokens, compact_session, compact_session_sync,
-    compact_session_sync_after_llm_failure, estimate_session_tokens, CompactionConfig,
-    CompactionError, CompactionResult, ReadFileTracker,
+    compact_session_sync_after_llm_failure, estimate_block_tokens, estimate_session_tokens,
+    CompactionConfig, CompactionError, CompactionResult, CompactionSummarySource, ContextBudget,
+    ReadFileTracker,
 };
 use crate::config::RuntimeFeatureConfig;
 use crate::hooks::{
@@ -154,6 +155,33 @@ pub trait ApiClient: Send {
     /// renderer a turn belongs to changes while the client does not. Clients
     /// whose transport has no retry loop ignore it.
     fn set_retry_sink(&mut self, _sink: Option<crate::conversation::RetrySink>) {}
+
+    /// The context-window budget for a request this client would send.
+    ///
+    /// Two of the four numbers are only knowable at the client layer: the
+    /// output reservation the provider will be asked for, and the fixed
+    /// request overhead (rendered system prompt plus the tool definitions
+    /// this client attaches). The default derives what the runtime can see
+    /// on its own — capabilities-table limits and the system prompt alone —
+    /// which is why a client that attaches tools should override it, as
+    /// `EngineApiClient` does. The runtime's in-turn guard and the engine
+    /// host's preflight both compact against whatever this returns.
+    fn context_budget(&self, model: &str, system_prompt: &SystemPrompt) -> ContextBudget {
+        let overhead_tokens = if system_prompt.is_empty() {
+            0
+        } else {
+            estimate_block_tokens(&ContentBlock::Text {
+                text: system_prompt.render(),
+            })
+        };
+        ContextBudget {
+            context_limit: crate::model_capabilities::context_window_or_default(model) as usize,
+            max_output_tokens: crate::model_capabilities::max_output_tokens_or_default(model)
+                as usize,
+            overhead_tokens,
+            buffer_tokens: autocompact_buffer_tokens(model) as usize,
+        }
+    }
 }
 
 /// Optional observer for runtime events emitted while processing a turn.
@@ -594,6 +622,43 @@ impl CompactionMethod {
         match self {
             Self::LlmSummary => "llm summary",
             Self::LocalHeuristic => "local heuristic",
+        }
+    }
+}
+
+/// How many times a single turn may compact its own history.
+///
+/// This was once per turn, which is what let a many-step turn die mid-flight:
+/// the salvage fired on the first rejection and the second overflow ended the
+/// turn. A long tool-using turn legitimately needs more than one pass, but
+/// every compaction is an LLM round-trip, so the allowance is bounded rather
+/// than open — once it is spent an overflow surfaces as a real error.
+const MAX_TURN_COMPACTIONS: usize = 8;
+
+/// Which guard asked for a compaction. Recorded on every attempt so a
+/// context-overflow report can be diagnosed from the session log: until this
+/// existed only the engine host's preflight emitted an event, and the two
+/// paths that actually run during a turn were silent — making a compaction
+/// that ran and worked indistinguishable from one that never happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionTrigger {
+    /// The per-turn preflight, before the turn starts.
+    Preflight,
+    /// The in-turn budget check, before dispatching an iteration's request.
+    InTurnBudget,
+    /// Salvage after the provider rejected a request as too large.
+    ProviderRejection,
+    /// The post-turn usage-threshold check.
+    PostTurnUsage,
+}
+
+impl CompactionTrigger {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Preflight => "preflight",
+            Self::InTurnBudget => "in_turn_budget",
+            Self::ProviderRejection => "provider_rejection",
+            Self::PostTurnUsage => "post_turn_usage",
         }
     }
 }
@@ -1448,7 +1513,7 @@ where
         let mut prompt_cache_events = Vec::new();
         let mut iterations = 0;
         let mut retried_empty_post_tool_deliverable = false;
-        let mut retried_context_window_overflow = false;
+        let mut turn_compactions = 0usize;
         let mut overflow_compaction: Option<AutoCompactionEvent> = None;
         let mut response_model: Option<String> = None;
 
@@ -1477,6 +1542,32 @@ where
                 );
                 self.record_turn_failed(iterations, &error);
                 return Err(error);
+            }
+
+            // Compact before dispatching, not after the provider rejects.
+            // A turn that takes many tool-call steps grows its own history
+            // while it runs; the per-turn preflight ran once, before any of
+            // those steps existed. Without this the first the runtime hears
+            // of the overflow is a rejection, and the single salvage below
+            // is all a long turn ever gets.
+            if turn_compactions < MAX_TURN_COMPACTIONS {
+                let budget = self
+                    .api_client
+                    .context_budget(self.compaction_model().as_str(), &self.system_prompt);
+                if estimate_session_tokens(&self.session) > budget.history_budget() {
+                    let config = CompactionConfig {
+                        max_estimated_tokens: 0,
+                        ..CompactionConfig::default()
+                    };
+                    if let Some(event) = self
+                        .compact_in_place(config, CompactionTrigger::InTurnBudget)
+                        .await
+                    {
+                        turn_compactions += 1;
+                        overflow_compaction =
+                            merge_auto_compaction(overflow_compaction, Some(event));
+                    }
+                }
             }
 
             let request = ApiRequest {
@@ -1514,15 +1605,20 @@ where
                 Err(error) => {
                     // A context-window rejection is the one request failure
                     // the runtime can fix on its own: compact the history and
-                    // resend. Once per turn — if the preserved tail is still
-                    // too large the error is real and must surface.
-                    if error.is_context_window_blocked() && !retried_context_window_overflow {
-                        retried_context_window_overflow = true;
+                    // resend. Shares the turn's compaction allowance with the
+                    // proactive check above; when compaction can no longer
+                    // remove anything the error is real and must surface.
+                    if error.is_context_window_blocked() && turn_compactions < MAX_TURN_COMPACTIONS
+                    {
                         let config = CompactionConfig {
                             max_estimated_tokens: 0,
                             ..CompactionConfig::default()
                         };
-                        if let Some(event) = self.compact_in_place(config).await {
+                        if let Some(event) = self
+                            .compact_in_place(config, CompactionTrigger::ProviderRejection)
+                            .await
+                        {
+                            turn_compactions += 1;
                             overflow_compaction =
                                 merge_auto_compaction(overflow_compaction, Some(event));
                             continue;
@@ -2386,6 +2482,16 @@ where
         self.session
     }
 
+    /// Model name used for capability lookups and compaction. Mirrors the
+    /// fallback `compact_in_place` already applies, so the in-turn budget is
+    /// derived from the same model the compaction itself will run against.
+    fn compaction_model(&self) -> String {
+        self.session
+            .model
+            .clone()
+            .unwrap_or_else(|| "claude-sonnet-4-6".to_string())
+    }
+
     async fn maybe_auto_compact(&mut self) -> Option<AutoCompactionEvent> {
         let running = self.running_model();
         let model = if running.is_empty() {
@@ -2417,7 +2523,9 @@ where
             max_estimated_tokens: 0,
             ..CompactionConfig::default()
         };
-        let event = self.compact_in_place(config).await;
+        let event = self
+            .compact_in_place(config, CompactionTrigger::PostTurnUsage)
+            .await;
         if event.is_some() {
             // Success → reset the noop counter so the breaker only trips on
             // SUSTAINED inability to shrink, not on transient threshold dance.
@@ -2441,7 +2549,9 @@ where
     pub async fn compact_in_place(
         &mut self,
         config: CompactionConfig,
+        trigger: CompactionTrigger,
     ) -> Option<AutoCompactionEvent> {
+        let estimated_before = estimate_session_tokens(&self.session);
         let model = self
             .session
             .model
@@ -2470,8 +2580,10 @@ where
         };
 
         if result.removed_message_count == 0 {
+            self.record_compaction(trigger, 0, estimated_before, estimated_before, None);
             return None;
         }
+        let summary_source = result.summary_source.clone();
 
         // Post-compact file restore: re-inject recently-read file content
         // so the model doesn't lose knowledge of files it just worked with.
@@ -2495,6 +2607,15 @@ where
         if let Err(error) = self.session.rewrite_persisted() {
             self.record_session_persist_error("compaction", &error.to_string());
         }
+
+        let estimated_after = estimate_session_tokens(&self.session);
+        self.record_compaction(
+            trigger,
+            result.removed_message_count,
+            estimated_before,
+            estimated_after,
+            Some(&summary_source),
+        );
 
         Some(AutoCompactionEvent {
             removed_message_count: result.removed_message_count,
@@ -2532,6 +2653,47 @@ where
         );
         attributes.insert("error".to_string(), Value::String(error.to_string()));
         session_tracer.record("session_persist_error", attributes);
+    }
+
+    fn record_compaction(
+        &self,
+        trigger: CompactionTrigger,
+        removed_message_count: usize,
+        estimated_before: usize,
+        estimated_after: usize,
+        summary_source: Option<&CompactionSummarySource>,
+    ) {
+        let Some(session_tracer) = &self.session_tracer else {
+            return;
+        };
+        let mut attributes = Map::new();
+        attributes.insert(
+            "trigger".to_string(),
+            Value::String(trigger.as_str().to_string()),
+        );
+        attributes.insert(
+            "removed_messages".to_string(),
+            Value::from(removed_message_count as u64),
+        );
+        attributes.insert(
+            "estimated_tokens_before".to_string(),
+            Value::from(estimated_before as u64),
+        );
+        attributes.insert(
+            "estimated_tokens_after".to_string(),
+            Value::from(estimated_after as u64),
+        );
+        // `local` means the structural fallback ran: it counts messages and
+        // lists tool names, it does not summarise content. Telling the two
+        // apart is the difference between "the summary is thin" and "the
+        // summariser never ran".
+        if let Some(source) = summary_source {
+            attributes.insert(
+                "summary_source".to_string(),
+                Value::String(source.to_string()),
+            );
+        }
+        session_tracer.record("session_compacted", attributes);
     }
 
     fn record_turn_started(&self, user_input: &str) {
@@ -5046,6 +5208,368 @@ mod tests {
         assert!(error
             .to_string()
             .contains("conversation loop exceeded the maximum number of iterations"));
+    }
+
+    /// A turn that grows past the window mid-flight must be compacted
+    /// *before* the request is dispatched. Reproduces the production failure:
+    /// the agent takes many tool-call steps in one turn, the history outgrows
+    /// the window, and the only salvage is a single reactive compaction after
+    /// the provider has already rejected — so the second overflow kills the
+    /// turn.
+    #[tokio::test]
+    async fn turn_compacts_proactively_instead_of_waiting_for_a_rejection() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const LIMIT: usize = 4_000;
+        const STEPS: usize = 12;
+
+        struct BudgetedApi {
+            rejections: Arc<AtomicUsize>,
+            steps: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl ApiClient for BudgetedApi {
+            fn context_budget(
+                &self,
+                _model: &str,
+                _system_prompt: &SystemPrompt,
+            ) -> crate::compact::ContextBudget {
+                crate::compact::ContextBudget {
+                    context_limit: LIMIT,
+                    max_output_tokens: 200,
+                    overhead_tokens: 100,
+                    buffer_tokens: 300,
+                }
+            }
+
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                let session_tokens: usize = request
+                    .messages
+                    .iter()
+                    .map(crate::compact::estimate_message_tokens)
+                    .sum();
+                if session_tokens + 100 + 200 > LIMIT {
+                    self.rejections.fetch_add(1, Ordering::Relaxed);
+                    return Err(RuntimeError::context_window_blocked(
+                        "prompt is too long for this model".to_string(),
+                    ));
+                }
+                let step = self.steps.fetch_add(1, Ordering::Relaxed);
+                if step < STEPS {
+                    Ok(events_to_stream(vec![
+                        AssistantEvent::ToolUse {
+                            id: format!("tool-{step}"),
+                            name: "bulk".to_string(),
+                            input: "go".to_string(),
+                            thought_signature: None,
+                        },
+                        AssistantEvent::MessageStop,
+                    ]))
+                } else {
+                    Ok(events_to_stream(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]))
+                }
+            }
+
+            async fn send_compaction(
+                &mut self,
+                _model: &str,
+                _system_prompt: &str,
+                _messages: Vec<crate::session::ConversationMessage>,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                Ok("<summary>Steps so far were bulk tool calls.</summary>".to_string())
+            }
+        }
+
+        let rejections = Arc::new(AtomicUsize::new(0));
+        let steps = Arc::new(AtomicUsize::new(0));
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            BudgetedApi {
+                rejections: Arc::clone(&rejections),
+                steps: Arc::clone(&steps),
+            },
+            // Each tool result adds ~1000 estimated tokens, so the 3.4K
+            // history budget is exhausted after three or four steps.
+            StaticToolExecutor::new().register("bulk", |_| Ok("x".repeat(4_000))),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_max_iterations(64);
+
+        let summary = runtime
+            .run_turn("do many steps", None, None)
+            .await
+            .expect("a turn that outgrows the window mid-flight should compact and finish");
+
+        assert!(
+            summary.iterations > STEPS,
+            "expected the turn to run all its steps, got {}",
+            summary.iterations
+        );
+        assert_eq!(
+            rejections.load(Ordering::Relaxed),
+            0,
+            "the runtime should compact before dispatching, never letting the provider reject"
+        );
+    }
+
+    /// Every compaction that runs must leave a trace. The two paths that
+    /// fire during a real turn used to record nothing at all — only the
+    /// engine host's preflight did — so a session log showed no compaction
+    /// even when one had run and worked, which is exactly what makes a
+    /// context-overflow report undiagnosable.
+    #[tokio::test]
+    async fn in_turn_compaction_is_recorded_with_its_trigger_and_summary_source() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const LIMIT: usize = 4_000;
+
+        struct TinyBudgetApi {
+            steps: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl ApiClient for TinyBudgetApi {
+            fn context_budget(
+                &self,
+                _model: &str,
+                _system_prompt: &SystemPrompt,
+            ) -> crate::compact::ContextBudget {
+                crate::compact::ContextBudget {
+                    context_limit: LIMIT,
+                    max_output_tokens: 200,
+                    overhead_tokens: 100,
+                    buffer_tokens: 300,
+                }
+            }
+
+            async fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                let step = self.steps.fetch_add(1, Ordering::Relaxed);
+                if step < 6 {
+                    Ok(events_to_stream(vec![
+                        AssistantEvent::ToolUse {
+                            id: format!("tool-{step}"),
+                            name: "bulk".to_string(),
+                            input: "go".to_string(),
+                            thought_signature: None,
+                        },
+                        AssistantEvent::MessageStop,
+                    ]))
+                } else {
+                    Ok(events_to_stream(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]))
+                }
+            }
+
+            async fn send_compaction(
+                &mut self,
+                _model: &str,
+                _system_prompt: &str,
+                _messages: Vec<crate::session::ConversationMessage>,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                Ok("<summary>Bulk steps.</summary>".to_string())
+            }
+        }
+
+        let sink = Arc::new(MemoryTelemetrySink::default());
+        let tracer = SessionTracer::new("session-compaction-trace", sink.clone());
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            TinyBudgetApi {
+                steps: Arc::new(AtomicUsize::new(0)),
+            },
+            StaticToolExecutor::new().register("bulk", |_| Ok("x".repeat(4_000))),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_max_iterations(64)
+        .with_session_tracer(tracer);
+
+        runtime
+            .run_turn("do many steps", None, None)
+            .await
+            .expect("turn should finish");
+
+        let events = sink.events();
+        let compactions: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                TelemetryEvent::SessionTrace(trace) if trace.name == "session_compacted" => {
+                    Some(&trace.attributes)
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            !compactions.is_empty(),
+            "an in-turn compaction must be recorded"
+        );
+        let attrs = compactions
+            .iter()
+            .find(|attrs| {
+                attrs
+                    .get("removed_messages")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0)
+                    > 0
+            })
+            .expect("at least one recorded compaction should have removed messages");
+        assert_eq!(
+            attrs.get("trigger").and_then(serde_json::Value::as_str),
+            Some("in_turn_budget")
+        );
+        assert_eq!(
+            attrs
+                .get("summary_source")
+                .and_then(serde_json::Value::as_str),
+            Some("llm"),
+            "the log must distinguish an LLM summary from the local structural fallback"
+        );
+        let before = attrs
+            .get("estimated_tokens_before")
+            .and_then(serde_json::Value::as_u64)
+            .expect("before estimate");
+        let after = attrs
+            .get("estimated_tokens_after")
+            .and_then(serde_json::Value::as_u64)
+            .expect("after estimate");
+        assert!(after < before, "compaction should shrink the estimate");
+    }
+
+    /// The salvage compaction used to be capped at once per turn, which is
+    /// what killed the reported session: the first rejection was recovered,
+    /// the history grew again, and the second rejection ended the turn with
+    /// `retried_context_window_overflow` already spent. A long turn must be
+    /// able to compact repeatedly and still terminate.
+    #[tokio::test]
+    async fn a_long_turn_compacts_more_than_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const LIMIT: usize = 4_000;
+
+        struct GrindingApi {
+            steps: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl ApiClient for GrindingApi {
+            fn context_budget(
+                &self,
+                _model: &str,
+                _system_prompt: &SystemPrompt,
+            ) -> crate::compact::ContextBudget {
+                crate::compact::ContextBudget {
+                    context_limit: LIMIT,
+                    max_output_tokens: 200,
+                    overhead_tokens: 100,
+                    buffer_tokens: 300,
+                }
+            }
+
+            async fn stream(
+                &mut self,
+                request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                let session_tokens: usize = request
+                    .messages
+                    .iter()
+                    .map(crate::compact::estimate_message_tokens)
+                    .sum();
+                if session_tokens + 100 + 200 > LIMIT {
+                    return Err(RuntimeError::context_window_blocked(
+                        "prompt is too long for this model".to_string(),
+                    ));
+                }
+                // 20 tool-calling steps: several compactions' worth of
+                // growth at this budget, but each compaction buys back enough
+                // headroom for a few more steps.
+                let step = self.steps.fetch_add(1, Ordering::Relaxed);
+                if step < 20 {
+                    Ok(events_to_stream(vec![
+                        AssistantEvent::ToolUse {
+                            id: format!("tool-{step}"),
+                            name: "bulk".to_string(),
+                            input: "go".to_string(),
+                            thought_signature: None,
+                        },
+                        AssistantEvent::MessageStop,
+                    ]))
+                } else {
+                    Ok(events_to_stream(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]))
+                }
+            }
+
+            async fn send_compaction(
+                &mut self,
+                _model: &str,
+                _system_prompt: &str,
+                _messages: Vec<crate::session::ConversationMessage>,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                Ok("<summary>Bulk steps so far.</summary>".to_string())
+            }
+        }
+
+        let sink = Arc::new(MemoryTelemetrySink::default());
+        let tracer = SessionTracer::new("session-many-compactions", sink.clone());
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            GrindingApi {
+                steps: Arc::new(AtomicUsize::new(0)),
+            },
+            StaticToolExecutor::new().register("bulk", |_| Ok("x".repeat(2_000))),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            SystemPrompt::default(),
+        )
+        .with_max_iterations(128)
+        .with_session_tracer(tracer);
+
+        let summary = runtime
+            .run_turn("grind", None, None)
+            .await
+            .expect("a long turn should compact as often as it needs and finish");
+        assert!(summary.iterations > 20);
+
+        let compactions = sink
+            .events()
+            .iter()
+            .filter(|event| {
+                matches!(event, TelemetryEvent::SessionTrace(trace)
+                    if trace.name == "session_compacted"
+                        && trace
+                            .attributes
+                            .get("removed_messages")
+                            .and_then(serde_json::Value::as_u64)
+                            .unwrap_or(0)
+                            > 0)
+            })
+            .count();
+        assert!(
+            compactions > 1,
+            "a turn this long needs more than one compaction, saw {compactions}"
+        );
+        assert!(
+            compactions <= super::MAX_TURN_COMPACTIONS,
+            "compaction must stay bounded, saw {compactions}"
+        );
     }
 
     #[tokio::test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -89,8 +89,8 @@ pub use compact::{
     autocompact_buffer_tokens, compact_session, compact_session_sync,
     compact_session_sync_after_llm_failure, estimate_block_tokens, estimate_session_tokens,
     format_compact_summary, get_compact_continuation_message, should_compact, CompactionConfig,
-    CompactionError, CompactionResult, CompactionSummarySource, AUTOCOMPACT_BUFFER_TOKENS,
-    COMPACT_MAX_OUTPUT_TOKENS,
+    CompactionError, CompactionResult, CompactionSummarySource, ContextBudget,
+    AUTOCOMPACT_BUFFER_TOKENS, COMPACT_MAX_OUTPUT_TOKENS,
 };
 pub use config::{
     default_config_home, load_plugin_mcp_servers, ConfigEntry, ConfigError, ConfigLoader,
@@ -111,7 +111,8 @@ pub use config_validate::{
 };
 pub use conversation::{
     auto_compact_threshold_for_model, ApiClient, ApiRequest, AssistantEvent, AssistantEventStream,
-    AutoCompactionEvent, CompactionMethod, ConversationRuntime, HookProgressSink, ProgressSink,
+    AutoCompactionEvent, CompactionMethod, CompactionTrigger, ConversationRuntime,
+    HookProgressSink, ProgressSink,
     PromptCacheEvent, RetryEvent, RetrySink, RuntimeError, RuntimeObserver, StaticToolExecutor,
     ToolDispatchContext, ToolError, ToolExecutor, ToolProgressEvent, TurnSummary,
     FORK_BOILERPLATE_TAG,


### PR DESCRIPTION
## The problem

A turn that takes many tool-call steps grows its own history while it runs, and nothing inside the tool loop checks the context budget.

The per-turn preflight (`engine-host/src/session_engine.rs`, `EngineDelegate::run_turn`) runs **once**, before the turn starts — before any of those steps exist. Inside `run_turn_with_blocks_inner`'s loop the only compaction is `compact_in_place` on the error path, and it is:

- **reactive** — it fires only after the provider has already rejected the request (`error.is_context_window_blocked()`), and
- **once per turn** — guarded by `retried_context_window_overflow`, which is declared, set, tested, and never reset.

Both `maybe_auto_compact` call sites are on turn-end paths. So a long turn recovers from its first overflow and dies on its second.

### Reproduction

Observed on a live deployment (`context_window` 40000, `maxOutputTokens` 8000, deepseek-v4-flash) in a single turn. Real context per step, computed as `input_tokens + cache_read_input_tokens`:

```
38726 → 45061   provider rejects
      → 18783   reactive salvage fired, retry succeeded, nothing logged
      → 15003
      → 29487
      → 36581   provider rejects again; allowance already spent → turn dies
```

The error the user finally sees:

```
Context window blocked
  Input estimate   ~33200 tokens (heuristic)
  Requested output 8000 tokens
  Total estimate   ~41200 tokens (heuristic)
  Context window   40000 tokens
```

Note the input alone fitted; the reserved output pushed the total over. In production that reservation is the model's declared `max_output_tokens` (64000 for deepseek-v4-*), so the same arithmetic bites much earlier.

A second problem surfaced while diagnosing this: **both compaction paths that run during a turn are silent.** Only the preflight records `auto_compact_check` / `auto_compact_result`. A compaction that ran and worked is indistinguishable in the session log from one that never happened, which is what made the report above hard to diagnose in the first place.

## What changed

**`ContextBudget`** (`runtime/src/compact.rs`) holds the four numbers the guard subtracts from the window and the two questions asked of them: `history_budget()` for "should we compact" and `fits()` for "would the provider accept". The engine-host preflight now builds one instead of computing the same arithmetic inline, so there is a single formula.

**`ApiClient::context_budget`** is the seam that supplies it. Two of the four numbers are only knowable at the client layer — the output reservation the provider will be asked for, and the tool definitions attached to every request — and the runtime cannot see either. The trait default derives what the runtime can (capabilities table plus the system prompt); `EngineApiClient` overrides it with the real numbers.

The override keys on `self.model`, **not** the caller's model name, because `stream` provably builds its `MessageRequest` with `self.model` and `api::max_tokens_for_model(&self.model)`. Budgeting against anything else would let the guard and the provider's rejection disagree.

**The tool loop** now checks the budget before dispatching each iteration's request and compacts when over, so the provider is no longer the first thing to notice.

**`retried_context_window_overflow: bool` becomes `turn_compactions: usize`** against `MAX_TURN_COMPACTIONS = 8`, shared by the proactive and reactive paths. A long turn can compact repeatedly; the allowance is bounded rather than open because every compaction is an LLM round-trip, and once spent an overflow surfaces as a real error rather than looping.

**Tracing.** `compact_in_place` is the single funnel both silent paths go through, so one event there covers both. It records `session_compacted` with `trigger` (`preflight` / `in_turn_budget` / `provider_rejection` / `post_turn_usage`), `removed_messages`, `estimated_tokens_before` / `_after`, and `summary_source`. That last field is the only way to tell an LLM summary from the local structural fallback, which counts messages and lists tool names but summarises no content. The preflight's existing `auto_compact_result` event is untouched, so anything parsing it keeps working.

## Deliberately not addressed

Three related defects were found in the same area and left alone; each is separate from this turn-scoped fix.

1. A session sitting at `[summary] + preserve_recent_messages` can never compact again. `should_compact` requires strictly more than the preserved count, and even past that gate `removed = messages[compacted_prefix_len..keep_from]` is empty for that shape, so `compact_session` returns `NothingToCompact` regardless. Fixing it means eating into the preserved tail while keeping `tool_use` / `tool_result` pairs intact.
2. Successive summaries are merged rather than re-summarised — `compact_session` sends the LLM only `removed`, which excludes the existing summary, and `merge_compact_summaries` carries the old highlights forward verbatim. Observed live: a persisted summary of 54,075 characters, with `message_count` pinned at 5 while `estimated_tokens` climbed 16809 → 24840 across five checks. Note `async_recompaction_merges_previous_and_new_summaries` currently pins this behaviour and would need rewriting.
3. `POST_COMPACT_TOKEN_BUDGET` re-injects up to 50k tokens of recently-read files *after* compacting, and `build_post_compact_file_messages` takes only the preserved messages — it has no idea how much room is left.

## Verification

Three tests added to `runtime/src/conversation.rs`. Before the fix, on unmodified `main`, the first one fails exactly as production did:

```
thread 'conversation::tests::turn_compacts_proactively_instead_of_waiting_for_a_rejection'
panicked at crates/runtime/src/conversation.rs:5130:14:
a turn that outgrows the window mid-flight should compact and finish:
RuntimeError { message: "prompt is too long for this model", kind: ContextWindowBlocked }
```

- `turn_compacts_proactively_instead_of_waiting_for_a_rejection` — a 12-step turn under a 4000-token budget finishes, and the provider is never allowed to reject.
- `a_long_turn_compacts_more_than_once` — a 20-step turn compacts repeatedly and stays within `MAX_TURN_COMPACTIONS`.
- `in_turn_compaction_is_recorded_with_its_trigger_and_summary_source` — asserts the trigger, an `llm` summary source, and that the estimate shrank.

After: `cargo build --workspace` clean, `cargo test --workspace --no-fail-fast` **1773 passed, 2 failed**, `cargo clippy --workspace --all-targets` 0 errors and no new warnings (runtime 216, engine-core 1, engine-host 37 — identical counts to clean `main`).

The 2 failures are `providers::anthropic::tests::read_api_key_requires_presence` and `read_api_key_requires_non_empty_value`. They are **pre-existing and environment-sensitive, not caused by this change** — verified failing on a clean `origin/main` worktree on the same machine. They clear the API-key environment variables but not `HOME`, so `read_api_key()` falls back to real credentials in `~/.nexus/sudocode/credentials.json` and the "missing key should error" assertion fails. Untouched here.