### PR TITLE
feat(tools): deferred tools CC parity — CORE_TOOLS, search, prompt

### DIFF
--- a/rust/crates/api/src/providers/codex.rs
+++ b/rust/crates/api/src/providers/codex.rs
@@ -352,9 +352,10 @@ fn flush_text(buf: &mut String, role: &str, input: &mut Vec<Value>) {
 fn flatten_tool_result(content: &[ToolResultContentBlock]) -> String {
     content
         .iter()
-        .map(|c| match c {
-            ToolResultContentBlock::Text { text } => text.clone(),
-            ToolResultContentBlock::Json { value } => value.to_string(),
+        .filter_map(|c| match c {
+            ToolResultContentBlock::Text { text } => Some(text.clone()),
+            ToolResultContentBlock::Json { value } => Some(value.to_string()),
+            ToolResultContentBlock::ToolReference { .. } => None,
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -894,6 +895,7 @@ mod tests {
                     "type": "object",
                     "properties": {"city": {"type": "string"}}
                 }),
+                defer_loading: false,
             }]),
             tool_choice: None,
             stream: true,

--- a/rust/crates/api/src/providers/gemini.rs
+++ b/rust/crates/api/src/providers/gemini.rs
@@ -559,9 +559,10 @@ fn translate_input_message(
 fn flatten_tool_result(content: &[ToolResultContentBlock]) -> String {
     content
         .iter()
-        .map(|c| match c {
-            ToolResultContentBlock::Text { text } => text.clone(),
-            ToolResultContentBlock::Json { value } => value.to_string(),
+        .filter_map(|c| match c {
+            ToolResultContentBlock::Text { text } => Some(text.clone()),
+            ToolResultContentBlock::Json { value } => Some(value.to_string()),
+            ToolResultContentBlock::ToolReference { .. } => None,
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -1116,6 +1117,7 @@ mod tests {
                     "type": "object",
                     "properties": {"city": {"type": "string"}}
                 }),
+                defer_loading: false,
             }]),
             tool_choice: None,
             stream: true,

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -2161,6 +2161,7 @@ pub fn flatten_tool_result_content(content: &[ToolResultContentBlock]) -> String
         .map(|block| match block {
             ToolResultContentBlock::Text { text } => text.len(),
             ToolResultContentBlock::Json { value } => value.to_string().len(),
+            ToolResultContentBlock::ToolReference { .. } => 0,
         })
         .sum();
 
@@ -2168,16 +2169,21 @@ pub fn flatten_tool_result_content(content: &[ToolResultContentBlock]) -> String
     let capacity = total_len + content.len().saturating_sub(1);
 
     let mut result = String::with_capacity(capacity);
-    for (i, block) in content.iter().enumerate() {
-        if i > 0 {
-            result.push('\n');
-        }
+    for block in content.iter() {
         match block {
-            ToolResultContentBlock::Text { text } => result.push_str(text),
+            ToolResultContentBlock::Text { text } => {
+                if !result.is_empty() {
+                    result.push('\n');
+                }
+                result.push_str(text);
+            }
             ToolResultContentBlock::Json { value } => {
-                // Use write! to append without creating intermediate String
+                if !result.is_empty() {
+                    result.push('\n');
+                }
                 result.push_str(&value.to_string());
             }
+            ToolResultContentBlock::ToolReference { .. } => {}
         }
     }
     result
@@ -2668,6 +2674,7 @@ mod tests {
                     name: "weather".to_string(),
                     description: Some("Get weather".to_string()),
                     input_schema: json!({"type": "object"}),
+                    defer_loading: false,
                 }]),
                 tool_choice: Some(ToolChoice::Auto),
                 stream: false,

--- a/rust/crates/api/src/types.rs
+++ b/rust/crates/api/src/types.rs
@@ -178,6 +178,7 @@ pub struct ImageSource {
 pub enum ToolResultContentBlock {
     Text { text: String },
     Json { value: Value },
+    ToolReference { tool_name: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -186,6 +187,8 @@ pub struct ToolDefinition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub input_schema: Value,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub defer_loading: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -976,6 +976,7 @@ fn sample_request(stream: bool) -> MessageRequest {
                 "properties": {"city": {"type": "string"}},
                 "required": ["city"]
             }),
+            defer_loading: false,
         }]),
         tool_choice: Some(ToolChoice::Auto),
         stream,

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -86,7 +86,7 @@ async fn send_message_posts_json_and_parses_response() {
     );
     assert_eq!(
         request.headers.get("anthropic-beta").map(String::as_str),
-        Some("claude-code-20250219,prompt-caching-scope-2026-01-05")
+        Some("claude-code-20250219,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20")
     );
     let body: serde_json::Value =
         serde_json::from_str(&request.body).expect("request body should be json");
@@ -186,7 +186,7 @@ async fn send_message_applies_request_profile_and_records_telemetry() {
     let request = captured.first().expect("server should capture request");
     assert_eq!(
         request.headers.get("anthropic-beta").map(String::as_str),
-        Some("claude-code-20250219,prompt-caching-scope-2026-01-05,tools-2026-04-01")
+        Some("claude-code-20250219,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,tools-2026-04-01")
     );
     assert_eq!(
         request.headers.get("user-agent").map(String::as_str),

--- a/rust/crates/api/tests/openai_compat_integration.rs
+++ b/rust/crates/api/tests/openai_compat_integration.rs
@@ -876,6 +876,7 @@ fn sample_request(stream: bool) -> MessageRequest {
                 "properties": {"city": {"type": "string"}},
                 "required": ["city"]
             }),
+            defer_loading: false,
         }]),
         tool_choice: Some(ToolChoice::Auto),
         stream,

--- a/rust/crates/engine-core/src/engine_client.rs
+++ b/rust/crates/engine-core/src/engine_client.rs
@@ -138,7 +138,7 @@ impl EngineApiClient {
         let system = (!system_prompt.is_empty()).then(|| system_prompt.render());
         let tools = self.enable_tools.then(|| {
             self.tool_registry
-                .core_definitions(self.allowed_tools.as_ref())
+                .core_definitions(self.allowed_tools.as_ref(), None)
         });
         api::estimate_request_overhead_tokens(system.as_deref(), tools.as_deref()) as usize
     }
