### PR TITLE
feat(tools): deferred tools CC parity

### DIFF
--- a/rust/crates/engine-core/src/engine_client.rs
+++ b/rust/crates/engine-core/src/engine_client.rs
@@ -136,9 +136,10 @@ impl EngineApiClient {
     #[must_use]
     pub fn fixed_request_overhead_tokens(&self, system_prompt: &runtime::SystemPrompt) -> usize {
         let system = (!system_prompt.is_empty()).then(|| system_prompt.render());
-        let tools = self
-            .enable_tools
-            .then(|| self.tool_registry.definitions(self.allowed_tools.as_ref()));
+        let tools = self.enable_tools.then(|| {
+            self.tool_registry
+                .core_definitions(self.allowed_tools.as_ref())
+        });
         api::estimate_request_overhead_tokens(system.as_deref(), tools.as_deref()) as usize
     }
 
@@ -363,9 +364,10 @@ impl ApiClient for EngineApiClient {
             max_tokens: api::max_tokens_for_model(&self.model),
             messages: tools::convert_messages(&request.messages),
             system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.render()),
-            tools: self
-                .enable_tools
-                .then(|| self.tool_registry.definitions(self.allowed_tools.as_ref())),
+            tools: self.enable_tools.then(|| {
+                self.tool_registry
+                    .core_definitions(self.allowed_tools.as_ref())
+            }),
             tool_choice: self.enable_tools.then_some(ToolChoice::Auto),
             stream: true,
             reasoning_effort: self.reasoning_effort.clone(),

--- a/rust/crates/engine-host/src/runtime_build.rs
+++ b/rust/crates/engine-host/src/runtime_build.rs
@@ -394,6 +394,13 @@ pub(crate) fn build_runtime_with_plugin_state(
     if let Some(section) = render_skills_prompt_section(cwd, Some(&plugin_load_outcome)) {
         system_prompt.dynamic_sections.push(section);
     }
+    // Deferred tools listing: inject `<available-deferred-tools>` so the
+    // model knows which tools exist beyond the core set visible in the API
+    // `tools` array. Discovery via ToolSearch, execution via ExecuteExtraTool.
+    let deferred_section = tool_registry.deferred_tools_prompt_section();
+    if !deferred_section.is_empty() {
+        system_prompt.dynamic_sections.push(deferred_section);
+    }
     // nexus A2A: teach the model its A2A identity + how to reach peers, so the
     // standalone loop knows it can `send_message` to a named peer.
     if let Some(session) = a2a {

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -169,6 +169,7 @@ enum Scenario {
     /// the transport's retry loop, and therefore the retry indicator, without
     /// waiting on a real provider to rate-limit us.
     RetryThenSucceed,
+    ExecuteExtraToolRoundtrip,
 }
 
 /// How long [`Scenario::DelayedText`] holds a request before answering.
@@ -211,6 +212,7 @@ impl Scenario {
             "delayed_text" => Some(Self::DelayedText),
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             "retry_then_succeed" => Some(Self::RetryThenSucceed),
+            "execute_extra_tool_roundtrip" => Some(Self::ExecuteExtraToolRoundtrip),
             _ => None,
         }
     }
@@ -249,6 +251,7 @@ impl Scenario {
             Self::DelayedText => "delayed_text",
             Self::AskUserQuestionRoundtrip => "ask_user_question_roundtrip",
             Self::RetryThenSucceed => "retry_then_succeed",
+            Self::ExecuteExtraToolRoundtrip => "execute_extra_tool_roundtrip",
         }
     }
 }
@@ -814,6 +817,16 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             // switches to streaming, this SSE path serves as a fallback.
             final_text_sse(CANNED_COMPACTION_SUMMARY)
         }
+        Scenario::ExecuteExtraToolRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => final_text_sse(&format!(
+                "execute_extra_tool roundtrip complete: {tool_output}"
+            )),
+            None => tool_use_sse(
+                "toolu_execute_extra",
+                "ExecuteExtraTool",
+                &[r#"{"tool_name":"CronList","params":{}}"#],
+            ),
+        },
     }
 }
 
