### PR TITLE
feat(tools): unified dispatch + compaction CC parity

### DIFF
--- a/rust/crates/engine-core/src/engine_client.rs
+++ b/rust/crates/engine-core/src/engine_client.rs
@@ -375,6 +375,64 @@ impl ApiClient for EngineApiClient {
         Ok(text)
     }
 
+    async fn send_cache_safe_compaction(
+        &mut self,
+        request: ApiRequest,
+        compaction_prompt: &str,
+        max_tokens: u32,
+    ) -> Result<String, RuntimeError> {
+        let cache_hints = (!request.system_prompt.is_empty()).then(|| CacheHints {
+            system_static: Some(request.system_prompt.static_text()),
+            system_dynamic: Some(request.system_prompt.dynamic_text()),
+            breakpoint_last_message: true,
+        });
+
+        let mut messages = tools::convert_messages(&request.messages);
+        messages.push(InputMessage {
+            role: "user".to_string(),
+            content: vec![api::InputContentBlock::Text {
+                text: compaction_prompt.to_string(),
+            }],
+        });
+
+        let message_request = MessageRequest {
+            model: self.model.clone(),
+            max_tokens,
+            messages,
+            system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.render()),
+            tools: None,
+            tool_choice: None,
+            stream: false,
+            reasoning_effort: None,
+            cache_hints,
+            thinking_enabled: false,
+            ..Default::default()
+        };
+
+        let response = self
+            .client
+            .send_message(&message_request, None)
+            .await
+            .map_err(|error| RuntimeError::new(format!("cache-safe compaction error: {error}")))?;
+
+        let text = response
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                OutputContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        if text.is_empty() {
+            return Err(RuntimeError::new(
+                "cache-safe compaction response contained no text content",
+            ));
+        }
+        Ok(text)
+    }
+
     async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
         let is_post_tool = request_ends_with_tool_result(&request);
         let cache_hints = (!request.system_prompt.is_empty()).then(|| CacheHints {

--- a/rust/crates/engine-host/src/tool_executor.rs
+++ b/rust/crates/engine-host/src/tool_executor.rs
@@ -55,6 +55,12 @@ pub(crate) struct ToolSearchRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct ExecuteExtraToolRequest {
+    tool_name: String,
+    params: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct McpToolRequest {
     #[serde(rename = "qualifiedName")]
     pub(crate) qualified_name: Option<String>,
@@ -294,6 +300,10 @@ impl ToolExecutor for CliToolExecutor {
             }
         }
 
+        if tool_name == "ExecuteExtraTool" {
+            return self.execute_extra_tool(value, ctx);
+        }
+
         let is_mcp_tool = self.tool_registry.has_runtime_tool(tool_name);
         if is_mcp_tool {
             if let Some(sink) = ctx.progress_sink.clone() {
@@ -375,6 +385,48 @@ struct AskUserQuestionCliOption {
 }
 
 impl CliToolExecutor {
+    fn execute_extra_tool(
+        &self,
+        value: serde_json::Value,
+        ctx: &runtime::ToolDispatchContext,
+    ) -> Result<String, ToolError> {
+        let req: ExecuteExtraToolRequest = serde_json::from_value(value)
+            .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+        let target = tools::canonicalize_tool_name(&req.tool_name);
+        if tools::is_core_tool(&target) {
+            return Err(ToolError::new(format!(
+                "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
+                req.tool_name
+            )));
+        }
+
+        let is_mcp_tool = self.tool_registry.has_runtime_tool(&target);
+        if is_mcp_tool {
+            if let Some(sink) = ctx.progress_sink.clone() {
+                runtime::set_mcp_progress_callback(mcp_progress_forward(sink));
+            }
+        }
+
+        let result = if is_mcp_tool {
+            self.execute_runtime_tool(&target, req.params)
+        } else {
+            self.tool_registry
+                .execute_with_abort_and_context(
+                    &target,
+                    &req.params,
+                    self.abort_signal.as_ref(),
+                    Some(ctx),
+                )
+                .map_err(ToolError::new)
+        };
+
+        if is_mcp_tool {
+            runtime::clear_mcp_progress_callback();
+        }
+
+        result
+    }
+
     fn execute_ask_user_question(&self, value: serde_json::Value) -> Result<String, ToolError> {
         let input: AskUserQuestionCliInput = serde_json::from_value(value)
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -181,6 +181,7 @@ enum Scenario {
     /// waiting on a real provider to rate-limit us.
     RetryThenSucceed,
     ExecuteExtraToolRoundtrip,
+    ExecuteExtraToolMcpRoundtrip,
 }
 
 /// How long [`Scenario::DelayedText`] holds a request before answering.
@@ -226,6 +227,7 @@ impl Scenario {
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             "retry_then_succeed" => Some(Self::RetryThenSucceed),
             "execute_extra_tool_roundtrip" => Some(Self::ExecuteExtraToolRoundtrip),
+            "execute_extra_tool_mcp_roundtrip" => Some(Self::ExecuteExtraToolMcpRoundtrip),
             _ => None,
         }
     }
@@ -267,6 +269,7 @@ impl Scenario {
             Self::ContextLimitThenText => "context_limit_then_text",
             Self::ToolLoopContextGrowth => "tool_loop_context_growth",
             Self::ExecuteExtraToolRoundtrip => "execute_extra_tool_roundtrip",
+            Self::ExecuteExtraToolMcpRoundtrip => "execute_extra_tool_mcp_roundtrip",
         }
     }
 }
@@ -881,6 +884,19 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
                 &[r#"{"tool_name":"CronList","params":{}}"#],
             ),
         },
+        Scenario::ExecuteExtraToolMcpRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => final_text_sse(&format!(
+                "execute_extra_tool_mcp roundtrip complete: {}",
+                mcp_echo_verdict(&tool_output)
+            )),
+            None => tool_use_sse(
+                "toolu_execute_extra_mcp",
+                "ExecuteExtraTool",
+                &[
+                    r#"{"tool_name":"mcp__parity__echo","params":{"text":"hello from deferred mcp"}}"#,
+                ],
+            ),
+        },
     }
 }
 
