### PR TITLE
chore(release): bump version to 0.2.7

### DIFF
--- a/docs/release-notes/v0.2.7.md
+++ b/docs/release-notes/v0.2.7.md
@@ -1,0 +1,89 @@
+# Sudo Code v0.2.7
+
+## What's New
+
+This release is about long turns. A turn that takes many tool-call steps grows
+its own context while it runs, and until now the runtime only noticed once the
+provider rejected the request — with a single salvage attempt, so the second
+overflow killed the turn. Three separate gaps kept that recovery from ever
+working end to end; all three are closed here. Alongside it, memory becomes
+something an ACP client can switch off per conversation.
+
+## Fixed
+
+**A long turn no longer dies on its second context overflow.** `maybe_auto_compact`
+only ran as a turn was ending — both call sites sat just before the `TurnSummary`
+was built. The tool loop now checks its budget *before dispatching each request*
+(`CompactionTrigger::InTurnBudget`) rather than waiting for a rejection, and the
+once-per-turn salvage cap becomes `MAX_TURN_COMPACTIONS = 8` shared by the
+proactive and reactive paths. The bound is derived, not asserted: each pass
+replaces everything before `preserve_recent_messages` with one summary, so a turn
+needing a ninth pass has summarised summaries eight times and is not making
+progress.
+
+Three further gaps turned up while verifying that, each of which alone was enough
+to keep the runtime from recovering:
+
+- **The classification never reached the runtime.** `is_context_window_blocked`
+  is set by construction, and both production API clients built every provider
+  failure with `RuntimeError::new` — so the flag was false on the one error it
+  exists for, and the reactive path could only ever run in tests that constructed
+  the error by hand.
+- **Anthropic's actual rejection matched no marker.** When `input + max_tokens`
+  overflows the window Anthropic answers ``input length and `max_tokens` exceed
+  context limit: N + M > W``. With a 200K model and 64K `max_tokens` that fires at
+  136K of input — long before `prompt is too long` — so it is the overflow a long
+  agentic session actually gets. None of the twelve existing markers matched it.
+- **The post-turn threshold sat above the rejection band.** It gave 167K for a
+  200K model while the provider rejects at 136K, so it could never fire in time.
+
+Budget arithmetic now has one home: `ContextBudget` in `runtime::compact`, served
+by `ApiClient::context_budget`, overridden by the clients that know the output
+reservation and tool definitions their requests carry, and read by the engine
+host's preflight instead of being rebuilt there. `CompactionTrigger` names the
+four paths (preflight, in-turn budget, provider rejection, post-turn usage) and
+every attempt is recorded, so a compaction that ran and worked is no longer
+indistinguishable in the logs from one that never happened.
+
+**`autoMemoryEnabled` no longer corrupts your settings.** The key was writable
+through `/config set` and the agent's `config` tool, nothing ever read it, and it
+was not in `SETTINGS_SCHEMA` — so setting it left `settings.json` failing
+validation with `unknown key "autoMemoryEnabled"`. The declaration is gone; the
+write now fails at the single writer, which is what a key with no reader should
+have done.
+
+## Added
+
+**Per-session memory switch for ACP clients.** `session/new` and `session/load`
+accept `memory` under `_meta.sudocode`: `"disabled"` gives that one session no
+auto-memory block in its system prompt and no standing permission to write the
+memory directory. Absent or `"enabled"` is today's behaviour, byte for byte.
+
+The switch is session-scoped — one `scode acp` process serves many sessions and
+each carries its own mode, same `cwd` and memory directory included. Disabling
+never deletes: nothing under the memory directory is read, written or removed,
+and a disabled session does not create it. Because the mode is not persisted with
+the transcript, a client that wants a resumed session to stay memory-less passes
+the key again on `session/load`. A value outside `"enabled"` / `"disabled"` is
+`invalid_params` rather than a silent default — the one failure mode this key must
+not have is leaving memory on while the caller believes it off. `initialize`
+advertises `_meta.sudocode.sessionMemory` for feature detection.
+
+Known gap: a disabled session's sub-agent spawns still get their own
+per-agent-type memory (`agent-memory/<type>/`, a separate directory).
+
+**Cache-safe compaction and microcompact (CC parity).** Compaction tries the main
+conversation's system prompt and message prefix first, for prompt-cache hits,
+before falling back to the stripped-message path. Old compactable tool results
+(Read, Bash, Grep, Glob, Edit, Write, WebFetch, WebSearch) have their content
+cleared before each request, keeping the two most recent per tool name.
+
+**Unified `ExecuteExtraTool` dispatch.** Interception moves to `CliToolExecutor`,
+so MCP tools, plugin tools and builtins are all reachable through
+`ExecuteExtraTool`; previously only builtins were.
+
+## Note on versions
+
+`v0.2.6` was tagged from a commit whose `rust/Cargo.toml` still said `0.2.5`, so
+binaries from that tag report `scode 0.2.5`. This release bumps the workspace
+version, so `scode --version` and the tag agree again.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "base64",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "api",
  "plugins",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "commands",
  "runtime",
