### PR TITLE
feat(cli): say what a one-shot turn is waiting on, instead of going silent

### DIFF
--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -476,7 +476,13 @@ pub fn proxy_account_for_model<'a>(
     let alias_lower = model_alias.trim().to_ascii_lowercase();
     let mapping_provider = resolve_model_for_mode(config, &alias_lower, Some("proxy"))
         .and_then(|entry| entry.providers.get("proxy"))
-        .map(|mapping| mapping.provider.as_str());
+        .map(|mapping| mapping.provider.as_str())
+        // An empty `provider` is "no pin", not "an account named empty string".
+        // Migrated configs carry exactly that, so passing it through unfiltered
+        // made this report fail to resolve an account that requests were
+        // resolving fine — the report disagreeing with the billing path, which
+        // is the failure this function exists to prevent.
+        .filter(|name| !name.is_empty());
     select_proxy_account(config, mapping_provider)
 }
 
@@ -1237,6 +1243,30 @@ mod tests {
             resolved.credential,
             Credential::ApiKey("sk-fujitoken-key".to_string())
         );
+    }
+
+    /// A migrated entry carries an empty `provider`, and the reporting path must
+    /// read that as "no pin" exactly as the billing path does. Reading it as an
+    /// account named `""` made `doctor` announce it could not resolve an account
+    /// while requests resolved one fine — the report disagreeing with the bill,
+    /// which is the whole failure this function exists to prevent.
+    #[test]
+    fn reporting_treats_an_empty_pin_as_no_pin() {
+        let mut config = sample_config();
+        assert_eq!(config.auth_modes["proxy"].len(), 1);
+        config
+            .models
+            .get_mut("opus")
+            .expect("opus entry")
+            .providers
+            .get_mut("proxy")
+            .expect("proxy mapping")
+            .provider = String::new();
+        assert!(config.selected_account.is_none());
+
+        let selected = proxy_account_for_model(&config, "opus")
+            .expect("an unpinned entry with one account is not ambiguous");
+        assert_eq!(selected.name, "sudorouter");
     }
 
     /// Unpinned and unselected is the one combination with no answer — it must

--- a/rust/crates/commands/src/reports.rs
+++ b/rust/crates/commands/src/reports.rs
@@ -1046,6 +1046,36 @@ pub fn render_doctor_report(build: &BuildInfo) -> Result<DoctorReport, Box<dyn s
 /// re-implements the decision can disagree with the code that spends the money,
 /// which is precisely how an unhonored `auth_profile` stayed invisible while
 /// every request billed a different account.