@@ -1306,6 +1322,21 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 json!({"tool_name": "CronList", "params": {}}),
             ),
         },
+        Scenario::ExecuteExtraToolMcpRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => text_message_response(
+                "msg_execute_extra_mcp_final",
+                &format!(
+                    "execute_extra_tool_mcp roundtrip complete: {}",
+                    mcp_echo_verdict(&tool_output)
+                ),
+            ),
+            None => tool_message_response(
+                "msg_execute_extra_mcp",
+                "toolu_execute_extra_mcp",
+                "ExecuteExtraTool",
+                json!({"tool_name": "mcp__parity__echo", "params": {"text": "hello from deferred mcp"}}),
+            ),
+        },
     }
 }
 
@@ -1348,6 +1379,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         Scenario::ContextLimitThenText => "req_context_limit_then_text",
         Scenario::ToolLoopContextGrowth => "req_tool_loop_context_growth",
         Scenario::ExecuteExtraToolRoundtrip => "req_execute_extra_tool_roundtrip",
+        Scenario::ExecuteExtraToolMcpRoundtrip => "req_execute_extra_tool_mcp_roundtrip",
     }
 }
 

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -285,6 +285,15 @@ async fn handle_connection(
     let normalized_body = normalize_system_field(&raw_body);
     let request: MessageRequest = serde_json::from_str(&normalized_body)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    // Cache-safe compaction sends the full conversation with a compaction
+    // prompt appended. Reject it with a proper HTTP 400 so the runtime
+    // falls back to the standard compaction path.
+    if is_cache_safe_compaction(&request) {
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"mock: cache-safe compaction not supported"}}"#;
+        let response = http_response("400 Bad Request", "application/json", body, &[]);
+        socket.write_all(response.as_bytes()).await?;
+        return Ok(());
+    }
     let scenario = detect_scenario(&request)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing parity scenario"))?;
 
@@ -439,6 +448,24 @@ fn detect_scenario(request: &MessageRequest) -> Option<Scenario> {
     }
 
     None