@@ -1207,6 +1220,18 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
         Scenario::LlmCompactionRoundtrip => {
             text_message_response("msg_llm_compaction", CANNED_COMPACTION_SUMMARY)
         }
+        Scenario::ExecuteExtraToolRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => text_message_response(
+                "msg_execute_extra_final",
+                &format!("execute_extra_tool roundtrip complete: {tool_output}"),
+            ),
+            None => tool_message_response(
+                "msg_execute_extra",
+                "toolu_execute_extra",
+                "ExecuteExtraTool",
+                json!({"tool_name": "CronList", "params": {}}),
+            ),
+        },
     }
 }
 
@@ -1246,6 +1271,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         Scenario::LlmCompactionRoundtrip => "req_llm_compaction_roundtrip",
         Scenario::AskUserQuestionRoundtrip => "req_ask_user_question_roundtrip",
         Scenario::RetryThenSucceed => "req_retry_then_succeed",
+        Scenario::ExecuteExtraToolRoundtrip => "req_execute_extra_tool_roundtrip",
     }
 }
 

--- a/rust/crates/rusty-sudocode-cli/tests/pty_deferred_tools.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_deferred_tools.rs
@@ -1,0 +1,33 @@
+//! PTY tests for the deferred tools mechanism (CC parity).
+//!
+//! Verifies the `ExecuteExtraTool` → deferred tool dispatch roundtrip:
+//! the mock LLM emits an `ExecuteExtraTool` call with `tool_name: "CronList"`,
+//! scode dispatches it, and the model sees the CronList result.
+//!
+//! ```bash
+//! cargo test --test pty_deferred_tools                          # mock (CI)
+//! SCODE_TEST_BACKEND=live cargo test --test pty_deferred_tools  # real API
+//! ```
+mod common;
+
+use common::TestEnv;
+
+#[test]
+fn execute_extra_tool_roundtrip() {
+    let env = TestEnv::new("execute-extra-tool");
+    let prompt = env.prompt(
+        "List all scheduled cron tasks using ExecuteExtraTool.",
+        "execute_extra_tool_roundtrip",
+    );
+
+    let mut sess = env.spawn(&["--permission-mode", "danger-full-access", &prompt]);
+
+    sess.expect("roundtrip complete")
+        .expect("should see roundtrip completion message");
+
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(
+        exit, 0,
+        "execute_extra_tool roundtrip should exit 0; got {exit}"
+    );
+}

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -646,6 +646,108 @@ impl GlobalToolRegistry {
         self.runtime_tools.iter().any(|tool| tool.name == name)
     }
 