+/// Name the upstream a turn is waiting on: the host being called and the
+/// account paying for it.
+///
+/// Resolves through `api::proxy_account_for_model`, the same selector the
+/// Account check below reports, so a message about a slow turn names the same
+/// account the report does. Lives here rather than in the CLI because the CLI
+/// has no direct `api` dependency — that seam is deliberate.
+///
+/// Falls back to the model alone when resolution fails: a caller that wants to
+/// say "still waiting" is better off saying less than saying nothing.
+#[must_use]
+pub fn describe_upstream_for(cwd: &Path, model: &str) -> String {
+    let loader = ConfigLoader::default_for(cwd);
+    let Ok(config) = loader.load_sudocode_config() else {
+        return format!("model {model}");
+    };
+    match api::proxy_account_for_model(&config, model) {
+        Ok(selected) => {
+            let url: &str = &selected.connection.base_url;
+            let host = url
+                .split("://")
+                .nth(1)
+                .and_then(|rest: &str| rest.split('/').next())
+                .unwrap_or(url);
+            format!("{host} (account {}, model {model})", selected.name)
+        }
+        Err(_) => format!("model {model}"),
+    }
+}
+
 fn check_account_health(config_loader: &ConfigLoader, resolved_model: &str) -> DiagnosticCheck {
     let config = match config_loader.load_sudocode_config() {
         Ok(config) => config,

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -290,15 +290,31 @@ struct WaitNotice {
 
 impl WaitNotice {
     /// Start announcing on stderr once a turn passes [`WAIT_NOTICE_FIRST`].
-    fn start(target: String) -> Self {
-        Self::start_with(target, WAIT_NOTICE_FIRST, WAIT_NOTICE_REPEAT, |line| {
-            eprintln!("{line}");
-        })
+    ///
+    /// The upstream is described lazily, inside the thread, on the first line it
+    /// actually prints. Resolving it up front would load the whole config on
+    /// every run — including the overwhelming majority that never wait long
+    /// enough to say anything — and that load warms the model-capabilities SSOT
+    /// as a side effect. Pulling an initialization earlier than it would
+    /// otherwise happen is how a previous change quietly broke an unrelated
+    /// test; a feature that only speaks in the slow case should also only do its
+    /// work there.
+    fn start(model: String) -> Self {
+        let cwd = env::current_dir().unwrap_or_default();
+        Self::start_lazily(
+            move || commands::reports::describe_upstream_for(&cwd, &model),
+            WAIT_NOTICE_FIRST,
+            WAIT_NOTICE_REPEAT,
+            |line| eprintln!("{line}"),
+        )
     }
 
-    /// Seam for tests: injectable clock intervals and sink.
-    fn start_with(
-        target: String,
+    /// Seam for tests: injectable description, clock intervals, and sink.
+    ///
+    /// `describe` runs at most once, and only if the wait lasts long enough to
+    /// report — a turn that finishes normally never calls it.
+    fn start_lazily(
+        describe: impl FnOnce() -> String + Send + 'static,
         first: Duration,
         repeat: Duration,
         emit: impl Fn(String) + Send + 'static,
@@ -307,14 +323,28 @@ impl WaitNotice {
         let thread = thread::spawn(move || {
             let mut interval = first;
             let mut waited = Duration::ZERO;
+            let mut target: Option<String> = None;
+            // `FnOnce` in an `Option` so the loop can take it exactly once and
+            // the compiler enforces that, rather than a comment promising it.
+            let mut describe = Some(describe);
             loop {
                 match stopped.recv_timeout(interval) {
                     // Turn finished, or the guard was dropped: say nothing more.
                     Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
                     Err(RecvTimeoutError::Timeout) => {
                         waited += interval;
+                        let described = match &target {
+                            Some(known) => known.clone(),
+                            None => {
+                                let described = describe
+                                    .take()
+                                    .map_or_else(String::new, |describe| describe());
+                                target = Some(described.clone());
+                                described
+                            }
+                        };
                         emit(format!(
-                            "scode: still waiting on {target} ({}s)",
+                            "scode: still waiting on {described} ({}s)",
                             waited.as_secs()
                         ));
                         interval = repeat;
@@ -336,18 +366,6 @@ impl Drop for WaitNotice {
             let _ = thread.join();
         }
     }
-}
-
-/// What to name in the waiting line: the host being called and the account
-/// paying for it.
-///
-/// Both come from `proxy_account_for_model`, the selector `doctor` reports
-/// through, so a slow turn names the same account the report does. Falls back
-/// to the model alone when resolution fails — a waiting line is worth printing
-/// even when it can say less.
-fn describe_wait_target(model: &str) -> String {
-    let cwd = env::current_dir().unwrap_or_default();
-    commands::reports::describe_upstream_for(&cwd, model)
 }
 
 /// One-time repair of the legacy config shape, run before any command.
@@ -833,9 +851,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             // Share the splash's env/config resolution so the one-shot prompt
             // can't disagree with the REPL banner.
             let resolved_model = resolve_repl_model(model);
-            // Resolved before the client is built, while the model name is still
-            // in hand and nothing has started waiting yet.
-            let wait_target = describe_wait_target(&resolved_model);
+            let wait_model = resolved_model.clone();
             let mut cli = LiveCli::new(
                 resolved_model,
                 true,
@@ -852,7 +868,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let _cancel_guard = SignalCancelGuard::install(cli.engine_handle.commands.clone());
             // Nothing renders until the model answers, so a slow upstream looks
             // exactly like a hang. Say what is being waited on instead.
-            let _wait_notice = WaitNotice::start(wait_target);
+            let _wait_notice = WaitNotice::start(wait_model);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
             drop(_wait_notice);
 
@@ -5752,13 +5768,22 @@ mod wait_notice_tests {
         let lines = Arc::new(Mutex::new(Vec::new()));
         {
             let sink = Arc::clone(&lines);
-            let _notice = WaitNotice::start_with(
-                "example.test".to_string(),
+            let described = Arc::new(Mutex::new(false));
+            let flag = Arc::clone(&described);
+            let _notice = WaitNotice::start_lazily(
+                move || {
+                    *flag.lock().expect("flag") = true;
+                    "example.test".to_string()
+                },
                 Duration::from_secs(2),
                 Duration::from_secs(2),
                 move |line| sink.lock().expect("sink").push(line),
             );
             thread::sleep(Duration::from_millis(20));
+            assert!(
+                !*described.lock().expect("flag"),
+                "a fast turn must not pay for describing an upstream it never names"
+            );
         }
         assert!(
             lines.lock().expect("sink").is_empty(),
@@ -5773,10 +5798,15 @@ mod wait_notice_tests {
     #[test]
     fn keeps_reporting_while_the_turn_runs_then_stops_on_drop() {
         let lines = Arc::new(Mutex::new(Vec::new()));
+        let calls = Arc::new(Mutex::new(0usize));
         {
             let sink = Arc::clone(&lines);
-            let _notice = WaitNotice::start_with(
-                "example.test".to_string(),
+            let counter = Arc::clone(&calls);
+            let _notice = WaitNotice::start_lazily(
+                move || {
+                    *counter.lock().expect("counter") += 1;
+                    "example.test".to_string()
+                },
                 Duration::from_millis(20),
                 Duration::from_millis(20),
                 move |line| sink.lock().expect("sink").push(line),
@@ -5794,6 +5824,12 @@ mod wait_notice_tests {
             captured[0].contains("example.test"),
             "should name the target, got: {}",
             captured[0]
+        );
+
+        assert_eq!(
+            *calls.lock().expect("counter"),
+            1,
+            "the upstream should be described once and reused, not re-resolved per line"
         );
 
         thread::sleep(Duration::from_millis(60));

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -263,6 +263,93 @@ fn enable_windows_ansi_support() {}
 /// Environment variable that suppresses the startup config migration.
 const SKIP_CONFIG_MIGRATION_ENV: &str = "SCODE_SKIP_CONFIG_MIGRATION";
 
+/// How long a one-shot turn may run before the first "still waiting" line.
+/// Long enough that an ordinary turn never prints one, short enough that a
+/// person does not start doubting the process.
+const WAIT_NOTICE_FIRST: Duration = Duration::from_secs(15);
+/// Cadence after the first line. Slow: this is reassurance, not telemetry.
+const WAIT_NOTICE_REPEAT: Duration = Duration::from_secs(30);
+
+/// Tells the user, on stderr, that a one-shot turn is still waiting — and on
+/// what — when it takes long enough to look like a hang.
+///
+/// The one-shot path renders nothing until the model answers, and the default
+/// read timeout allows a stalled connection five minutes of silence. Those two
+/// facts together make a slow upstream indistinguishable from a hung process.
+/// It is not a hypothetical confusion: it sent one debugging session down six
+/// rounds of bisecting and three throwaway builds looking for a regression that
+/// did not exist, because "no output at all" reads as "broken", never as
+/// "waiting".
+///
+/// Writes to stderr, never stdout — stdout carries `--output-format json`, and
+/// one stray line there would turn a working run into a parse error.
+struct WaitNotice {
+    stop: Option<Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl WaitNotice {
+    /// Start announcing on stderr once a turn passes [`WAIT_NOTICE_FIRST`].
+    fn start(target: String) -> Self {
+        Self::start_with(target, WAIT_NOTICE_FIRST, WAIT_NOTICE_REPEAT, |line| {
+            eprintln!("{line}");
+        })
+    }
+
+    /// Seam for tests: injectable clock intervals and sink.
+    fn start_with(
+        target: String,
+        first: Duration,
+        repeat: Duration,
+        emit: impl Fn(String) + Send + 'static,
+    ) -> Self {
+        let (stop, stopped) = mpsc::channel::<()>();
+        let thread = thread::spawn(move || {
+            let mut interval = first;
+            let mut waited = Duration::ZERO;
+            loop {
+                match stopped.recv_timeout(interval) {
+                    // Turn finished, or the guard was dropped: say nothing more.
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
+                    Err(RecvTimeoutError::Timeout) => {
+                        waited += interval;
+                        emit(format!(
+                            "scode: still waiting on {target} ({}s)",
+                            waited.as_secs()
+                        ));
+                        interval = repeat;
+                    }
+                }
+            }
+        });
+        Self {
+            stop: Some(stop),
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for WaitNotice {
+    fn drop(&mut self) {
+        drop(self.stop.take());
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// What to name in the waiting line: the host being called and the account
+/// paying for it.
+///
+/// Both come from `proxy_account_for_model`, the selector `doctor` reports
+/// through, so a slow turn names the same account the report does. Falls back
+/// to the model alone when resolution fails — a waiting line is worth printing
+/// even when it can say less.
+fn describe_wait_target(model: &str) -> String {
+    let cwd = env::current_dir().unwrap_or_default();
+    commands::reports::describe_upstream_for(&cwd, model)
+}
+
 /// One-time repair of the legacy config shape, run before any command.
 ///
 /// **Temporary shim — added 2026-09, delete once installs have turned over.**
@@ -746,6 +833,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             // Share the splash's env/config resolution so the one-shot prompt
             // can't disagree with the REPL banner.
             let resolved_model = resolve_repl_model(model);
+            // Resolved before the client is built, while the model name is still
+            // in hand and nothing has started waiting yet.
+            let wait_target = describe_wait_target(&resolved_model);
             let mut cli = LiveCli::new(
                 resolved_model,
                 true,
@@ -760,7 +850,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             // REPL wires this through its input path; the one-shot path has no
             // key reader, so install a scoped signal→Cancel monitor here.
             let _cancel_guard = SignalCancelGuard::install(cli.engine_handle.commands.clone());
+            // Nothing renders until the model answers, so a slow upstream looks
+            // exactly like a hang. Say what is being waited on instead.
+            let _wait_notice = WaitNotice::start(wait_target);
             cli.run_turn_with_output(&effective_prompt, output_format, compact)?;
+            drop(_wait_notice);
 
             // Record token usage and session ended event for non-interactive prompt mode
             let duration_ms = session_start.elapsed().as_millis() as u64;
@@ -5644,6 +5738,71 @@ fn slash_command_completion_candidates_with_sessions(
     }
 
     completions.into_iter().collect()
+}
+
+#[cfg(test)]
+mod wait_notice_tests {
+    use super::*;
+
+    /// A turn that finishes normally must print nothing. The notice exists for
+    /// the pathological case; if it spoke on every run it would be noise, and
+    /// noise is what people learn to ignore.
+    #[test]
+    fn says_nothing_when_the_turn_finishes_promptly() {
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        {
+            let sink = Arc::clone(&lines);
+            let _notice = WaitNotice::start_with(
+                "example.test".to_string(),
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+                move |line| sink.lock().expect("sink").push(line),
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            lines.lock().expect("sink").is_empty(),
+            "a fast turn should be silent, got: {:?}",
+            lines.lock().expect("sink")
+        );
+    }
+
+    /// A turn that keeps running must keep saying so, and must name what it is
+    /// waiting on — "still running" without a target leaves the reader exactly
+    /// as stuck as silence does.
+    #[test]
+    fn keeps_reporting_while_the_turn_runs_then_stops_on_drop() {
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        {
+            let sink = Arc::clone(&lines);
+            let _notice = WaitNotice::start_with(
+                "example.test".to_string(),
+                Duration::from_millis(20),
+                Duration::from_millis(20),
+                move |line| sink.lock().expect("sink").push(line),
+            );
+            thread::sleep(Duration::from_millis(300));
+        }
+        // The guard's Drop joins the thread, so nothing can arrive after this.
+        let captured = lines.lock().expect("sink").clone();
+        assert!(
+            captured.len() >= 2,
+            "should keep reporting, got {} line(s): {captured:?}",
+            captured.len()
+        );
+        assert!(
+            captured[0].contains("example.test"),
+            "should name the target, got: {}",
+            captured[0]
+        );
+
+        thread::sleep(Duration::from_millis(60));
+        assert_eq!(
+            lines.lock().expect("sink").len(),
+            captured.len(),
+            "dropping the guard must stop the thread, not just detach it"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/rusty-sudocode-cli/src/render_engine.rs
+++ b/rust/crates/rusty-sudocode-cli/src/render_engine.rs
@@ -98,10 +98,6 @@ impl EngineEventRenderer {
     /// it is set too, so a long backoff also reads on the live status line
     /// rather than only in scrollback.
     fn render_retry(&mut self, event: &RetryEvent) {
-        {
-            use std::io::Write as _;
-            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("C:/Users/songym/AppData/Local/Temp/claude/C--Users-songym-cursor-projects-nexus/98991364-6741-4069-89d2-900c0379fb58/scratchpad/retry_dbg.log") { let _ = writeln!(f, "renderer render_retry {:?}", event); }
-        }
         match event {
             RetryEvent::Waiting {
                 attempt,

--- a/rust/crates/rusty-sudocode-cli/tests/interrupt_e2e.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/interrupt_e2e.rs
@@ -2,7 +2,7 @@
 //! ends without a follow-up model call, and the process still prints its JSON
 //! and exits 0.
 //!
-//! Runs on Windows too — see `send_interrupt` for how the interrupt is
+//! Runs on Windows too — see `ArmedInterrupt` for how the interrupt is
 //! delivered there, and `common/isolated_env.rs` for why `env_clear()` alone
 //! isn't a survivable environment for a Windows child.
 
@@ -53,12 +53,12 @@ fn sigint_during_bash_tool_returns_interrupted_result_without_continuing_turn() 
     {
         use std::os::windows::process::CommandExt;
         // CREATE_NEW_PROCESS_GROUP — makes the child its own group leader, so
-        // `send_interrupt` can target it by pid without the console event also
-        // hitting the test runner. See `send_interrupt`.
+        // `ArmedInterrupt` can target it by pid without the console event also
+        // hitting the test runner. See `ArmedInterrupt`.
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         command.creation_flags(CREATE_NEW_PROCESS_GROUP);
     }
-    let mut child = command
+    let child = command
         .args([
             "--auth",
             "api-key",
@@ -77,13 +77,24 @@ fn sigint_during_bash_tool_returns_interrupted_result_without_continuing_turn() 
         .spawn()
         .expect("scode should launch");
 
+    let mut child = ChildGuard(child);
+
+    // Arm the interrupt *now*, before the window it has to land in opens.
+    // The window is the tool's `sleep 30`; on Windows arming means compiling
+    // a P/Invoke shim, which on a cold runner can take longer than the whole
+    // window. Paying that cost up front is what keeps the interrupt inside
+    // it. See `ArmedInterrupt`.
+    let interrupt = ArmedInterrupt::arm(child.id(), &workspace);
+
     // Generous: this is a liveness wait, not the assertion. Under a parallel
     // `cargo test --workspace` the machine is running many other `scode`
     // children, and 10s was not always enough for this one to start and reach
     // the mock server.
     wait_for_message_request(&runtime, &server, 1, Duration::from_secs(60));
+    interrupt.wait_until_armed(Duration::from_secs(120));
     thread::sleep(Duration::from_millis(1500));
-    send_interrupt(child.id());
+    assert_running(&mut child, "before the interrupt is fired");
+    interrupt.fire();
 
     let status = wait_for_exit(&mut child, Duration::from_secs(60))
         .expect("scode should exit after the interrupt");
@@ -181,18 +192,94 @@ fn wait_for_exit(
     }
 }
 
-/// Ask the OS to interrupt the running `scode`, the way a user pressing Ctrl-C
-/// at a terminal would.
+/// Keeps the spawned `scode` from outliving the test. Every assertion below
+/// can panic, and a leaked `scode` holds a `sleep 30` grandchild that goes on
+/// competing for a shared CI runner long after the test that spawned it.
+struct ChildGuard(std::process::Child);
+
+impl std::ops::Deref for ChildGuard {
+    type Target = std::process::Child;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ChildGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        // Already reaped on the happy path; both calls are then no-ops.
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Fail with what actually happened rather than with the interrupt's own
+/// second-order symptom. An interrupt aimed at a process that has already
+/// exited reports "could not attach to that pid", which reads like a bug in
+/// the interrupt machinery when the real news is that `scode` finished the
+/// turn early — a different failure with a different fix.
+fn assert_running(child: &mut ChildGuard, when: &str) {
+    let Ok(Some(status)) = child.try_wait() else {
+        return;
+    };
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    panic!(
+        "scode already exited {when} (status {status:?}); the interrupt had \
+         nothing to interrupt, so the tool never reached its `sleep 30`\
+         \nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+    );
+}
+
+/// An interrupt that is fully prepared but not yet delivered.
 ///
+/// Split in two because *preparing* to interrupt can cost more than the
+/// window the interrupt has to land in. The window here is the tool's
+/// `sleep 30`; on Windows preparation means compiling a C# P/Invoke shim
+/// (see the platform impl), which on a cold runner can take tens of seconds.
+/// Doing that after the turn starts spends the window on the preparation and
+/// delivers the signal to a process that has already finished — which is not
+/// what the assertion is about. `arm` runs before the turn, `wait_until_armed`
+/// confirms it finished, and only then does `fire` deliver.
+struct ArmedInterrupt {
+    pid: u32,
+    #[cfg(windows)]
+    helper: std::process::Child,
+    #[cfg(windows)]
+    ready_path: PathBuf,
+    #[cfg(windows)]
+    go_path: PathBuf,
+}
+
 /// Unix: `kill -INT`, the signal `SignalCancelGuard` installs a handler for.
+/// Nothing to prepare, so arming is bookkeeping and the wait returns at once.
 #[cfg(unix)]
-fn send_interrupt(pid: u32) {
-    let status = Command::new("kill")
-        .arg("-INT")
-        .arg(pid.to_string())
-        .status()
-        .expect("kill should launch");
-    assert!(status.success(), "kill -INT should succeed");
+impl ArmedInterrupt {
+    fn arm(pid: u32, _workspace: &std::path::Path) -> Self {
+        Self { pid }
+    }
+
+    fn wait_until_armed(&self, _timeout: Duration) {}
+
+    fn fire(self) {
+        let status = Command::new("kill")
+            .arg("-INT")
+            .arg(self.pid.to_string())
+            .status()
+            .expect("kill should launch");
+        assert!(status.success(), "kill -INT should succeed");
+    }
 }
 
 /// Windows has no `kill -INT`; the equivalent is a *console control event*,
@@ -209,32 +296,80 @@ fn send_interrupt(pid: u32) {
 /// helper must `FreeConsole` before `AttachConsole`, since a process can be
 /// attached to only one console at a time.
 #[cfg(windows)]
-fn send_interrupt(pid: u32) {
-    const CTRL_BREAK_EVENT: u32 = 1;
-    let script = format!(
-        r#"
+impl ArmedInterrupt {
+    /// Start the helper and let it compile. `Add-Type -MemberDefinition`
+    /// compiles C# at run time — the slow part, and the reason arming is
+    /// separate from firing. The helper reports readiness and waits for the
+    /// go-ahead through two marker files rather than its own stdio: it must
+    /// `FreeConsole` before it can attach to the target's console, and
+    /// nothing that depends on the helper's console can be relied on across
+    /// that call.
+    fn arm(pid: u32, workspace: &std::path::Path) -> Self {
+        const CTRL_BREAK_EVENT: u32 = 1;
+        let ready_path = workspace.join("interrupt-helper-ready");
+        let go_path = workspace.join("interrupt-helper-go");
+        let script = format!(
+            r#"
 $signature = @'
 [DllImport("kernel32.dll", SetLastError = true)] public static extern bool FreeConsole();
 [DllImport("kernel32.dll", SetLastError = true)] public static extern bool AttachConsole(uint dwProcessId);
 [DllImport("kernel32.dll", SetLastError = true)] public static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
 '@
 $kernel32 = Add-Type -MemberDefinition $signature -Name 'Kernel32' -Namespace 'Interrupt' -PassThru
+New-Item -ItemType File -Path '{ready}' -Force | Out-Null
+while (-not (Test-Path -LiteralPath '{go}')) {{ Start-Sleep -Milliseconds 20 }}
 [void]$kernel32::FreeConsole()
 if (-not $kernel32::AttachConsole({pid})) {{ exit 2 }}
 if (-not $kernel32::GenerateConsoleCtrlEvent({CTRL_BREAK_EVENT}, {pid})) {{ exit 3 }}
 exit 0
-"#
-    );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-        .output()
-        .expect("powershell should launch");
-    assert!(
-        output.status.success(),
-        "console Ctrl-Break to pid {pid} failed (exit {:?}; 2 = AttachConsole, 3 = GenerateConsoleCtrlEvent)\nstderr:\n{}",
-        output.status.code(),
-        String::from_utf8_lossy(&output.stderr),
-    );
+"#,
+            ready = ready_path.display(),
+            go = go_path.display(),
+        );
+        let helper = Command::new("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("powershell should launch");
+        Self {
+            pid,
+            helper,
+            ready_path,
+            go_path,
+        }
+    }
+
+    fn wait_until_armed(&self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while !self.ready_path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "console-interrupt helper did not finish compiling within {timeout:?}"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    /// Release the helper and wait for it to report what the Win32 calls did.
+    fn fire(self) {
+        let Self {
+            pid,
+            helper,
+            go_path,
+            ..
+        } = self;
+        fs::write(&go_path, b"").expect("go marker should be written");
+        let output = helper
+            .wait_with_output()
+            .expect("console-interrupt helper should exit");
+        assert!(
+            output.status.success(),
+            "console Ctrl-Break to pid {pid} failed (exit {:?}; 2 = AttachConsole, 3 = GenerateConsoleCtrlEvent)\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
 }
 
 fn write_config(config_home: &std::path::Path, base_url: &str) {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -127,10 +127,19 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
         panic!("prompt: {e}\nPTY:\n{screen}");
     });
 
-    // Settle: on macOS CI the signal handler may not be fully wired
-    // when the prompt first renders. A brief pause avoids Ctrl-C
-    // arriving before the REPL's SIGINT handler is installed.
-    std::thread::sleep(Duration::from_millis(200));
+    // Readiness, not a guess. Until iocraft has taken the terminal out of
+    // canonical mode, ^C is still a terminal signal and would kill the child
+    // outright instead of arriving as a key event. The prompt can be on
+    // screen before that happens, so the prompt alone is not the signal —
+    // a keystroke that renders is: it proves iocraft owns the keyboard and
+    // is distributing key events. (A fixed sleep here was the old guard;
+    // any duration is either too short on a loaded runner or wasted.)
+    // Ctrl-C clears the input line, so the probe leaves nothing behind.
+    sess.send("~probe~").expect("type readiness probe");
+    sess.expect("~probe~").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("iocraft should render typed input before Ctrl-C is sent: {e}\nPTY:\n{screen}");
+    });
 
     // Press Ctrl-C once — should show hint in footer area.
     sess.send("\x03").expect("send Ctrl-C");
@@ -141,8 +150,18 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
             panic!("Ctrl-C hint should appear in footer: {e}\nPTY:\n{screen}");
         });
 
-    // Clean exit.
-    sess.send("/exit\r").expect("send /exit");
+    // Clean exit. Type and submit as two steps, waiting for the line to
+    // render in between: Enter is only a submit if the input state has
+    // caught up with the characters, and Ctrl-C just cleared that state.
+    // Sending "/exit\r" as one write makes an unrendered line and its Enter
+    // race, and the failure is silent — an empty line submits nothing, so
+    // the test learns about it 60s later as "no EOF" with no clue why.
+    sess.send("/exit").expect("type /exit");
+    sess.expect("/exit").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("typed /exit should render before Enter: {e}\nPTY:\n{screen}");
+    });
+    sess.send("\r").expect("send Enter");
     sess.set_default_timeout(EXIT_BUDGET);
     let exit = sess.expect_eof().unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());


### PR DESCRIPTION
## Problem

`scode <prompt>` renders nothing until the model answers, and the default read timeout allows a stalled connection **five minutes** before it gives up. Together those make a slow upstream indistinguishable from a hung process.

Not a hypothetical confusion. It sent one debugging session through six rounds of bisecting and three throwaway builds hunting a regression that did not exist — every test was cut off before the timeout could fire, so the only evidence was *no output at all*, which reads as broken and never as waiting. The turn had been working the whole time.

## Change

A one-shot turn announces itself on stderr after 15s, then every 30s, naming the host, the account paying, and the model:

```
scode: still waiting on api.sudorouter.ai (account fujitoken, model claude-sonnet-4-6) (15s)
```

- **Silent for a normal turn.** The notice is for the pathological case; one that spoke on every run would be noise, which is what people learn to ignore.
- **stderr, never stdout.** stdout carries `--output-format json`; one stray line turns a working run into a parse error.
- **Stops on drop**, joining the thread rather than detaching it.

The target comes from `commands::reports::describe_upstream_for`, resolving through `proxy_account_for_model` — the same selector `doctor` reports — so a slow turn names the account the report names. It lives in `commands` rather than the CLI because the CLI has no direct `api` dependency; that seam is deliberate.

## Also in here

**A defect in that selector, found by this feature's own live test.** `proxy_account_for_model` passed an empty `provider` through as though it named an account, so a migrated config (#570 strips those pins) with no `auth_profile` and a single account made `doctor` report *could not resolve a proxy account* while requests resolved one fine. The request path already filtered empty pins; the reporting path did not. The report disagreeing with the bill is exactly what that function exists to prevent.

**A debug write left in `render_retry` by 23681aa8** — an append to a hardcoded path under one developer's scratchpad, attempted on every retry render. Harmless where the path does not exist, but it ships a personal directory inside the binary. Removed; happy to restore it if the trace is still wanted somewhere less permanent.

## Not in here

`⟳ retry n/8` currently renders to **stdout**, which corrupts `--output-format json` on the non-interactive path. Noticed while testing this, left alone: it belongs to the retry indicator that 23681aa8 has just reworked, and whether it moves to stderr or is suppressed in JSON mode is that author's call.

## Tests

The notice stays silent for a fast turn, keeps reporting for a slow one, names its target, and stops on drop rather than detaching; an empty pin resolves as "no pin" on the reporting path.

**Verified live against an unreachable host**: two notices on stderr at 15s and 45s, stdout untouched.

## Two flaky tests, fixed here rather than retried

This PR's macOS and Windows runs failed on tests that pass locally, so both were traced instead of re-run.

**`sigint_during_bash_tool_...` (Windows).** The interrupt is delivered by a PowerShell helper whose `Add-Type -MemberDefinition` compiles a C# P/Invoke shim at run time — and that preparation ran *inside* the window the interrupt has to land in, the tool's `sleep 30`. A runner slow enough for the shim to approach that budget spends the window preparing and then signals a process that has already finished its turn; `AttachConsole` fails and reports what looks like a broken interrupt. Arming is now split from firing: the helper starts before the turn, readiness is confirmed, and only then is the signal delivered. Readiness and go-ahead use marker files rather than the helper's stdio, since it must `FreeConsole` before it can attach to the target's console. When scode *does* exit early, the test now says so with the process output, and a `ChildGuard` keeps a panicking assertion from leaking a `scode` plus its `sleep 30` onto a shared runner.

**`iocraft_repl_ctrlc_hint_in_footer` (macOS).** Two guesses, both load-sensitive. A fixed 200ms sleep stood in for "iocraft has taken the terminal out of canonical mode" — until it has, `^C` is still a terminal signal that kills the child, and the prompt can render before that point, so the prompt is not the signal. It now types a probe and waits for it to render, which proves key events are being distributed. And the exit step sent `/exit` as one write; Enter only submits if the input state has caught up with the characters, and Ctrl-C had just cleared that state. Typing and submitting are now two steps with a render check between them — the pattern this file already uses elsewhere.

Both pass 10/10 and 6/6 under CPU load on Windows, and the suite they belong to is green.

One suspicion was checked and dropped rather than "fixed": that the parent's Enter handler could read input state before the child `TextInput` had written it, since `use_terminal_events` drains a hook's whole queue at once. `InstantiatedComponent::poll_change` polls children before its own hooks, so the child always writes first. No product change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
