### PR TITLE
chore(config): drop the autoMemoryEnabled key that nothing reads

### DIFF
--- a/rust/crates/tools/.sudocode-tasks.json
+++ b/rust/crates/tools/.sudocode-tasks.json
@@ -1,0 +1,52 @@
+[
+  {
+    "task_id": "task_6aa230cb_1",
+    "subject": "Write parser",
+    "prompt": "Write parser",
+    "description": "Build the AST parser module",
+    "activeForm": "Writing parser",
+    "task_packet": null,
+    "status": "pending",
+    "created_at": 1789014219,
+    "updated_at": 1789014219,
+    "messages": [],
+    "output": ""
+  },
+  {
+    "task_id": "task_6aa230cc_2",
+    "subject": "Run tests",
+    "prompt": "Run tests",
+    "description": "Execute test suite",
+    "task_packet": null,
+    "status": "completed",
+    "created_at": 1789014220,
+    "updated_at": 1789014220,
+    "messages": [],
+    "output": ""
+  },
+  {
+    "task_id": "task_6aa23140_3",
+    "subject": "Write parser",
+    "prompt": "Write parser",
+    "description": "Build the AST parser module",
+    "activeForm": "Writing parser",
+    "task_packet": null,
+    "status": "pending",
+    "created_at": 1789014336,
+    "updated_at": 1789014336,
+    "messages": [],
+    "output": ""
+  },
+  {
+    "task_id": "task_6aa23141_4",
+    "subject": "Run tests",
+    "prompt": "Run tests",
+    "description": "Execute test suite",
+    "task_packet": null,
+    "status": "completed",
+    "created_at": 1789014337,
+    "updated_at": 1789014337,
+    "messages": [],
+    "output": ""
+  }
+]

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7991,12 +7991,6 @@ fn supported_config_setting(setting: &str) -> Option<ConfigSettingSpec> {
             path: &["autoCompactEnabled"],
             options: None,
         },
-        "autoMemoryEnabled" => ConfigSettingSpec {
-            scope: ConfigScope::Settings,
-            kind: ConfigKind::Boolean,
-            path: &["autoMemoryEnabled"],
-            options: None,
-        },
         "autoDreamEnabled" => ConfigSettingSpec {
             scope: ConfigScope::Settings,
             kind: ConfigKind::Boolean,


### PR DESCRIPTION
## 问题

`autoMemoryEnabled` 是一个**能设、没人读、而且设了会把配置文件弄坏**的键。

- `tools::supported_config_setting` 里有它的完整声明，所以 REPL 的 `/config set` 和
  agent 的 `config` 工具都能把它写进 settings.json（两者共用 `set_config_setting` 这一个写入口）。
- 全仓库没有任何代码读它：`RuntimeFeatureConfig` 里没有对应字段。
- 它**不在 `SETTINGS_SCHEMA`** 里，而未知键是会被拒的。所以设完之后：

```
$ scode config validate
error: settings.json: unknown key "autoMemoryEnabled" (line 3)
```

不是"设了不生效"，是"设了让配置非法"。

## 改了什么

删掉 `supported_config_setting` 里的那一段声明（6 行）。之后写入会在唯一的写入口失败并报错，
这是一个没有读者的键本来就该有的行为。

## 为什么是删而不是接线

关记忆是 ACP 客户端的诉求（apeiron），由 #585 的 `_meta.sudocode.memory` 提供。
产品决定：命令行用户不需要这个开关。#561 走的是把这个键接上的路，已按此决定关闭。

已经在 settings.json 里设了这个键的用户，现在本来就在报 validate 错误，本改动不会让他们更糟。

## 没做什么

`autoCompactEnabled`、`autoDreamEnabled`、`todoFeatureEnabled` 形状完全相同：
能设、无人读、不在 schema 里。**只报告，不夹带**。`autoCompactEnabled` 尤其值得单独看一眼，
自动压缩是真功能，这个开关不该是死的。

## 怎么验证的

```
$ cargo check -p tools        # 通过
$ cargo fmt --all --check     # 干净
$ cargo test -p tools         # 118 + 4 + 4 + 3 + 4 passed / 0 failed
```

删除前的行为是我在本地实测确认的（用一个隔离的 config home 写入该键后跑 `config validate`，
得到上面那条 unknown key 报错）。**未验证**：删除后 `/config set autoMemoryEnabled` 的
交互式表现 —— `config set` 是 REPL 内的斜杠命令，不是 CLI 子命令，我没有驱动 REPL 去点它。
代码路径上它会走到 `supported_config_setting` 返回 `None` 那个分支并报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)