+}
+
+fn is_cache_safe_compaction(request: &MessageRequest) -> bool {
+    let is_standard_compaction = request
+        .system
+        .as_ref()
+        .map_or(false, |s| s.contains("summarizing conversations"));
+    if is_standard_compaction {
+        return false;
+    }
+    request.messages.last().map_or(false, |msg| {
+        msg.content.iter().any(|block| match block {
+            InputContentBlock::Text { text } => {
+                text.contains("create a detailed summary of the conversation")
+            }
+            _ => false,
+        })
+    })
 }
 
 fn latest_tool_result(request: &MessageRequest) -> Option<(String, bool)> {

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -800,6 +800,88 @@ pub async fn compact_session<C: ApiClient>(
     })
 }
 
+/// Cache-safe compaction: sends the compaction prompt over the same
+/// system-prompt + message prefix the previous conversation turn used,
+/// enabling prompt cache reuse. Falls back to [`CompactionError::ApiError`]
+/// when the API client doesn't support it.
+///
+/// Matches CC's `streamCompactSummary` path with `tengu_compact_cache_prefix`.
+pub async fn compact_session_cache_safe<C: ApiClient>(
+    session: &Session,
+    config: CompactionConfig,
+    api_client: &mut C,
+    model: &str,
+    system_prompt: &crate::prompt::SystemPrompt,
+    custom_instructions: Option<&str>,
+) -> Result<CompactionResult, CompactionError> {
+    if !should_compact(session, config) {
+        return Err(CompactionError::NothingToCompact);
+    }
+
+    let existing_summary = session
+        .messages
+        .first()
+        .and_then(extract_existing_compacted_summary);
+    let compacted_prefix_len = usize::from(existing_summary.is_some());
+
+    let raw_keep_from = session
+        .messages
+        .len()
+        .saturating_sub(config.preserve_recent_messages);
+    let keep_from = find_safe_compaction_boundary(session, raw_keep_from, compacted_prefix_len);
+
+    let existing_usage = session.compaction.as_ref().and_then(|value| value.usage);
+    let removed = &session.messages[compacted_prefix_len..keep_from];
+    let preserved = session.messages[keep_from..].to_vec();
+
+    if removed.is_empty() {
+        return Err(CompactionError::NothingToCompact);
+    }
+
+    let compacted_usage = aggregate_compaction_usage(existing_usage, removed);
+    let prompt = build_compaction_prompt(custom_instructions);
+
+    let max_tokens = std::cmp::min(
+        COMPACT_MAX_OUTPUT_TOKENS,
+        crate::model_capabilities::max_output_tokens_or_default(model),
+    );
+
+    let request = crate::conversation::ApiRequest {
+        system_prompt: system_prompt.clone(),
+        messages: session.messages.clone(),
+        trace_id: None,
+    };
+
+    let llm_summary = api_client
+        .send_cache_safe_compaction(request, &prompt, max_tokens)
+        .await
+        .map_err(|error| CompactionError::ApiError(error.to_string()))?;
+
+    let summary = merge_compact_summaries(existing_summary.as_deref(), &llm_summary);
+    let formatted_summary = format_compact_summary(&summary);
+    let continuation = get_compact_continuation_message(&summary, true, !preserved.is_empty());
+
+    let mut compacted_messages = vec![ConversationMessage {
+        role: MessageRole::System,
+        blocks: vec![ContentBlock::Text { text: continuation }],
+        usage: None,
+        model: None,
+    }];
+    compacted_messages.extend(preserved);
+
+    let mut compacted_session = session.clone();
+    compacted_session.messages = compacted_messages;
+    compacted_session.record_compaction_with_usage(summary.clone(), removed.len(), compacted_usage);
+
+    Ok(CompactionResult {
+        summary,
+        formatted_summary,
+        compacted_session,
+        removed_message_count: removed.len(),
+        summary_source: CompactionSummarySource::Llm,
+    })
+}
+
 /// Local fallback for callers whose LLM compaction attempt failed with
 /// `error`; identical to [`compact_session_sync`] except that the result
 /// records why the lossier local summary was used.
