### PR TITLE
chore(release): bump version to 0.2.5

### DIFF
--- a/RELEASE_NOTES_v0.2.5.md
+++ b/RELEASE_NOTES_v0.2.5.md
@@ -1,0 +1,52 @@
+# Sudo Code v0.2.5
+
+## What's New
+
+This release is about the model you actually run on, and about paste. Bracketed
+paste now works on Windows and behaves like Claude Code; the model default is
+resolved from one place so changing it actually sticks; and a class of dropped
+streams no longer surfaces as a spurious error.
+
+## Fixed
+
+**Bracketed paste on Windows, and a REPL freeze on paste + Enter.** Pasting
+multi-line text into the REPL now shows a compact `[Pasted text #N +M lines]`
+placeholder instead of submitting one turn per line, on Windows as well as
+Unix. Windows support comes from the sudoprivacy `crossterm` fork (upstream
+`crossterm-rs/crossterm#1030`): the legacy Win32 console never produced
+`Event::Paste`, so it enables VT console input for the lifetime of bracketed
+paste and feeds the byte stream through the shared parser. Two paste bugs came
+out with it: pasting content that itself contained a `[Pasted text #N]` string
+and pressing Enter looped the placeholder-expansion forever and froze the whole
+REPL (keyboard and Ctrl-C dead); and Windows clipboards deliver CR/CRLF, which
+the line counter ignored, so multi-line pastes showed no `+N lines`. Both
+fixed, with the trigger now matching Claude Code: only long (> 800 chars) or
+multi-line (> 2 lines) pastes collapse into a placeholder; shorter pastes insert
+literally.
+
+**The model default is resolved from config, everywhere.** Two independent
+issues made a resumed or `auto` session ignore your configured model. `--resume`
+pinned the model recorded in the transcript, so changing the global default did
+not apply on resume; it now reads the config default (an explicit `--model`
+still wins, and `/model` switches remain runtime-only). And the `auto` alias was
+hardcoded to `claude-sonnet-4-6`, silently overriding any configured default for
+anyone on `model: auto`; `auto` now resolves to the compiled-in default. Both
+paths agree on one source of truth, so auto-compaction sizes the context window
+correctly regardless of what a transcript recorded.
+
+**A dropped stream at the very end no longer forces a retry.** When a proxy cut
+the connection right after Anthropic's terminal `message_stop` event, only the
+closing bytes of the final frame were lost, but the parser reported a retryable
+`IncompleteStream` -- forcing a wasteful whole-turn retry, or an infinite loop
+against a proxy that kept truncating the same terminal frame. A truncated
+`message_stop` is now treated as the complete message it is; a mid-content
+truncation still errors and stays retryable.
+
+## Testing
+
+The bracketed-paste behavior is covered by human-fidelity PTY tests that drive
+`scode` through a real PTY (Unix pty and Windows ConPTY) and assert on the
+rendered screen: multi-line placeholder counts for LF/CRLF/CR, short paste stays
+literal, and paste-containing-placeholder + Enter does not freeze. The model and
+SSE fixes carry focused unit tests, including the resume resolver and the `auto`
+alias.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "api",
  "plugins",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "commands",
  "runtime",
@@ -1359,7 +1359,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-acp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "engine-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "api",
  "async-trait",
@@ -1397,14 +1397,14 @@ dependencies = [
 
 [[package]]
 name = "engine-events"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "runtime",
 ]
 
 [[package]]
 name = "engine-host"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "commands",
  "engine-core",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "api",
  "serde_json",
@@ -2649,7 +2649,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c1
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3944,7 +3944,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arboard",
  "async-trait",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
﻿## Summary

Release v0.2.5. Bumps the workspace version 0.2.4 -> 0.2.5 and adds
`RELEASE_NOTES_v0.2.5.md`. Tag `v0.2.5` on the merge commit to publish.

Headline changes since v0.2.4 (all already merged to main):
- Windows bracketed paste + CC-parity placeholder trigger, no-freeze expansion, CR/CRLF line counts (#573)
- `--resume` reads the model from config SSOT, not the session pin (#578)
- `auto` model alias resolves to the default, not sonnet (#582)
- A truncated terminal `message_stop` frame is treated as a complete message, not a retryable error (#576)

## Test plan

- `cargo build -p rusty-sudocode-cli` clean; Cargo.lock regenerated to 0.2.5.
- Full CI (fmt / clippy / test / bench across Linux, macOS, Windows) on this PR.