+    /// Return only core tool definitions (always visible in the API `tools`
+    /// array). Deferred tools are excluded — the LLM discovers them via
+    /// `<available-deferred-tools>` in the system prompt and executes them
+    /// through `ExecuteExtraTool`.
+    #[must_use]
+    pub fn core_definitions(
+        &self,
+        allowed_tools: Option<&BTreeSet<String>>,
+    ) -> Vec<ToolDefinition> {
+        let coord_gate =
+            |name: &str| runtime::coordinator_mode::is_tool_allowed_in_coordinator_mode(name);
+        let builtin = mvp_tool_specs()
+            .into_iter()
+            .filter(|spec| is_core_tool(spec.name))
+            .filter(|spec| allowed_tools.is_none_or(|allowed| allowed.contains(spec.name)))
+            .filter(|spec| coord_gate(spec.name))
+            .map(ToolDefinition::from);
+        let runtime = self
+            .runtime_tools
+            .iter()
+            .filter(|tool| is_core_tool(&tool.name))
+            .filter(|tool| allowed_tools.is_none_or(|allowed| allowed.contains(tool.name.as_str())))
+            .filter(|tool| coord_gate(tool.name.as_str()))
+            .map(|tool| ToolDefinition {
+                name: tool.name.clone(),
+                description: tool.description.clone(),
+                input_schema: tool.input_schema.clone(),
+            });
+        let plugin = self
+            .plugin_tools
+            .iter()
+            .filter(|tool| is_core_tool(tool.definition().name.as_str()))
+            .filter(|tool| {
+                allowed_tools
+                    .is_none_or(|allowed| allowed.contains(tool.definition().name.as_str()))
+            })
+            .filter(|tool| coord_gate(tool.definition().name.as_str()))
+            .map(|tool| ToolDefinition {
+                name: tool.definition().name.clone(),
+                description: tool.definition().description.clone(),
+                input_schema: tool.definition().input_schema.clone(),
+            });
+        builtin.chain(runtime).chain(plugin).collect()
+    }
+
+    /// Return `(name, description)` pairs for all deferred tools — the data
+    /// that populates the `<available-deferred-tools>` system prompt section.
+    /// MCP and plugin tools are included alongside builtins.
+    #[must_use]
+    pub fn deferred_tool_listing(&self) -> Vec<(String, String)> {
+        let builtin = mvp_tool_specs()
+            .into_iter()
+            .filter(|spec| !is_core_tool(spec.name))
+            .map(|spec| (spec.name.to_string(), spec.description.to_string()));
+        let runtime = self
+            .runtime_tools
+            .iter()
+            .filter(|tool| !is_core_tool(&tool.name))
+            .map(|tool| {
+                (
+                    tool.name.clone(),
+                    tool.description.clone().unwrap_or_default(),
+                )
+            });
+        let plugin = self
+            .plugin_tools
+            .iter()
+            .filter(|tool| !is_core_tool(tool.definition().name.as_str()))
+            .map(|tool| {
+                (
+                    tool.definition().name.clone(),
+                    tool.definition().description.clone().unwrap_or_default(),
+                )
+            });
+        builtin.chain(runtime).chain(plugin).collect()
+    }
+
+    /// Format the `<available-deferred-tools>` XML block for system prompt
+    /// injection. Each tool gets one line: `name — description`.
+    #[must_use]
+    pub fn deferred_tools_prompt_section(&self) -> String {
+        let listing = self.deferred_tool_listing();
+        if listing.is_empty() {
+            return String::new();
+        }
+        let mut lines = vec![
+            "<available-deferred-tools>".to_string(),
+            "The following tools are available but not loaded by default. Use ToolSearch to load their full schema, then ExecuteExtraTool to call them.".to_string(),
+        ];
+        for (name, desc) in &listing {
+            let short_desc = desc.split('\n').next().unwrap_or(desc);
+            let short_desc = if short_desc.len() > 120 {
+                format!("{}…", &short_desc[..117])
+            } else {
+                short_desc.to_string()
+            };
+            lines.push(format!("{name} — {short_desc}"));
+        }
+        lines.push("</available-deferred-tools>".to_string());
+        lines.join("\n")
+    }
+
     #[must_use]
     pub fn search(
         &self,
@@ -662,7 +764,17 @@ impl GlobalToolRegistry {
             matches,
             query,
             normalized_query,
-            total_deferred_tools: self.searchable_tool_specs().len(),
+            total_deferred_tools: deferred_tool_specs().len()
+                + self
+                    .runtime_tools
+                    .iter()
+                    .filter(|t| !is_core_tool(&t.name))
+                    .count()
+                + self
+                    .plugin_tools
+                    .iter()
+                    .filter(|t| !is_core_tool(t.definition().name.as_str()))
+                    .count(),
             pending_mcp_servers,
             mcp_degraded,
         }
@@ -722,12 +834,10 @@ impl GlobalToolRegistry {
     }
 
     fn searchable_tool_specs(&self) -> Vec<SearchableToolSpec> {
-        let builtin = deferred_tool_specs()
-            .into_iter()
-            .map(|spec| SearchableToolSpec {
-                name: spec.name.to_string(),
-                description: spec.description.to_string(),
-            });
+        let builtin = mvp_tool_specs().into_iter().map(|spec| SearchableToolSpec {
+            name: spec.name.to_string(),
+            description: spec.description.to_string(),
+        });
         let runtime = self.runtime_tools.iter().map(|tool| SearchableToolSpec {
             name: tool.name.clone(),
             description: tool.description.clone().unwrap_or_default(),
@@ -1015,6 +1125,26 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::ReadOnly,
+        },
+        ToolSpec {
+            name: "ExecuteExtraTool",
+            description: "Execute a deferred tool by name. Use ToolSearch to discover available deferred tools and load their schemas before calling this tool.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "tool_name": {
+                        "type": "string",
+                        "description": "The exact name of the target tool to execute (e.g., \"CronCreate\", \"TaskCreate\")."
+                    },
+                    "params": {
+                        "type": "object",
+                        "description": "The parameters to pass to the target tool."
+                    }
+                },
+                "required": ["tool_name", "params"],
+                "additionalProperties": false
+            }),
+            required_permission: PermissionMode::DangerFullAccess,
         },
         ToolSpec {
             name: "Sleep",
@@ -1687,6 +1817,17 @@ fn execute_tool_with_enforcer(
             from_value::<AgentInput>(&input).and_then(|input| run_agent(input, ctx))
         }
         "ToolSearch" => from_value::<ToolSearchInput>(input).and_then(run_tool_search),
+        "ExecuteExtraTool" => {
+            let eti: ExecuteExtraToolInput = from_value(input)?;
+            let target = canonicalize_tool_name(&eti.tool_name);
+            if is_core_tool(&target) {
+                return Err(format!(
+                    "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
+                    eti.tool_name
+                ));
+            }
+            execute_tool_with_enforcer(enforcer, &target, &eti.params, abort_signal, ctx, fs)
+        }
         "Sleep" => from_value::<SleepInput>(input).and_then(|input| run_sleep(input, abort_signal)),
         "Config" => from_value::<ConfigInput>(input).and_then(run_config),
         "EnterPlanMode" => from_value::<EnterPlanModeInput>(input).and_then(run_enter_plan_mode),
@@ -3643,6 +3784,12 @@ struct AgentInput {
 struct ToolSearchInput {
     query: String,
     max_results: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecuteExtraToolInput {
+    tool_name: String,
+    params: Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -7119,15 +7266,38 @@ fn execute_tool_search(input: ToolSearchInput) -> ToolSearchOutput {
     GlobalToolRegistry::builtin().search(&input.query, input.max_results.unwrap_or(5), None, None)
 }
 
+/// Tools always visible in the API `tools` array — the LLM sees their
+/// full schema on every turn. Everything else is "deferred": listed by
+/// name + one-line description in `<available-deferred-tools>` and
+/// accessed through `ToolSearch` (discovery) + `ExecuteExtraTool`
+/// (execution).
+const CORE_TOOLS: &[&str] = &[
+    "bash",
+    "read_file",
+    "read_tool_output",
+    "write_file",
+    "edit_file",
+    "glob_search",
+    "grep_search",
+    "WebFetch",
+    "WebSearch",
+    "Skill",
+    "agent_spawn",
+    "agent_list",
+    "pid_fork",
+    "ToolSearch",
+    "ExecuteExtraTool",
+    "AskUserQuestion",
+];
+
+fn is_core_tool(name: &str) -> bool {
+    CORE_TOOLS.contains(&name)
+}
+
 fn deferred_tool_specs() -> Vec<ToolSpec> {
     mvp_tool_specs()
         .into_iter()
-        .filter(|spec| {
-            !matches!(
-                spec.name,
-                "bash" | "read_file" | "write_file" | "edit_file" | "glob_search" | "grep_search"
-            )
-        })
+        .filter(|spec| !is_core_tool(spec.name))
         .collect()
 }
 
@@ -9707,6 +9877,126 @@ mod tests {
             serde_json::from_str(&selected_with_alias).expect("valid json");
         assert_eq!(selected_with_alias_output["matches"][0], "Agent");
         assert_eq!(selected_with_alias_output["matches"][1], "Skill");
+    }
+
+    #[test]
+    fn core_tools_are_subset_of_mvp_tool_specs() {
+        let all_names: BTreeSet<&str> = mvp_tool_specs().iter().map(|s| s.name).collect();
+        for &core in super::CORE_TOOLS {
+            assert!(
+                all_names.contains(core),
+                "CORE_TOOLS entry `{core}` not found in mvp_tool_specs()"
+            );
+        }
+    }
+
+    #[test]
+    fn core_definitions_excludes_deferred_tools() {
+        let registry = GlobalToolRegistry::builtin();
+        let core = registry.core_definitions(None);
+        let all = registry.definitions(None);
+        assert!(
+            core.len() < all.len(),
+            "core should be a strict subset of all"
+        );
+        let core_names: BTreeSet<_> = core.iter().map(|d| d.name.as_str()).collect();
+        assert!(core_names.contains("bash"));
+        assert!(core_names.contains("ToolSearch"));
+        assert!(core_names.contains("ExecuteExtraTool"));
+        assert!(
+            !core_names.contains("CronCreate"),
+            "CronCreate should be deferred"
+        );
+        assert!(!core_names.contains("Sleep"), "Sleep should be deferred");
+        assert!(
+            !core_names.contains("TaskCreate"),
+            "TaskCreate should be deferred"
+        );
+    }
+
+    #[test]
+    fn deferred_tool_listing_returns_non_core_tools() {
+        let registry = GlobalToolRegistry::builtin();
+        let listing = registry.deferred_tool_listing();
+        let names: BTreeSet<_> = listing.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains("CronCreate"));
+        assert!(names.contains("Sleep"));
+        assert!(names.contains("TaskCreate"));
+        assert!(!names.contains("bash"), "bash is core");
+        assert!(!names.contains("ToolSearch"), "ToolSearch is core");
+        assert!(
+            !names.contains("ExecuteExtraTool"),
+            "ExecuteExtraTool is core"
+        );
+        for (_, desc) in &listing {
+            assert!(
+                !desc.is_empty(),
+                "every deferred tool should have a description"
+            );
+        }
+    }
+
+    #[test]
+    fn deferred_tools_prompt_section_has_xml_tags() {
+        let registry = GlobalToolRegistry::builtin();
+        let section = registry.deferred_tools_prompt_section();
+        assert!(section.starts_with("<available-deferred-tools>"));
+        assert!(section.ends_with("</available-deferred-tools>"));
+        assert!(section.contains("CronCreate"));
+        assert!(section.contains("Sleep"));
+        assert!(
+            !section.contains("\nbash —"),
+            "core tools should not appear"
+        );
+    }
+
+    #[test]
+    fn execute_extra_tool_dispatches_to_deferred_tool() {
+        let _guard = env_guard();
+        let result = execute_tool(
+            "ExecuteExtraTool",
+            &json!({
+                "tool_name": "CronList",
+                "params": {}
+            }),
+        );
+        assert!(
+            result.is_ok(),
+            "ExecuteExtraTool should dispatch CronList: {result:?}"
+        );
+    }
+
+    #[test]
+    fn execute_extra_tool_rejects_core_tool() {
+        let _guard = env_guard();
+        let result = execute_tool(
+            "ExecuteExtraTool",
+            &json!({
+                "tool_name": "bash",
+                "params": {"command": "echo hi"}
+            }),
+        );
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("core tool"),
+            "should tell model to call core tools directly"
+        );
+    }
+
+    #[test]
+    fn execute_extra_tool_resolves_aliases() {
+        let _guard = env_guard();
+        let result = execute_tool(
+            "ExecuteExtraTool",
+            &json!({
+                "tool_name": "TaskList",
+                "params": {}
+            }),
+        );
+        assert!(
+            result.is_ok(),
+            "ExecuteExtraTool should resolve alias TaskList → pid_status: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/sudo-code-roadmap.html
+++ b/sudo-code-roadmap.html
@@ -545,7 +545,8 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>LSP <code>findReferences</code></td><td data-priority="nice">nice</td><td data-status="gap-l2">Gap (L2)</td><td>—</td><td></td></tr>
     <tr><td>LSP <code>hover</code></td><td data-priority="nice">nice</td><td data-status="gap-l2">Gap (L2)</td><td>—</td><td></td></tr>
     <tr><td>LSP <code>documentSymbol</code></td><td data-priority="nice">nice</td><td data-status="gap-l2">Gap (L2)</td><td>—</td><td></td></tr>
-    <tr><td><code>ToolSearch</code></td><td data-priority="must-have">must-have</td><td data-status="gap">Gap</td><td>—</td><td>Search for tools by keyword</td></tr>
+    <tr><td><code>ToolSearch</code></td><td data-priority="must-have">must-have</td><td data-status="covered"><strong>Covered</strong></td><td><code>tools::tool_search_supports_keyword_and_select_queries</code></td><td>Keyword + <code>select:</code> exact-match queries, alias resolution. ToolSearch covers the full tool registry (core + deferred + MCP + plugin).</td></tr>
+    <tr><td>Deferred tools CC parity (<code>ExecuteExtraTool</code> + <code>&lt;available-deferred-tools&gt;</code>)</td><td data-priority="must-have">must-have</td><td data-status="covered"><strong>Covered</strong></td><td><code>tools::{core_tools_are_subset_of_mvp_tool_specs, core_definitions_excludes_deferred_tools, deferred_tool_listing_returns_non_core_tools, deferred_tools_prompt_section_has_xml_tags, execute_extra_tool_dispatches_to_deferred_tool, execute_extra_tool_rejects_core_tool, execute_extra_tool_resolves_aliases}</code></td><td>CC-style two-step deferred tools: <code>CORE_TOOLS</code> (16 tools) visible in API <code>tools</code> array; remaining ~22 tools listed by name + one-line description in <code>&lt;available-deferred-tools&gt;</code> system prompt section. <code>ExecuteExtraTool</code> dispatches to any deferred tool by name with permission enforcement; rejects direct calls to core tools. Alias resolution (TaskList → pid_status) works through <code>ExecuteExtraTool</code>.</td></tr>
   </tbody>
 </table>
 
@@ -740,7 +741,7 @@ coverage starts fresh and is tracked here as the single source.</p>
     <tr><td>File Operations</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>5</strong></td></tr>
     <tr><td>Execution</td><td>4</td><td>0</td><td>0</td><td>4</td><td><strong>1</strong></td></tr>
     <tr><td>Search &amp; Web</td><td>3</td><td>0</td><td>0</td><td>3</td><td>0</td></tr>
-    <tr><td>Code Intelligence</td><td>5</td><td>0</td><td>4</td><td>1</td><td>0</td></tr>
+    <tr><td>Code Intelligence</td><td>7</td><td>0</td><td>4</td><td>3</td><td><strong>2</strong></td></tr>
     <tr><td>Planning &amp; Structured</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>3</strong></td></tr>
     <tr><td>Background &amp; Parallel</td><td>11</td><td>0</td><td>0</td><td>11</td><td><strong>7</strong></td></tr>
     <tr><td>Git Workflow</td><td>5</td><td>0</td><td>0</td><td>5</td><td><strong>1</strong></td></tr><!-- 3 must-have (bash git ops) + 2 nice (skill shortcuts) -->


### PR DESCRIPTION
## Summary

- Implement CC-style deferred tools: 16 CORE_TOOLS in API `tools` array, everything else listed by name+description in `<available-deferred-tools>` system prompt section
- Add `ExecuteExtraTool` — in-memory dispatch proxy that canonicalizes target name via TOOL_ALIASES, rejects core tools, recursively calls `execute_tool_with_enforcer()` for deferred tools
- Add `GlobalToolRegistry::core_definitions()`, `deferred_tool_listing()`, `deferred_tools_prompt_section()`
- Switch `engine_client` to `core_definitions()` for API requests (saves ~tokens per request)
- Inject `deferred_tools_prompt_section()` into runtime system prompt dynamic sections
- Add `ExecuteExtraToolRoundtrip` mock scenario + PTY test
- 7 new unit tests: core/deferred partitioning, ExecuteExtraTool dispatch/rejection/alias resolution

## Test plan

- [x] 118 unit tests pass (`cargo test -p tools`)
- [x] PTY test `execute_extra_tool_roundtrip` passes
- [x] Full `cargo test` passes (all crates)
- [ ] CI green