@@ -1121,6 +1203,102 @@ fn extract_existing_compacted_summary(message: &ConversationMessage) -> Option<S
         .split_once(&format!("\n{COMPACT_DIRECT_RESUME_INSTRUCTION}"))
         .map_or(summary, |(value, _)| value);
     Some(summary.trim().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Microcompact (CC parity: time-based tool result clearing)
+// ---------------------------------------------------------------------------
+
+/// Tool names whose results are safe to content-clear after they age out.
+/// Matches CC's `COMPACTABLE_TOOLS` list.
+const COMPACTABLE_TOOLS: &[&str] = &[
+    "read_file",
+    "Read",
+    "bash",
+    "Bash",
+    "grep_search",
+    "Grep",
+    "glob_search",
+    "Glob",
+    "WebFetch",
+    "WebSearch",
+    "edit_file",
+    "Edit",
+    "write_file",
+    "Write",
+    "read_tool_output",
+];
+
+const CLEARED_TOOL_RESULT_PLACEHOLDER: &str = "[Old tool result content cleared]";
+
+/// How many recent tool results to keep per tool name.
+/// Older results from compactable tools are content-cleared.
+const MICROCOMPACT_KEEP_RECENT: usize = 2;
+
+/// Content-clear old compactable tool results in `messages` to reduce
+/// token count before sending an API request. Returns the number of
+/// tool results that were cleared.
+///
+/// Only clears `ToolResult` blocks from compactable tools. Keeps the
+/// most recent `MICROCOMPACT_KEEP_RECENT` results per tool name.
+/// Already-cleared results (matching the placeholder) are not counted.
+///
+/// Matches CC's time-based microcompact path.
+pub fn microcompact_messages(messages: &mut [ConversationMessage]) -> usize {
+    // Collect indices of all compactable tool results, newest first.
+    let mut tool_result_indices: Vec<(usize, usize, String)> = Vec::new();
+    for (msg_idx, msg) in messages.iter().enumerate().rev() {
+        for (block_idx, block) in msg.blocks.iter().enumerate() {
+            if let ContentBlock::ToolResult {
+                tool_name, output, ..
+            } = block
+            {
+                if is_compactable_tool(tool_name) && output != CLEARED_TOOL_RESULT_PLACEHOLDER {
+                    tool_result_indices.push((msg_idx, block_idx, tool_name.clone()));
+                }
+            }
+        }
+    }
+
+    // Count per tool name, keeping the most recent MICROCOMPACT_KEEP_RECENT.
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut to_clear: Vec<(usize, usize)> = Vec::new();
+    for (msg_idx, block_idx, tool_name) in &tool_result_indices {
+        let canonical = canonicalize_compactable_tool(tool_name);
+        let count = counts.entry(canonical).or_insert(0);
+        *count += 1;
+        if *count > MICROCOMPACT_KEEP_RECENT {
+            to_clear.push((*msg_idx, *block_idx));
+        }
+    }
+
+    // Apply the clearing.
+    let cleared_count = to_clear.len();
+    for (msg_idx, block_idx) in to_clear {
+        if let Some(ContentBlock::ToolResult { output, .. }) =
+            messages[msg_idx].blocks.get_mut(block_idx)
+        {
+            *output = CLEARED_TOOL_RESULT_PLACEHOLDER.to_string();
+        }
+    }
+
+    cleared_count
+}
+
+fn is_compactable_tool(name: &str) -> bool {
+    COMPACTABLE_TOOLS.contains(&name)
+}
+
+fn canonicalize_compactable_tool(name: &str) -> String {
+    match name {
+        "Read" | "read_file" => "read_file".to_string(),
+        "Bash" | "bash" => "bash".to_string(),
+        "Grep" | "grep_search" => "grep_search".to_string(),
+        "Glob" | "glob_search" => "glob_search".to_string(),
+        "Edit" | "edit_file" => "edit_file".to_string(),
+        "Write" | "write_file" => "write_file".to_string(),
+        other => other.to_string(),
+    }
 }
 
 fn first_text_block(message: &ConversationMessage) -> Option<&str> {
@@ -2533,5 +2711,224 @@ mod tests {
             ConversationMessage::user_text("two"),
         ];
         assert!(super::truncate_head_for_ptl(&messages).is_none());
+    }
+
+    #[test]
+    fn microcompact_clears_old_tool_results() {
+        let mut messages = vec![
+            ConversationMessage::user_text("hello"),
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "t1".to_string(),
+                name: "read_file".to_string(),
+                input: r#"{"path":"a.txt"}"#.to_string(),
+                thought_signature: None,
+            }]),
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".to_string(),
+                    tool_name: "read_file".to_string(),
+                    output: "content of a.txt".to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "t2".to_string(),
+                name: "read_file".to_string(),
+                input: r#"{"path":"b.txt"}"#.to_string(),
+                thought_signature: None,
+            }]),
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t2".to_string(),
+                    tool_name: "read_file".to_string(),
+                    output: "content of b.txt".to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "t3".to_string(),
+                name: "read_file".to_string(),
+                input: r#"{"path":"c.txt"}"#.to_string(),
+                thought_signature: None,
+            }]),
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t3".to_string(),
+                    tool_name: "read_file".to_string(),
+                    output: "content of c.txt".to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+        ];
+
+        let cleared = super::microcompact_messages(&mut messages);
+
+        // 3 read_file results, keep 2 most recent → 1 cleared
+        assert_eq!(cleared, 1);
+
+        // Oldest result (a.txt) should be cleared
+        if let ContentBlock::ToolResult { output, .. } = &messages[2].blocks[0] {
+            assert_eq!(output, super::CLEARED_TOOL_RESULT_PLACEHOLDER);
+        } else {
+            panic!("expected ToolResult");
+        }
+
+        // b.txt and c.txt should be preserved
+        if let ContentBlock::ToolResult { output, .. } = &messages[4].blocks[0] {
+            assert_eq!(output, "content of b.txt");
+        }
+        if let ContentBlock::ToolResult { output, .. } = &messages[6].blocks[0] {
+            assert_eq!(output, "content of c.txt");
+        }
+    }
+
+    #[test]
+    fn microcompact_skips_non_compactable_tools() {
+        let mut messages = vec![
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "t1".to_string(),
+                name: "CronList".to_string(),
+                input: "{}".to_string(),
+                thought_signature: None,
+            }]),
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".to_string(),
+                    tool_name: "CronList".to_string(),
+                    output: "no crons".to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+        ];
+
+        let cleared = super::microcompact_messages(&mut messages);
+        assert_eq!(cleared, 0);
+
+        if let ContentBlock::ToolResult { output, .. } = &messages[1].blocks[0] {
+            assert_eq!(output, "no crons");
+        }
+    }
+
+    #[test]
+    fn microcompact_idempotent_on_already_cleared() {
+        let mut messages = vec![
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "t1".to_string(),
+                name: "bash".to_string(),
+                input: r#"{"command":"ls"}"#.to_string(),
+                thought_signature: None,
+            }]),
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".to_string(),
+                    tool_name: "bash".to_string(),
+                    output: super::CLEARED_TOOL_RESULT_PLACEHOLDER.to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+        ];
+
+        let cleared = super::microcompact_messages(&mut messages);
+        assert_eq!(cleared, 0);
+    }
+
+    #[tokio::test]
+    async fn cache_safe_compaction_uses_original_system_prompt() {
+        use crate::conversation::{ApiClient, ApiRequest, AssistantEventStream, RuntimeError};
+        use async_trait::async_trait;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        static CACHE_SAFE_CALLED: AtomicBool = AtomicBool::new(false);
+
+        struct CacheSafeClient;
+
+        #[async_trait]
+        impl ApiClient for CacheSafeClient {
+            async fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<AssistantEventStream, RuntimeError> {
+                Err(RuntimeError::new("not used"))
+            }
+
+            async fn send_cache_safe_compaction(
+                &mut self,
+                request: ApiRequest,
+                compaction_prompt: &str,
+                _max_tokens: u32,
+            ) -> Result<String, RuntimeError> {
+                CACHE_SAFE_CALLED.store(true, Ordering::SeqCst);
+                assert!(
+                    request
+                        .system_prompt
+                        .render()
+                        .contains("test system prompt"),
+                    "cache-safe compaction must use the original system prompt"
+                );
+                assert!(
+                    compaction_prompt.contains("CRITICAL: Respond with TEXT ONLY"),
+                    "compaction prompt must include no-tools preamble"
+                );
+                Ok("<analysis>Cache-safe analysis</analysis>\n<summary>\n1. Primary Request and Intent:\n   Cache-safe compaction test.\n</summary>".to_string())
+            }
+        }
+
+        CACHE_SAFE_CALLED.store(false, Ordering::SeqCst);
+
+        let mut session = Session::new();
+        session.messages = vec![
+            ConversationMessage::user_text("one ".repeat(200)),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "two ".repeat(200),
+            }]),
+            ConversationMessage::user_text("three ".repeat(200)),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "four ".repeat(200),
+            }]),
+            ConversationMessage::user_text("recent"),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "kept".to_string(),
+            }]),
+        ];
+
+        let config = super::CompactionConfig {
+            preserve_recent_messages: 2,
+            max_estimated_tokens: 1,
+        };
+        let mut system_prompt = crate::prompt::SystemPrompt::default();
+        system_prompt.override_static_sections("test system prompt");
+
+        let mut client = CacheSafeClient;
+        let result = super::compact_session_cache_safe(
+            &session,
+            config,
+            &mut client,
+            "claude-sonnet-4-6",
+            &system_prompt,
+            None,
+        )
+        .await
+        .expect("cache-safe compaction should succeed");
+
+        assert!(CACHE_SAFE_CALLED.load(Ordering::SeqCst));
+        assert!(result.removed_message_count > 0);
+        assert!(result
+            .formatted_summary
+            .contains("Cache-safe compaction test"));
     }
 }

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 use telemetry::SessionTracer;
 
 use crate::compact::{
-    autocompact_buffer_tokens, compact_session, compact_session_sync,
+    autocompact_buffer_tokens, compact_session, compact_session_cache_safe, compact_session_sync,
     compact_session_sync_after_llm_failure, estimate_block_tokens, estimate_session_tokens,
     CompactionConfig, CompactionError, CompactionResult, CompactionSummarySource, ContextBudget,
     ReadFileTracker,
@@ -146,6 +146,27 @@ pub trait ApiClient: Send {
     ) -> Result<String, RuntimeError> {
         Err(RuntimeError::new(
             "compaction not supported by this API client",
+        ))
+    }
+
+    /// Cache-safe compaction: sends the compaction prompt over the same
+    /// system-prompt + message prefix the previous conversation turn used,
+    /// enabling the provider's prompt cache to hit on the shared prefix.
+    ///
+    /// `request` carries the runtime's system prompt and the full session
+    /// messages (identical to the last regular turn). `compaction_prompt`
+    /// is appended as a final user message. Returns the raw summary text.
+    ///
+    /// The default implementation returns an error — providers that support
+    /// prompt caching override this.
+    async fn send_cache_safe_compaction(
+        &mut self,
+        _request: ApiRequest,
+        _compaction_prompt: &str,
+        _max_tokens: u32,
+    ) -> Result<String, RuntimeError> {
+        Err(RuntimeError::new(
+            "cache-safe compaction not supported by this API client",
         ))
     }
 
@@ -1581,6 +1602,8 @@ where
                 return Err(error);
             }
 
