### PR TITLE
fix(a2a): resume the standalone inbox from a durable cursor, not the tail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ status-help.txt
 .sandbox-home/
 .hydra
 sudocode.json
+
+# Task registry written by the tools test-suite into whatever directory it
+# runs in. A test artifact, never a source file — without this every
+# `cargo test` leaves the tree dirty.
+.sudocode-tasks.json

--- a/rust/crates/engine-host/src/nexus_a2a.rs
+++ b/rust/crates/engine-host/src/nexus_a2a.rs
@@ -14,6 +14,7 @@
 //! transport (config, dial, send, poll) still lives once in
 //! `runtime::nexus_mailbox`; this module only owns the process-lifetime handle.
 
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
 
@@ -28,6 +29,50 @@ use runtime::HookAbortSignal;
 /// the deadline so the loop can re-check `abort`. This is event-driven, not a
 /// poll interval — an idle receiver costs one parked RPC, not a `sleep` spin.
 const INBOX_WAIT_MS: u64 = 500;
+
+/// Where this client remembers how far it has read its own inbox.
+///
+/// Client-local, and deliberately not in the nexus namespace: the co-host
+/// stores its cursor there because the co-host *is* the node, but a standalone
+/// `scode` is one of possibly several clients of a remote node, and "which
+/// messages has THIS client shown its user" is not the node's business.
+///
+/// Keyed by agent so two identities on one machine do not share a position.
+fn cursor_path_for(agent: &str) -> PathBuf {
+    let safe: String = agent
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    runtime::config::default_config_home().join(format!("a2a-cursor-{safe}"))
+}
+
+/// The last offset this client consumed, or `None` when it has never run.
+///
+/// `None` and `Some(0)` mean different things and the difference is the point:
+/// never-run seeks to the tail (a first-time receiver should not replay an
+/// inbox it was never party to), while a recorded 0 resumes from the head.
+/// Any unreadable or unparsable cursor is treated as never-run.
+fn load_cursor(agent: &str) -> Option<u64> {
+    std::fs::read_to_string(cursor_path_for(agent))
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+}
+
+/// Record how far this client has read. Best-effort: losing a write only costs
+/// the no-loss guarantee on the next start, never correctness now.
+fn save_cursor(agent: &str, offset: u64) {
+    let path = cursor_path_for(agent);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, offset.to_string());
+}
 
 /// The resolved, connected standalone A2A session.
 pub struct Session {
@@ -117,15 +162,33 @@ pub fn spawn_poller(
     std::thread::Builder::new()
         .name("nexus-a2a-receiver".into())
         .spawn(move || {
-            // Seek to tail: a non-blocking (block_ms=0) drain-and-discard once
-            // to fix the cursor at the current end, so only messages that
-            // arrive after startup surface.
-            let mut cursor = match nexus_mailbox::poll_new(&client, &agent, 0, &api_key, 0) {
-                Ok((_history, tail)) => tail,
-                Err(e) => {
-                    eprintln!("[nexus-a2a] initial inbox seek failed: {e}");
-                    0
-                }
+            // Resume where this client left off, so a message that arrived
+            // while nothing was listening is still delivered.
+            //
+            // Seeking to the tail on every start looks reasonable — nobody
+            // wants their history replayed — but it makes delivery depend on
+            // the receiver happening to be running at the moment of the send.
+            // Two agents handing off asynchronously then lose messages that
+            // the sender was told were delivered and that are sitting durably
+            // in the stream: observed live in the Win↔Mac duet, where a reply
+            // landed while the peer was between processes and no later reader
+            // ever looked back at it.
+            //
+            // A first run still seeks to the tail: a receiver that has never
+            // read this inbox was not party to what came before, and replaying
+            // it would be the other failure (the #81 re-reply storm).
+            let mut cursor = match load_cursor(&agent) {
+                Some(saved) => saved,
+                None => match nexus_mailbox::poll_new(&client, &agent, 0, &api_key, 0) {
+                    Ok((_history, tail)) => {
+                        save_cursor(&agent, tail);
+                        tail
+                    }
+                    Err(e) => {
+                        eprintln!("[nexus-a2a] initial inbox seek failed: {e}");
+                        0
+                    }
+                },
             };
             while !abort.is_aborted() {
                 // Block on the tail up to INBOX_WAIT_MS, then drain the burst.
@@ -134,7 +197,16 @@ pub fn spawn_poller(
                         for m in &msgs {
                             sink(m);
                         }
-                        cursor = next;
+                        // Persist only on real forward progress: an idle
+                        // deadline return would otherwise rewrite the same
+                        // offset twice a second. Saving after the sink has run
+                        // makes a crash re-deliver the last message rather than
+                        // drop it — at-least-once, which is the right side to
+                        // err on for mail.
+                        if next > cursor {
+                            cursor = next;
+                            save_cursor(&agent, cursor);
+                        }
                     }
                     Err(e) => {
                         eprintln!("[nexus-a2a] inbox poll failed: {e}");

--- a/rust/crates/rusty-sudocode-cli/examples/a2a_poke.rs
+++ b/rust/crates/rusty-sudocode-cli/examples/a2a_poke.rs
@@ -1,0 +1,49 @@
+//! Write one A2A envelope into an agent's inbox over mTLS, then exit.
+//!
+//! A stand-in for the far end of a duet while the other machine is still
+//! building: it proves the auth-on receive path — dial, stamp, deliver — with
+//! nothing but a cert, so the first real cross-machine attempt is not also the
+//! first time this chain has ever run.
+//!
+//! ```text
+//! cargo run -p rusty-sudocode-cli --example a2a_poke -- \
+//!   <endpoint> <from-agent> <to-agent> <cert-dir> <body>
+//! ```
+//!
+//! `<cert-dir>` is a minted agent bundle (`agent.pem`, `agent-key.pem`,
+//! `ca.pem`). The node overwrites the authored `from` with the authenticated
+//! identity, so passing a `<from-agent>` that does not match the cert is the
+//! forgery check, not a way to spoof.
+
+use std::sync::Arc;
+
+use nexus_vfs_client::NexusVfsClient;
+use runtime::nexus_mailbox::{ensure_inbox, send};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let [_, endpoint, from, to, cert_dir, body] = args.as_slice() else {
+        eprintln!("usage: a2a_poke <endpoint> <from> <to> <cert-dir> <body>");
+        std::process::exit(2);
+    };
+
+    let read = |name: &str| {
+        std::fs::read(std::path::Path::new(cert_dir).join(name))
+            .unwrap_or_else(|e| panic!("read {cert_dir}/{name}: {e}"))
+    };
+    let client = Arc::new(
+        NexusVfsClient::connect_tls(
+            endpoint,
+            read("ca.pem"),
+            read("agent.pem"),
+            read("agent-key.pem"),
+            "nexus-node",
+        )
+        .unwrap_or_else(|e| panic!("dial {endpoint} over mTLS: {e}")),
+    );
+
+    // Idempotent, and the sender's own inbox has to exist for a reply to land.
+    ensure_inbox(&client, from, "").unwrap_or_else(|e| panic!("ensure {from} inbox: {e}"));
+    send(&client, from, to, body, "").unwrap_or_else(|e| panic!("send to {to}: {e}"));
+    println!("sent as {from} -> {to}: {body}");
+}

--- a/rust/crates/rusty-sudocode-cli/examples/a2a_read.rs
+++ b/rust/crates/rusty-sudocode-cli/examples/a2a_read.rs
@@ -1,0 +1,50 @@
+//! Dump an agent's whole inbox from offset 0, over mTLS.
+//!
+//! The receiver a `scode` client runs is deliberately forward-only — it
+//! resumes from where that client last read, and a brand-new client seeks to
+//! the tail. Neither ever looks backwards. So when a message is known to have
+//! been delivered but nobody was there to see it, this is how you read it: the
+//! frames are durable in the DT_STREAM, it is only the client cursors that
+//! moved past them.
+//!
+//! ```text
+//! cargo run -p rusty-sudocode-cli --example a2a_read -- <endpoint> <agent> <cert-dir>
+//! ```
+
+use std::sync::Arc;
+
+use nexus_vfs_client::NexusVfsClient;
+use runtime::nexus_mailbox::poll_new;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let [_, endpoint, agent, cert_dir] = args.as_slice() else {
+        eprintln!("usage: a2a_read <endpoint> <agent> <cert-dir>");
+        std::process::exit(2);
+    };
+
+    let read = |name: &str| {
+        std::fs::read(std::path::Path::new(cert_dir).join(name))
+            .unwrap_or_else(|e| panic!("read {cert_dir}/{name}: {e}"))
+    };
+    let client = Arc::new(
+        NexusVfsClient::connect_tls(
+            endpoint,
+            read("ca.pem"),
+            read("agent.pem"),
+            read("agent-key.pem"),
+            "nexus-node",
+        )
+        .unwrap_or_else(|e| panic!("dial {endpoint} over mTLS: {e}")),
+    );
+
+    // From the head, non-blocking: everything the inbox holds, right now.
+    let (msgs, next) = poll_new(&client, agent, 0, "", 0).unwrap_or_else(|e| panic!("read: {e}"));
+    println!(
+        "{agent} inbox: {} message(s), next offset {next}",
+        msgs.len()
+    );
+    for (i, m) in msgs.iter().enumerate() {
+        println!("  [{i}] from={} :: {}", m.from, m.body);
+    }
+}

--- a/rust/crates/rusty-sudocode-cli/tests/acp_a2a_receive.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/acp_a2a_receive.rs
@@ -26,7 +26,8 @@
 //! sender exactly.
 
 use std::io::{BufRead, BufReader, Write};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -47,7 +48,14 @@ const NOTIFICATION_BUDGET: Duration = Duration::from_secs(30);
 struct AcpStdio {
     child: Child,
     stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
+    /// Lines pumped off stdout by a reader thread.
+    ///
+    /// Reading inline would make every budget in this file a lie: a blocking
+    /// `read_line` on a stream that never produces another byte cannot notice
+    /// its own deadline, so a failing assertion presents as a hang and the test
+    /// has to be killed by hand. The pump turns "nothing arrived" into a
+    /// timeout, which is what a test is supposed to report.
+    lines: Receiver<String>,
     next_id: u64,
 }
 
@@ -67,14 +75,22 @@ impl AcpStdio {
     }
 
     fn read_message(&mut self) -> Value {
-        let mut line = String::new();
-        let read = self
-            .stdout
-            .read_line(&mut line)
-            .expect("read from scode acp");
-        assert!(read > 0, "scode acp closed its stdout unexpectedly");
-        serde_json::from_str(&line)
-            .unwrap_or_else(|e| panic!("non-JSON line from acp: {e}: {line}"))
+        self.read_message_within(NOTIFICATION_BUDGET)
+            .unwrap_or_else(|| panic!("no line from scode acp within {NOTIFICATION_BUDGET:?}"))
+    }
+
+    /// The next line, or `None` if the stream stayed silent for `budget`.
+    fn read_message_within(&mut self, budget: Duration) -> Option<Value> {
+        match self.lines.recv_timeout(budget) {
+            Ok(line) => Some(
+                serde_json::from_str(&line)
+                    .unwrap_or_else(|e| panic!("non-JSON line from acp: {e}: {line}")),
+            ),
+            Err(RecvTimeoutError::Timeout) => None,
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("scode acp closed its stdout unexpectedly")
+            }
+        }
     }
 
     /// Read notifications until one satisfies `matches`, or the budget expires.
@@ -83,16 +99,29 @@ impl AcpStdio {
     /// notifications: what is under test is precisely whether the server can
     /// speak to the client with nothing in flight.
     fn await_notification(&mut self, matches: impl Fn(&Value) -> bool) -> Value {
-        let deadline = Instant::now() + NOTIFICATION_BUDGET;
+        self.try_await_notification(matches, NOTIFICATION_BUDGET)
+            .unwrap_or_else(|seen| {
+                panic!("no matching notification within {NOTIFICATION_BUDGET:?}; saw {seen:#?}")
+            })
+    }
+
+    /// `Ok(notification)` or `Err(everything that did arrive)` — so a test can
+    /// assert that something did NOT show up without the absence being a hang.
+    fn try_await_notification(
+        &mut self,
+        matches: impl Fn(&Value) -> bool,
+        budget: Duration,
+    ) -> Result<Value, Vec<Value>> {
+        let deadline = Instant::now() + budget;
         let mut seen = Vec::new();
-        while Instant::now() < deadline {
-            let msg = self.read_message();
-            if msg.get("method").is_some() && matches(&msg) {
-                return msg;
+        while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+            match self.read_message_within(remaining) {
+                Some(msg) if msg.get("method").is_some() && matches(&msg) => return Ok(msg),
+                Some(msg) => seen.push(msg),
+                None => break,
             }
-            seen.push(msg);
         }
-        panic!("no matching notification within {NOTIFICATION_BUDGET:?}; saw {seen:#?}");
+        Err(seen)
     }
 }
 
@@ -100,6 +129,55 @@ impl Drop for AcpStdio {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+/// Start `scode acp` wired to `endpoint` as `agent`, with an isolated config
+/// home so the durable read cursor a test writes cannot leak into another test
+/// or into the developer's own.
+fn spawn_acp(
+    endpoint: &str,
+    agent: &str,
+    peer: &str,
+    workspace: &tempfile::TempDir,
+    config_home: &tempfile::TempDir,
+) -> AcpStdio {
+    // An isolated config home needs a config: the point of isolating it is the
+    // read cursor, not to test scode's behaviour without providers.
+    std::fs::write(
+        config_home.path().join("sudocode.json"),
+        runtime::SAMPLE_SUDOCODE_JSON,
+    )
+    .expect("seed the isolated config home");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_scode"));
+    cmd.arg("acp")
+        .current_dir(workspace.path())
+        .env("SUDO_CODE_CONFIG_HOME", config_home.path())
+        .env("NEXUS_A2A_ENDPOINT", endpoint)
+        .env("NEXUS_A2A_AGENT", agent)
+        .env("NEXUS_A2A_PEER", peer)
+        .env("SUDOCODE_INTERRUPT_QUEUE_MODE", "off")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let mut child = cmd.spawn().expect("spawn scode acp");
+    let stdin = child.stdin.take().expect("stdin piped");
+    let stdout = child.stdout.take().expect("stdout piped");
+    let (tx, lines) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    AcpStdio {
+        child,
+        stdin,
+        lines,
+        next_id: 0,
     }
 }
 
@@ -117,25 +195,8 @@ fn a2a_peer_message_reaches_an_acp_client() {
     ensure_inbox(&client, PEER_AGENT, "").expect("provision the peer inbox");
 
     let workspace = tempfile::tempdir().expect("temp workspace");
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_scode"));
-    cmd.arg("acp")
-        .current_dir(workspace.path())
-        .env("NEXUS_A2A_ENDPOINT", &endpoint)
-        .env("NEXUS_A2A_AGENT", SELF_AGENT)
-        .env("NEXUS_A2A_PEER", PEER_AGENT)
-        .env("SUDOCODE_INTERRUPT_QUEUE_MODE", "off")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit());
-    let mut child = cmd.spawn().expect("spawn scode acp");
-    let stdin = child.stdin.take().expect("stdin piped");
-    let stdout = child.stdout.take().expect("stdout piped");
-    let mut acp = AcpStdio {
-        child,
-        stdin,
-        stdout: BufReader::new(stdout),
-        next_id: 0,
-    };
+    let config_home = tempfile::tempdir().expect("temp config home");
+    let mut acp = spawn_acp(&endpoint, SELF_AGENT, PEER_AGENT, &workspace, &config_home);
 
     let init = acp.request(
         "initialize",
@@ -182,5 +243,137 @@ fn a2a_peer_message_reaches_an_acp_client() {
         notification["params"]["_meta"]["sudocode"]["a2a"]["from"], PEER_AGENT,
         "the sender is also structured, so a client can tell peer mail from a \
          human typing rather than parsing the prose: {notification}"
+    );
+}
+
+/// A message that arrives while nothing is listening is still delivered to the
+/// next receiver.
+///
+/// The receiver used to seek to the tail on every start, which made delivery
+/// depend on the receiver happening to be running at the moment of the send.
+/// Two agents handing off asynchronously then lose mail that the sender was
+/// told was delivered and that is sitting durably in the stream — observed live
+/// in the Win↔Mac duet, where a reply landed while the peer was between
+/// processes and no later reader ever looked back at it.
+#[test]
+#[ignore = "requires a running nexusd-cluster; set NEXUS_A2A_TEST_ENDPOINT"]
+fn a_message_sent_while_offline_is_delivered_on_the_next_start() {
+    let endpoint =
+        std::env::var("NEXUS_A2A_TEST_ENDPOINT").expect("set NEXUS_A2A_TEST_ENDPOINT=host:port");
+    // A fresh identity per run, so "has this client ever read?" is unambiguous.
+    let agent = format!("offline-probe-{}", std::process::id());
+    let peer = format!("{agent}-peer");
+
+    let client = Arc::new(NexusVfsClient::connect(&endpoint).expect("dial the daemon"));
+    ensure_inbox(&client, &agent, "").expect("provision the agent inbox");
+    ensure_inbox(&client, &peer, "").expect("provision the peer inbox");
+
+    let workspace = tempfile::tempdir().expect("temp workspace");
+    let config_home = tempfile::tempdir().expect("temp config home");
+
+    // First run: establishes the cursor, then goes away.
+    let cursor_file = config_home.path().join(format!("a2a-cursor-{agent}"));
+    {
+        let mut acp = spawn_acp(&endpoint, &agent, &peer, &workspace, &config_home);
+        acp.request(
+            "initialize",
+            json!({"protocolVersion": 1, "clientCapabilities": {}}),
+        );
+        acp.request(
+            "session/new",
+            json!({"cwd": workspace.path().to_string_lossy(), "mcpServers": []}),
+        );
+        // Wait for the cursor to actually exist before killing the process.
+        // The premise of this test is "a client that HAS read this inbox
+        // before"; without the wait it would sometimes assert that against a
+        // client that was killed mid-handshake, which is a different scenario
+        // and would fail for the wrong reason.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !cursor_file.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            cursor_file.exists(),
+            "the first run should record a read cursor at {}",
+            cursor_file.display()
+        );
+    } // dropped: the receiver is gone
+
+    // The peer writes into a mailbox nobody is watching.
+    let body = "sent while the receiver was down";
+    send(&client, &peer, &agent, body, "").expect("peer writes while nothing listens");
+
+    // Second run: must pick up where the first left off.
+    let mut acp = spawn_acp(&endpoint, &agent, &peer, &workspace, &config_home);
+    acp.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    acp.request(
+        "session/new",
+        json!({"cwd": workspace.path().to_string_lossy(), "mcpServers": []}),
+    );
+    let notification = acp.await_notification(|msg| {
+        msg["method"] == "session/update"
+            && msg["params"]["update"]["sessionUpdate"] == "user_message_chunk"
+    });
+    let text = notification["params"]["update"]["content"]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("update carries text: {notification}"));
+    assert!(
+        text.contains(body),
+        "a message sent while offline must survive to the next start: {text}"
+    );
+}
+
+/// A receiver that has never read this inbox does not replay its history.
+///
+/// The other direction, and the reason the fix is a resumed cursor rather than
+/// "always start from zero": an agent that was never party to a conversation
+/// should not wake up and answer all of it. That is the re-reply storm the
+/// co-host path had to fix once already.
+#[test]
+#[ignore = "requires a running nexusd-cluster; set NEXUS_A2A_TEST_ENDPOINT"]
+fn a_first_time_receiver_does_not_replay_history() {
+    let endpoint =
+        std::env::var("NEXUS_A2A_TEST_ENDPOINT").expect("set NEXUS_A2A_TEST_ENDPOINT=host:port");
+    let agent = format!("virgin-probe-{}", std::process::id());
+    let peer = format!("{agent}-peer");
+
+    let client = Arc::new(NexusVfsClient::connect(&endpoint).expect("dial the daemon"));
+    ensure_inbox(&client, &agent, "").expect("provision the agent inbox");
+    ensure_inbox(&client, &peer, "").expect("provision the peer inbox");
+
+    // History accumulates before this client has ever existed.
+    send(&client, &peer, &agent, "ancient history", "").expect("write history");
+
+    let workspace = tempfile::tempdir().expect("temp workspace");
+    let config_home = tempfile::tempdir().expect("temp config home");
+    let mut acp = spawn_acp(&endpoint, &agent, &peer, &workspace, &config_home);
+    acp.request(
+        "initialize",
+        json!({"protocolVersion": 1, "clientCapabilities": {}}),
+    );
+    acp.request(
+        "session/new",
+        json!({"cwd": workspace.path().to_string_lossy(), "mcpServers": []}),
+    );
+
+    // A live message proves the receiver is working, and its arrival is the
+    // point at which "history was not replayed" becomes a fact rather than a
+    // race with a slow delivery.
+    let live = "sent after the receiver came up";
+    std::thread::sleep(Duration::from_millis(500));
+    send(&client, &peer, &agent, live, "").expect("write a live message");
+    let notification = acp.await_notification(|msg| {
+        msg["method"] == "session/update"
+            && msg["params"]["update"]["sessionUpdate"] == "user_message_chunk"
+    });
+    let text = notification["params"]["update"]["content"]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("update carries text: {notification}"));
+    assert!(
+        text.contains(live) && !text.contains("ancient history"),
+        "the first delivery should be the live message, not replayed history: {text}"
     );
 }


### PR DESCRIPTION
## The bug, caught live

The standalone receiver sought to the tail on every start — a drain-and-discard that pins the cursor at the current end so history is not replayed. That makes delivery depend on the receiver happening to be running **at the moment of the send**. Two agents handing off asynchronously then lose mail that the sender was told was delivered and that is sitting durably in the stream.

Observed in the Win↔Mac duet an hour ago: `win-ai`'s reply reported `"message delivered to mac-ai"`, the frame was in the DT_STREAM, and `mac-ai`'s next receiver seeked straight past it. Nothing errored and nothing retried, because from both ends it looked like it had worked. That is the worst shape a delivery bug can take.

## The fix

The cursor is remembered between runs. Two cases, and keeping them apart is the whole design:

| state | behaviour | why |
|---|---|---|
| never read this inbox | seek to the tail | a receiver that was not party to a conversation should not wake up and answer all of it — the co-host's #81 re-reply storm |
| read it before | resume from where it left off | nothing that arrived in between is lost |

So `None` and `Some(0)` mean different things, and the code says which.

**Stored client-side**, unlike the co-host's cursor which lives in the nexus namespace. The co-host *is* the node; a standalone `scode` is one of possibly several clients of a remote node, and "which messages has THIS client shown its user" is not the node's business. Keyed by agent so two identities on one machine do not share a position.

Saved only on real forward progress — an idle deadline return would otherwise rewrite the same offset twice a second — and **after** the sink has run, so a crash re-delivers the last message rather than dropping it. At-least-once is the right side to err on for mail.

## Verification

Two new live E2E tests, one per row of that table, against a real `nexusd-cluster`:

```
a2a_peer_message_reaches_an_acp_client ......................... ok
a_first_time_receiver_does_not_replay_history .................. ok
a_message_sent_while_offline_is_delivered_on_the_next_start .... ok
```

The offline test failed first time for the *right* reason — its first run was killed before the poller had recorded a cursor, so it was asserting "a client that has read before" against a client that had not. It now waits for the cursor to exist, which is the premise it actually needs.

Plus two example binaries, `a2a_poke` and `a2a_read` — how you write to and read an inbox by hand when a client's cursor has moved past something. They are what I used to diagnose this.

## Incidental, and worth a look

**This file's own test harness had a defect that made a failure look like a hang.** `await_notification` carried a 30s budget but read through a blocking `read_line`, which cannot notice its own deadline on a stream that goes quiet. A failing assertion therefore produced no output and had to be killed by hand after seven minutes. Reads now come off a pump thread with `recv_timeout`: the same failure reported in 62 seconds **and named its cause** (an isolated config home with no `sudocode.json`). A timeout that cannot fire is worse than no timeout.

**`.sudocode-tasks.json` is now gitignored.** The tools test-suite writes it into whatever directory it runs in, so every `cargo test --workspace` was leaving the tree dirty and it nearly rode into this PR.

`cargo test --workspace`: **123 binaries, 0 failures** on Windows; clippy and fmt clean.