@@ -1359,7 +1359,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-acp"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "engine-core"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "api",
  "async-trait",
@@ -1397,14 +1397,14 @@ dependencies = [
 
 [[package]]
 name = "engine-events"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "runtime",
 ]
 
 [[package]]
 name = "engine-host"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "commands",
  "engine-core",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "api",
  "serde_json",
@@ -2649,7 +2649,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c1
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -3944,7 +3944,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-sudocode-cli"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "arboard",
  "async-trait",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.7"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Cuts a stable release from current `main` (`86d64d25`), which is **17 commits
ahead of `v0.2.6`** and carries the whole in-turn-compaction fix plus the
per-session memory switch.

## What lands in 0.2.7

- **#587** in-turn compaction — a long turn no longer dies on its second
  context overflow. Includes the three gaps found while verifying it: the
  classification never reaching the runtime, Anthropic's actual rejection text
  matching no marker, and the post-turn threshold sitting above the rejection
  band.
- **#585** per-session memory switch (`_meta.sudocode.memory`).
- **#593** drop the `autoMemoryEnabled` key that nothing read and that left
  `settings.json` failing validation.
- **#598** cache-safe compaction + microcompact, unified `ExecuteExtraTool`
  dispatch.
- **#595 / #596** PTY and live-subagent test fixes.

## Why 0.2.7 and not 0.2.6

`v0.2.6` was tagged (2026-09-10 08:40) on a commit whose `rust/Cargo.toml`
still said `0.2.5` — its own tag message reads "Sudo Code v0.2.5". Binaries
from that tag report `scode 0.2.5`. This PR bumps the workspace version so the
tag and `scode --version` agree again. `v0.2.6` is left as published.

Note also that `v0.2.6` predates the `#585` merge by about 80 minutes, so the
memory switch is in no released tag today — which is what prompted this
release.

## Changed

`rust/Cargo.toml` 0.2.5 → 0.2.7, `rust/Cargo.lock` refreshed by `cargo check`
(28 lines, same shape as the 0.2.5 bump in #589), and
`docs/release-notes/v0.2.7.md`.

## Verification

`cargo check --workspace` clean. Everything else in this release was gated on
its own PR; `main` at `86d64d25` shows 14/14 checks green.

Not done: the documented channel discipline is nightly → RC → stable
("tag `vX.Y.Z` on the RC's commit once it has soaked", CONTRIBUTING). This
release tags `main` directly, as `v0.2.6` did. Flagging rather than silently
departing from the runbook.

## After merge

`git tag v0.2.7 <merge commit> && git push origin v0.2.7` — `release.yml`
builds the platform matrix and publishes; stable tags also mirror to the
Tencent COS `release/latest/` bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)