+            crate::compact::microcompact_messages(&mut self.session.messages);
+
             // Compact before dispatching, not after the provider rejects.
             // A turn that takes many tool-call steps grows its own history
             // while it runs; the per-turn preflight ran once, before any of
@@ -1599,16 +1622,8 @@ where
                         overflow_compaction =
                             merge_auto_compaction(overflow_compaction, Some(event));
                     }
-                    // Counted whether or not anything was removed: a pass
-                    // that shrinks nothing has still spent its round-trip,
-                    // and repeating it every iteration would burn the rest
-                    // of the turn on compactions that cannot help.
                     turn_compactions += 1;
                 } else if !recorded_compaction_budget_exhausted {
-                    // The guard wants to compact and cannot. Every request
-                    // from here on is expected to be rejected, so say so
-                    // once — otherwise the turn's failure looks like the
-                    // guard never ran.
                     self.record_compaction_budget_exhausted(CompactionTrigger::InTurnBudget);
                     recorded_compaction_budget_exhausted = true;
                 }
@@ -2376,6 +2391,24 @@ where
             .model
             .clone()
             .unwrap_or_else(|| "claude-sonnet-4-6".to_string());
+
+        // Try cache-safe compaction first: reuses the main conversation's
+        // system prompt + message prefix so the provider's prompt cache hits.
+        // Falls back to the stripped-message path on failure (unsupported
+        // client, PTL, transient error).
+        if let Ok(result) = compact_session_cache_safe(
+            &self.session,
+            config,
+            &mut self.api_client,
+            &model,
+            &self.system_prompt,
+            custom_instructions,
+        )
+        .await
+        {
+            return (result, CompactionMethod::LlmSummary);
+        }
+
         match compact_session(
             &self.session,
             config,

--- a/rust/crates/rusty-sudocode-cli/tests/pty_deferred_tools.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_deferred_tools.rs
@@ -4,10 +4,17 @@
 //! the mock LLM emits an `ExecuteExtraTool` call with `tool_name: "CronList"`,
 //! scode dispatches it, and the model sees the CronList result.
 //!
+//! The second test verifies that `ExecuteExtraTool` can dispatch to an MCP
+//! tool: the mock LLM targets `mcp__parity__echo` through `ExecuteExtraTool`,
+//! and the MCP echo response round-trips back.
+//!
 //! ```bash
 //! cargo test --test pty_deferred_tools                          # mock (CI)
 //! ```
 mod common;
+
+use std::fs;
+use std::path::Path;
 
 use common::TestEnv;
 
@@ -32,5 +39,122 @@ fn execute_extra_tool_roundtrip() {
     assert_eq!(
         exit, 0,
         "execute_extra_tool roundtrip should exit 0; got {exit}"
+    );
+}
+
+/// Minimal NDJSON MCP server — same as `pty_mcp_tool` but reused here to
+/// verify the unified dispatch path through `ExecuteExtraTool`.
+const MCP_SERVER_SCRIPT: &str = r#"import json, sys
+
+def read_message():
+    line = sys.stdin.buffer.readline()
+    if not line:
+        return None
+    return json.loads(line.decode())
+
+def send_message(message):
+    payload = json.dumps(message).encode()
+    sys.stdout.buffer.write(payload + b'\n')
+    sys.stdout.buffer.flush()
+
+while True:
+    request = read_message()
+    if request is None:
+        break
+    method = request.get('method')
+    if method == 'initialize':
+        send_message({
+            'jsonrpc': '2.0',
+            'id': request['id'],
+            'result': {
+                'protocolVersion': request['params']['protocolVersion'],
+                'capabilities': {'tools': {}},
+                'serverInfo': {'name': 'parity-mcp', 'version': '0.1.0'},
+            },
+        })
+    elif method == 'tools/list':
+        send_message({
+            'jsonrpc': '2.0',
+            'id': request['id'],
+            'result': {
+                'tools': [
+                    {
+                        'name': 'echo',
+                        'description': 'Echoes the provided text back as echo:<text>',
+                        'inputSchema': {
+                            'type': 'object',
+                            'properties': {'text': {'type': 'string'}},
+                            'required': ['text'],
+                        },
+                    }
+                ]
+            },
+        })
+    elif method == 'tools/call':
+        args = request['params'].get('arguments') or {}
+        text = args.get('text', '')
+        send_message({
+            'jsonrpc': '2.0',
+            'id': request['id'],
+            'result': {
+                'content': [{'type': 'text', 'text': f'echo:{text}'}],
+                'isError': False,
+            },
+        })
+    elif 'id' in request:
+        send_message({
+            'jsonrpc': '2.0',
+            'id': request['id'],
+            'error': {'code': -32601, 'message': f'unknown method: {method}'},
+        })
+"#;
+
+fn configure_mcp_server(workspace_root: &Path) {
+    let script_path = workspace_root.join("parity-mcp-server.py");
+    fs::write(&script_path, MCP_SERVER_SCRIPT).expect("mcp server script should write");
+
+    let settings_dir = workspace_root.join(".nexus").join("sudocode");
+    fs::create_dir_all(&settings_dir).expect("project config dir should be created");
+    let settings = serde_json::json!({
+        "mcpServers": {
+            "parity": {
+                "command": common::resolve_python(),
+                "args": [script_path.display().to_string()],
+            }
+        }
+    });
+    fs::write(
+        settings_dir.join("settings.json"),
+        serde_json::to_string_pretty(&settings).expect("settings json"),
+    )
+    .expect("project settings.json should write");
+}
+
+/// ExecuteExtraTool dispatches to an MCP tool through the unified path:
+/// model emits `ExecuteExtraTool { tool_name: "mcp__parity__echo", ... }`,
+/// the `CliToolExecutor` intercept routes to `execute_runtime_tool`, and
+/// the MCP echo response round-trips back.
+#[test]
+fn execute_extra_tool_dispatches_mcp_tool() {
+    let env = TestEnv::new("execute-extra-tool-mcp");
+    configure_mcp_server(env.workspace_root());
+
+    let prompt = env.prompt(
+        "Use ExecuteExtraTool to call the parity echo MCP tool with text 'hello from deferred mcp'.",
+        "execute_extra_tool_mcp_roundtrip",
+    );
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "danger-full-access", &prompt],
+        &[("SUDOCODE_ENABLE_MCP", "1")],
+    );
+
+    sess.expect("echo:hello from deferred mcp")
+        .expect("MCP echo response should round-trip through ExecuteExtraTool");
+
+    let exit = sess.expect_eof().expect("scode should exit");
+    assert_eq!(
+        exit, 0,
+        "ExecuteExtraTool → MCP roundtrip should exit 0; got {exit}"
     );
 }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7336,7 +7336,7 @@ const CORE_TOOLS: &[&str] = &[
     "AskUserQuestion",
 ];
 
