### PR TITLE
fix(repl): Up/Down arrow CC-parity — move-to-edge first, then history

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -1097,6 +1097,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     // Never persisted — the real content goes into the submitted message.
     let mut paste_store = hooks.use_state(|| std::collections::HashMap::<u32, String>::new());
     let mut next_paste_id = hooks.use_state(|| 1u32);
+    let mut text_input_handle = hooks.use_ref_default::<TextInputHandle>();
 
     // Clone handles for the future (StdoutHandle is Clone).
     let stdout_for_future = stdout.clone();
@@ -1407,34 +1408,75 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             input_value.set(String::new());
                         }
                     }
-                    // ── Up/Down — TextInput history ────────────────────
+                    // ── Up/Down — TextInput: CC-parity two-step arrow keys ──
+                    //
+                    // Behavior mirrors rustyline's UpArrowHandler / DownArrowHandler
+                    // (src/input.rs).  Three tiers per direction:
+                    //
+                    //   Up:  1) cursor NOT on first logical line  → pass-through
+                    //            (TextInput moves to previous line)
+                    //        2) cursor on first line, not at pos 0 → move to 0
+                    //        3) cursor at pos 0 (or empty)         → history prev
+                    //
+                    //   Down: 1) cursor NOT on last logical line   → pass-through
+                    //            (TextInput moves to next line)
+                    //         2) cursor on last line, not at end   → move to end
+                    //         3) cursor at end (or empty)          → history next
+                    //
+                    // "Logical line" = delimited by '\n'.  TextInput normalises
+                    // platform newlines, so this is cross-platform safe.
                     KeyCode::Up if matches!(current_slot, InputSlot::TextInput) => {
-                        let h = history.read();
-                        if !h.is_empty() {
-                            let cursor = history_cursor.get();
-                            let new_cursor = match cursor {
-                                None => {
-                                    saved_input.set(input_value.read().clone());
-                                    h.len() - 1
+                        if history_cursor.get().is_some() {
+                            let h = history.read();
+                            let c = history_cursor.get().unwrap_or(0);
+                            let nc = c.saturating_sub(1);
+                            if !h.is_empty() {
+                                input_value.set(h[nc].clone());
+                                history_cursor.set(Some(nc));
+                            }
+                        } else {
+                            let val = input_value.read().clone();
+                            let cursor_pos = text_input_handle.read().cursor_offset();
+                            let on_first_line = !val.get(..cursor_pos)
+                                .unwrap_or(&val)
+                                .contains('\n');
+                            if val.is_empty() || (on_first_line && cursor_pos == 0) {
+                                let h = history.read();
+                                if !h.is_empty() {
+                                    saved_input.set(val);
+                                    input_value.set(h[h.len() - 1].clone());
+                                    history_cursor.set(Some(h.len() - 1));
                                 }
-                                Some(0) => 0,
-                                Some(c) => c - 1,
-                            };
-                            input_value.set(h[new_cursor].clone());
-                            history_cursor.set(Some(new_cursor));
+                            } else if on_first_line {
+                                text_input_handle.write().set_cursor_offset(0);
+                            }
+                            // else: not on first line — TextInput handles
+                            // cursor movement to the line above.
                         }
                     }
                     KeyCode::Down if matches!(current_slot, InputSlot::TextInput) => {
-                        if let Some(cursor) = history_cursor.get() {
+                        if let Some(c) = history_cursor.get() {
                             let h = history.read();
-                            if cursor + 1 < h.len() {
-                                let new_cursor = cursor + 1;
-                                input_value.set(h[new_cursor].clone());
-                                history_cursor.set(Some(new_cursor));
+                            if c + 1 < h.len() {
+                                input_value.set(h[c + 1].clone());
+                                history_cursor.set(Some(c + 1));
                             } else {
                                 input_value.set(saved_input.read().clone());
                                 history_cursor.set(None);
                             }
+                        } else {
+                            let val = input_value.read().clone();
+                            let cursor_pos = text_input_handle.read().cursor_offset();
+                            let on_last_line = !val.get(cursor_pos..)
+                                .unwrap_or_default()
+                                .contains('\n');
+                            if on_last_line && cursor_pos < val.len() {
+                                text_input_handle.write().set_cursor_offset(val.len());
+                            }
+                            // else if on_last_line && at end: nothing to do
+                            // (no "forward history" in CC).
+                            // else: not on last line — TextInput handles
+                            // cursor movement to the line below.
                         }
                     }
                     // ── Digit shortcut — DialPad only ─────────────────
@@ -1659,6 +1701,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             has_focus: true,
                             multiline: true,
                             auto_grow: true,
+                            handle: Some(text_input_handle.clone()),
                             on_change: move |new_val: String| {
                                 input_value.set(new_val);
                             },


### PR DESCRIPTION
## Summary

- Fix regression where Up arrow did nothing when prompt history was empty
- Implement CC-parity two-step arrow key behavior in the iocraft REPL:
  - **Up**: move cursor to beginning of line first, then navigate history (matching rustyline's `UpArrowHandler`)
  - **Down**: move cursor to end of line first, then navigate history
- Correctly handle multi-line inputs: only intercept on first/last logical line, let TextInput handle inter-line cursor movement
- Cross-platform: uses `\n` for logical line detection (iocraft normalises platform newlines internally)

## Test plan

- [x] Manual: single-line input → Up moves cursor to beginning, Up again enters history
- [x] Manual: empty input → Up enters history directly
- [x] Manual: history navigation with Up/Down works as before
- [x] Build clean, no clippy warnings on changed code
- [ ] CI green