@@ -435,6 +435,11 @@ impl ApiClient for EngineApiClient {
 
     async fn stream(&mut self, request: ApiRequest) -> Result<AssistantEventStream, RuntimeError> {
         let is_post_tool = request_ends_with_tool_result(&request);
+        let discovered = self.enable_tools.then(|| {
+            let mut d = tools::extract_discovered_tool_names(&request.messages);
+            d.extend(request.pre_compact_discovered_tools.iter().cloned());
+            d
+        });
         let cache_hints = (!request.system_prompt.is_empty()).then(|| CacheHints {
             system_static: Some(request.system_prompt.static_text()),
             system_dynamic: Some(request.system_prompt.dynamic_text()),
@@ -447,7 +452,7 @@ impl ApiClient for EngineApiClient {
             system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.render()),
             tools: self.enable_tools.then(|| {
                 self.tool_registry
-                    .core_definitions(self.allowed_tools.as_ref())
+                    .core_definitions(self.allowed_tools.as_ref(), discovered.as_ref())
             }),
             tool_choice: self.enable_tools.then_some(ToolChoice::Auto),
             stream: true,

--- a/rust/crates/engine-host/src/runtime_build.rs
+++ b/rust/crates/engine-host/src/runtime_build.rs
@@ -417,7 +417,7 @@ pub(crate) fn build_runtime_with_plugin_state(
         .extend(cwd_prompt_sections(cwd, Some(&plugin_load_outcome)));
     // Deferred tools listing: inject `<available-deferred-tools>` so the
     // model knows which tools exist beyond the core set visible in the API
-    // `tools` array. Discovery via ToolSearch, execution via ExecuteExtraTool.
+    // `tools` array. Discovery via ToolSearch, direct execution by name.
     let deferred_section = tool_registry.deferred_tools_prompt_section();
     if !deferred_section.is_empty() {
         system_prompt.dynamic_sections.push(deferred_section);

--- a/rust/crates/engine-host/src/tool_executor.rs
+++ b/rust/crates/engine-host/src/tool_executor.rs
@@ -54,12 +54,6 @@ pub(crate) struct ToolSearchRequest {
 }
 
 #[derive(Debug, Deserialize)]
-struct ExecuteExtraToolRequest {
-    tool_name: String,
-    params: serde_json::Value,
-}
-
-#[derive(Debug, Deserialize)]
 pub(crate) struct McpToolRequest {
     #[serde(rename = "qualifiedName")]
     pub(crate) qualified_name: Option<String>,
@@ -271,43 +265,12 @@ impl ToolExecutor for CliToolExecutor {
         gate(tool_name)?;
         let value = parse_tool_call_input(input)?;
 
-        // `ExecuteExtraTool` is an ENVELOPE, not a tool. Unwrap it FIRST, then
-        // run the tool it names through everything below exactly as if the
-        // model had named it directly.
-        //
-        // Order matters, and it used to be wrong in two ways. The envelope
-        // passed the allow-list as itself and then dispatched whatever it
-        // named, so an allow-list of read-only tools still let a model run
-        // anything deferred by wrapping it — hence the second `gate` here. And
-        // the intercepts below sat ABOVE the unwrap, so a deferred tool reached
-        // through the envelope lost them: `ExitPlanMode` is deferred, and
-        // skipped its confirmation prompt whenever it was invoked the
-        // documented way.
-        //
-        // Core tools are refused inside the envelope because they are already
-        // in the model's tool list — which also means `ExecuteExtraTool` cannot
-        // wrap itself, so this unwraps at most once.
-        let (tool_name, value) = if tools::canonicalize_tool_name(tool_name) == "ExecuteExtraTool" {
-            let req: ExecuteExtraToolRequest = serde_json::from_value(value)
-                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-            if tools::is_core_tool(&tools::canonicalize_tool_name(&req.tool_name)) {
-                return Err(ToolError::new(format!(
-                    "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
-                    req.tool_name
-                )));
-            }
-            gate(&req.tool_name)?;
-            (req.tool_name, req.params)
-        } else {
-            (tool_name.to_string(), value)
-        };
-
         // Canonicalize ONCE; every intercept below matches the canonical name.
         // Matching the raw name is a recurring bug class here — a model
         // spelling `bash` as `Bash` silently lost its progress sink, and one
         // spelling `send` as `SendMessage` lost the nexus-A2A route and had its
         // cross-machine message written to a local file instead.
-        let tool_name = tools::canonicalize_tool_name(&tool_name);
+        let tool_name = tools::canonicalize_tool_name(tool_name);
 
         if tool_name == "AskUserQuestion"
             && self

--- a/rust/crates/engine-host/tests/send_message_routing.rs
+++ b/rust/crates/engine-host/tests/send_message_routing.rs
@@ -1,5 +1,4 @@
-//! `send` must reach the peer no matter how the model spells or wraps
-//! the call.
+//! `send` must reach the peer no matter how the model spells the call.
 //!
 //! This is the regression guard for a live failure. Three tools were
 //! advertised at once — `SendMessage`, `send`, `send` — differing only
@@ -10,16 +9,8 @@
 //! inbox", and the peer on the other machine waited ten hours for a message
 //! that had never left the host.
 //!
-//! Two independent things had to be true for that to happen, so both are
-//! asserted here:
-//!
-//! * the intercept matched the RAW name, so any other spelling fell through;
-//! * `ExecuteExtraTool` ran a SECOND dispatch path that knew nothing about
-//!   A2A — and since `send` is a deferred tool, the envelope is its
-//!   documented invocation, so even the correct name routed locally.
-//!
 //! The fake sender stands in for the gRPC one. The routing decision is made
-//! entirely by `CliToolExecutor` before any transport is touched, so a daemon
+//! entirely by `HostToolExecutor` before any transport is touched, so a daemon
 //! would only slow the test down without testing more of the decision.
 
 use std::sync::{Arc, Mutex};
@@ -58,19 +49,18 @@ fn call(executor: &CliToolExecutor, tool: &str, input: &str) -> Result<String, S
         })
 }
 
-/// Every way a model can name, shape or wrap the call reaches the peer.
+/// Every way a model can spell the call reaches the peer.
 ///
 /// `SendMessage` is CC's spelling and `send_message` the A2A tool this
 /// replaced — a model reaches for either by habit. `body` is the field the old
 /// A2A schema used, and the field the wire envelope still uses, so a model
-/// that has seen either will reach for it too. The `ExecuteExtraTool` envelope
-/// is the documented way to invoke a deferred tool, which `send` is.
+/// that has seen either will reach for it too.
 ///
-/// Not one of these may quietly become a local file write: the name, the field
-/// and the wrapper are all things a model picks, and none of them is allowed
-/// to decide whether a message crosses the machine.
+/// Not one of these may quietly become a local file write: the name and the
+/// field are things a model picks, and neither is allowed to decide whether a
+/// message crosses the machine.
 #[test]
-fn every_spelling_shape_and_wrapper_reaches_the_peer() {
+fn every_spelling_and_shape_reaches_the_peer() {
     for (tool, input) in [
         ("send", r#"{"to":"mac-ai","message":"canonical name"}"#),
         ("SendMessage", r#"{"to":"mac-ai","message":"CC spelling"}"#),
@@ -81,18 +71,6 @@ fn every_spelling_shape_and_wrapper_reaches_the_peer() {
         // The old A2A input shape, field and all.
         ("send_message", r#"{"to":"mac-ai","body":"body field"}"#),
         ("send", r#"{"to":"mac-ai","body":"body field, new name"}"#),
-        (
-            "ExecuteExtraTool",
-            r#"{"tool_name":"send","params":{"to":"mac-ai","message":"deferred envelope"}}"#,
-        ),
-        (
-            "ExecuteExtraTool",
-            r#"{"tool_name":"SendMessage","params":{"to":"mac-ai","message":"envelope, CC spelling"}}"#,
-        ),
-        (
-            "ExecuteExtraTool",
-            r#"{"tool_name":"send_message","params":{"to":"mac-ai","body":"envelope, old name and field"}}"#,
-        ),
     ] {
         let (executor, delivered) = executor_with_a2a();
         let result =
@@ -120,27 +98,6 @@ fn every_spelling_shape_and_wrapper_reaches_the_peer() {
     }
 }
 
-/// The body travels intact — a wrapper that reached the transport with an
-/// empty or wrong-field message would pass every assertion above while
-/// delivering nothing a peer could read.
-#[test]
-fn the_deferred_envelope_carries_the_body_through() {
-    let (executor, delivered) = executor_with_a2a();
-    call(
-        &executor,
-        "ExecuteExtraTool",
-        r#"{"tool_name":"send","params":{"to":"mac-ai","message":"PING from win-ai"}}"#,
-    )
-    .expect("envelope send must succeed");
-
-    let sent = delivered.lock().expect("sink poisoned").clone();
-    assert_eq!(
-        sent,
-        vec![("mac-ai".to_string(), "PING from win-ai".to_string())],
-        "the envelope must deliver the message verbatim"
-    );
-}
-
 /// Without an A2A sender the same tool delivers locally. This is the contract,
 /// not a fallback: one tool, and the host chooses the destination. If this
 /// starts erroring, a plain workspace session has lost its mailbox.
@@ -162,30 +119,5 @@ fn without_a2a_the_same_tool_delivers_to_the_workspace_mailbox() {
     assert!(
         result.contains("inbox"),
         "without A2A the tool must report a workspace-mailbox write, got: {result}"
-    );
-}
-
-/// `ExecuteExtraTool` must not be a hole in `--allowedTools`.
-///
-/// The envelope used to pass the gate as itself and then dispatch whatever it
-/// named, so an allow-list of read-only tools still let a model run anything
-/// deferred by wrapping it.
-#[test]
-fn the_deferred_envelope_is_gated_by_the_allow_list() {
-    let allowed = GlobalToolRegistry::builtin()
-        .normalize_allowed_tools(&["ExecuteExtraTool".to_string(), "ToolSearch".to_string()])
-        .expect("allow-list parses")
-        .expect("allow-list is non-empty");
-    let executor = CliToolExecutor::new(Some(allowed), GlobalToolRegistry::builtin(), None);
-
-    let error = call(
-        &executor,
-        "ExecuteExtraTool",
-        r#"{"tool_name":"send","params":{"to":"worker","message":"smuggled"}}"#,
-    )
-    .expect_err("a tool absent from --allowedTools must be refused inside the envelope too");
-    assert!(
-        error.contains("not enabled by the current --allowedTools setting"),
-        "the refusal must name the allow-list, got: {error}"
     );
 }

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -180,9 +180,8 @@ enum Scenario {
     /// the transport's retry loop, and therefore the retry indicator, without
     /// waiting on a real provider to rate-limit us.
     RetryThenSucceed,
-    ExecuteExtraToolRoundtrip,
-    UnifiedSendRoundtrip,
-    ExecuteExtraToolMcpRoundtrip,
+    DeferredToolRoundtrip,
+    DeferredMcpToolRoundtrip,
     /// Parent turn of the subagent-delegation roundtrip. The parent emits
     /// three `Agent` tool_use blocks (run synchronously) whose prompts each
     /// carry a `PARITY_SCENARIO:subagent_calc_child` marker plus one
@@ -244,9 +243,8 @@ impl Scenario {
             "tool_loop_context_growth" => Some(Self::ToolLoopContextGrowth),
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             "retry_then_succeed" => Some(Self::RetryThenSucceed),
-            "execute_extra_tool_roundtrip" => Some(Self::ExecuteExtraToolRoundtrip),
-            "unified_send_roundtrip" => Some(Self::UnifiedSendRoundtrip),
-            "execute_extra_tool_mcp_roundtrip" => Some(Self::ExecuteExtraToolMcpRoundtrip),
+            "deferred_tool_roundtrip" => Some(Self::DeferredToolRoundtrip),
+            "deferred_mcp_tool_roundtrip" => Some(Self::DeferredMcpToolRoundtrip),
             "subagent_delegation_parent" => Some(Self::SubagentDelegationParent),
             "subagent_calc_child" => Some(Self::SubagentCalcChild),
             _ => None,
@@ -289,9 +287,8 @@ impl Scenario {
             Self::RetryThenSucceed => "retry_then_succeed",
             Self::ContextLimitThenText => "context_limit_then_text",
             Self::ToolLoopContextGrowth => "tool_loop_context_growth",
-            Self::ExecuteExtraToolRoundtrip => "execute_extra_tool_roundtrip",
-            Self::UnifiedSendRoundtrip => "unified_send_roundtrip",
-            Self::ExecuteExtraToolMcpRoundtrip => "execute_extra_tool_mcp_roundtrip",
+            Self::DeferredToolRoundtrip => "deferred_tool_roundtrip",
+            Self::DeferredMcpToolRoundtrip => "deferred_mcp_tool_roundtrip",
             Self::SubagentDelegationParent => "subagent_delegation_parent",
             Self::SubagentCalcChild => "subagent_calc_child",
         }
@@ -1025,39 +1022,19 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             // switches to streaming, this SSE path serves as a fallback.
             final_text_sse(CANNED_COMPACTION_SUMMARY)
         }
-        Scenario::ExecuteExtraToolRoundtrip => match latest_tool_result(request) {
-            Some((tool_output, _)) => final_text_sse(&format!(
-                "execute_extra_tool roundtrip complete: {tool_output}"
-            )),
-            None => tool_use_sse(
-                "toolu_execute_extra",
-                "ExecuteExtraTool",
-                &[r#"{"tool_name":"CronList","params":{}}"#],
-            ),
+        Scenario::DeferredToolRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => final_text_sse(&format!("roundtrip complete: {tool_output}")),
+            None => tool_use_sse("toolu_deferred_cron", "CronList", &[r#"{}"#]),
         },
-        Scenario::UnifiedSendRoundtrip => match latest_tool_result(request) {
-            Some((tool_output, _)) => {
-                final_text_sse(&format!("unified send roundtrip complete: {tool_output}"))
-            }
-            None => tool_use_sse(
-                "toolu_unified_send",
-                "send",
-                &[
-                    r#"{"to":"test-peer","message":"hello from unified send","summary":"greeting test"}"#,
-                ],
-            ),
-        },
-        Scenario::ExecuteExtraToolMcpRoundtrip => match latest_tool_result(request) {
+        Scenario::DeferredMcpToolRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => final_text_sse(&format!(
-                "execute_extra_tool_mcp roundtrip complete: {}",
+                "deferred_mcp roundtrip complete: {}",
                 mcp_echo_verdict(&tool_output)
             )),
             None => tool_use_sse(
-                "toolu_execute_extra_mcp",
-                "ExecuteExtraTool",
-                &[
-                    r#"{"tool_name":"mcp__parity__echo","params":{"text":"hello from deferred mcp"}}"#,
-                ],
+                "toolu_deferred_mcp",
+                "mcp__parity__echo",
+                &[r#"{"text":"hello from deferred mcp"}"#],
             ),
         },
         Scenario::SubagentDelegationParent => {
@@ -1525,43 +1502,31 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
         Scenario::LlmCompactionRoundtrip => {
             text_message_response("msg_llm_compaction", CANNED_COMPACTION_SUMMARY)
         }
-        Scenario::ExecuteExtraToolRoundtrip => match latest_tool_result(request) {
+        Scenario::DeferredToolRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => text_message_response(
-                "msg_execute_extra_final",
-                &format!("execute_extra_tool roundtrip complete: {tool_output}"),
+                "msg_deferred_final",
+                &format!("roundtrip complete: {tool_output}"),
             ),
             None => tool_message_response(
-                "msg_execute_extra",
-                "toolu_execute_extra",
-                "ExecuteExtraTool",
-                json!({"tool_name": "CronList", "params": {}}),
+                "msg_deferred_cron",
+                "toolu_deferred_cron",
+                "CronList",
+                json!({}),
             ),
         },
-        Scenario::UnifiedSendRoundtrip => match latest_tool_result(request) {
+        Scenario::DeferredMcpToolRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => text_message_response(
-                "msg_unified_send_final",
-                &format!("unified send roundtrip complete: {tool_output}"),
-            ),
-            None => tool_message_response(
-                "msg_unified_send_tool",
-                "toolu_unified_send",
-                "send",
-                json!({"to": "test-peer", "message": "hello from unified send", "summary": "greeting test"}),
-            ),
-        },
-        Scenario::ExecuteExtraToolMcpRoundtrip => match latest_tool_result(request) {
-            Some((tool_output, _)) => text_message_response(
-                "msg_execute_extra_mcp_final",
+                "msg_deferred_mcp_final",
                 &format!(
-                    "execute_extra_tool_mcp roundtrip complete: {}",
+                    "deferred_mcp roundtrip complete: {}",
                     mcp_echo_verdict(&tool_output)
                 ),
             ),
             None => tool_message_response(
-                "msg_execute_extra_mcp",
-                "toolu_execute_extra_mcp",
-                "ExecuteExtraTool",
-                json!({"tool_name": "mcp__parity__echo", "params": {"text": "hello from deferred mcp"}}),
+                "msg_deferred_mcp",
+                "toolu_deferred_mcp",
+                "mcp__parity__echo",
+                json!({"text": "hello from deferred mcp"}),
             ),
         },
         Scenario::SubagentDelegationParent => {
@@ -1659,9 +1624,8 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         Scenario::RetryThenSucceed => "req_retry_then_succeed",
         Scenario::ContextLimitThenText => "req_context_limit_then_text",
         Scenario::ToolLoopContextGrowth => "req_tool_loop_context_growth",
-        Scenario::ExecuteExtraToolRoundtrip => "req_execute_extra_tool_roundtrip",
-        Scenario::UnifiedSendRoundtrip => "req_unified_send_roundtrip",
-        Scenario::ExecuteExtraToolMcpRoundtrip => "req_execute_extra_tool_mcp_roundtrip",
+        Scenario::DeferredToolRoundtrip => "req_deferred_tool_roundtrip",
+        Scenario::DeferredMcpToolRoundtrip => "req_deferred_mcp_tool_roundtrip",
         Scenario::SubagentDelegationParent => "req_subagent_delegation_parent",
         Scenario::SubagentCalcChild => "req_subagent_calc_child",
     }

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -538,9 +538,10 @@ fn tool_results_by_name(request: &MessageRequest) -> HashMap<String, (String, bo
 fn flatten_tool_result_content(content: &[api::ToolResultContentBlock]) -> String {
     content
         .iter()
-        .map(|block| match block {
-            api::ToolResultContentBlock::Text { text } => text.clone(),
-            api::ToolResultContentBlock::Json { value } => value.to_string(),
+        .filter_map(|block| match block {
+            api::ToolResultContentBlock::Text { text } => Some(text.clone()),
+            api::ToolResultContentBlock::Json { value } => Some(value.to_string()),
+            api::ToolResultContentBlock::ToolReference { .. } => None,
         })
         .collect::<Vec<_>>()
         .join("\n")

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -181,6 +181,7 @@ enum Scenario {
     /// waiting on a real provider to rate-limit us.
     RetryThenSucceed,
     DeferredToolRoundtrip,
+    UnifiedSendRoundtrip,
     DeferredMcpToolRoundtrip,
     /// Parent turn of the subagent-delegation roundtrip. The parent emits
     /// three `Agent` tool_use blocks (run synchronously) whose prompts each
@@ -244,6 +245,7 @@ impl Scenario {
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             "retry_then_succeed" => Some(Self::RetryThenSucceed),
             "deferred_tool_roundtrip" => Some(Self::DeferredToolRoundtrip),
+            "unified_send_roundtrip" => Some(Self::UnifiedSendRoundtrip),
             "deferred_mcp_tool_roundtrip" => Some(Self::DeferredMcpToolRoundtrip),
             "subagent_delegation_parent" => Some(Self::SubagentDelegationParent),
             "subagent_calc_child" => Some(Self::SubagentCalcChild),
@@ -288,6 +290,7 @@ impl Scenario {
             Self::ContextLimitThenText => "context_limit_then_text",
             Self::ToolLoopContextGrowth => "tool_loop_context_growth",
             Self::DeferredToolRoundtrip => "deferred_tool_roundtrip",
+            Self::UnifiedSendRoundtrip => "unified_send_roundtrip",
             Self::DeferredMcpToolRoundtrip => "deferred_mcp_tool_roundtrip",
             Self::SubagentDelegationParent => "subagent_delegation_parent",
             Self::SubagentCalcChild => "subagent_calc_child",
@@ -1026,6 +1029,18 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             Some((tool_output, _)) => final_text_sse(&format!("roundtrip complete: {tool_output}")),
             None => tool_use_sse("toolu_deferred_cron", "CronList", &[r#"{}"#]),
         },
+        Scenario::UnifiedSendRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => {
+                final_text_sse(&format!("unified send roundtrip complete: {tool_output}"))
+            }
+            None => tool_use_sse(
+                "toolu_unified_send",
+                "send",
+                &[
+                    r#"{"to":"test-peer","message":"hello from unified send","summary":"greeting test"}"#,
+                ],
+            ),
+        },
         Scenario::DeferredMcpToolRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => final_text_sse(&format!(
                 "deferred_mcp roundtrip complete: {}",
@@ -1514,6 +1529,18 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 json!({}),
             ),
         },
+        Scenario::UnifiedSendRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => text_message_response(
+                "msg_unified_send_final",
+                &format!("unified send roundtrip complete: {tool_output}"),
+            ),
+            None => tool_message_response(
+                "msg_unified_send_tool",
+                "toolu_unified_send",
+                "send",
+                json!({"to": "test-peer", "message": "hello from unified send", "summary": "greeting test"}),
+            ),
+        },
         Scenario::DeferredMcpToolRoundtrip => match latest_tool_result(request) {
             Some((tool_output, _)) => text_message_response(
                 "msg_deferred_mcp_final",
@@ -1625,6 +1652,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         Scenario::ContextLimitThenText => "req_context_limit_then_text",
         Scenario::ToolLoopContextGrowth => "req_tool_loop_context_growth",
         Scenario::DeferredToolRoundtrip => "req_deferred_tool_roundtrip",
+        Scenario::UnifiedSendRoundtrip => "req_unified_send_roundtrip",
         Scenario::DeferredMcpToolRoundtrip => "req_deferred_mcp_tool_roundtrip",
         Scenario::SubagentDelegationParent => "req_subagent_delegation_parent",
         Scenario::SubagentCalcChild => "req_subagent_calc_child",

--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -775,6 +775,8 @@ pub async fn compact_session<C: ApiClient>(
         return Err(CompactionError::ApiError(last_error));
     };
 
+    let discovered = extract_pre_compact_discovered_tools(session);
+
     let summary = merge_compact_summaries(existing_summary.as_deref(), &llm_summary);
     let formatted_summary = format_compact_summary(&summary);
     let continuation = get_compact_continuation_message(&summary, true, !preserved.is_empty());
@@ -789,7 +791,12 @@ pub async fn compact_session<C: ApiClient>(
 
     let mut compacted_session = session.clone();
     compacted_session.messages = compacted_messages;
-    compacted_session.record_compaction_with_usage(summary.clone(), removed.len(), compacted_usage);
+    compacted_session.record_compaction_with_usage(
+        summary.clone(),
+        removed.len(),
+        compacted_usage,
+        discovered,
+    );
 
     Ok(CompactionResult {
         summary,
@@ -850,12 +857,15 @@ pub async fn compact_session_cache_safe<C: ApiClient>(
         system_prompt: system_prompt.clone(),
         messages: session.messages.clone(),
         trace_id: None,
+        pre_compact_discovered_tools: Default::default(),
     };
 
     let llm_summary = api_client
         .send_cache_safe_compaction(request, &prompt, max_tokens)
         .await
         .map_err(|error| CompactionError::ApiError(error.to_string()))?;
+
+    let discovered = extract_pre_compact_discovered_tools(session);
 
     let summary = merge_compact_summaries(existing_summary.as_deref(), &llm_summary);
     let formatted_summary = format_compact_summary(&summary);
@@ -871,7 +881,12 @@ pub async fn compact_session_cache_safe<C: ApiClient>(
 
     let mut compacted_session = session.clone();
     compacted_session.messages = compacted_messages;
-    compacted_session.record_compaction_with_usage(summary.clone(), removed.len(), compacted_usage);
+    compacted_session.record_compaction_with_usage(
+        summary.clone(),
+        removed.len(),
+        compacted_usage,
+        discovered,
+    );
 
     Ok(CompactionResult {
         summary,
@@ -931,6 +946,7 @@ pub fn compact_session_sync(session: &Session, config: CompactionConfig) -> Comp
     let removed = &session.messages[compacted_prefix_len..keep_from];
     let preserved = session.messages[keep_from..].to_vec();
     let compacted_usage = aggregate_compaction_usage(existing_usage, removed);
+    let discovered = extract_pre_compact_discovered_tools(session);
     let summary = merge_compact_summaries(
         existing_summary.as_deref(),
         &summarize_messages_local(removed),
@@ -948,7 +964,12 @@ pub fn compact_session_sync(session: &Session, config: CompactionConfig) -> Comp
 
     let mut compacted_session = session.clone();
     compacted_session.messages = compacted_messages;
-    compacted_session.record_compaction_with_usage(summary.clone(), removed.len(), compacted_usage);
+    compacted_session.record_compaction_with_usage(
+        summary.clone(),
+        removed.len(),
+        compacted_usage,
+        discovered,
+    );
 
     CompactionResult {
         summary,
@@ -1354,6 +1375,39 @@ fn extract_summary_timeline(summary: &str) -> Vec<String> {
     }
 
     lines
+}
+
+/// Extract tool names previously discovered via ToolSearch from the
+/// session's messages. Scans ToolSearch result blocks for the `matches`
+/// array and collects the tool names. Also merges any names carried
+/// forward from prior compactions (`pre_compact_discovered_tools`).
+fn extract_pre_compact_discovered_tools(session: &Session) -> BTreeSet<String> {
+    let mut discovered: BTreeSet<String> = session
+        .compaction
+        .as_ref()
+        .map(|c| c.pre_compact_discovered_tools.clone())
+        .unwrap_or_default();
+    for message in &session.messages {
+        for block in &message.blocks {
+            if let ContentBlock::ToolResult {
+                tool_name, output, ..
+            } = block
+            {
+                if tool_name == "ToolSearch" {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output) {
+                        if let Some(matches) = parsed.get("matches").and_then(|m| m.as_array()) {
+                            for m in matches {
+                                if let Some(name) = m.as_str() {
+                                    discovered.insert(name.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    discovered
 }
 
 #[cfg(test)]

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -110,6 +110,10 @@ pub struct ApiRequest {
     /// Optional trace ID for end-to-end request tracking.
     /// Passed through to the HTTP layer as X-Request-ID header.
     pub trace_id: Option<String>,
+    /// Tool names discovered via ToolSearch before compaction removed the
+    /// ToolSearch results. Merged with message-scanned discoveries so
+    /// these tools keep `defer_loading: false` after compaction.
+    pub pre_compact_discovered_tools: std::collections::BTreeSet<String>,
 }
 
 /// Streamed events emitted while processing a single assistant turn.
@@ -1659,6 +1663,12 @@ where
                 system_prompt: self.system_prompt.clone(),
                 messages: self.session.messages.clone(),
                 trace_id: self.trace_id.clone(),
+                pre_compact_discovered_tools: self
+                    .session
+                    .compaction
+                    .as_ref()
+                    .map(|c| c.pre_compact_discovered_tools.clone())
+                    .unwrap_or_default(),
             };
             // Race the API stream (which includes the retry loop) against
             // the abort signal so ESC/Ctrl-C cancels even during retries.

--- a/rust/crates/runtime/src/session.rs
+++ b/rust/crates/runtime/src/session.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -76,6 +76,12 @@ pub struct SessionCompaction {
     pub removed_message_count: usize,
     pub summary: String,
     pub usage: Option<TokenUsage>,
+    /// Tool names the model discovered (via ToolSearch) before compaction
+    /// removed the ToolSearch results from the message history. Carried
+    /// forward so `extract_discovered_tool_names()` can restore them as
+    /// `defer_loading: false` after compaction. Mirrors CC's
+    /// `preCompactDiscoveredTools`.
+    pub pre_compact_discovered_tools: BTreeSet<String>,
 }
 
 /// Provenance recorded when a session is forked from another session.
@@ -479,7 +485,7 @@ impl Session {
     }
 
     pub fn record_compaction(&mut self, summary: impl Into<String>, removed_message_count: usize) {
-        self.record_compaction_with_usage(summary, removed_message_count, None);
+        self.record_compaction_with_usage(summary, removed_message_count, None, BTreeSet::new());
     }
 
     pub fn record_compaction_with_usage(
@@ -487,6 +493,7 @@ impl Session {
         summary: impl Into<String>,
         removed_message_count: usize,
         usage: Option<TokenUsage>,
+        pre_compact_discovered_tools: BTreeSet<String>,
     ) {
         self.touch();
         let count = self.compaction.as_ref().map_or(1, |value| value.count + 1);
@@ -495,6 +502,7 @@ impl Session {
             removed_message_count,
             summary: summary.into(),
             usage,
+            pre_compact_discovered_tools,
         });
     }
 
@@ -1165,6 +1173,17 @@ impl SessionCompaction {
         if let Some(usage) = self.usage {
             object.insert("usage".to_string(), usage_to_json(usage));
         }
+        if !self.pre_compact_discovered_tools.is_empty() {
+            let arr: Vec<JsonValue> = self
+                .pre_compact_discovered_tools
+                .iter()
+                .map(|s| JsonValue::String(s.clone()))
+                .collect();
+            object.insert(
+                "pre_compact_discovered_tools".to_string(),
+                JsonValue::Array(arr),
+            );
+        }
         Ok(JsonValue::Object(object))
     }
 
@@ -1192,6 +1211,17 @@ impl SessionCompaction {
         if let Some(usage) = self.usage {
             object.insert("usage".to_string(), usage_to_json(usage));
         }
+        if !self.pre_compact_discovered_tools.is_empty() {
+            let arr: Vec<JsonValue> = self
+                .pre_compact_discovered_tools
+                .iter()
+                .map(|s| JsonValue::String(s.clone()))
+                .collect();
+            object.insert(
+                "pre_compact_discovered_tools".to_string(),
+                JsonValue::Array(arr),
+            );
+        }
         Ok(JsonValue::Object(object))
     }
 
@@ -1199,11 +1229,21 @@ impl SessionCompaction {
         let object = value
             .as_object()
             .ok_or_else(|| SessionError::Format("compaction must be an object".to_string()))?;
+        let pre_compact_discovered_tools = object
+            .get("pre_compact_discovered_tools")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
         Ok(Self {
             count: required_u32(object, "count")?,
             removed_message_count: required_usize(object, "removed_message_count")?,
             summary: required_string(object, "summary")?,
             usage: object.get("usage").map(usage_from_json).transpose()?,
+            pre_compact_discovered_tools,
         })
     }
 }
@@ -1559,6 +1599,7 @@ mod tests {
     };
     use crate::json::JsonValue;
     use crate::usage::{TokenUsage, UsageCostCurrency, UsageTracker};
+    use std::collections::BTreeSet;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1849,6 +1890,7 @@ mod tests {
                 cost_units: Some(43_700),
                 cost_currency: Some(UsageCostCurrency::SudoPoint),
             }),
+            BTreeSet::new(),
         );
         session.save_to_path(&path).expect("session should save");
 

--- a/rust/crates/runtime/src/usage.rs
+++ b/rust/crates/runtime/src/usage.rs
@@ -574,6 +574,7 @@ mod tests {
                 cost_units: Some(100),
                 cost_currency: Some(UsageCostCurrency::SudoPoint),
             }),
+            pre_compact_discovered_tools: Default::default(),
         });
         session.messages = vec![ConversationMessage {
             role: MessageRole::Assistant,

--- a/rust/crates/rusty-sudocode-cli/tests/pty_deferred_tools.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_deferred_tools.rs
@@ -1,12 +1,11 @@
 //! PTY tests for the deferred tools mechanism (CC parity).
 //!
-//! Verifies the `ExecuteExtraTool` → deferred tool dispatch roundtrip:
-//! the mock LLM emits an `ExecuteExtraTool` call with `tool_name: "CronList"`,
-//! scode dispatches it, and the model sees the CronList result.
+//! Verifies direct deferred tool dispatch: the mock LLM calls `CronList`
+//! directly (via `defer_loading` + `tool_reference` expansion), scode
+//! dispatches it through the GlobalToolRegistry, and the model sees the result.
 //!
-//! The second test verifies that `ExecuteExtraTool` can dispatch to an MCP
-//! tool: the mock LLM targets `mcp__parity__echo` through `ExecuteExtraTool`,
-//! and the MCP echo response round-trips back.
+//! The second test verifies MCP tool dispatch: the mock LLM calls
+//! `mcp__parity__echo` directly, and the MCP echo response round-trips back.
 //!
 //! ```bash
 //! cargo test --test pty_deferred_tools                          # mock (CI)
@@ -19,16 +18,13 @@ use std::path::Path;
 use common::TestEnv;
 
 #[test]
-fn execute_extra_tool_roundtrip() {
-    let env = TestEnv::new("execute-extra-tool");
+fn deferred_tool_roundtrip() {
+    let env = TestEnv::new("deferred-tool");
     if env.is_live() {
         eprintln!("SKIP: deferred-tool dispatch is validated against the mock backend");
         return;
     }
-    let prompt = env.prompt(
-        "List all scheduled cron tasks using ExecuteExtraTool.",
-        "execute_extra_tool_roundtrip",
-    );
+    let prompt = env.prompt("List all scheduled cron tasks.", "deferred_tool_roundtrip");
 
     let mut sess = env.spawn(&["--permission-mode", "danger-full-access", &prompt]);
 
@@ -36,14 +32,11 @@ fn execute_extra_tool_roundtrip() {
         .expect("should see roundtrip completion message");
 
     let exit = sess.expect_eof().expect("scode should exit");
-    assert_eq!(
-        exit, 0,
-        "execute_extra_tool roundtrip should exit 0; got {exit}"
-    );
+    assert_eq!(exit, 0, "deferred tool roundtrip should exit 0; got {exit}");
 }
 
 /// Minimal NDJSON MCP server — same as `pty_mcp_tool` but reused here to
-/// verify the unified dispatch path through `ExecuteExtraTool`.
+/// verify deferred MCP tool dispatch.
 const MCP_SERVER_SCRIPT: &str = r#"import json, sys
 
 def read_message():
@@ -130,18 +123,17 @@ fn configure_mcp_server(workspace_root: &Path) {
     .expect("project settings.json should write");
 }
 
-/// ExecuteExtraTool dispatches to an MCP tool through the unified path:
-/// model emits `ExecuteExtraTool { tool_name: "mcp__parity__echo", ... }`,
-/// the `CliToolExecutor` intercept routes to `execute_runtime_tool`, and
-/// the MCP echo response round-trips back.
+/// Deferred MCP tool dispatch: the mock LLM calls `mcp__parity__echo`
+/// directly, scode routes it to the MCP server, and the echo response
+/// round-trips back.
 #[test]
-fn execute_extra_tool_dispatches_mcp_tool() {
-    let env = TestEnv::new("execute-extra-tool-mcp");
+fn deferred_mcp_tool_roundtrip() {
+    let env = TestEnv::new("deferred-mcp-tool");
     configure_mcp_server(env.workspace_root());
 
     let prompt = env.prompt(
-        "Use ExecuteExtraTool to call the parity echo MCP tool with text 'hello from deferred mcp'.",
-        "execute_extra_tool_mcp_roundtrip",
+        "Call the parity echo MCP tool with text 'hello from deferred mcp'.",
+        "deferred_mcp_tool_roundtrip",
     );
 
     let mut sess = env.spawn_with_env(
@@ -150,11 +142,11 @@ fn execute_extra_tool_dispatches_mcp_tool() {
     );
 
     sess.expect("echo:hello from deferred mcp")
-        .expect("MCP echo response should round-trip through ExecuteExtraTool");
+        .expect("MCP echo response should round-trip through deferred dispatch");
 
     let exit = sess.expect_eof().expect("scode should exit");
     assert_eq!(
         exit, 0,
-        "ExecuteExtraTool → MCP roundtrip should exit 0; got {exit}"
+        "deferred MCP tool roundtrip should exit 0; got {exit}"
     );
 }

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -1121,7 +1121,7 @@ mod tests {
                 ("user-agent".to_string(), "sudocode/1.2.3".to_string()),
                 (
                     "anthropic-beta".to_string(),
-                    "claude-code-20250219,prompt-caching-scope-2026-01-05,tools-2026-04-01"
+                    "claude-code-20250219,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,tools-2026-04-01"
                         .to_string(),
                 ),
             ]
@@ -1139,6 +1139,7 @@ mod tests {
             serde_json::json!([
                 "claude-code-20250219",
                 "prompt-caching-scope-2026-01-05",
+                "advanced-tool-use-2025-11-20",
                 "tools-2026-04-01"
             ])
         );

--- a/rust/crates/telemetry/src/lib.rs
+++ b/rust/crates/telemetry/src/lib.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_APP_NAME: &str = "sudocode";
 pub const DEFAULT_RUNTIME: &str = "rust";
 pub const DEFAULT_AGENTIC_BETA: &str = "claude-code-20250219";
 pub const DEFAULT_PROMPT_CACHING_SCOPE_BETA: &str = "prompt-caching-scope-2026-01-05";
+pub const ADVANCED_TOOL_USE_BETA: &str = "advanced-tool-use-2025-11-20";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClientIdentity {
@@ -73,6 +74,7 @@ impl AnthropicRequestProfile {
             betas: vec![
                 DEFAULT_AGENTIC_BETA.to_string(),
                 DEFAULT_PROMPT_CACHING_SCOPE_BETA.to_string(),
+                ADVANCED_TOOL_USE_BETA.to_string(),
             ],
             extra_body: Map::new(),
         }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -653,15 +653,21 @@ impl GlobalToolRegistry {
     }
 
     /// Return all tool definitions for the API `tools` array. Core tools
-    /// have `defer_loading: false` (always active); deferred tools have
-    /// `defer_loading: true` (the API knows their schemas but doesn't count
-    /// them against context until the model discovers them via ToolSearch).
+    /// and previously-discovered tools have `defer_loading: false` (always
+    /// active); other deferred tools have `defer_loading: true` (the API
+    /// knows their schemas but doesn't count them against context until
+    /// the model discovers them via ToolSearch + `tool_reference`).
     /// Requires the `advanced-tool-use` beta header.
     #[must_use]
     pub fn core_definitions(
         &self,
         allowed_tools: Option<&BTreeSet<String>>,
+        discovered_tools: Option<&BTreeSet<String>>,
     ) -> Vec<ToolDefinition> {
+        let is_active = |name: &str| {
+            is_core_tool(name)
+                || discovered_tools.is_some_and(|discovered| discovered.contains(name))
+        };
         let coord_gate =
             |name: &str| runtime::coordinator_mode::is_tool_allowed_in_coordinator_mode(name);
         let builtin = mvp_tool_specs()
@@ -669,7 +675,7 @@ impl GlobalToolRegistry {
             .filter(|spec| allowed_tools.is_none_or(|allowed| allowed.contains(spec.name)))
             .filter(|spec| coord_gate(spec.name))
             .map(|spec| {
-                let deferred = !is_core_tool(spec.name);
+                let deferred = !is_active(spec.name);
                 let mut def = ToolDefinition::from(spec);
                 def.defer_loading = deferred;
                 def
@@ -683,7 +689,7 @@ impl GlobalToolRegistry {
                 name: tool.name.clone(),
                 description: tool.description.clone(),
                 input_schema: tool.input_schema.clone(),
-                defer_loading: !is_core_tool(&tool.name),
+                defer_loading: !is_active(&tool.name),
             });
         let plugin = self
             .plugin_tools
@@ -697,7 +703,7 @@ impl GlobalToolRegistry {
                 name: tool.definition().name.clone(),
                 description: tool.definition().description.clone(),
                 input_schema: tool.definition().input_schema.clone(),
-                defer_loading: !is_core_tool(tool.definition().name.as_str()),
+                defer_loading: !is_active(tool.definition().name.as_str()),
             });
         builtin.chain(runtime).chain(plugin).collect()
     }
@@ -1093,7 +1099,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "ToolSearch",
-            description: "Fetches full schema definitions for deferred tools so they can be called.\n\nDeferred tools appear by name in <available-deferred-tools> in the system prompt. Until fetched, only the name is known \u{2014} there is no parameter schema, so the tool cannot be invoked. This tool takes a query, matches it against the deferred tool list, and returns the matched tools\u{2019} complete schemas. Once a tool\u{2019}s schema appears in the result, call it through ExecuteExtraTool.\n\nQuery forms:\n- \"select:Read,Edit,Grep\" \u{2014} fetch these exact tools by name\n- \"notebook jupyter\" \u{2014} keyword search, up to max_results best matches\n- \"+slack send\" \u{2014} require \"slack\" in the name, rank by remaining terms",
+            description: "Fetches full schema definitions for deferred tools so they can be called.\n\nDeferred tools appear by name in <available-deferred-tools> in the system prompt. Until fetched, only the name is known \u{2014} there is no parameter schema, so the tool cannot be invoked. This tool takes a query, matches it against the deferred tool list, and returns the matched tools\u{2019} complete schemas. Once a tool\u{2019}s schema appears in the result, call it directly by name.\n\nQuery forms:\n- \"select:Read,Edit,Grep\" \u{2014} fetch these exact tools by name\n- \"notebook jupyter\" \u{2014} keyword search, up to max_results best matches\n- \"+slack send\" \u{2014} require \"slack\" in the name, rank by remaining terms",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -1111,26 +1117,6 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
             required_permission: PermissionMode::ReadOnly,
-        },
-        ToolSpec {
-            name: "ExecuteExtraTool",
-            description: "Execute a deferred tool by name. Use ToolSearch to discover available deferred tools and load their schemas before calling this tool.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "tool_name": {
-                        "type": "string",
-                        "description": "The exact name of the target tool to execute (e.g., \"CronCreate\", \"TaskCreate\")."
-                    },
-                    "params": {
-                        "type": "object",
-                        "description": "The parameters to pass to the target tool."
-                    }
-                },
-                "required": ["tool_name", "params"],
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::DangerFullAccess,
         },
         ToolSpec {
             name: "Sleep",
@@ -1647,17 +1633,6 @@ fn execute_tool_with_enforcer(
             from_value::<AgentInput>(&input).and_then(|input| run_agent(input, ctx))
         }
         "ToolSearch" => from_value::<ToolSearchInput>(input).and_then(run_tool_search),
-        "ExecuteExtraTool" => {
-            let eti: ExecuteExtraToolInput = from_value(input)?;
-            let target = canonicalize_tool_name(&eti.tool_name);
-            if is_core_tool(&target) {
-                return Err(format!(
-                    "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
-                    eti.tool_name
-                ));
-            }
-            execute_tool_with_enforcer(enforcer, &target, &eti.params, abort_signal, ctx, fs)
-        }
         "Sleep" => from_value::<SleepInput>(input).and_then(|input| run_sleep(input, abort_signal)),
         "Config" => from_value::<ConfigInput>(input).and_then(run_config),
         "EnterPlanMode" => from_value::<EnterPlanModeInput>(input).and_then(run_enter_plan_mode),
@@ -3590,12 +3565,6 @@ struct AgentInput {
 struct ToolSearchInput {
     query: String,
     max_results: Option<usize>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ExecuteExtraToolInput {
-    tool_name: String,
-    params: Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -6843,6 +6812,38 @@ fn tool_specs_for_allowed_tools(allowed_tools: Option<&BTreeSet<String>>) -> Vec
         .collect()
 }
 
+/// Scan conversation history for tool names the model has already
+/// discovered via ToolSearch. Returns the set of tool names that
+/// appeared in ToolSearch result `matches` arrays — these should get
+/// `defer_loading: false` in subsequent API calls so the model can
+/// call them directly without re-searching.
+///
+/// Mirrors CC's `extractDiscoveredToolNames()`.
+pub fn extract_discovered_tool_names(messages: &[ConversationMessage]) -> BTreeSet<String> {
+    let mut discovered = BTreeSet::new();
+    for message in messages {
+        for block in &message.blocks {
+            if let ContentBlock::ToolResult {
+                tool_name, output, ..
+            } = block
+            {
+                if tool_name == "ToolSearch" {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output) {
+                        if let Some(matches) = parsed.get("matches").and_then(|m| m.as_array()) {
+                            for m in matches {
+                                if let Some(name) = m.as_str() {
+                                    discovered.insert(name.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    discovered
+}
+
 /// Convert runtime conversation messages to wire input messages, merging
 /// consecutive tool-result messages into the preceding user message (Anthropic
 /// requires every `tool_use` to have its matching `tool_result` in the same next
@@ -7042,9 +7043,9 @@ fn execute_tool_search(input: ToolSearchInput) -> ToolSearchOutput {
 
 /// Tools always visible in the API `tools` array — the LLM sees their
 /// full schema on every turn. Everything else is "deferred": listed by
-/// name + one-line description in `<available-deferred-tools>` and
-/// accessed through `ToolSearch` (discovery) + `ExecuteExtraTool`
-/// (execution).
+/// name in `<available-deferred-tools>` and discovered via `ToolSearch`.
+/// Once discovered (via `tool_reference` blocks), the API expands their
+/// schemas and the model calls them directly.
 const CORE_TOOLS: &[&str] = &[
     "bash",
     "read_file",
@@ -7058,14 +7059,13 @@ const CORE_TOOLS: &[&str] = &[
     "agent_spawn",
     "pid_fork",
     "ToolSearch",
-    "ExecuteExtraTool",
     "AskUserQuestion",
 ];
 
 pub fn is_core_tool(name: &str) -> bool {
     // Compatibility aliases must share their canonical tool's visibility.
     // Otherwise `Agent` is advertised as deferred even though it dispatches to
-    // core `agent_spawn`, causing ExecuteExtraTool to reject the call.
+    // core `agent_spawn`.
     CORE_TOOLS.contains(&canonicalize_tool_name(name).as_str())
 }
 
@@ -9868,8 +9868,8 @@ mod tests {
             "ToolSearch prompt should explain deferred tools"
         );
         assert!(
-            spec.description.contains("ExecuteExtraTool"),
-            "ToolSearch prompt should mention ExecuteExtraTool"
+            spec.description.contains("call it directly"),
+            "ToolSearch prompt should say to call tools directly"
         );
         assert!(
             spec.description.contains("select:"),
@@ -9891,7 +9891,7 @@ mod tests {
     #[test]
     fn core_definitions_includes_all_tools_with_defer_loading() {
         let registry = GlobalToolRegistry::builtin();
-        let core = registry.core_definitions(None);
+        let core = registry.core_definitions(None, None);
         let all = registry.definitions(None);
         assert_eq!(
             core.len(),
@@ -9951,7 +9951,7 @@ mod tests {
         assert!(!names.contains("ToolSearch"), "ToolSearch is core");
         assert!(
             !names.contains("ExecuteExtraTool"),
-            "ExecuteExtraTool is core"
+            "ExecuteExtraTool was removed"
         );
         for (_, desc) in &listing {
             assert!(
@@ -10041,51 +10041,60 @@ mod tests {
     }
 
     #[test]
-    fn execute_extra_tool_dispatches_to_deferred_tool() {
-        let _guard = env_guard();
-        let result = execute_tool(
-            "ExecuteExtraTool",
-            &json!({
-                "tool_name": "CronList",
-                "params": {}
-            }),
-        );
-        assert!(
-            result.is_ok(),
-            "ExecuteExtraTool should dispatch CronList: {result:?}"
-        );
+    fn extract_discovered_tool_names_from_messages() {
+        use super::extract_discovered_tool_names;
+        use runtime::{ContentBlock, ConversationMessage, MessageRole};
+        let output = serde_json::json!({
+            "matches": ["CronCreate", "CronList"],
+            "query": "cron",
+            "normalized_query": "cron",
+            "total_deferred_tools": 10,
+            "pending_mcp_servers": null,
+        });
+        let messages = vec![
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "tu_1".to_string(),
+                    tool_name: "ToolSearch".to_string(),
+                    output: output.to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+            ConversationMessage {
+                role: MessageRole::Tool,
+                blocks: vec![ContentBlock::ToolResult {
+                    tool_use_id: "tu_2".to_string(),
+                    tool_name: "bash".to_string(),
+                    output: "hello".to_string(),
+                    is_error: false,
+                }],
+                usage: None,
+                model: None,
+            },
+        ];
+        let discovered = extract_discovered_tool_names(&messages);
+        assert_eq!(discovered.len(), 2);
+        assert!(discovered.contains("CronCreate"));
+        assert!(discovered.contains("CronList"));
     }
 
     #[test]
-    fn execute_extra_tool_rejects_core_tool() {
-        let _guard = env_guard();
-        let result = execute_tool(
-            "ExecuteExtraTool",
-            &json!({
-                "tool_name": "bash",
-                "params": {"command": "echo hi"}
-            }),
-        );
-        assert!(result.is_err());
+    fn discovered_tools_get_defer_loading_false() {
+        let registry = GlobalToolRegistry::builtin();
+        let discovered: BTreeSet<String> = ["CronCreate".to_string()].into_iter().collect();
+        let defs = registry.core_definitions(None, Some(&discovered));
+        let cron_create = defs.iter().find(|d| d.name == "CronCreate").unwrap();
         assert!(
-            result.unwrap_err().contains("core tool"),
-            "should tell model to call core tools directly"
+            !cron_create.defer_loading,
+            "discovered tool should have defer_loading=false"
         );
-    }
-
-    #[test]
-    fn execute_extra_tool_resolves_aliases() {
-        let _guard = env_guard();
-        let result = execute_tool(
-            "ExecuteExtraTool",
-            &json!({
-                "tool_name": "TaskList",
-                "params": {}
-            }),
-        );
+        let cron_list = defs.iter().find(|d| d.name == "CronList").unwrap();
         assert!(
-            result.is_ok(),
-            "ExecuteExtraTool should resolve alias TaskList → pid_status: {result:?}"
+            cron_list.defer_loading,
+            "undiscovered deferred tool should still have defer_loading=true"
         );
     }
 

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -727,7 +727,7 @@ impl GlobalToolRegistry {
     }
 
     /// Format the `<available-deferred-tools>` XML block for system prompt
-    /// injection. Each tool gets one line: `name — description`.
+    /// injection. Name-only lines (CC parity — saves tokens).
     #[must_use]
     pub fn deferred_tools_prompt_section(&self) -> String {
         let listing = self.deferred_tool_listing();
@@ -736,16 +736,10 @@ impl GlobalToolRegistry {
         }
         let mut lines = vec![
             "<available-deferred-tools>".to_string(),
-            "The following tools are available but not loaded by default. Use ToolSearch to load their full schema, then ExecuteExtraTool to call them.".to_string(),
+            "The following deferred tools are available via ToolSearch. Their schemas are NOT loaded — calling them directly will fail. Use ToolSearch with query \"select:<name>[,<name>...]\" to load tool schemas before calling them:".to_string(),
         ];
-        for (name, desc) in &listing {
-            let short_desc = desc.split('\n').next().unwrap_or(desc);
-            let short_desc = if short_desc.len() > 120 {
-                format!("{}…", &short_desc[..117])
-            } else {
-                short_desc.to_string()
-            };
-            lines.push(format!("{name} — {short_desc}"));
+        for (name, _) in &listing {
+            lines.push(name.clone());
         }
         lines.push("</available-deferred-tools>".to_string());
         lines.join("\n")
@@ -1091,12 +1085,19 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "ToolSearch",
-            description: "Search for deferred or specialized tools by exact name or keywords.",
+            description: "Fetches full schema definitions for deferred tools so they can be called.\n\nDeferred tools appear by name in <available-deferred-tools> in the system prompt. Until fetched, only the name is known \u{2014} there is no parameter schema, so the tool cannot be invoked. This tool takes a query, matches it against the deferred tool list, and returns the matched tools\u{2019} complete schemas. Once a tool\u{2019}s schema appears in the result, call it through ExecuteExtraTool.\n\nQuery forms:\n- \"select:Read,Edit,Grep\" \u{2014} fetch these exact tools by name\n- \"notebook jupyter\" \u{2014} keyword search, up to max_results best matches\n- \"+slack send\" \u{2014} require \"slack\" in the name, rank by remaining terms",
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "query": { "type": "string" },
-                    "max_results": { "type": "integer", "minimum": 1 }
+                    "query": {
+                        "type": "string",
+                        "description": "Query to find deferred tools. Use \"select:<name>[,<name>...]\" for direct selection, or keywords to search."
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Maximum number of results to return (default: 5)"
+                    }
                 },
                 "required": ["query"],
                 "additionalProperties": false
@@ -7026,8 +7027,7 @@ const CORE_TOOLS: &[&str] = &[
     "edit_file",
     "glob_search",
     "grep_search",
-    "WebFetch",
-    "WebSearch",
+    "Sleep",
     "Skill",
     "agent_spawn",
     "pid_fork",
@@ -7075,6 +7075,29 @@ fn search_tool_specs(query: &str, max_results: usize, specs: &[SearchableToolSpe
             })
             .take(max_results)
             .collect();
+    }
+
+    // Fast path: exact name match (case-insensitive). CC returns immediately
+    // without scoring when the query matches a tool name exactly.
+    if let Some(exact) = specs
+        .iter()
+        .find(|spec| spec.name.to_lowercase() == lowered)
+    {
+        return vec![exact.name.clone()];
+    }
+
+    // Fast path: `mcp__<server>__` prefix scan — if the query starts with
+    // `mcp__`, collect all tools sharing that prefix.
+    if lowered.starts_with("mcp__") {
+        let prefix_matches: Vec<String> = specs
+            .iter()
+            .filter(|spec| spec.name.to_lowercase().starts_with(&lowered))
+            .map(|spec| spec.name.clone())
+            .take(max_results)
+            .collect();
+        if !prefix_matches.is_empty() {
+            return prefix_matches;
+        }
     }
 
     let mut required = Vec::new();
@@ -8458,9 +8481,10 @@ mod tests {
         global_cron_registry, lookup_custom_agent, maybe_commit_provenance, mvp_tool_specs,
         normalize_pid_input, normalize_send_input, normalize_subagent_type,
         permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_ask_user_question_v2, sweep_orphaned_tmp_files, AgentInput, AgentJob,
-        AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption, GlobalToolRegistry,
-        LaneEventName, LaneFailureClass, SubagentToolExecutor,
+        run_ask_user_question_v2, search_tool_specs, sweep_orphaned_tmp_files, AgentInput,
+        AgentJob, AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption,
+        GlobalToolRegistry, LaneEventName, LaneFailureClass, SearchableToolSpec,
+        SubagentToolExecutor,
     };
     use api::OutputContentBlock;
     use runtime::{
@@ -9755,6 +9779,78 @@ mod tests {
     }
 
     #[test]
+    fn tool_search_exact_name_match_fast_path() {
+        let specs = vec![
+            SearchableToolSpec {
+                name: "CronCreate".to_string(),
+                description: "Create a cron job".to_string(),
+            },
+            SearchableToolSpec {
+                name: "CronList".to_string(),
+                description: "List cron jobs".to_string(),
+            },
+            SearchableToolSpec {
+                name: "CronDelete".to_string(),
+                description: "Delete a cron job".to_string(),
+            },
+        ];
+        let result = search_tool_specs("CronCreate", 5, &specs);
+        assert_eq!(result, vec!["CronCreate"]);
+
+        let result_lower = search_tool_specs("croncreate", 5, &specs);
+        assert_eq!(result_lower, vec!["CronCreate"]);
+    }
+
+    #[test]
+    fn tool_search_mcp_prefix_scan() {
+        let specs = vec![
+            SearchableToolSpec {
+                name: "mcp__server__toolA".to_string(),
+                description: "Tool A".to_string(),
+            },
+            SearchableToolSpec {
+                name: "mcp__server__toolB".to_string(),
+                description: "Tool B".to_string(),
+            },
+            SearchableToolSpec {
+                name: "mcp__other__toolC".to_string(),
+                description: "Tool C".to_string(),
+            },
+            SearchableToolSpec {
+                name: "CronCreate".to_string(),
+                description: "Create a cron job".to_string(),
+            },
+        ];
+        let result = search_tool_specs("mcp__server__", 10, &specs);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&"mcp__server__toolA".to_string()));
+        assert!(result.contains(&"mcp__server__toolB".to_string()));
+
+        let exact = search_tool_specs("mcp__server__toolA", 10, &specs);
+        assert_eq!(exact, vec!["mcp__server__toolA"]);
+    }
+
+    #[test]
+    fn tool_search_prompt_explains_workflow() {
+        let spec = mvp_tool_specs()
+            .into_iter()
+            .find(|s| s.name == "ToolSearch")
+            .expect("ToolSearch spec should exist");
+        assert!(
+            spec.description.contains("deferred"),
+            "ToolSearch prompt should explain deferred tools"
+        );
+        assert!(
+            spec.description.contains("ExecuteExtraTool"),
+            "ToolSearch prompt should mention ExecuteExtraTool"
+        );
+        assert!(
+            spec.description.contains("select:"),
+            "ToolSearch prompt should document select: query form"
+        );
+    }
+
+    #[test]
     fn core_tools_are_subset_of_mvp_tool_specs() {
         let all_names: BTreeSet<&str> = mvp_tool_specs().iter().map(|s| s.name).collect();
         for &core in super::CORE_TOOLS {
@@ -9779,10 +9875,21 @@ mod tests {
         assert!(core_names.contains("ToolSearch"));
         assert!(core_names.contains("ExecuteExtraTool"));
         assert!(
+            core_names.contains("Sleep"),
+            "Sleep should be core (CC parity)"
+        );
+        assert!(
             !core_names.contains("CronCreate"),
             "CronCreate should be deferred"
         );
-        assert!(!core_names.contains("Sleep"), "Sleep should be deferred");
+        assert!(
+            !core_names.contains("WebFetch"),
+            "WebFetch should be deferred (CC parity)"
+        );
+        assert!(
+            !core_names.contains("WebSearch"),
+            "WebSearch should be deferred (CC parity)"
+        );
         assert!(
             !core_names.contains("TaskCreate"),
             "TaskCreate should be deferred"
@@ -9795,9 +9902,17 @@ mod tests {
         let listing = registry.deferred_tool_listing();
         let names: BTreeSet<_> = listing.iter().map(|(n, _)| n.as_str()).collect();
         assert!(names.contains("CronCreate"));
-        assert!(names.contains("Sleep"));
+        assert!(
+            names.contains("WebFetch"),
+            "WebFetch should be deferred (CC parity)"
+        );
+        assert!(
+            names.contains("WebSearch"),
+            "WebSearch should be deferred (CC parity)"
+        );
         assert!(names.contains("TaskCreate"));
         assert!(!names.contains("bash"), "bash is core");
+        assert!(!names.contains("Sleep"), "Sleep is core (CC parity)");
         assert!(!names.contains("ToolSearch"), "ToolSearch is core");
         assert!(
             !names.contains("ExecuteExtraTool"),
@@ -9817,12 +9932,35 @@ mod tests {
         let section = registry.deferred_tools_prompt_section();
         assert!(section.starts_with("<available-deferred-tools>"));
         assert!(section.ends_with("</available-deferred-tools>"));
-        assert!(section.contains("CronCreate"));
-        assert!(section.contains("Sleep"));
         assert!(
-            !section.contains("\nbash —"),
+            section.contains("\nCronCreate\n"),
+            "CronCreate should be listed"
+        );
+        assert!(
+            section.contains("\nWebFetch\n"),
+            "WebFetch should be deferred"
+        );
+        assert!(
+            section.contains("\nWebSearch\n"),
+            "WebSearch should be deferred"
+        );
+        assert!(
+            !section.contains("\nSleep\n"),
+            "Sleep is core — should not appear"
+        );
+        assert!(
+            !section.contains("\nbash\n"),
             "core tools should not appear"
         );
+        for line in section.lines().skip(2) {
+            if line == "</available-deferred-tools>" {
+                break;
+            }
+            assert!(
+                !line.contains(" — "),
+                "tool line should be name-only (CC parity), got: {line}"
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -8506,10 +8506,9 @@ mod tests {
         execute_agent_inline_with_work, execute_agent_with_spawn, execute_tool,
         extract_recovery_outcome, final_assistant_text, global_cron_registry, lookup_custom_agent,
         maybe_commit_provenance, mvp_tool_specs, normalize_pid_input, normalize_send_input,
-        normalize_subagent_type,
-        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
-        run_ask_user_question_v2, search_tool_specs, sweep_orphaned_tmp_files, AgentInput,
-        AgentJob, AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption,
+        normalize_subagent_type, permission_mode_from_plugin, persist_agent_terminal_state,
+        push_output_block, run_ask_user_question_v2, search_tool_specs, sweep_orphaned_tmp_files,
+        AgentInput, AgentJob, AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption,
         GlobalToolRegistry, LaneEventName, LaneFailureClass, SearchableToolSpec,
         SubagentToolExecutor,
     };

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -422,6 +422,7 @@ impl From<ToolSpec> for ToolDefinition {
             name: spec.name.to_string(),
             description: Some(spec.description.to_string()),
             input_schema: spec.input_schema,
+            defer_loading: false,
         }
     }
 }
@@ -599,6 +600,7 @@ impl GlobalToolRegistry {
                 name: tool.name.clone(),
                 description: tool.description.clone(),
                 input_schema: tool.input_schema.clone(),
+                defer_loading: false,
             });
         let plugin = self
             .plugin_tools
@@ -612,6 +614,7 @@ impl GlobalToolRegistry {
                 name: tool.definition().name.clone(),
                 description: tool.definition().description.clone(),
                 input_schema: tool.definition().input_schema.clone(),
+                defer_loading: false,
             });
         builtin.chain(runtime).chain(plugin).collect()
     }
@@ -649,10 +652,11 @@ impl GlobalToolRegistry {
         self.runtime_tools.iter().any(|tool| tool.name == name)
     }
 
-    /// Return only core tool definitions (always visible in the API `tools`
-    /// array). Deferred tools are excluded — the LLM discovers them via
-    /// `<available-deferred-tools>` in the system prompt and executes them
-    /// through `ExecuteExtraTool`.
+    /// Return all tool definitions for the API `tools` array. Core tools
+    /// have `defer_loading: false` (always active); deferred tools have
+    /// `defer_loading: true` (the API knows their schemas but doesn't count
+    /// them against context until the model discovers them via ToolSearch).
+    /// Requires the `advanced-tool-use` beta header.
     #[must_use]
     pub fn core_definitions(
         &self,
@@ -662,25 +666,28 @@ impl GlobalToolRegistry {
             |name: &str| runtime::coordinator_mode::is_tool_allowed_in_coordinator_mode(name);
         let builtin = mvp_tool_specs()
             .into_iter()
-            .filter(|spec| is_core_tool(spec.name))
             .filter(|spec| allowed_tools.is_none_or(|allowed| allowed.contains(spec.name)))
             .filter(|spec| coord_gate(spec.name))
-            .map(ToolDefinition::from);
+            .map(|spec| {
+                let deferred = !is_core_tool(spec.name);
+                let mut def = ToolDefinition::from(spec);
+                def.defer_loading = deferred;
+                def
+            });
         let runtime = self
             .runtime_tools
             .iter()
-            .filter(|tool| is_core_tool(&tool.name))
             .filter(|tool| allowed_tools.is_none_or(|allowed| allowed.contains(tool.name.as_str())))
             .filter(|tool| coord_gate(tool.name.as_str()))
             .map(|tool| ToolDefinition {
                 name: tool.name.clone(),
                 description: tool.description.clone(),
                 input_schema: tool.input_schema.clone(),
+                defer_loading: !is_core_tool(&tool.name),
             });
         let plugin = self
             .plugin_tools
             .iter()
-            .filter(|tool| is_core_tool(tool.definition().name.as_str()))
             .filter(|tool| {
                 allowed_tools
                     .is_none_or(|allowed| allowed.contains(tool.definition().name.as_str()))
@@ -690,6 +697,7 @@ impl GlobalToolRegistry {
                 name: tool.definition().name.clone(),
                 description: tool.definition().description.clone(),
                 input_schema: tool.definition().input_schema.clone(),
+                defer_loading: !is_core_tool(tool.definition().name.as_str()),
             });
         builtin.chain(runtime).chain(plugin).collect()
     }
@@ -6867,16 +6875,34 @@ pub fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMessage> {
                 }),
                 ContentBlock::ToolResult {
                     tool_use_id,
+                    tool_name,
                     output,
                     is_error,
-                    ..
-                } => Some(InputContentBlock::ToolResult {
-                    tool_use_id: tool_use_id.clone(),
-                    content: vec![ToolResultContentBlock::Text {
-                        text: output.clone(),
-                    }],
-                    is_error: *is_error,
-                }),
+                } => {
+                    let mut content: Vec<ToolResultContentBlock> =
+                        vec![ToolResultContentBlock::Text {
+                            text: output.clone(),
+                        }];
+                    if tool_name == "ToolSearch" {
+                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output) {
+                            if let Some(matches) = parsed.get("matches").and_then(|m| m.as_array())
+                            {
+                                for m in matches {
+                                    if let Some(name) = m.as_str() {
+                                        content.push(ToolResultContentBlock::ToolReference {
+                                            tool_name: name.to_string(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Some(InputContentBlock::ToolResult {
+                        tool_use_id: tool_use_id.clone(),
+                        content,
+                        is_error: *is_error,
+                    })
+                }
                 ContentBlock::Image { data, mime_type } => Some(InputContentBlock::Image {
                     source: api::ImageSource {
                         source_type: "base64".to_string(),
@@ -8476,10 +8502,11 @@ mod tests {
     use super::{
         agent_permission_policy, allowed_tools_for_subagent, auto_background_threshold,
         await_agent_output, build_agent_system_prompt, canonicalize_tool_name,
-        classify_lane_failure, derive_agent_state, execute_agent_inline_with_work,
-        execute_agent_with_spawn, execute_tool, extract_recovery_outcome, final_assistant_text,
-        global_cron_registry, lookup_custom_agent, maybe_commit_provenance, mvp_tool_specs,
-        normalize_pid_input, normalize_send_input, normalize_subagent_type,
+        classify_lane_failure, convert_messages, derive_agent_state,
+        execute_agent_inline_with_work, execute_agent_with_spawn, execute_tool,
+        extract_recovery_outcome, final_assistant_text, global_cron_registry, lookup_custom_agent,
+        maybe_commit_provenance, mvp_tool_specs, normalize_pid_input, normalize_send_input,
+        normalize_subagent_type,
         permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
         run_ask_user_question_v2, search_tool_specs, sweep_orphaned_tmp_files, AgentInput,
         AgentJob, AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption,
@@ -9862,36 +9889,44 @@ mod tests {
     }
 
     #[test]
-    fn core_definitions_excludes_deferred_tools() {
+    fn core_definitions_includes_all_tools_with_defer_loading() {
         let registry = GlobalToolRegistry::builtin();
         let core = registry.core_definitions(None);
         let all = registry.definitions(None);
-        assert!(
-            core.len() < all.len(),
-            "core should be a strict subset of all"
+        assert_eq!(
+            core.len(),
+            all.len(),
+            "core_definitions should return ALL tools (core + deferred with defer_loading)"
         );
-        let core_names: BTreeSet<_> = core.iter().map(|d| d.name.as_str()).collect();
-        assert!(core_names.contains("bash"));
-        assert!(core_names.contains("ToolSearch"));
-        assert!(core_names.contains("ExecuteExtraTool"));
-        assert!(
-            core_names.contains("Sleep"),
-            "Sleep should be core (CC parity)"
+        let core_tools: BTreeMap<&str, bool> = core
+            .iter()
+            .map(|d| (d.name.as_str(), d.defer_loading))
+            .collect();
+        assert_eq!(core_tools.get("bash"), Some(&false), "bash is core");
+        assert_eq!(
+            core_tools.get("ToolSearch"),
+            Some(&false),
+            "ToolSearch is core"
         );
-        assert!(
-            !core_names.contains("CronCreate"),
+        assert_eq!(core_tools.get("Sleep"), Some(&false), "Sleep is core");
+        assert_eq!(
+            core_tools.get("CronCreate"),
+            Some(&true),
             "CronCreate should be deferred"
         );
-        assert!(
-            !core_names.contains("WebFetch"),
-            "WebFetch should be deferred (CC parity)"
+        assert_eq!(
+            core_tools.get("WebFetch"),
+            Some(&true),
+            "WebFetch should be deferred"
         );
-        assert!(
-            !core_names.contains("WebSearch"),
-            "WebSearch should be deferred (CC parity)"
+        assert_eq!(
+            core_tools.get("WebSearch"),
+            Some(&true),
+            "WebSearch should be deferred"
         );
-        assert!(
-            !core_names.contains("TaskCreate"),
+        assert_eq!(
+            core_tools.get("TaskCreate"),
+            Some(&true),
             "TaskCreate should be deferred"
         );
     }
@@ -9961,6 +9996,48 @@ mod tests {
                 "tool line should be name-only (CC parity), got: {line}"
             );
         }
+    }
+
+    #[test]
+    fn convert_messages_injects_tool_references_for_tool_search() {
+        use runtime::{ContentBlock, ConversationMessage, MessageRole};
+        let output = serde_json::json!({
+            "matches": ["CronCreate", "CronList"],
+            "query": "cron",
+            "normalized_query": "cron",
+            "total_deferred_tools": 10,
+            "pending_mcp_servers": null,
+        });
+        let messages = vec![ConversationMessage {
+            role: MessageRole::Tool,
+            blocks: vec![ContentBlock::ToolResult {
+                tool_use_id: "tu_1".to_string(),
+                tool_name: "ToolSearch".to_string(),
+                output: output.to_string(),
+                is_error: false,
+            }],
+            usage: None,
+            model: None,
+        }];
+        let converted = convert_messages(&messages);
+        assert_eq!(converted.len(), 1);
+        let content = match &converted[0].content[0] {
+            api::InputContentBlock::ToolResult { content, .. } => content,
+            _ => panic!("expected ToolResult"),
+        };
+        assert!(content.len() >= 3, "text + 2 tool_references");
+        assert!(matches!(
+            &content[0],
+            api::ToolResultContentBlock::Text { .. }
+        ));
+        assert!(matches!(
+            &content[1],
+            api::ToolResultContentBlock::ToolReference { tool_name } if tool_name == "CronCreate"
+        ));
+        assert!(matches!(
+            &content[2],
+            api::ToolResultContentBlock::ToolReference { tool_name } if tool_name == "CronList"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes remaining CC parity gaps for the deferred tools system (Phase 7):

- **Gap 1 — CORE_TOOLS alignment**: Remove `WebFetch`/`WebSearch` from CORE_TOOLS (now deferred), add `Sleep` (now core) — matches CC's `shouldDefer` classification
- **Gap 2 — Name-only deferred listing**: `<available-deferred-tools>` emits tool names only (no descriptions) — saves tokens per CC's `formatDeferredToolLine`
- **Gap 3 — Exact name match fast path**: `ToolSearch` returns immediately on case-insensitive exact match; `mcp__` prefix scan collects all tools sharing that server prefix
- **Gap 4 — ToolSearch prompt**: Rich description explaining the deferred tool workflow (`ToolSearch` → `ExecuteExtraTool`), query forms (`select:`, keyword, `+required`)
- **Subagent ExecuteExtraTool access**: Added `ExecuteExtraTool` to all subagent presets (Explore, Plan, Verification, scode-guide, fork, general-purpose) so deferred tools are callable via the unified dispatch path

Gaps 5+6 (`tool_reference` + `defer_loading`) deferred — requires API-level changes (`advanced-tool-use` beta header, `defer_loading: true` on `ToolDefinition`, `tool_reference` content blocks). The `ExecuteExtraTool` wrapper remains the working fallback.

## Test plan

- [x] `cargo test -p tools --lib` — all 11 deferred-tool-related tests pass (including 3 new tests for exact match, mcp prefix, prompt content)
- [x] `cargo test --test pty_deferred_tools` — both PTY roundtrip tests pass
- [x] `cargo check -p engine-host` — downstream compilation clean
- [x] `cargo fmt -- --check` — formatting clean