-fn is_core_tool(name: &str) -> bool {
+pub fn is_core_tool(name: &str) -> bool {
     CORE_TOOLS.contains(&name)
 }
 


### PR DESCRIPTION
## Summary

- **Unified ExecuteExtraTool dispatch**: intercept at `CliToolExecutor` level so MCP tools, plugin tools, and builtins are all reachable through `ExecuteExtraTool` (previously only builtins were reachable via `execute_tool_with_enforcer()`)
- **Cache-safe compaction**: try the main conversation's system prompt + message prefix first for prompt cache hits before falling back to the stripped-message path
- **Microcompact**: content-clear old compactable tool results (Read, Bash, Grep, Glob, Edit, Write, WebFetch, WebSearch) before each API request, keeping the 2 most recent per tool name

## Changes

### Phase 0: ExecuteExtraTool unified dispatch
- `tools/src/lib.rs`: make `is_core_tool()` pub
- `engine-host/src/tool_executor.rs`: add `ExecuteExtraToolRequest`, `execute_extra_tool()`, intercept before three-way dispatch
- `mock-anthropic-service/src/lib.rs`: add `ExecuteExtraToolMcpRoundtrip` scenario
- `tests/pty_deferred_tools.rs`: add `execute_extra_tool_dispatches_mcp_tool` PTY test

### Phase 4: Cache-safe compaction
- `runtime/src/conversation.rs`: add `send_cache_safe_compaction()` to `ApiClient` trait; `compact_with_method` tries cache-safe first
- `engine-core/src/engine_client.rs`: implement `send_cache_safe_compaction()` with cache hints matching `stream()`
- `runtime/src/compact.rs`: add `compact_session_cache_safe()`

### Phase 5: Microcompact
- `runtime/src/compact.rs`: add `microcompact_messages()` with `COMPACTABLE_TOOLS` list
- `runtime/src/conversation.rs`: call microcompact before each API request in the turn loop

## Test plan

- [x] `execute_extra_tool_roundtrip` PTY test (existing, still passes)
- [x] `execute_extra_tool_dispatches_mcp_tool` PTY test (new — MCP through ExecuteExtraTool)
- [x] `mcp_echo_tool_round_trips_through_ndjson_stdio` PTY test (existing, still passes)
- [x] `cache_safe_compaction_uses_original_system_prompt` unit test
- [x] `microcompact_clears_old_tool_results` unit test
- [x] `microcompact_skips_non_compactable_tools` unit test
- [x] `microcompact_idempotent_on_already_cleared` unit test
- [x] 725+ runtime crate tests pass
- [x] `cargo fmt -- --check` clean