### PR TITLE
runtime: make turns interruptible

### DIFF
--- a/rust/crates/engine-core/src/session.rs
+++ b/rust/crates/engine-core/src/session.rs
@@ -48,7 +48,7 @@
 //! ACP delegate already does exactly this.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 
@@ -175,6 +175,7 @@ enum PendingAnswer {
 struct RequestTable {
     pending: Arc<Mutex<HashMap<RequestId, PendingAnswer>>>,
     next_id: Arc<AtomicU64>,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl RequestTable {
@@ -183,10 +184,13 @@ impl RequestTable {
     }
 
     fn insert(&self, id: RequestId, answer: PendingAnswer) {
-        self.pending
+        let mut pending = self
+            .pending
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(id, answer);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !self.cancelled.load(Ordering::SeqCst) {
+            pending.insert(id, answer);
+        }
     }
 
     fn take(&self, id: RequestId) -> Option<PendingAnswer> {
@@ -194,6 +198,16 @@ impl RequestTable {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(&id)
+    }
+
+    /// Dropping the answer senders wakes a worker blocked in a permission or
+    /// question prompt when the enclosing turn is cancelled.
+    fn cancel_all(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
     }
 }
 
@@ -324,10 +338,14 @@ async fn run_one_turn(
                 Some(EngineCommand::Close) => {
                     closing = true;
                     abort.abort();
+                    table.cancel_all();
                 }
                 // Cancel / a dropped channel abort the in-flight turn; it then
                 // finishes (cancelled) and we fall through to the `result` arm.
-                Some(EngineCommand::Cancel) | None => abort.abort(),
+                Some(EngineCommand::Cancel) | None => {
+                    abort.abort();
+                    table.cancel_all();
+                }
                 // A Prompt arriving mid-turn is a renderer bug (renderers serialize
                 // turns). Ignore it rather than interleave.
                 Some(_) => {}

--- a/rust/crates/engine-host/src/tool_executor.rs
+++ b/rust/crates/engine-host/src/tool_executor.rs
@@ -1,10 +1,9 @@
-use std::cell::RefCell;
 use std::io::{self, IsTerminal};
 use std::sync::{Arc, Mutex};
 
 use runtime::{
     ContentBlock, PermissionMode, PermissionPolicy, QuestionField, QuestionKind, QuestionOption,
-    QuestionPromptRequest, QuestionPrompter, ToolError, ToolExecutor,
+    QuestionPromptRequest, QuestionPrompter, ToolError, ToolExecutor, WorkspaceRootHandoff,
 };
 use serde::Deserialize;
 use tools::GlobalToolRegistry;
@@ -97,10 +96,9 @@ pub struct CliToolExecutor {
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     // Single-threaded interior mutability: `execute` is `&self` (so a
     // concurrency-safe batch can share the dispatcher), but the interactive
-    // AskUserQuestion prompter needs `&mut` to drive a prompt. AskUserQuestion
-    // is non-concurrency-safe (runs serial), so a `RefCell` (not a `Mutex`) is
-    // correct — the CLI turn loop is single-threaded.
-    question_prompter: RefCell<Option<Box<dyn QuestionPrompter>>>,
+    // AskUserQuestion prompts remain serial, but normal tools now run on the
+    // blocking pool, so the prompter must be protected across threads.
+    question_prompter: Mutex<Option<Box<dyn QuestionPrompter>>>,
     abort_signal: Option<runtime::HookAbortSignal>,
     /// Optional nexus A2A send capability. When set (nexus-A2A configured),
     /// `send_message` writes to the peer's `/agents/<to>/chat-with-me`
@@ -120,7 +118,7 @@ impl CliToolExecutor {
             allowed_tools,
             tool_registry,
             mcp_state,
-            question_prompter: RefCell::new(None),
+            question_prompter: Mutex::new(None),
             abort_signal: None,
             mailbox_sender: None,
         }
@@ -135,7 +133,10 @@ impl CliToolExecutor {
     }
 
     pub fn set_question_prompter(&mut self, prompter: Box<dyn QuestionPrompter>) {
-        *self.question_prompter.get_mut() = Some(prompter);
+        *self
+            .question_prompter
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(prompter);
     }
 
     fn execute_search_tool(&self, value: serde_json::Value) -> Result<String, ToolError> {
@@ -156,59 +157,59 @@ impl CliToolExecutor {
         ))
         .map_err(|error| ToolError::new(error.to_string()))
     }
+}
 
-    fn execute_runtime_tool(
-        &self,
-        tool_name: &str,
-        value: serde_json::Value,
-    ) -> Result<String, ToolError> {
-        let Some(mcp_state) = &self.mcp_state else {
-            return Err(ToolError::new(format!(
-                "runtime tool `{tool_name}` is unavailable without configured MCP servers"
-            )));
-        };
-        let mut mcp_state = mcp_state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+fn execute_runtime_tool_with_state(
+    mcp_state: Option<&Arc<Mutex<RuntimeMcpState>>>,
+    tool_name: &str,
+    value: serde_json::Value,
+) -> Result<String, ToolError> {
+    let Some(mcp_state) = mcp_state else {
+        return Err(ToolError::new(format!(
+            "runtime tool `{tool_name}` is unavailable without configured MCP servers"
+        )));
+    };
+    let mut mcp_state = mcp_state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        match tool_name {
-            "MCPTool" => {
-                let input: McpToolRequest = serde_json::from_value(value)
-                    .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-                let qualified_name = input
-                    .qualified_name
-                    .or(input.tool)
-                    .ok_or_else(|| ToolError::new("missing required field `qualifiedName`"))?;
-                mcp_state.call_tool(&qualified_name, input.arguments)
-            }
-            "ListMcpResourcesTool" => {
-                let input: ListMcpResourcesRequest = serde_json::from_value(value)
-                    .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-                match input.server {
-                    Some(server_name) => mcp_state.list_resources_for_server(&server_name),
-                    None => mcp_state.list_resources_for_all_servers(),
-                }
-            }
-            "ReadMcpResourceTool" => {
-                let input: ReadMcpResourceRequest = serde_json::from_value(value)
-                    .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-                mcp_state.read_resource(&input.server, &input.uri)
-            }
-            "ListMcpPromptsTool" => {
-                let input: ListMcpPromptsRequest = serde_json::from_value(value)
-                    .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-                match input.server {
-                    Some(server_name) => mcp_state.list_prompts_for_server(&server_name),
-                    None => mcp_state.list_prompts_for_all_servers(),
-                }
-            }
-            "GetMcpPromptTool" => {
-                let input: GetMcpPromptRequest = serde_json::from_value(value)
-                    .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-                mcp_state.get_prompt(&input.server, &input.name, input.arguments)
-            }
-            _ => mcp_state.call_tool(tool_name, Some(value)),
+    match tool_name {
+        "MCPTool" => {
+            let input: McpToolRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            let qualified_name = input
+                .qualified_name
+                .or(input.tool)
+                .ok_or_else(|| ToolError::new("missing required field `qualifiedName`"))?;
+            mcp_state.call_tool(&qualified_name, input.arguments)
         }
+        "ListMcpResourcesTool" => {
+            let input: ListMcpResourcesRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            match input.server {
+                Some(server_name) => mcp_state.list_resources_for_server(&server_name),
+                None => mcp_state.list_resources_for_all_servers(),
+            }
+        }
+        "ReadMcpResourceTool" => {
+            let input: ReadMcpResourceRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            mcp_state.read_resource(&input.server, &input.uri)
+        }
+        "ListMcpPromptsTool" => {
+            let input: ListMcpPromptsRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            match input.server {
+                Some(server_name) => mcp_state.list_prompts_for_server(&server_name),
+                None => mcp_state.list_prompts_for_all_servers(),
+            }
+        }
+        "GetMcpPromptTool" => {
+            let input: GetMcpPromptRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            mcp_state.get_prompt(&input.server, &input.name, input.arguments)
+        }
+        _ => mcp_state.call_tool(tool_name, Some(value)),
     }
 }
 
@@ -267,18 +268,14 @@ impl ToolExecutor for CliToolExecutor {
                 "tool `{tool_name}` is not enabled by the current --allowedTools setting"
             )));
         }
-        // nexus A2A: when configured, `send_message` routes to the peer's
-        // replicated DT_STREAM inbox over gRPC — the SAME shared handler the
-        // co-host's `ManagedToolExecutor` uses (only the transport differs).
-        // Absent config the tool is never advertised, so this is unreachable.
-        if tool_name == "send_message" {
-            if let Some(sender) = &self.mailbox_sender {
-                return runtime::spawn_task::handle_send_message(sender, input)
-                    .map_err(ToolError::new);
-            }
-        }
         let value = parse_tool_call_input(input)?;
-        if tool_name == "AskUserQuestion" && self.question_prompter.borrow().is_some() {
+        if tool_name == "AskUserQuestion"
+            && self
+                .question_prompter
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_some()
+        {
             return self.execute_ask_user_question(value);
         }
         // Intercept ExitPlanMode to ask the user (across the seam) how to
@@ -287,61 +284,88 @@ impl ToolExecutor for CliToolExecutor {
         // works on every renderer (REPL dialog, iocraft, ACP client) and on
         // Windows (no raw stdin read_line). `handle_exit_plan_mode` itself falls
         // back to "execute normally" for non-interactive / no-prompter contexts.
-        if tool_name == "ExitPlanMode" && self.question_prompter.borrow().is_some() {
+        if tool_name == "ExitPlanMode"
+            && self
+                .question_prompter
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_some()
+        {
             return self.handle_exit_plan_mode(&value, ctx);
         }
-        // Live bash/MCP progress crosses the seam: when the renderer supplied a
-        // progress sink (`ctx.progress_sink`), forward STRUCTURED progress to it
-        // and the renderer formats + draws it (EngineEvent::ToolProgress). The
-        // executor never writes progress to the terminal itself.
-        if tool_name == "bash" {
-            if let Some(sink) = ctx.progress_sink.clone() {
-                runtime::set_bash_progress_callback(bash_progress_forward(sink));
+        let (tool_name, value) = if tool_name == "ExecuteExtraTool" {
+            let req: ExecuteExtraToolRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            let target = tools::canonicalize_tool_name(&req.tool_name);
+            if tools::is_core_tool(&target) {
+                return Err(ToolError::new(format!(
+                    "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
+                    req.tool_name
+                )));
             }
-        }
-
-        if tool_name == "ExecuteExtraTool" {
-            return self.execute_extra_tool(value, ctx);
-        }
-
-        let is_mcp_tool = self.tool_registry.has_runtime_tool(tool_name);
-        if is_mcp_tool {
-            if let Some(sink) = ctx.progress_sink.clone() {
-                runtime::set_mcp_progress_callback(mcp_progress_forward(sink));
-            }
-        }
-
-        let result = if tool_name == "ToolSearch" {
-            self.execute_search_tool(value)
-        } else if is_mcp_tool {
-            self.execute_runtime_tool(tool_name, value)
+            (target, req.params)
         } else {
-            self.tool_registry
-                .execute_with_abort_and_context(
-                    tool_name,
-                    &value,
-                    self.abort_signal.as_ref(),
-                    Some(ctx),
-                )
-                .map_err(ToolError::new)
+            (tool_name.to_string(), value)
         };
 
-        // Ensure the thread-local is cleaned up regardless of the code
-        // path that was taken (the callback is consumed inside
-        // `execute_bash_with_abort`, but clear defensively).
-        if tool_name == "bash" {
-            runtime::clear_bash_progress_callback();
+        let is_mcp_tool = self.tool_registry.has_runtime_tool(&tool_name);
+        if tool_name == "ToolSearch" {
+            self.execute_search_tool(value)
+        } else {
+            // Core filesystem tools and MCP clients perform blocking work. Keep
+            // them off the turn's polling thread so Ctrl-C can win the runtime's
+            // cancellation select while a slow search or remote server is active.
+            let registry = self.tool_registry.clone();
+            let mcp_state = self.mcp_state.clone();
+            let mailbox_sender = self.mailbox_sender.clone();
+            let abort_signal = self.abort_signal.clone();
+            let ctx = ctx.clone();
+            let workspace = WorkspaceRootHandoff::capture();
+            tokio::task::spawn_blocking(move || {
+                let _workspace = workspace.enter();
+                if tool_name == "bash" {
+                    if let Some(sink) = ctx.progress_sink.clone() {
+                        runtime::set_bash_progress_callback(bash_progress_forward(sink));
+                    }
+                }
+                if is_mcp_tool {
+                    if let Some(sink) = ctx.progress_sink.clone() {
+                        runtime::set_mcp_progress_callback(mcp_progress_forward(sink));
+                    }
+                }
+
+                let result = if tool_name == "send_message" {
+                    mailbox_sender
+                        .as_ref()
+                        .ok_or_else(|| {
+                            ToolError::new("send_message is unavailable without nexus A2A")
+                        })
+                        .and_then(|sender| {
+                            runtime::spawn_task::handle_send_message(
+                                sender,
+                                &serde_json::to_string(&value).unwrap_or_default(),
+                            )
+                            .map_err(ToolError::new)
+                        })
+                } else if is_mcp_tool {
+                    execute_runtime_tool_with_state(mcp_state.as_ref(), &tool_name, value)
+                } else {
+                    registry
+                        .execute_with_abort_and_context(
+                            &tool_name,
+                            &value,
+                            abort_signal.as_ref(),
+                            Some(&ctx),
+                        )
+                        .map_err(ToolError::new)
+                };
+                runtime::clear_bash_progress_callback();
+                runtime::clear_mcp_progress_callback();
+                result
+            })
+            .await
+            .map_err(|error| ToolError::new(format!("tool task join error: {error}")))?
         }
-        if is_mcp_tool {
-            runtime::clear_mcp_progress_callback();
-        }
-        // Task-list panel updates are a RENDERER concern: the renderer derives
-        // them from `EngineEvent::ToolResult` for the Task* tools (which it
-        // already receives across the seam), NOT from an engine-side side-channel.
-        // Tool results reach the renderer via RuntimeObserver::on_tool_result
-        // -> EngineEvent::ToolResult -> EngineEventRenderer (the seam). The
-        // executor stays renderer-agnostic and never writes to the terminal.
-        result
     }
 
     fn set_abort_signal(&mut self, abort_signal: runtime::HookAbortSignal) {
@@ -385,53 +409,14 @@ struct AskUserQuestionCliOption {
 }
 
 impl CliToolExecutor {
-    fn execute_extra_tool(
-        &self,
-        value: serde_json::Value,
-        ctx: &runtime::ToolDispatchContext,
-    ) -> Result<String, ToolError> {
-        let req: ExecuteExtraToolRequest = serde_json::from_value(value)
-            .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-        let target = tools::canonicalize_tool_name(&req.tool_name);
-        if tools::is_core_tool(&target) {
-            return Err(ToolError::new(format!(
-                "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
-                req.tool_name
-            )));
-        }
-
-        let is_mcp_tool = self.tool_registry.has_runtime_tool(&target);
-        if is_mcp_tool {
-            if let Some(sink) = ctx.progress_sink.clone() {
-                runtime::set_mcp_progress_callback(mcp_progress_forward(sink));
-            }
-        }
-
-        let result = if is_mcp_tool {
-            self.execute_runtime_tool(&target, req.params)
-        } else {
-            self.tool_registry
-                .execute_with_abort_and_context(
-                    &target,
-                    &req.params,
-                    self.abort_signal.as_ref(),
-                    Some(ctx),
-                )
-                .map_err(ToolError::new)
-        };
-
-        if is_mcp_tool {
-            runtime::clear_mcp_progress_callback();
-        }
-
-        result
-    }
-
     fn execute_ask_user_question(&self, value: serde_json::Value) -> Result<String, ToolError> {
         let input: AskUserQuestionCliInput = serde_json::from_value(value)
             .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
 
-        let mut prompter_guard = self.question_prompter.borrow_mut();
+        let mut prompter_guard = self
+            .question_prompter
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let Some(prompter) = prompter_guard.as_mut() else {
             return Err(ToolError::new(
                 "AskUserQuestion requires an interactive question prompter",
@@ -651,7 +636,10 @@ impl CliToolExecutor {
 
         // Compute the choice, dropping the prompter borrow before we act on it.
         let choice = {
-            let mut guard = self.question_prompter.borrow_mut();
+            let mut guard = self
+                .question_prompter
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let Some(prompter) = guard.as_mut() else {
                 return execute_normally();
             };

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -49,6 +49,32 @@ const MAX_CONSECUTIVE_AUTO_COMPACT_NOOPS: u8 = 3;
 
 /// Message used in synthetic tool results when a turn is interrupted.
 const INTERRUPT_MESSAGE: &str = "Interrupted · What should Sudo Code do instead?";
+
+/// Preserve the bash result wire contract when cancellation wins the race with
+/// the blocking tool task. Other tools have no structured interruption shape.
+fn interrupted_tool_output(tool_name: &str) -> String {
+    if tool_name.eq_ignore_ascii_case("bash") {
+        serde_json::json!({
+            "stdout": "",
+            "stderr": "Command interrupted by user",
+            "rawOutputPath": null,
+            "interrupted": true,
+            "isImage": null,
+            "backgroundTaskId": null,
+            "backgroundedByUser": null,
+            "assistantAutoBackgrounded": null,
+            "dangerouslyDisableSandbox": null,
+            "returnCodeInterpretation": "interrupted",
+            "noOutputExpected": true,
+            "structuredContent": null,
+            "sandboxStatus": null,
+        })
+        .to_string()
+    } else {
+        INTERRUPT_MESSAGE.to_string()
+    }
+}
+
 const EMPTY_POST_TOOL_DELIVERABLE_REMINDER: &str = "\
 <system-reminder>
 The previous model response was empty after a tool completed. The user requested a file deliverable, but the current turn has not produced a matching final file yet. Continue the same task now: create or execute whatever is needed to produce the requested file, then verify it exists before ending the turn.
@@ -1260,8 +1286,8 @@ where
         for (tool_use_id, tool_name) in pending_tool_ids {
             let _ = self.session.push_message(ConversationMessage::tool_result(
                 tool_use_id,
-                tool_name,
-                INTERRUPT_MESSAGE,
+                tool_name.clone(),
+                interrupted_tool_output(&tool_name),
                 true,
             ));
         }
@@ -1394,7 +1420,7 @@ where
             let result_message = ConversationMessage::tool_result(
                 tool_use_id.clone(),
                 tool_name.clone(),
-                INTERRUPT_MESSAGE,
+                interrupted_tool_output(tool_name),
                 true,
             );
             self.push_tool_result_message(observer, iterations, tool_results, result_message)?;
@@ -2005,7 +2031,7 @@ where
                             let result_message = ConversationMessage::tool_result(
                                 p.tool_use_id.clone(),
                                 p.tool_name.clone(),
-                                INTERRUPT_MESSAGE,
+                                interrupted_tool_output(&p.tool_name),
                                 true,
                             );
                             self.push_tool_result_message(
@@ -2236,8 +2262,8 @@ where
                             // "every tool_use has a tool_result" invariant.
                             let result_message = ConversationMessage::tool_result(
                                 tool_use_id,
-                                tool_name,
-                                INTERRUPT_MESSAGE,
+                                tool_name.clone(),
+                                interrupted_tool_output(&tool_name),
                                 true,
                             );
                             self.push_tool_result_message(

--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -509,6 +509,15 @@ pub fn glob_search(
 
 /// Runs a regex search over workspace files with optional context lines.
 pub fn grep_search(fs: &dyn FsBackend, input: &GrepSearchInput) -> io::Result<GrepSearchOutput> {
+    grep_search_with_abort(fs, input, None)
+}
+
+/// Runs [`grep_search`] while observing the turn's cancellation signal.
+pub fn grep_search_with_abort(
+    fs: &dyn FsBackend,
+    input: &GrepSearchInput,
+    abort_signal: Option<&crate::HookAbortSignal>,
+) -> io::Result<GrepSearchOutput> {
     let base_path = match input.path.as_deref() {
         Some(p) => fs.normalize(p)?,
         None => fs.working_root()?,
@@ -537,7 +546,8 @@ pub fn grep_search(fs: &dyn FsBackend, input: &GrepSearchInput) -> io::Result<Gr
     let mut content_lines = Vec::new();
     let mut total_matches = 0usize;
 
-    for file_path in collect_search_files_via_backend(fs, &base_path) {
+    for file_path in collect_search_files_via_backend(fs, &base_path, abort_signal)? {
+        check_abort(abort_signal)?;
         if !matches_optional_filters(Path::new(&file_path), glob_filter.as_ref(), file_type) {
             continue;
         }
@@ -558,6 +568,9 @@ pub fn grep_search(fs: &dyn FsBackend, input: &GrepSearchInput) -> io::Result<Gr
         let lines: Vec<&str> = file_contents.lines().collect();
         let mut matched_lines = Vec::new();
         for (index, line) in lines.iter().enumerate() {
+            if index % 256 == 0 {
+                check_abort(abort_signal)?;
+            }
             if regex.is_match(line) {
                 total_matches += 1;
                 matched_lines.push(index);
@@ -688,15 +701,47 @@ fn is_absolute_path(p: &str) -> bool {
 /// Unlike `glob_search` this does NOT prune heavy directories — grep over an
 /// explicit path searches everything the caller pointed at (parity with the
 /// prior `WalkDir`-over-everything behaviour).
-fn collect_search_files_via_backend(fs: &dyn FsBackend, base: &str) -> Vec<String> {
+fn collect_search_files_via_backend(
+    fs: &dyn FsBackend,
+    base: &str,
+    abort_signal: Option<&crate::HookAbortSignal>,
+) -> io::Result<Vec<String>> {
     if let Ok(meta) = fs.stat(base) {
         if meta.is_file {
-            return vec![base.to_string()];
+            return Ok(vec![base.to_string()]);
         }
     }
     let mut files = Vec::new();
-    walk_files_via_backend(fs, base, &|_| false, &mut files);
-    files
+    walk_search_files_via_backend(fs, base, abort_signal, &mut files)?;
+    Ok(files)
+}
+
+fn walk_search_files_via_backend(
+    fs: &dyn FsBackend,
+    root: &str,
+    abort_signal: Option<&crate::HookAbortSignal>,
+    out: &mut Vec<String>,
+) -> io::Result<()> {
+    check_abort(abort_signal)?;
+    for entry in fs.readdir(root).unwrap_or_default() {
+        let child = fs.join_path(root, &entry.name);
+        if entry.is_dir {
+            walk_search_files_via_backend(fs, &child, abort_signal, out)?;
+        } else {
+            out.push(child);
+        }
+    }
+    Ok(())
+}
+
+fn check_abort(abort_signal: Option<&crate::HookAbortSignal>) -> io::Result<()> {
+    if abort_signal.is_some_and(crate::HookAbortSignal::is_aborted) {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "tool execution cancelled",
+        ));
+    }
+    Ok(())
 }
 
 fn matches_optional_filters(

--- a/rust/crates/runtime/src/hooks.rs
+++ b/rust/crates/runtime/src/hooks.rs
@@ -123,10 +123,19 @@ impl HookAbortSignal {
     /// Returns a future that resolves when the abort signal is triggered.
     /// If already aborted, resolves immediately.
     pub async fn cancelled(&self) {
-        if self.is_aborted() {
-            return;
+        loop {
+            if self.is_aborted() {
+                return;
+            }
+
+            // `Notify::notify_waiters` intentionally does not retain a permit.
+            // Poll as well as waiting so an abort between the check above and
+            // subscription cannot strand a turn forever.
+            tokio::select! {
+                () = self.notify.notified() => {}
+                () = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
         }
-        self.notify.notified().await;
     }
 }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -118,9 +118,10 @@ pub use conversation::{
 };
 pub use file_intent::{detect_file_intent, FileIntent, FileOpKind, UserRequestIntent};
 pub use file_ops::{
-    edit_file, edit_file_with_intent, glob_search, grep_search, read_file, write_file,
-    write_file_with_intent, EditFileOutput, FileOpResult, GlobSearchOutput, GrepSearchInput,
-    GrepSearchOutput, ReadFileOutput, StructuredPatchHunk, TextFilePayload, WriteFileOutput,
+    edit_file, edit_file_with_intent, glob_search, grep_search, grep_search_with_abort, read_file,
+    write_file, write_file_with_intent, EditFileOutput, FileOpResult, GlobSearchOutput,
+    GrepSearchInput, GrepSearchOutput, ReadFileOutput, StructuredPatchHunk, TextFilePayload,
+    WriteFileOutput,
 };
 pub use file_redirect::{get_drafts_dir, is_in_drafts, redirect_to_drafts, DRAFTS_DIR_NAME};
 pub use file_snapshot::{FileChangeSnapshot, FileChangeSnapshotWithMtime};

--- a/rust/crates/rusty-sudocode-cli/tests/pty_core_conversation.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_core_conversation.rs
@@ -195,8 +195,27 @@ fn sigint_cancels_streaming() {
         .expect("scode should exit after Ctrl+C, not hang");
 }
 
+/// Ctrl+C also cancels while the provider has not returned its first response.
+/// This guards the abort-notification race that previously left a turn waiting
+/// forever if SIGINT arrived just before the request future subscribed.
+#[test]
+fn sigint_cancels_pending_llm_request() {
+    let env = TestEnv::new("sigint-pending-llm");
+    let prompt = env.prompt("Reply after a short delay.", "delayed_text");
+
+    let mut sess = env.spawn(&["--permission-mode", "read-only", &prompt]);
+    sess.expect("(?i)(thinking|sonnet|auto|claude|⠋|⠙|⠹)")
+        .expect("should see request activity before cancelling");
+    sess.send_ctrl('c').expect("send Ctrl+C");
+
+    sess.set_default_timeout(Duration::from_secs(15));
+    let _exit = sess
+        .expect_eof()
+        .expect("scode should exit while the LLM request is pending");
+}
+
 // ──────────────────────────────────────────────────────────────────────
-// 6. ESC key cancels mid-execution (CC parity)
+// 7. ESC key cancels mid-execution (CC parity)
 // ──────────────────────────────────────────────────────────────────────
 
 /// ESC key during a long-running bash tool exits cleanly (CC parity).

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -214,7 +214,7 @@ use runtime::{
     check_freshness,
     cron_registry::CronRegistry,
     current_workspace_root, dedupe_superseded_commit_events, edit_file, execute_bash_with_abort,
-    glob_search, grep_search,
+    glob_search,
     permission_enforcer::{EnforcementResult, PermissionEnforcer},
     read_file,
     summary_compression::compress_summary_text,
@@ -1795,7 +1795,8 @@ fn execute_tool_with_enforcer(
         }
         "grep_search" => {
             maybe_enforce_permission_check(enforcer, name, input)?;
-            from_value::<GrepSearchInput>(input).and_then(|input| run_grep_search(input, fs))
+            from_value::<GrepSearchInput>(input)
+                .and_then(|input| run_grep_search(input, fs, abort_signal))
         }
         "WebFetch" => from_value::<WebFetchInput>(input).and_then(run_web_fetch),
         "WebSearch" => from_value::<WebSearchInput>(input).and_then(run_web_search),
@@ -3465,8 +3466,12 @@ fn run_glob_search(input: GlobSearchInputValue, fs: &dyn FsBackend) -> Result<St
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn run_grep_search(input: GrepSearchInput, fs: &dyn FsBackend) -> Result<String, String> {
-    to_pretty_json(grep_search(fs, &input).map_err(io_to_string)?)
+fn run_grep_search(
+    input: GrepSearchInput,
+    fs: &dyn FsBackend,
+    abort_signal: Option<&HookAbortSignal>,
+) -> Result<String, String> {
+    to_pretty_json(runtime::grep_search_with_abort(fs, &input, abort_signal).map_err(io_to_string)?)
 }
 
 #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
## Summary
- fix the abort-notification race during pending model requests
- run blocking CLI tools off the turn polling thread and make grep traversal observe cancellation
- unblock pending permission/question prompts on cancellation
- add PTY coverage for Ctrl+C while an LLM response is pending

## Testing
- `cargo fmt --all --check`
- `cargo test -p rusty-sudocode-cli --test pty_core_conversation`

## Notes
- Full workspace Clippy is currently blocked by pre-existing `telemetry` crate warnings under `-D warnings`.