### PR TITLE
fix(tools): one name per capability (per unified-agent-pid-tools), one dispatch path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "serde",
  "serde_json",
  "telemetry",
+ "tempfile",
  "tokio",
  "tools",
 ]

--- a/rust/crates/engine-host/Cargo.toml
+++ b/rust/crates/engine-host/Cargo.toml
@@ -37,5 +37,11 @@ telemetry = { path = "../telemetry" }
 # skills (incl. plugin-provided roots) in the system prompt.
 commands = { path = "../commands" }
 
+[dev-dependencies]
+# `send_message_routing` drives the executor's async trait method to
+# completion and needs a workspace to prove the local delivery path.
+tokio = { version = "1", features = ["rt", "macros"] }
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/rust/crates/engine-host/src/runtime_build.rs
+++ b/rust/crates/engine-host/src/runtime_build.rs
@@ -375,11 +375,13 @@ pub(crate) fn build_runtime_with_plugin_state(
     }
     // nexus A2A: when configured, keep the peer-reply tool available even under
     // an explicit --allowedTools restriction (absent a restriction it is
-    // already advertised). Its handler is the CliToolExecutor intercept wired
-    // below; the co-host advertises the same tool the same way.
+    // already advertised). Its network handler is the CliToolExecutor intercept
+    // wired below; the co-host advertises the same tool the same way. The tool
+    // exists either way — absent A2A it delivers to the workspace mailbox — so
+    // this line controls reachability under a restriction, nothing more.
     if a2a.is_some() {
         if let Some(allowed) = config.allowed_tools.as_mut() {
-            allowed.extend(["send_message".to_string()]);
+            allowed.extend(["send".to_string()]);
         }
     }
     let policy = match permission_policy(
@@ -412,7 +414,7 @@ pub(crate) fn build_runtime_with_plugin_state(
         system_prompt.dynamic_sections.push(deferred_section);
     }
     // nexus A2A: teach the model its A2A identity + how to reach peers, so the
-    // standalone loop knows it can `send_message` to a named peer.
+    // standalone loop knows it can `send` to a named peer.
     if let Some(session) = a2a {
         system_prompt
             .dynamic_sections
@@ -447,9 +449,11 @@ pub(crate) fn build_runtime_with_plugin_state(
     )
     .with_session_known_date(runtime::today_local())
     .with_session_known_model(config.model.clone());
-    // nexus A2A: give the CLI executor the send half so `send_message` routes
-    // to the peer's replicated DT_STREAM inbox (the shared handler the co-host
-    // uses). Set only when configured; absent it the tool is never advertised.
+    // nexus A2A: give the CLI executor the send half so `send` routes to the
+    // peer's replicated DT_STREAM inbox (the shared handler the co-host uses)
+    // instead of the workspace mailbox. Set only when configured — this sender
+    // IS the difference between the two destinations, which is why the model is
+    // offered one tool and never asked to pick a transport.
     if let Some(session) = a2a {
         runtime
             .tool_executor_mut()

--- a/rust/crates/engine-host/src/tool_executor.rs
+++ b/rust/crates/engine-host/src/tool_executor.rs
@@ -256,19 +256,59 @@ impl ToolExecutor for CliToolExecutor {
         // allow-listed run refused every tool call while, because the model then
         // explained itself politely, looking like it had simply chosen not to
         // act. Comparing only the canonical name is wrong too — the allow-list
-        // parser deliberately keeps the *spec* name for PascalCase-native tools
-        // (`--allowedTools TaskList` stores `TaskList`, not its `pid_status`
-        // dispatch alias), so canonicalising `TaskList` would miss its own
-        // entry. Either spelling matching is what "this tool is allowed" means.
-        if self.allowed_tools.as_ref().is_some_and(|allowed| {
-            !allowed.contains(tool_name)
-                && !allowed.contains(&tools::canonicalize_tool_name(tool_name))
-        }) {
-            return Err(ToolError::new(format!(
-                "tool `{tool_name}` is not enabled by the current --allowedTools setting"
-            )));
-        }
+        // parser stores the *spec* name, and not every spec has an alias. Either
+        // spelling matching is what "this tool is allowed" means.
+        let gate = |name: &str| -> Result<(), ToolError> {
+            if self.allowed_tools.as_ref().is_some_and(|allowed| {
+                !allowed.contains(name) && !allowed.contains(&tools::canonicalize_tool_name(name))
+            }) {
+                return Err(ToolError::new(format!(
+                    "tool `{name}` is not enabled by the current --allowedTools setting"
+                )));
+            }
+            Ok(())
+        };
+        gate(tool_name)?;
         let value = parse_tool_call_input(input)?;
+
+        // `ExecuteExtraTool` is an ENVELOPE, not a tool. Unwrap it FIRST, then
+        // run the tool it names through everything below exactly as if the
+        // model had named it directly.
+        //
+        // Order matters, and it used to be wrong in two ways. The envelope
+        // passed the allow-list as itself and then dispatched whatever it
+        // named, so an allow-list of read-only tools still let a model run
+        // anything deferred by wrapping it — hence the second `gate` here. And
+        // the intercepts below sat ABOVE the unwrap, so a deferred tool reached
+        // through the envelope lost them: `ExitPlanMode` is deferred, and
+        // skipped its confirmation prompt whenever it was invoked the
+        // documented way.
+        //
+        // Core tools are refused inside the envelope because they are already
+        // in the model's tool list — which also means `ExecuteExtraTool` cannot
+        // wrap itself, so this unwraps at most once.
+        let (tool_name, value) = if tools::canonicalize_tool_name(tool_name) == "ExecuteExtraTool" {
+            let req: ExecuteExtraToolRequest = serde_json::from_value(value)
+                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
+            if tools::is_core_tool(&tools::canonicalize_tool_name(&req.tool_name)) {
+                return Err(ToolError::new(format!(
+                    "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
+                    req.tool_name
+                )));
+            }
+            gate(&req.tool_name)?;
+            (req.tool_name, req.params)
+        } else {
+            (tool_name.to_string(), value)
+        };
+
+        // Canonicalize ONCE; every intercept below matches the canonical name.
+        // Matching the raw name is a recurring bug class here — a model
+        // spelling `bash` as `Bash` silently lost its progress sink, and one
+        // spelling `send` as `SendMessage` lost the nexus-A2A route and had its
+        // cross-machine message written to a local file instead.
+        let tool_name = tools::canonicalize_tool_name(&tool_name);
+
         if tool_name == "AskUserQuestion"
             && self
                 .question_prompter
@@ -293,20 +333,6 @@ impl ToolExecutor for CliToolExecutor {
         {
             return self.handle_exit_plan_mode(&value, ctx);
         }
-        let (tool_name, value) = if tool_name == "ExecuteExtraTool" {
-            let req: ExecuteExtraToolRequest = serde_json::from_value(value)
-                .map_err(|error| ToolError::new(format!("invalid tool input JSON: {error}")))?;
-            let target = tools::canonicalize_tool_name(&req.tool_name);
-            if tools::is_core_tool(&target) {
-                return Err(ToolError::new(format!(
-                    "tool `{}` is a core tool — call it directly instead of through ExecuteExtraTool",
-                    req.tool_name
-                )));
-            }
-            (target, req.params)
-        } else {
-            (tool_name.to_string(), value)
-        };
 
         let is_mcp_tool = self.tool_registry.has_runtime_tool(&tool_name);
         if tool_name == "ToolSearch" {

--- a/rust/crates/engine-host/src/tool_executor.rs
+++ b/rust/crates/engine-host/src/tool_executor.rs
@@ -334,19 +334,34 @@ impl ToolExecutor for CliToolExecutor {
                     }
                 }
 
-                let result = if tool_name == "send_message" {
-                    mailbox_sender
-                        .as_ref()
-                        .ok_or_else(|| {
-                            ToolError::new("send_message is unavailable without nexus A2A")
-                        })
-                        .and_then(|sender| {
-                            runtime::spawn_task::handle_send_message(
-                                sender,
-                                &serde_json::to_string(&value).unwrap_or_default(),
+                // nexus A2A: when the host wired a mailbox sender, `send`
+                // delivers to the peer's replicated DT_STREAM inbox over gRPC
+                // via the SAME shared handler the co-host uses — only the
+                // transport differs. Absent that sender it falls through to the
+                // registry, whose `send` writes the workspace mailbox.
+                //
+                // Falling through is the contract, not a failure path: `send`
+                // is ONE tool, and which destination it reaches is the host's
+                // choice, never the model's. The input is normalized with the
+                // SAME helper the registry arm uses, so the field a model
+                // picked — `message`, or the wire envelope's `body` — cannot
+                // decide the destination either.
+                let result = if tool_name == "send" {
+                    match mailbox_sender.as_ref() {
+                        Some(sender) => runtime::spawn_task::handle_send_message(
+                            sender,
+                            &tools::normalize_send_input(&value),
+                        )
+                        .map_err(ToolError::new),
+                        None => registry
+                            .execute_with_abort_and_context(
+                                &tool_name,
+                                &value,
+                                abort_signal.as_ref(),
+                                Some(&ctx),
                             )
-                            .map_err(ToolError::new)
-                        })
+                            .map_err(ToolError::new),
+                    }
                 } else if is_mcp_tool {
                     execute_runtime_tool_with_state(mcp_state.as_ref(), &tool_name, value)
                 } else {

--- a/rust/crates/engine-host/tests/send_message_routing.rs
+++ b/rust/crates/engine-host/tests/send_message_routing.rs
@@ -1,0 +1,191 @@
+//! `send` must reach the peer no matter how the model spells or wraps
+//! the call.
+//!
+//! This is the regression guard for a live failure. Three tools were
+//! advertised at once — `SendMessage`, `send`, `send` — differing only
+//! in which schema field carried the text, and only the literal name
+//! `send` was intercepted for nexus A2A. A model on a cross-machine
+//! session picked `send`, its reply was written to a local
+//! `.sudocode-inbox/` file, the tool answered "Message sent to <peer>'s
+//! inbox", and the peer on the other machine waited ten hours for a message
+//! that had never left the host.
+//!
+//! Two independent things had to be true for that to happen, so both are
+//! asserted here:
+//!
+//! * the intercept matched the RAW name, so any other spelling fell through;
+//! * `ExecuteExtraTool` ran a SECOND dispatch path that knew nothing about
+//!   A2A — and since `send` is a deferred tool, the envelope is its
+//!   documented invocation, so even the correct name routed locally.
+//!
+//! The fake sender stands in for the gRPC one. The routing decision is made
+//! entirely by `CliToolExecutor` before any transport is touched, so a daemon
+//! would only slow the test down without testing more of the decision.
+
+use std::sync::{Arc, Mutex};
+
+use engine_host::tool_executor::CliToolExecutor;
+use runtime::{ToolDispatchContext, ToolExecutor};
+use tools::GlobalToolRegistry;
+
+/// Records what the A2A transport was asked to deliver.
+type Delivered = Arc<Mutex<Vec<(String, String)>>>;
+
+fn executor_with_a2a() -> (CliToolExecutor, Delivered) {
+    let delivered: Delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&delivered);
+    let mut executor = CliToolExecutor::new(None, GlobalToolRegistry::builtin(), None);
+    executor.set_mailbox_sender(Arc::new(move |to: &str, body: &str| {
+        sink.lock()
+            .expect("sender sink poisoned")
+            .push((to.to_string(), body.to_string()));
+        Ok(())
+    }));
+    (executor, delivered)
+}
+
+/// Run one tool call to completion on a throwaway runtime.
+fn call(executor: &CliToolExecutor, tool: &str, input: &str) -> Result<String, String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build test runtime")
+        .block_on(async {
+            executor
+                .execute_with_context(tool, input, &ToolDispatchContext::default())
+                .await
+                .map_err(|e| e.to_string())
+        })
+}
+
+/// Every way a model can name, shape or wrap the call reaches the peer.
+///
+/// `SendMessage` is CC's spelling and `send_message` the A2A tool this
+/// replaced — a model reaches for either by habit. `body` is the field the old
+/// A2A schema used, and the field the wire envelope still uses, so a model
+/// that has seen either will reach for it too. The `ExecuteExtraTool` envelope
+/// is the documented way to invoke a deferred tool, which `send` is.
+///
+/// Not one of these may quietly become a local file write: the name, the field
+/// and the wrapper are all things a model picks, and none of them is allowed
+/// to decide whether a message crosses the machine.
+#[test]
+fn every_spelling_shape_and_wrapper_reaches_the_peer() {
+    for (tool, input) in [
+        ("send", r#"{"to":"mac-ai","message":"canonical name"}"#),
+        ("SendMessage", r#"{"to":"mac-ai","message":"CC spelling"}"#),
+        (
+            "send_message",
+            r#"{"to":"mac-ai","message":"superseded A2A name"}"#,
+        ),
+        // The old A2A input shape, field and all.
+        ("send_message", r#"{"to":"mac-ai","body":"body field"}"#),
+        ("send", r#"{"to":"mac-ai","body":"body field, new name"}"#),
+        (
+            "ExecuteExtraTool",
+            r#"{"tool_name":"send","params":{"to":"mac-ai","message":"deferred envelope"}}"#,
+        ),
+        (
+            "ExecuteExtraTool",
+            r#"{"tool_name":"SendMessage","params":{"to":"mac-ai","message":"envelope, CC spelling"}}"#,
+        ),
+        (
+            "ExecuteExtraTool",
+            r#"{"tool_name":"send_message","params":{"to":"mac-ai","body":"envelope, old name and field"}}"#,
+        ),
+    ] {
+        let (executor, delivered) = executor_with_a2a();
+        let result =
+            call(&executor, tool, input).unwrap_or_else(|e| panic!("`{tool}` must not fail: {e}"));
+
+        let sent = delivered.lock().expect("sink poisoned").clone();
+        assert_eq!(
+            sent.len(),
+            1,
+            "`{tool}` must hand exactly one message to the A2A transport, got {sent:?}"
+        );
+        assert_eq!(sent[0].0, "mac-ai", "`{tool}` addressed the wrong peer");
+
+        // The result string is what a human reads to decide whether a message
+        // crossed the machine. "delivered to" is the network path; anything
+        // mentioning an inbox file means it did not leave the host.
+        assert!(
+            result.contains("message delivered to mac-ai"),
+            "`{tool}` must report network delivery, got: {result}"
+        );
+        assert!(
+            !result.contains("inbox"),
+            "`{tool}` reported a workspace-mailbox write while A2A was configured: {result}"
+        );
+    }
+}
+
+/// The body travels intact — a wrapper that reached the transport with an
+/// empty or wrong-field message would pass every assertion above while
+/// delivering nothing a peer could read.
+#[test]
+fn the_deferred_envelope_carries_the_body_through() {
+    let (executor, delivered) = executor_with_a2a();
+    call(
+        &executor,
+        "ExecuteExtraTool",
+        r#"{"tool_name":"send","params":{"to":"mac-ai","message":"PING from win-ai"}}"#,
+    )
+    .expect("envelope send must succeed");
+
+    let sent = delivered.lock().expect("sink poisoned").clone();
+    assert_eq!(
+        sent,
+        vec![("mac-ai".to_string(), "PING from win-ai".to_string())],
+        "the envelope must deliver the message verbatim"
+    );
+}
+
+/// Without an A2A sender the same tool delivers locally. This is the contract,
+/// not a fallback: one tool, and the host chooses the destination. If this
+/// starts erroring, a plain workspace session has lost its mailbox.
+#[test]
+fn without_a2a_the_same_tool_delivers_to_the_workspace_mailbox() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let executor = CliToolExecutor::new(None, GlobalToolRegistry::builtin(), None);
+    let previous = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(workspace.path()).expect("chdir into workspace");
+
+    let result = call(
+        &executor,
+        "send",
+        r#"{"to":"worker","message":"local hand-off","summary":"local hand-off"}"#,
+    );
+
+    std::env::set_current_dir(previous).expect("restore cwd");
+    let result = result.expect("workspace delivery must succeed");
+    assert!(
+        result.contains("inbox"),
+        "without A2A the tool must report a workspace-mailbox write, got: {result}"
+    );
+}
+
+/// `ExecuteExtraTool` must not be a hole in `--allowedTools`.
+///
+/// The envelope used to pass the gate as itself and then dispatch whatever it
+/// named, so an allow-list of read-only tools still let a model run anything
+/// deferred by wrapping it.
+#[test]
+fn the_deferred_envelope_is_gated_by_the_allow_list() {
+    let allowed = GlobalToolRegistry::builtin()
+        .normalize_allowed_tools(&["ExecuteExtraTool".to_string(), "ToolSearch".to_string()])
+        .expect("allow-list parses")
+        .expect("allow-list is non-empty");
+    let executor = CliToolExecutor::new(Some(allowed), GlobalToolRegistry::builtin(), None);
+
+    let error = call(
+        &executor,
+        "ExecuteExtraTool",
+        r#"{"tool_name":"send","params":{"to":"worker","message":"smuggled"}}"#,
+    )
+    .expect_err("a tool absent from --allowedTools must be refused inside the envelope too");
+    assert!(
+        error.contains("not enabled by the current --allowedTools setting"),
+        "the refusal must name the allow-list, got: {error}"
+    );
+}

--- a/rust/crates/runtime/src/agent_mailbox.rs
+++ b/rust/crates/runtime/src/agent_mailbox.rs
@@ -1,11 +1,11 @@
-//! Filesystem-backed per-agent mailbox for the SendMessage inter-agent
+//! Filesystem-backed per-agent mailbox for the `send` inter-agent
 //! coordination surface.
 //!
 //! Ported semantics from `sudoprivacy/claude-code`'s
 //! `utils/teammateMailbox.ts` — the flag-off default path. Each
 //! recipient has one append-only JSONL file at
 //! `<workspace>/.sudocode-inbox/<recipient>.jsonl`. The receiving
-//! agent (e.g. a task launched by `Agent(run_in_background=true)`) is
+//! agent (e.g. a task launched by `agent_spawn(run_in_background=true)`) is
 //! expected to read new lines from its own inbox and process them at
 //! its next tool round. This crate only writes; consumption lives
 //! wherever the receiving agent loop lives.
@@ -91,7 +91,7 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
-/// Process-global lock so concurrent SendMessage calls into the same
+/// Process-global lock so concurrent `send` calls into the same
 /// recipient's mailbox never interleave partial JSON lines. The lock
 /// covers only the "open, append, flush, close" critical section —
 /// contention is negligible in practice because most agents write to

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -3270,18 +3270,22 @@ fn push_thinking_block(
 /// larger step. Extend cautiously (e.g. same-class writes on distinct paths)
 /// only behind a conflict check.
 fn is_concurrency_safe_tool(tool_name: &str) -> bool {
+    // Canonicalize first: the name arrives as the model spelled it, and a
+    // CC-trained model says `TaskGet` where this codebase says `pid_status`.
+    // Matching the raw name is how the `Task*` → `pid_*` rename silently
+    // dropped these from concurrent batches.
     matches!(
-        tool_name,
+        crate::tool_names::canonicalize_tool_name(tool_name).as_str(),
         // File reads
         "read_file"
             | "glob_search"
             | "grep_search"
             // Search
             | "ToolSearch"
-            // Task reads (CC marks TaskGet read-only; List/Output are symmetric)
-            | "TaskGet"
-            | "TaskList"
-            | "TaskOutput"
+            // Process-status reads (CC marks TaskGet read-only; the
+            // list/output queries are symmetric)
+            | "pid_status"
+            | "pid_output"
     )
 }
 

--- a/rust/crates/runtime/src/coordinator_mode.rs
+++ b/rust/crates/runtime/src/coordinator_mode.rs
@@ -39,10 +39,17 @@ pub const COORDINATOR_ENV_VAR: &str = "SUDOCODE_COORDINATOR_MODE";
 /// `edit_file`, `PowerShell`, `EnterPlanMode`,
 /// `ExitPlanMode`) is intentionally excluded so a
 /// non-compliant model that tries them gets an instructive error
-/// pointing back to `Agent(...)`. Read-only tools (`read_file`,
+/// pointing back to `agent_spawn(...)`. Read-only tools (`read_file`,
 /// `glob_search`, `grep_search`, `WebSearch`, `WebFetch`) remain
 /// available so the coordinator can peek at code without spawning a
 /// worker for trivial lookups.
+///
+/// Entries are CANONICAL names only. [`is_tool_allowed_in_coordinator_mode`]
+/// canonicalizes what the model asked for before looking it up, so a
+/// CC-spelled `Agent`/`TaskList`/`SendMessage` is admitted by its canonical
+/// entry rather than by a second one listed here. Listing both spellings is
+/// how this set silently kept admitting names the tool list no longer
+/// advertises.
 ///
 /// The set is consumed by [`is_tool_allowed_in_coordinator_mode`]
 /// (dispatch-side guard) and by
@@ -53,18 +60,12 @@ pub const COORDINATOR_ENV_VAR: &str = "SUDOCODE_COORDINATOR_MODE";
 pub fn coordinator_allowed_tools() -> BTreeSet<&'static str> {
     [
         // Delegation surface
-        "Agent",
         "agent_list",
         "agent_spawn",
-        "TaskStop",
         "pid_kill",
-        "TaskGet",
-        "TaskList",
         "pid_status",
-        "TaskOutput",
         "pid_output",
         "pid_fork",
-        "SendMessage",
         "send",
         // Skills + web (read-only research)
         "Skill",
@@ -88,15 +89,16 @@ pub fn coordinator_allowed_tools() -> BTreeSet<&'static str> {
 
 /// Predicate consumed at tool-dispatch time. When coordinator mode is
 /// off this returns `true` for every tool (fast path — never blocks).
-/// When coordinator mode is on it returns `true` iff `tool_name` is in
-/// [`coordinator_allowed_tools`]. Deliberately keyed by name string so
-/// callers don't have to depend on the tools crate.
+/// When coordinator mode is on it returns `true` iff `tool_name`
+/// canonicalizes into [`coordinator_allowed_tools`]. Deliberately keyed by
+/// name string so callers don't have to depend on the tools crate.
 #[must_use]
 pub fn is_tool_allowed_in_coordinator_mode(tool_name: &str) -> bool {
     if !is_coordinator_mode() {
         return true;
     }
-    coordinator_allowed_tools().contains(tool_name)
+    coordinator_allowed_tools()
+        .contains(crate::tool_names::canonicalize_tool_name(tool_name).as_str())
 }
 
 /// Return `true` when the `coordinatorMode` experiment is enabled —
@@ -112,7 +114,7 @@ pub fn is_coordinator_mode() -> bool {
 /// The coordinator role + workflow system prompt. Ported near-verbatim
 /// from CC-fork's `getCoordinatorSystemPrompt()`.
 ///
-/// SendMessage is included as the "continue an existing worker"
+/// `send` is included as the "continue an existing worker"
 /// mechanism. Live delivery for `shutdown_request` is wired
 /// end-to-end via the process-wide abort-signal registry
 /// (`tools::abort_registered_agent`). Live delivery for plain-text
@@ -141,21 +143,21 @@ Every message you send is to the user. Worker results and system notifications a
 
 ## 2. Your Tools
 
-- **Agent** - Spawn a new worker
-- **SendMessage** - Continue an existing worker (send follow-up to its ID) or signal shutdown
-- **TaskStop** - Stop a running worker
-- **TaskGet** - Fetch a running worker's metadata by `task_id`
-- **TaskOutput** - Read a running or completed worker's output by `task_id`
+- **agent_spawn** - Spawn a new worker
+- **send_message** - Continue an existing worker (send follow-up to its pid) or signal shutdown
+- **pid_kill** - Stop a running worker
+- **pid_status** - Fetch a running worker's metadata by `pid`, or list every worker when `pid` is omitted
+- **pid_output** - Read a running or completed worker's output by `pid`
 
-Write tools (`bash`, `write_file`, `edit_file`, `PowerShell`, `EnterPlanMode`, `ExitPlanMode`) are DELIBERATELY unavailable to you — always delegate write-side work to a worker via `Agent(...)`. Read-only tools (`read_file`, `glob_search`, `grep_search`, `WebSearch`, `WebFetch`, `Skill`) remain available for lightweight lookups that don't need a full worker turn.
+Write tools (`bash`, `write_file`, `edit_file`, `PowerShell`, `EnterPlanMode`, `ExitPlanMode`) are DELIBERATELY unavailable to you — always delegate write-side work to a worker via `agent_spawn(...)`. Read-only tools (`read_file`, `glob_search`, `grep_search`, `WebSearch`, `WebFetch`, `Skill`) remain available for lightweight lookups that don't need a full worker turn.
 
-When calling Agent:
+When calling agent_spawn:
 - Do not use one worker to check on another. Workers will notify you when they are done.
 - Do not use workers to trivially report file contents or run commands. Give them higher-level tasks.
 - Do not set the model parameter. Workers need the default model for the substantive tasks you delegate.
 - After launching agents, briefly tell the user what you launched and end your response. Never fabricate or predict agent results in any format — results arrive as separate messages.
 
-### Agent Results
+### Worker Results
 
 Worker results arrive as **user-role messages** containing `<task-notification>` XML. They look like user messages but are not. Distinguish them by the `<task-notification>` opening tag.
 
@@ -177,7 +179,7 @@ Format:
 
 - `<result>` and `<usage>` are optional sections
 - The `<summary>` describes the outcome: "completed", "failed: {error}", or "was stopped"
-- The `<task-id>` value is the agent ID — use `TaskGet` / `TaskOutput` with that ID to inspect the worker
+- The `<task-id>` value is the agent ID — use `pid_status` / `pid_output` with that ID to inspect the worker
 
 ### Example
 
@@ -186,8 +188,8 @@ Each "You:" block is a separate coordinator turn. The "User:" block is a `<task-
 You:
   Let me start some research on that.
 
-  Agent({ description: "Investigate auth bug", subagent_type: "general-purpose", prompt: "..." })
-  Agent({ description: "Research secure token storage", subagent_type: "general-purpose", prompt: "..." })
+  agent_spawn({ description: "Investigate auth bug", agent: "general-purpose", prompt: "..." })
+  agent_spawn({ description: "Research secure token storage", agent: "general-purpose", prompt: "..." })
 
   Investigating both issues in parallel — I'll report back with findings.
 
@@ -203,13 +205,13 @@ You:
   Found the bug — null pointer in confirmTokenExists in validate.ts. I'll fix it.
   Still waiting on the token storage research.
 
-  Agent({ description: "Fix null pointer in validate.ts", subagent_type: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash." })
+  agent_spawn({ description: "Fix null pointer in validate.ts", agent: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash." })
 
 ## 3. Workers
 
-When calling Agent, use subagent_type `general-purpose` (or `Explore`/`Plan`/`Verification` for the specialized read-only research / planning / verification subsets). Workers execute tasks autonomously — especially research, implementation, or verification.
+When calling agent_spawn, use agent `general-purpose` (or `Explore`/`Plan`/`Verification` for the specialized read-only research / planning / verification subsets). Workers execute tasks autonomously — especially research, implementation, or verification.
 
-Workers have access to standard tools (bash, read_file, write_file, edit_file, glob_search, grep_search, WebFetch, WebSearch, TaskCreate, TaskUpdate, TaskList, ToolSearch, Sleep, StructuredOutput, PowerShell, Config) and project skills via the Skill tool. Delegate skill invocations (e.g. /commit, /verify) to workers.
+Workers have access to standard tools (bash, read_file, write_file, edit_file, glob_search, grep_search, WebFetch, WebSearch, TaskCreate, TaskUpdate, pid_status, ToolSearch, Sleep, StructuredOutput, PowerShell, Config) and project skills via the Skill tool. Delegate skill invocations (e.g. /commit, /verify) to workers.
 
 ## 4. Task Workflow
 
@@ -250,18 +252,18 @@ When a worker reports failure (tests failed, build errors, file not found):
 
 ### Stopping Workers
 
-Use TaskStop to stop a worker you sent in the wrong direction — for example, when you realize mid-flight that the approach is wrong, or the user changes requirements after you launched the worker. Pass the `task_id` from the Agent tool's launch result.
+Use pid_kill to stop a worker you sent in the wrong direction — for example, when you realize mid-flight that the approach is wrong, or the user changes requirements after you launched the worker. Pass the `pid` from the agent_spawn tool's launch result.
 
 ```
 // Launched a worker to refactor auth to use JWT
-Agent({ description: "Refactor auth to JWT", subagent_type: "general-purpose", prompt: "Replace session-based auth with JWT..." })
+agent_spawn({ description: "Refactor auth to JWT", agent: "general-purpose", prompt: "Replace session-based auth with JWT..." })
 // ... returns task_id: "agent-x7q" ...
 
 // User clarifies: "Actually, keep sessions — just fix the null pointer"
-TaskStop({ task_id: "agent-x7q" })
+pid_kill({ pid: "agent-x7q" })
 
 // Spawn a fresh worker with corrected instructions
-Agent({ description: "Fix null pointer in validate.ts", subagent_type: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42..." })
+agent_spawn({ description: "Fix null pointer in validate.ts", agent: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42..." })
 ```
 
 ## 5. Writing Worker Prompts
@@ -276,11 +278,11 @@ Never write "based on your findings" or "based on the research." These phrases d
 
 ```
 // Anti-pattern — lazy delegation
-Agent({ prompt: "Based on your findings, fix the auth bug", ... })
-Agent({ prompt: "The worker found an issue in the auth module. Please fix it.", ... })
+agent_spawn({ prompt: "Based on your findings, fix the auth bug", ... })
+agent_spawn({ prompt: "The worker found an issue in the auth module. Please fix it.", ... })
 
 // Good — synthesized spec
-Agent({ prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash.", ... })
+agent_spawn({ prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash.", ... })
 ```
 
 A well-synthesized spec gives the worker everything it needs in a few sentences.
@@ -476,7 +478,7 @@ pub fn render_task_notification(view: &TaskNotificationView<'_>) -> String {
 ///
 /// Non-coordinator sessions keep whatever JSON manifest their caller
 /// already emits — this preserves backwards-compatibility with tools
-/// that consume `TaskOutput` in non-coordinator mode.
+/// that consume `pid_output` in non-coordinator mode.
 #[must_use]
 pub fn render_task_notification_if_enabled(view: &TaskNotificationView<'_>) -> Option<String> {
     if is_coordinator_mode() {

--- a/rust/crates/runtime/src/coordinator_notification.rs
+++ b/rust/crates/runtime/src/coordinator_notification.rs
@@ -22,7 +22,7 @@
 //!
 //! The well-known recipient string [`COORDINATOR_INBOX_RECIPIENT`] is
 //! `coordinator`. Sub-agents write to this recipient via the same
-//! [`crate::agent_mailbox::append_envelope`] path SendMessage uses,
+//! [`crate::agent_mailbox::append_envelope`] path `send` uses,
 //! so the wire format is unchanged.
 //!
 //! ## Non-coordinator sessions
@@ -83,7 +83,7 @@ pub fn emit(workspace_root: &Path, from: &str, task_notification_xml: &str) -> R
 /// result to the coordinator's next user prompt.
 ///
 /// Non-`task_notification` envelopes in the inbox (e.g., a
-/// hypothetical future SendMessage-to-coordinator flow) are skipped
+/// hypothetical future send_message-to-coordinator flow) are skipped
 /// but ALSO count toward the consumed offset, so mixing kinds in
 /// the same file is safe.
 ///

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -71,6 +71,7 @@ pub mod summary_compression;
 pub mod task_packet;
 pub mod task_registry;
 mod time;
+pub mod tool_names;
 #[cfg(test)]
 mod trust_resolver;
 mod usage;

--- a/rust/crates/runtime/src/nexus_mailbox.rs
+++ b/rust/crates/runtime/src/nexus_mailbox.rs
@@ -162,8 +162,10 @@ impl Config {
     pub fn peer_system_prompt(&self) -> String {
         let mut s = format!(
             "## Agent-to-agent messaging\n\nYou are reachable on a nexus A2A network as the agent \"{}\". \
-             To message another agent, call the `send_message` tool with a JSON object \
-             {{\"to\": \"<agent name>\", \"body\": \"<your message>\"}}. \
+             To message another agent, call the `send` tool with a JSON object \
+             {{\"to\": \"<agent name>\", \"message\": \"<your message>\"}}. \
+             A successful send returns `message delivered to <agent name>`; any other result \
+             means the message did NOT leave this machine — say so rather than reporting success. \
              Messages other agents send you are delivered into this conversation as they arrive.",
             self.agent
         );
@@ -221,7 +223,7 @@ pub fn send(
 /// standalone counterpart to [`crate::spawn_task::mailbox_sender`] (which is
 /// backed by the in-process kernel). Both feed the SAME shared
 /// [`crate::spawn_task::handle_send_message`], so co-host and standalone
-/// `send_message` share every line except this transport closure.
+/// `send` share every line except this transport closure.
 ///
 /// `from` is the standalone agent's own name (advisory — the node stamps the
 /// authenticated identity under auth-on). `client` is shared (constructed
@@ -405,10 +407,7 @@ mod tests {
         };
         let p = cfg.peer_system_prompt();
         assert!(p.contains("\"operator\""), "prompt must name self: {p}");
-        assert!(
-            p.contains("send_message"),
-            "prompt must teach the tool: {p}"
-        );
+        assert!(p.contains("send"), "prompt must teach the tool: {p}");
         assert!(
             p.contains("win-ai, mac-ai"),
             "prompt must list known peers: {p}"

--- a/rust/crates/runtime/src/permissions.rs
+++ b/rust/crates/runtime/src/permissions.rs
@@ -245,10 +245,26 @@ impl PermissionPolicy {
         self.active_mode = mode;
     }
 
+    /// The permission a tool needs, defaulting to the strictest when the tool
+    /// is unknown.
+    ///
+    /// The table is keyed by SPEC name while `tool_name` is whatever the model
+    /// spelled, so an unresolved CC spelling does not read as "unknown tool" —
+    /// it reads as `DangerFullAccess`, and the call is refused under any mode
+    /// short of full access. That is how `--allowedTools TaskList` came to
+    /// dispatch nothing at all once `TaskList` stopped being a spec of its own:
+    /// the gate let it through and the permission layer, one lookup later,
+    /// silently required more than the session had. Try the name as given
+    /// first — a plugin may register a literal name that also happens to be an
+    /// alias key — then the canonical tool it names.
     #[must_use]
     pub fn required_mode_for(&self, tool_name: &str) -> PermissionMode {
         self.tool_requirements
             .get(tool_name)
+            .or_else(|| {
+                self.tool_requirements
+                    .get(&crate::tool_names::canonicalize_tool_name(tool_name))
+            })
             .copied()
             .unwrap_or(PermissionMode::DangerFullAccess)
     }
@@ -585,6 +601,41 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The requirement table is keyed by SPEC name; the model spells tools its
+    /// own way. Resolving one against the other is not a nicety — an unmatched
+    /// name falls through to `DangerFullAccess`, so a CC-spelled call is not
+    /// "unknown", it is REFUSED under every mode below full access, and the
+    /// refusal names a permission problem rather than a spelling one.
+    #[test]
+    fn cc_spelled_tools_resolve_to_their_canonical_requirement() {
+        let policy = PermissionPolicy::new(PermissionMode::WorkspaceWrite)
+            .with_tool_requirement("pid_status", PermissionMode::ReadOnly)
+            .with_tool_requirement("send", PermissionMode::WorkspaceWrite);
+
+        for cc_name in ["TaskList", "TaskGet"] {
+            assert_eq!(
+                policy.required_mode_for(cc_name),
+                PermissionMode::ReadOnly,
+                "`{cc_name}` must resolve to pid_status's requirement, not the \
+                 DangerFullAccess default"
+            );
+            assert_eq!(
+                policy.authorize(cc_name, "{}", None),
+                PermissionOutcome::Allow
+            );
+        }
+        assert_eq!(
+            policy.required_mode_for("SendMessage"),
+            PermissionMode::WorkspaceWrite
+        );
+        // A genuinely unknown tool still gets the strictest default — the
+        // fallback resolves spelling, it must not become a way in.
+        assert_eq!(
+            policy.required_mode_for("MadeUpTool"),
+            PermissionMode::DangerFullAccess
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -4,7 +4,7 @@
 //! on the agent's mailbox (via a blocking `sys_read` on the DT_STREAM tail)
 //! for inbound [`MailboxEnvelope`]s and drives each one through a
 //! [`crate::ConversationRuntime`]. The loop does NOT auto-reply: the agent
-//! decides whether to respond by calling the `send_message` tool during the
+//! decides whether to respond by calling the `send` tool during the
 //! turn (routed through [`mailbox_sender`]). Not calling it = silence, so a
 //! two-agent conversation ends instead of ping-ponging every turn forever.
 //!
@@ -134,33 +134,42 @@ impl Mailbox {
 }
 
 /// A type-erased "send a message to a peer's mailbox" capability handed to the
-/// co-hosted agent's `send_message` tool. This is the ONE place a co-hosted
+/// co-hosted agent's `send` tool. This is the ONE place a co-hosted
 /// agent's reply is written: the poll loop no longer auto-forwards turn output,
 /// so a reply happens ONLY when the agent deliberately calls the tool. It writes
 /// a [`MailboxEnvelope`] (the a2a SSOT) to the recipient's inbox; the a2a stamp
 /// hook overwrites `from` with the authenticated caller when auth is armed.
 pub type MailboxSender = Arc<dyn Fn(&str, &str) -> Result<(), String> + Send + Sync>;
 
-/// Shared handler for the `send_message` A2A tool: parse `{to, body}` from the
-/// raw tool input and hand it to `sender`. BOTH the co-host
+/// Shared handler for the `send` A2A tool: read `{to, message}` from the
+/// parsed tool input and hand it to `sender`. BOTH the co-host
 /// (`ManagedToolExecutor`) and the standalone CLI executor route their
-/// `send_message` here, so the parse + delivery contract is defined ONCE — only
+/// `send` here, so the parse + delivery contract is defined ONCE — only
 /// the `sender` differs by deployment (in-process [`mailbox_sender`] vs gRPC
 /// `crate::nexus_mailbox::grpc_sender`).
 ///
+/// `message` is the TOOL's field name, shared with the workspace-mailbox
+/// delivery the same tool performs when no A2A sender is configured. It is
+/// deliberately NOT the wire field: [`mailbox_sender`] puts the text into a
+/// [`MailboxEnvelope`]'s `body`, because `{from,to,body}` is the a2a
+/// substrate's contract and is not the tool's to rename.
+///
 /// # Errors
-/// Returns a `String` error when the input is not `{to, body}` or the send fails.
-pub fn handle_send_message(sender: &MailboxSender, input: &str) -> Result<String, String> {
-    let v: serde_json::Value = serde_json::from_str(input).map_err(|e| e.to_string())?;
-    let to = v
+/// Returns a `String` error when the input lacks a string `to`/`message`, or
+/// when the send fails.
+pub fn handle_send_message(
+    sender: &MailboxSender,
+    input: &serde_json::Value,
+) -> Result<String, String> {
+    let to = input
         .get("to")
         .and_then(|x| x.as_str())
         .ok_or_else(|| "send_message requires a string 'to'".to_string())?;
-    let body = v
-        .get("body")
+    let message = input
+        .get("message")
         .and_then(|x| x.as_str())
-        .ok_or_else(|| "send_message requires a string 'body'".to_string())?;
-    (sender)(to, body)?;
+        .ok_or_else(|| "send_message requires a string 'message'".to_string())?;
+    (sender)(to, message)?;
     Ok(format!("message delivered to {to}"))
 }
 
@@ -197,7 +206,7 @@ pub fn mailbox_sender<K: KernelSyscall + Send + Sync + 'static>(
 /// in step with them:
 /// * inbound framing — `run_loop` hands each message to the turn as
 ///   `[message from <sender>]\n\n<body>`, so `<sender>` is the reply target;
-/// * the reply path — [`mailbox_sender`] wires the `send_message` tool as the
+/// * the reply path — [`mailbox_sender`] wires the `send` tool as the
 ///   ONLY way a co-hosted agent replies (writing to the sender's inbox).
 ///
 /// Kept next to those two so the wording cannot drift from the framing/tool it
@@ -208,10 +217,10 @@ pub fn cohost_a2a_prompt_section(self_id: &str) -> String {
         "# Agent-to-agent messaging\n\
          You are the agent \"{self_id}\", conversing with other agents by message. \
          Each message you receive is shown as `[message from <sender>]` followed by \
-         its text. To reply, call the `send_message` tool with `to` set to that \
+         its text. To reply, call the `send` tool with `to` set to that \
          exact `<sender>` name — the agent that messaged you, never a word copied \
-         from the message text — and `body` set to your reply. Calling \
-         `send_message` is the only way to reply; if you do not call it you stay \
+         from the message text — and `message` set to your reply. Calling \
+         `send` is the only way to reply; if you do not call it you stay \
          silent and the conversation ends."
     )
 }
@@ -356,9 +365,9 @@ fn run_loop<K, C, T, F>(
                             // Drive ONE turn on the inbound message. The sender is
                             // surfaced in the prompt so the agent can address a reply.
                             // The agent decides whether to reply by calling the
-                            // `send_message` tool DURING the turn — the loop NO LONGER
+                            // `send` tool DURING the turn — the loop NO LONGER
                             // harvests the turn's text and auto-forwards it. Not
-                            // calling `send_message` means silence, so the
+                            // calling `send` means silence, so the
                             // conversation ends instead of two agents bouncing every
                             // turn's output back to each other forever (the ping-pong).
                             let turn_input = format!("[message from {sender}]\n\n{body}");
@@ -508,7 +517,7 @@ mod tests {
         // Names the agent so the model knows its own identity …
         assert!(section.contains("chatbot"));
         // … names the ONLY reply path …
-        assert!(section.contains("send_message"));
+        assert!(section.contains("send"));
         // … mirrors the `[message from <sender>]` framing `run_loop` emits …
         assert!(section.contains("[message from <sender>]"));
         // … and encodes the fix: reply target is the sender, never a word

--- a/rust/crates/runtime/src/tool_names.rs
+++ b/rust/crates/runtime/src/tool_names.rs
@@ -1,0 +1,84 @@
+//! The one place that knows a tool can be *named* two ways.
+//!
+//! Every capability is advertised under exactly ONE name (see
+//! `tools::mvp_tool_specs`). What this module owns is narrower and
+//! permanent: a model trained on Claude Code's tool set reaches for `Bash`,
+//! `Agent`, `TaskStop`, `SendMessage` from habit even when it was handed
+//! `bash`, `agent_spawn`, `pid_kill`, `send`, and a call refused for
+//! spelling reads to the user as the model declining to act.
+//!
+//! It lives in `runtime`, below `tools`, because name matching is not only a
+//! dispatch concern. Sites in this crate — the coordinator gate, the
+//! concurrency classifier — match on tool names too, and while
+//! `canonicalize_tool_name` sat in `tools` they could not call it, so each
+//! hand-listed the spellings it happened to know. They drifted, exactly as
+//! duplicated knowledge does: after the `Task*` → `pid_*` rename,
+//! `is_concurrency_safe_tool` still listed only the old names, silently
+//! dropping `pid_status`/`pid_output` from concurrent batches. Any site that
+//! matches a model-supplied tool name canonicalises through here first.
+
+/// Superseded tool name → this codebase's canonical tool name.
+///
+/// The canonical names are the Unified Agent/PID design's: `{layer}_{verb}`
+/// for `agent_*` and `pid_*` (underscores, not the design's conceptual dots,
+/// because a `.` in a JSON tool name breaks some providers), with `send` as
+/// the deliberate exception — one messaging tool, auto-routed by target.
+///
+/// This is NOT a deprecation shim. Nothing here is reachable as a second
+/// entry in the tool list; advertising a capability twice is what let a model
+/// pick the wrong destination for a cross-machine message, so the alias table
+/// and the spec list are kept strictly apart. What it buys is that a model
+/// trained on Claude Code's tool set — which reaches for `Bash`, `Agent`,
+/// `TaskStop`, `SendMessage` from habit — is not refused over spelling, since
+/// a refusal reads to the user as the model declining to act.
+///
+/// Keys are the NORMALIZED (lower-cased, `-` → `_`) form. Note that
+/// `SendMessage` and `send_message` normalize to DIFFERENT keys, so both are
+/// listed. Tools whose canonical name IS the CC name (`Skill`, `WebFetch`,
+/// `TaskCreate`, `AskUserQuestion`, …) need no entry —
+/// [`canonicalize_tool_name`] passes them through unchanged.
+const TOOL_ALIASES: &[(&str, &str)] = &[
+    ("bash", "bash"),
+    ("read", "read_file"),
+    ("write", "write_file"),
+    ("edit", "edit_file"),
+    ("glob", "glob_search"),
+    ("grep", "grep_search"),
+    ("sendmessage", "send"),      // CC: SendMessage
+    ("send_message", "send"),     // the A2A tool this replaced
+    ("agent", "agent_spawn"),     // CC: Agent
+    ("taskstop", "pid_kill"),     // CC: TaskStop
+    ("taskget", "pid_status"),    // CC: TaskGet
+    ("tasklist", "pid_status"),   // CC: TaskList — both map to pid_status
+    ("taskoutput", "pid_output"), // CC: TaskOutput
+];
+
+/// Lower-case and fold `-` to `_` so `Web-Fetch`, `web_fetch` and `WebFetch`
+/// all compare equal.
+fn normalize_tool_name(value: &str) -> String {
+    value.trim().replace('-', "_").to_ascii_lowercase()
+}
+
+/// Canonicalize a tool name from the model into the name the dispatcher and
+/// every name-matching site use.
+///
+/// Unknown names pass through unchanged: this resolves spelling, it does not
+/// validate. Dispatch rejects a name it has no arm for, and that error names
+/// what the model actually asked for.
+#[must_use]
+pub fn canonicalize_tool_name(name: &str) -> String {
+    let normalized = normalize_tool_name(name);
+    for &(alias, canonical) in TOOL_ALIASES {
+        if normalized == alias {
+            return canonical.to_string();
+        }
+    }
+    name.to_string()
+}
+
+/// The alias pairs, for callers that must enumerate them (the
+/// `--allowedTools` parser accepts either spelling of a tool).
+#[must_use]
+pub fn tool_aliases() -> &'static [(&'static str, &'static str)] {
+    TOOL_ALIASES
+}

--- a/rust/crates/runtime/src/verification_watcher.rs
+++ b/rust/crates/runtime/src/verification_watcher.rs
@@ -43,7 +43,7 @@ pub const DEFAULT_VERIFICATION_STREAK_THRESHOLD: usize = 3;
 /// tag so the model treats it as a systemic hint rather than a user
 /// message — mirrors the CC-fork convention.
 pub const VERIFICATION_NUDGE_TEXT: &str = "<system-reminder>\n\
-3 or more tasks have been closed without a Verification pass. Spawn `Agent(subagent_type=\"Verification\", …)` to prove the changes actually work — running the code, exercising edge cases, checking failures — before continuing. Rubber-stamping is worse than nothing.\n\
+3 or more tasks have been closed without a Verification pass. Spawn `agent_spawn(agent=\"Verification\", …)` to prove the changes actually work — running the code, exercising edge cases, checking failures — before continuing. Rubber-stamping is worse than nothing.\n\
 </system-reminder>";
 
 /// Process-global counter. Starts at 0. Simple atomic — no locking
@@ -257,7 +257,7 @@ mod tests {
         // The message the model sees MUST be actionable — name the
         // exact tool call, and tag it as a system-reminder so the
         // model distinguishes it from user input.
-        assert!(VERIFICATION_NUDGE_TEXT.contains("Agent(subagent_type=\"Verification\""));
+        assert!(VERIFICATION_NUDGE_TEXT.contains("agent_spawn(agent=\"Verification\""));
         assert!(VERIFICATION_NUDGE_TEXT.starts_with("<system-reminder>"));
         assert!(VERIFICATION_NUDGE_TEXT.ends_with("</system-reminder>"));
     }

--- a/rust/crates/runtime/tests/coordinator_gate.rs
+++ b/rust/crates/runtime/tests/coordinator_gate.rs
@@ -56,16 +56,40 @@ impl Drop for EnvGuard {
 fn allowlist_contains_delegation_surface() {
     let allowed = coordinator_allowed_tools();
     for name in [
+        "agent_spawn",
+        "agent_list",
+        "send",
+        "pid_kill",
+        "pid_status",
+        "pid_output",
+        "pid_fork",
+    ] {
+        assert!(
+            allowed.contains(name),
+            "coordinator allowlist MUST include delegation-surface tool `{name}`"
+        );
+    }
+}
+
+/// The set holds canonical names ONLY. A CC spelling is admitted because the
+/// predicate canonicalizes, not because the set lists it twice — listing both
+/// is how the set kept silently admitting names the tool list had stopped
+/// advertising, long after they were unreachable.
+#[test]
+fn allowlist_holds_canonical_names_only() {
+    let allowed = coordinator_allowed_tools();
+    for cc_name in [
         "Agent",
         "SendMessage",
         "TaskStop",
         "TaskGet",
         "TaskList",
         "TaskOutput",
+        "send_message",
     ] {
         assert!(
-            allowed.contains(name),
-            "coordinator allowlist MUST include delegation-surface tool `{name}`"
+            !allowed.contains(cc_name),
+            "`{cc_name}` is not a canonical tool name and MUST NOT be a second entry"
         );
     }
 }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3616,16 +3616,20 @@ impl LiveCli {
                     output,
                     is_error,
                 } => {
-                    // A successful Task* mutation changes the shared task list.
+                    // A successful task mutation changes the shared task list.
                     // The iocraft REPL's context panel derives live from the
                     // tool-result stream it already receives across the seam —
                     // NOT from an engine-side side-channel into the executor
                     // (that was a boundary leak, removed with `set_ui_sender`).
+                    //
+                    // Canonicalize first: this name is whatever the model
+                    // spelled, and matching it raw is how the `Task*` → `pid_*`
+                    // rename would leave the panel stale on every `pid_kill`.
                     if let Some(ui) = ui {
                         if !*is_error
                             && matches!(
-                                name.as_str(),
-                                "TaskCreate" | "TaskUpdate" | "TaskList" | "TaskStop"
+                                tools::canonicalize_tool_name(name).as_str(),
+                                "TaskCreate" | "TaskUpdate" | "pid_status" | "pid_kill"
                             )
                         {
                             ui.update_context(tools::global_task_list());

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -533,10 +533,12 @@ impl GlobalToolRegistry {
             .map(|name| (normalize_tool_name(name), name.clone()))
             .collect::<BTreeMap<_, _>>();
 
-        for &(alias, canonical) in TOOL_ALIASES {
-            // Don't overwrite a spec-name mapping — `--allowedTools TaskList`
-            // must resolve to the spec name `"TaskList"` (not the dispatch
-            // alias `"pid_status"`) so `definitions()` can match `spec.name`.
+        for &(alias, canonical) in runtime::tool_names::tool_aliases() {
+            // Don't overwrite a spec-name mapping: a spec whose own name
+            // normalizes to an alias key (`bash`) must keep resolving to the
+            // spec name so `definitions()` can match `spec.name`. Aliases with
+            // no spec of their own (`TaskList`, `SendMessage`) fall through to
+            // the canonical tool they name.
             name_map
                 .entry(alias.to_string())
                 .or_insert_with(|| canonical.to_string());
@@ -1046,27 +1048,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             }),
             required_permission: PermissionMode::ReadOnly,
         },
-        ToolSpec {
-            name: "Agent",
-            description: "Launch a specialized agent task. By default runs in the background and returns immediately. Set run_in_background=false to run synchronously. Use TaskOutput(agent_id=..., block=true) to await a background agent.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "description": { "type": "string", "description": "A short (3-5 word) description of the task" },
-                    "prompt": { "type": "string", "description": "The full task prompt for the agent" },
-                    "subagent_type": { "type": "string", "description": "Agent type specialization: general-purpose (default), Explore (read-only research), Plan (planning), Verification (bash + read), scode-guide, statusline-setup." },
-                    "name": { "type": "string", "description": "Optional human-readable label for this agent" },
-                    "model": { "type": "string", "description": "Model ID override; defaults to the system default" },
-                    "run_in_background": { "type": "boolean", "description": "When true (default), launch async and retrieve result later with TaskOutput(agent_id=..., block=true). When false, run synchronously and return the result." },
-                    "auth_mode": { "type": "string", "enum": ["api-key", "proxy", "subscription"], "description": "Explicit auth mode for the subagent. Overrides auto-detection from config." },
-                    "permission_mode": { "type": "string", "enum": ["bubble"], "description": "Permission escalation mode. `bubble` (the default and only currently-supported value) routes any permission prompt the sub-agent would show up to the parent process's terminal/ACP prompter — the parent human (or the driving ACP client) approves on the sub-agent's behalf. Reserved for future modes." }
-                },
-                "required": ["description", "prompt"],
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::DangerFullAccess,
-        },
-        // ── Unified agent_list ────────────────────────────────────────
+        // ── agent_list ────────────────────────────────────────────────
         // Discovery tool: list all available agent types (builtin +
         // custom `.md` agents from ~/.nexus/sudocode/agents/ and
         // .sudocode/agents/).
@@ -1080,11 +1062,12 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             }),
             required_permission: PermissionMode::ReadOnly,
         },
-        // ── Unified agent_spawn ───────────────────────────────────────
-        // Canonical replacement for `Agent`. Adds `fresh` flag:
-        // `false` (default) = auto-resume most recent session;
-        // `true` = start a clean session. The old `Agent` name is
-        // retained as a deprecated alias via `TOOL_ALIASES`.
+        // ── agent_spawn ───────────────────────────────────────────────
+        // The one spawn tool. `fresh: false` (default) auto-resumes the
+        // agent's most recent session; `true` starts a clean one. A model
+        // trained on the CC tool set will name this `Agent` and pass
+        // `subagent_type`; `TOOL_ALIASES` + `normalize_agent_spawn_input`
+        // accept that spelling without advertising it as a second tool.
         ToolSpec {
             name: "agent_spawn",
             description: concat!(
@@ -1097,15 +1080,15 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "agent": { "type": "string", "description": "Agent type/name to spawn (e.g. general-purpose, Explore, Plan)." },
+                    "agent": { "type": "string", "description": "Agent type specialization: general-purpose (default), Explore (read-only research), Plan (planning), Verification (bash + read), scode-guide, statusline-setup." },
                     "prompt": { "type": "string", "description": "The full task prompt for the agent." },
                     "fresh": { "type": "boolean", "description": "When true, start a clean session instead of resuming. Default false (auto-resume)." },
                     "description": { "type": "string", "description": "A short (3-5 word) description of the task." },
                     "name": { "type": "string", "description": "Optional human-readable label for this agent." },
                     "model": { "type": "string", "description": "Model ID override; defaults to the system default." },
-                    "run_in_background": { "type": "boolean", "description": "When true (default), launch async. When false, run synchronously." },
-                    "auth_mode": { "type": "string", "enum": ["api-key", "proxy", "subscription"], "description": "Explicit auth mode override." },
-                    "permission_mode": { "type": "string", "enum": ["bubble"], "description": "Permission escalation mode." }
+                    "run_in_background": { "type": "boolean", "description": "When true (default), launch async and retrieve the result later with pid_output(pid, block: true). When false, run synchronously and return the result." },
+                    "auth_mode": { "type": "string", "enum": ["api-key", "proxy", "subscription"], "description": "Explicit auth mode for the subagent. Overrides auto-detection from config." },
+                    "permission_mode": { "type": "string", "enum": ["bubble"], "description": "Permission escalation mode. `bubble` (the default and only currently-supported value) routes any permission prompt the sub-agent would show up to the parent process's terminal/ACP prompter — the parent human (or the driving ACP client) approves on the sub-agent's behalf. Reserved for future modes." }
                 },
                 "required": ["prompt"],
                 "additionalProperties": false
@@ -1293,49 +1276,8 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             required_permission: PermissionMode::WorkspaceWrite,
         },
         ToolSpec {
-            name: "TaskGet",
-            description: "Get the status and details of a background task by ID.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "task_id": { "type": "string" }
-                },
-                "required": ["task_id"],
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::ReadOnly,
-        },
-        ToolSpec {
-            name: "TaskList",
-            description: "List all background tasks and background sub-agents with their current status. Sub-agents come from the Agent tool and appear under `background_agents` in the response. Use `backgrounded_only=true` to narrow to sub-agents whose status is `backgrounded` or `running` — the useful set when the coordinator wants to switch between live workers.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "backgrounded_only": {
-                        "type": "boolean",
-                        "description": "When true, `background_agents` includes only sub-agents whose status is `backgrounded` or `running`. Defaults to false (all statuses)."
-                    }
-                },
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::ReadOnly,
-        },
-        ToolSpec {
-            name: "TaskStop",
-            description: "Stop a running background task by ID.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "task_id": { "type": "string" }
-                },
-                "required": ["task_id"],
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::DangerFullAccess,
-        },
-        ToolSpec {
             name: "TaskUpdate",
-            description: "Update a task's status, subject, or other fields. A task must exist first (created via TaskCreate); use TaskList to see available task IDs.",
+            description: "Update a task's status, subject, or other fields. The task must exist first — TaskCreate returns its id.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -1361,28 +1303,15 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             }),
             required_permission: PermissionMode::WorkspaceWrite,
         },
-        ToolSpec {
-            name: "TaskOutput",
-            description: "Retrieve output from a background task or agent. Use task_id for TaskRegistry tasks. Use agent_id to retrieve (and optionally await) a background agent launched with Agent(run_in_background=true). Set block=true to wait until the agent finishes. A single blocking call waits at most 60000 ms (clamped); if the agent is still running it returns retrieval_status=\"timeout\" — call TaskOutput again to keep waiting.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "task_id": { "type": "string", "description": "ID of a TaskRegistry task to retrieve output from" },
-                    "agent_id": { "type": "string", "description": "ID of a background agent launched with Agent(run_in_background=true)" },
-                    "block": { "type": "boolean", "description": "When true (default), wait until the agent finishes before returning" },
-                    "timeout_ms": { "type": "integer", "minimum": 0, "description": "Maximum milliseconds to wait when block=true (default 30000, capped at 60000). On timeout the response has retrieval_status=\"timeout\" — re-call to keep waiting." }
-                },
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::ReadOnly,
-        },
-        // ── Unified pid.* tools ───────────────────────────────────────
-        // Canonical replacements for TaskStop, TaskGet/TaskList, and
-        // TaskOutput. The old names are retained as deprecated aliases
-        // via TOOL_ALIASES.
+        // ── pid.* tools ───────────────────────────────────────────────
+        // The one process-control family. A CC-trained model will name
+        // these `TaskStop`/`TaskGet`/`TaskList`/`TaskOutput` and pass
+        // `task_id`/`agent_id`; `TOOL_ALIASES` + the `normalize_pid_*`
+        // helpers accept those spellings without advertising them as a
+        // second set of tools.
         ToolSpec {
             name: "pid_kill",
-            description: "Terminate a running agent by pid. Replaces TaskStop.",
+            description: "Terminate a running agent by pid.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -1398,8 +1327,8 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             description: concat!(
                 "Query the status of one or all agent pids. ",
                 "With `pid`: returns READY/BUSY/TERMINATED for that pid. ",
-                "Without `pid`: lists all pids with their statuses (replaces TaskList). ",
-                "Also replaces TaskGet for single-pid queries."
+                "Without `pid`: returns `background_agents` (every spawned agent and its ",
+                "status) plus `tasks` (the session's task list)."
             ),
             input_schema: json!({
                 "type": "object",
@@ -1418,9 +1347,10 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             name: "pid_output",
             description: concat!(
                 "Retrieve output from a pid (background agent or task). ",
-                "Set `block: true` to wait until the agent finishes (max 60s per call). ",
-                "`merge: true` merges the agent's result into the caller's context. ",
-                "Replaces TaskOutput."
+                "Set `block: true` to wait until the agent finishes (max 60s per call); ",
+                "if it is still running the response has retrieval_status=\"timeout\" — ",
+                "call again to keep waiting. ",
+                "`merge: true` merges the agent's result into the caller's context."
             ),
             input_schema: json!({
                 "type": "object",
@@ -1496,97 +1426,33 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             }),
             required_permission: PermissionMode::ReadOnly,
         },
-        ToolSpec {
-            name: "SendMessage",
-            description: concat!(
-                "Send a message to another agent teammate via the workspace mailbox. ",
-                "Recipients receive one JSONL line at ",
-                "<workspace>/.sudocode-inbox/<recipient>.jsonl. ",
-                "Set `to` to a bare teammate name or \"*\" for broadcast. ",
-                "`message` is either a plain string (requires `summary`) or a structured object ",
-                "{type: shutdown_request|shutdown_response|plan_approval_response, ...}. ",
-                "Structured messages CANNOT be broadcast (`to: \"*\"`). ",
-                "Live delivery: `shutdown_request` calls abort() on the target subagent's ",
-                "HookAbortSignal via the process-wide agent-abort registry, so an in-process ",
-                "background subagent stops on its next tool-loop check. Plain-text messages sent ",
-                "to a running background subagent are picked up by its multi-turn loop at the end ",
-                "of its current turn and become its next user-turn prompt."
-            ),
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "to": {
-                        "type": "string",
-                        "description": "Recipient: teammate name, or \"*\" for broadcast to all teammates."
-                    },
-                    "summary": {
-                        "type": "string",
-                        "description": "A 5-10 word summary shown as a preview in the UI (required when message is a string)."
-                    },
-                    "message": {
-                        "description": "Plain text (string) or a structured message object.",
-                        "oneOf": [
-                            { "type": "string" },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["shutdown_request", "shutdown_response", "plan_approval_response"]
-                                    },
-                                    "request_id": { "type": "string" },
-                                    "approve": { "type": "boolean" },
-                                    "reason": { "type": "string" },
-                                    "feedback": { "type": "string" }
-                                },
-                                "required": ["type"]
-                            }
-                        ]
-                    },
-                    "sender": {
-                        "type": "string",
-                        "description": "Optional sender name; defaults to \"team-lead\" for the main agent."
-                    }
-                },
-                "required": ["to", "message"],
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::WorkspaceWrite,
-        },
-        ToolSpec {
-            name: "send_message",
-            description: "Send a message to another agent's mailbox. Call this ONLY \
-                          when you decide to reply to a peer; if you have nothing to \
-                          say, do NOT call it — staying silent lets the conversation \
-                          end instead of bouncing forever. Only available to agents \
-                          that have a mailbox (A2A / co-hosted).",
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "to": { "type": "string", "description": "The recipient agent's id." },
-                    "body": { "type": "string", "description": "The message to send." }
-                },
-                "required": ["to", "body"],
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::WorkspaceWrite,
-        },
-        // ── Unified send ──────────────────────────────────────────────
-        // Canonical replacement for both `SendMessage` (coordinator /
-        // sub-agent mailbox) and `send_message` (A2A / co-hosted).
-        // Both old names are retained as deprecated aliases via
-        // `TOOL_ALIASES` so existing prompts and tool calls keep working.
+        // ── send_message ──────────────────────────────────────────────
+        // ONE outbound-message tool. Where it delivers is a property of the
+        // PROCESS, not of the name the model picks: when the host wired a
+        // nexus-A2A sender, `CliToolExecutor` routes it to the peer's
+        // replicated DT_STREAM inbox; otherwise it lands in the workspace
+        // mailbox below. Two names for those two destinations is what let a
+        // cross-machine reply be written silently to local disk and reported
+        // as sent, so there is deliberately only one.
         ToolSpec {
             name: "send",
             description: concat!(
                 "Send a message to an agent by name or pid. ",
-                "Unified replacement for SendMessage and send_message. ",
-                "When `to` is an agent name the message is delivered to its ",
-                "workspace mailbox (.sudocode-inbox/<name>.jsonl). ",
+                "Delivery is chosen by the host, not by you: on an agent-to-agent ",
+                "network the message is delivered to the peer over the network and the ",
+                "result reads `message delivered to <name>`; otherwise it lands in the ",
+                "recipient's workspace mailbox (.sudocode-inbox/<name>.jsonl). ",
                 "When `to` is a pid it is routed to the running process. ",
-                "`to: \"*\"` broadcasts to all teammates. ",
-                "`message` accepts a plain string (requires `summary` for named agents) ",
-                "or a structured object {type: shutdown_request|shutdown_response|plan_approval_response, ...}."
+                "`to: \"*\"` broadcasts to all teammates (structured messages CANNOT be broadcast). ",
+                "`message` accepts a plain string (pass `summary` too so the UI has a preview) ",
+                "or a structured object {type: shutdown_request|shutdown_response|plan_approval_response, ...}. ",
+                "Live delivery: `shutdown_request` calls abort() on the target subagent's ",
+                "HookAbortSignal via the process-wide agent-abort registry, so an in-process ",
+                "background subagent stops on its next tool-loop check. Plain-text messages sent ",
+                "to a running background subagent are picked up by its multi-turn loop at the end ",
+                "of its current turn and become its next user-turn prompt. ",
+                "When replying to a peer, call this ONLY if you have something to say — ",
+                "staying silent lets the conversation end instead of bouncing forever."
             ),
             input_schema: json!({
                 "type": "object",
@@ -1617,7 +1483,11 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                     },
                     "summary": {
                         "type": "string",
-                        "description": "A 5-10 word summary shown as a preview in the UI (required when message is a string)."
+                        "description": "A 5-10 word summary shown as a preview in the UI. Supply it whenever `message` is plain text."
+                    },
+                    "sender": {
+                        "type": "string",
+                        "description": "Optional sender name; defaults to \"team-lead\" for the main agent. Ignored on an agent-to-agent network, where the node stamps the authenticated sender."
                     }
                 },
                 "required": ["to", "message"],
@@ -1694,55 +1564,12 @@ pub fn execute_tool_with_abort(
     execute_tool_with_enforcer(None, name, input, abort_signal, None, &StdFsBackend)
 }
 
-/// PascalCase / short-name → canonical snake_case tool name.
-///
-/// SSOT: the alias pairs live here once and are consumed by both
-/// `parse_allowed_tools` (for `--allowedTools` CLI flag) and
-/// `execute_tool_with_enforcer` (for model-returned tool names).
-///
-/// Keys are the NORMALIZED (lower-cased) alias form — the CC PascalCase
-/// names (`Bash`, `Read`, …) normalize to these. Only tools whose
-/// `execute_tool` match arm is lower/snake_case appear here; PascalCase-
-/// native tools (`EnterPlanMode`, `TaskCreate`, `Skill`, `Agent`, …) are
-/// NOT aliased — [`canonicalize_tool_name`] passes them through unchanged.
-const TOOL_ALIASES: &[(&str, &str)] = &[
-    ("bash", "bash"),
-    ("read", "read_file"),
-    ("write", "write_file"),
-    ("edit", "edit_file"),
-    ("glob", "glob_search"),
-    ("grep", "grep_search"),
-    // Unified send: both old names → canonical "send"
-    ("sendmessage", "send"),  // SendMessage (normalized)
-    ("send_message", "send"), // send_message (managed-agent A2A)
-    // Unified agent_spawn: old name → canonical
-    ("agent", "agent_spawn"), // Agent (normalized)
-    // Unified pid.*: old Task* names → canonical pid.* names
-    ("taskstop", "pid_kill"),     // TaskStop (normalized)
-    ("taskget", "pid_status"),    // TaskGet (normalized)
-    ("tasklist", "pid_status"),   // TaskList (normalized) — both map to pid_status
-    ("taskoutput", "pid_output"), // TaskOutput (normalized)
-];
-
-/// Canonicalize a tool name from the model into the internal name used
-/// by the `execute_tool` match. Models may return PascalCase names
-/// (CC-style: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`) while
-/// scode registers snake_case (`bash`, `read_file`, etc.).
-///
-/// Names NOT in [`TOOL_ALIASES`] pass through UNCHANGED — critical for
-/// the PascalCase-native tools (`EnterPlanMode`, `ExitPlanMode`,
-/// `TaskCreate`, `WebFetch`, `Skill`, `Agent`, `TaskUpdate`, …) whose
-/// `execute_tool` match arms are PascalCase: lower-casing them (the prior
-/// behaviour) turned every one into `unsupported tool`.
-pub fn canonicalize_tool_name(name: &str) -> String {
-    let normalized = normalize_tool_name(name);
-    for &(alias, canonical) in TOOL_ALIASES {
-        if normalized == alias {
-            return canonical.to_string();
-        }
-    }
-    name.to_string()
-}
+/// The alias table's SSOT is [`runtime::tool_names`] — `runtime` sits below
+/// this crate and matches tool names too (the coordinator gate, the
+/// concurrency classifier), so the knowledge lives where every site can
+/// reach it. Re-exported here because `tools::canonicalize_tool_name` is the
+/// name the CLI, the engine host and the ACP server already call.
+pub use runtime::tool_names::canonicalize_tool_name;
 
 fn execute_tool_with_enforcer(
     enforcer: Option<&PermissionEnforcer>,
@@ -1761,7 +1588,7 @@ fn execute_tool_with_enforcer(
     // SUDOCODE_COORDINATOR_MODE is truthy; no cost otherwise.
     if !runtime::coordinator_mode::is_tool_allowed_in_coordinator_mode(name) {
         return Err(format!(
-            "tool `{name}` is not available in coordinator mode; delegate write-side work to a worker via `Agent(...)` (or use SendMessage to continue an existing worker)."
+            "tool `{name}` is not available in coordinator mode; delegate write-side work to a worker via `agent_spawn(...)` (or use `send` to continue an existing worker)."
         ));
     }
     match name {
@@ -1802,8 +1629,8 @@ fn execute_tool_with_enforcer(
         "WebSearch" => from_value::<WebSearchInput>(input).and_then(run_web_search),
         "Skill" => from_value::<SkillInput>(input).and_then(run_skill),
         "agent_list" => run_agent_list(),
-        // Canonical "agent_spawn" — also reached by the deprecated
-        // alias "Agent" (via TOOL_ALIASES). Normalize `agent` →
+        // agent_spawn. A CC-trained model names this `Agent`;
+        // TOOL_ALIASES folds that spelling onto this arm. Normalize `agent` →
         // `subagent_type` so the new schema's field name maps to
         // `AgentInput`. `fresh` is accepted but currently no-op
         // (session resume is future work).
@@ -1848,8 +1675,9 @@ fn execute_tool_with_enforcer(
         }
         "TaskCreate" => from_value::<TaskCreateInput>(input).and_then(run_task_create),
         "TaskUpdate" => from_value::<TaskUpdateInput>(input).and_then(run_task_update),
-        // Canonical pid.* — also reached by the deprecated aliases
-        // TaskStop, TaskGet, TaskList, TaskOutput (via TOOL_ALIASES).
+        // The pid.* family. A CC-trained model names these TaskStop,
+        // TaskGet, TaskList and TaskOutput; TOOL_ALIASES folds those
+        // spellings onto these arms.
         "pid_kill" => {
             let input = normalize_pid_input(input);
             from_value::<TaskIdInput>(&input).and_then(run_task_stop)
@@ -1876,13 +1704,12 @@ fn execute_tool_with_enforcer(
         "CronCreate" => from_value::<CronCreateInput>(input).and_then(run_cron_create),
         "CronDelete" => from_value::<CronDeleteInput>(input).and_then(run_cron_delete),
         "CronList" => run_cron_list(input.clone()),
-        // Canonical "send" — also reached by the deprecated aliases
-        // "SendMessage" and "send_message" (via TOOL_ALIASES).
-        // Normalize `body` → `message` so the old `send_message` input
-        // format `{to, body}` deserializes into `SendMessageInput`.
+        // Workspace-mailbox delivery. A host that wired a nexus-A2A sender
+        // intercepts `send` before dispatch reaches here and delivers over the
+        // network instead; this arm is the local destination, not a fallback
+        // for a failed one.
         "send" => {
-            let input = normalize_send_input(input);
-            from_value::<SendMessageInput>(&input).and_then(run_send_message)
+            from_value::<SendMessageInput>(&normalize_send_input(input)).and_then(run_send_message)
         }
         _ => Err(format!("unsupported tool: {name}")),
     }
@@ -2604,22 +2431,6 @@ fn sanitize_recipient(name: &str) -> String {
     out
 }
 
-/// Normalize the input `Value` for the unified `send` tool so that
-/// the old `send_message` format `{to, body}` is accepted alongside
-/// the `SendMessage` format `{to, message, ...}`. If `message` is
-/// absent but `body` is present, copies `body` into `message`.
-fn normalize_send_input(input: &Value) -> Value {
-    let mut v = input.clone();
-    if let Some(obj) = v.as_object_mut() {
-        if !obj.contains_key("message") {
-            if let Some(body) = obj.remove("body") {
-                obj.insert("message".to_string(), body);
-            }
-        }
-    }
-    v
-}
-
 /// Normalize `pid` → `task_id` for the unified `pid_kill` and
 /// `pid_status` tools, so the new schema's field name maps to
 /// `TaskIdInput`. If `task_id` already exists, `pid` is ignored.
@@ -2629,6 +2440,31 @@ fn normalize_pid_input(input: &Value) -> Value {
         if !obj.contains_key("task_id") {
             if let Some(pid) = obj.remove("pid") {
                 obj.insert("task_id".to_string(), pid);
+            }
+        }
+    }
+    v
+}
+
+/// Normalize `body` → `message` for `send`.
+///
+/// `send` advertises one field, `message`. `body` was the field name of the
+/// A2A `send_message` tool it replaced, and it is also the field name in the
+/// [`MailboxEnvelope`](runtime::spawn_task) that carries the text on the
+/// wire — so a model that has seen either will reach for it. Accepting it is
+/// input normalization, not a second advertised name.
+///
+/// Public because the nexus-A2A intercept in `CliToolExecutor` reads the tool
+/// input before dispatch reaches the arm below, and both destinations must
+/// accept exactly the same input or the field a model chose would decide
+/// where its message went.
+#[must_use]
+pub fn normalize_send_input(input: &Value) -> Value {
+    let mut v = input.clone();
+    if let Some(obj) = v.as_object_mut() {
+        if !obj.contains_key("message") {
+            if let Some(body) = obj.remove("body") {
+                obj.insert("message".to_string(), body);
             }
         }
     }
@@ -7368,10 +7204,19 @@ fn search_tool_specs(query: &str, max_results: usize, specs: &[SearchableToolSpe
             .map(str::trim)
             .filter(|part| !part.is_empty())
             .filter_map(|wanted| {
-                let wanted = canonical_tool_token(wanted);
+                // Try the name as asked, then the canonical tool it aliases.
+                // `select:` is an exact match, so without this a CC-trained
+                // model asking for `select:SendMessage` — the spelling the
+                // alias table exists to absorb — gets an empty result and no
+                // way to learn the name it should have used.
+                let asked = canonical_tool_token(wanted);
+                let aliased = alias_token(&asked);
                 specs
                     .iter()
-                    .find(|spec| canonical_tool_token(&spec.name) == wanted)
+                    .find(|spec| {
+                        let token = canonical_tool_token(&spec.name);
+                        token == asked || token == aliased
+                    })
                     .map(|spec| spec.name.clone())
             })
             .take(max_results)
@@ -7425,6 +7270,13 @@ fn search_tool_specs(query: &str, max_results: usize, specs: &[SearchableToolSpe
                 if canonical_name == canonical_term {
                     score += 12;
                 }
+                // A CC tool name is an exact hit on the tool it aliases, and
+                // must outscore every tool that merely shares the word:
+                // `AgentTool` means CC's `Agent`, i.e. `agent_spawn`, not
+                // `agent_list`.
+                if canonical_name == alias_token(&canonical_term) {
+                    score += 12;
+                }
                 if normalized_haystack.contains(&canonical_term) {
                     score += 3;
                 }
@@ -7453,6 +7305,19 @@ fn normalize_tool_search_query(query: &str) -> String {
         .map(canonical_tool_token)
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Resolve a search token through the alias table and return the canonical
+/// tool's own token.
+///
+/// Search compares TOKENS (`canonical_tool_token`: alphanumerics only, a
+/// trailing `tool` stripped) while the alias table is keyed by normalized
+/// NAMES, so `AgentTool` → token `agent` has to be fed back through the table
+/// as a name to reach `agent_spawn` → token `agentspawn`. Comparing the two
+/// forms directly is why `AgentTool` scored no better against `agent_spawn`
+/// than against `agent_list` and the tie went to whichever spec came first.
+fn alias_token(token: &str) -> String {
+    canonical_tool_token(&canonicalize_tool_name(token))
 }
 
 fn canonical_tool_token(value: &str) -> String {
@@ -8937,7 +8802,8 @@ mod tests {
         assert!(names.contains(&"TaskCreate"));
         assert!(names.contains(&"TaskUpdate"));
         assert!(names.contains(&"Skill"));
-        assert!(names.contains(&"Agent"));
+        assert!(names.contains(&"agent_spawn"));
+        assert!(names.contains(&"send"));
         assert!(names.contains(&"ToolSearch"));
         assert!(names.contains(&"Sleep"));
         assert!(names.contains(&"Config"));
@@ -8945,6 +8811,43 @@ mod tests {
         assert!(names.contains(&"ExitPlanMode"));
         assert!(names.contains(&"StructuredOutput"));
         assert!(names.contains(&"PowerShell"));
+    }
+
+    /// The invariant that keeps a model from having to guess: a capability is
+    /// advertised under exactly ONE name.
+    ///
+    /// It regressed once — `SendMessage`, `send` and `send` were all
+    /// advertised at the same time, differing only in which schema field
+    /// carried the text, and a model on a cross-machine A2A session picked the
+    /// workspace-mailbox one. Its reply was written to a local file and
+    /// reported as delivered, and the peer waited ten hours for a message that
+    /// had never left the machine.
+    ///
+    /// An alias exists so a CC-trained model's spelling still dispatches. The
+    /// moment an alias key is ALSO a spec name, the model sees two entries for
+    /// one capability and the guessing is back.
+    #[test]
+    fn no_capability_is_advertised_under_two_names() {
+        let names = mvp_tool_specs()
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<Vec<_>>();
+        for &(alias, canonical) in runtime::tool_names::tool_aliases() {
+            if alias == canonical {
+                // A tool whose canonical name already IS the normalized key
+                // (`bash`): the entry is an identity, not a second name.
+                continue;
+            }
+            let clashing = names
+                .iter()
+                .find(|name| super::normalize_tool_name(name) == alias)
+                .copied();
+            assert_eq!(
+                clashing, None,
+                "`{alias}` is an alias for `{canonical}` AND has a spec of its own — \
+                 the model would see one capability twice and have to guess"
+            );
+        }
     }
 
     #[test]
@@ -8979,10 +8882,14 @@ mod tests {
                 "{tool} must not be mangled"
             );
         }
-        // Unified tool aliases: old names → new canonical names.
+        // Superseded tool names fold onto the canonical one. `SendMessage`
+        // and `send_message` normalize to DIFFERENT keys, so both must be
+        // listed in the table — losing either sends a model to the wrong
+        // destination or refuses it outright.
         assert_eq!(canonicalize_tool_name("Agent"), "agent_spawn");
         assert_eq!(canonicalize_tool_name("SendMessage"), "send");
         assert_eq!(canonicalize_tool_name("send_message"), "send");
+        assert_eq!(canonicalize_tool_name("send"), "send");
         assert_eq!(canonicalize_tool_name("TaskStop"), "pid_kill");
         assert_eq!(canonicalize_tool_name("TaskGet"), "pid_status");
         assert_eq!(canonicalize_tool_name("TaskList"), "pid_status");
@@ -9097,18 +9004,18 @@ mod tests {
     fn allowed_tools_resolves_deprecated_names_to_spec_names() {
         let registry = GlobalToolRegistry::builtin();
 
-        // Old names (TaskList, SendMessage, Agent, etc.) still have
-        // specs in mvp_tool_specs(). --allowedTools with these names
-        // must resolve to the SPEC name (not the dispatch alias) so
-        // that definitions() can filter by spec.name.
-        for (old_name, spec_name) in [
-            ("TaskList", "TaskList"),
-            ("TaskGet", "TaskGet"),
-            ("TaskStop", "TaskStop"),
-            ("TaskOutput", "TaskOutput"),
-            ("SendMessage", "SendMessage"),
-            ("Agent", "Agent"),
-            // New canonical names resolve to themselves
+        // A CC tool name has no spec of its own, so --allowedTools with one
+        // must resolve to the canonical tool it names — otherwise the flag
+        // would admit a name `definitions()` can never match against
+        // `spec.name`, silently allow-listing nothing.
+        for (requested, spec_name) in [
+            ("TaskList", "pid_status"),
+            ("TaskGet", "pid_status"),
+            ("TaskStop", "pid_kill"),
+            ("TaskOutput", "pid_output"),
+            ("SendMessage", "send"),
+            ("Agent", "agent_spawn"),
+            // Canonical names resolve to themselves.
             ("pid_status", "pid_status"),
             ("pid_kill", "pid_kill"),
             ("pid_output", "pid_output"),
@@ -9117,12 +9024,12 @@ mod tests {
             ("agent_list", "agent_list"),
         ] {
             let allowed = registry
-                .normalize_allowed_tools(&[old_name.to_string()])
-                .unwrap_or_else(|e| panic!("--allowedTools {old_name} should succeed: {e}"))
+                .normalize_allowed_tools(&[requested.to_string()])
+                .unwrap_or_else(|e| panic!("--allowedTools {requested} should succeed: {e}"))
                 .expect("should produce a non-empty set");
             assert!(
                 allowed.contains(spec_name),
-                "--allowedTools {old_name} must resolve to spec name \"{spec_name}\", got: {allowed:?}"
+                "--allowedTools {requested} must resolve to spec name \"{spec_name}\", got: {allowed:?}"
             );
         }
     }
@@ -9910,26 +9817,39 @@ mod tests {
         let matches = keyword_output["matches"].as_array().expect("matches");
         assert!(matches.iter().any(|value| value == "WebSearch"));
 
-        let selected = execute_tool("ToolSearch", &json!({"query": "select:Agent,Skill"}))
+        let selected = execute_tool("ToolSearch", &json!({"query": "select:agent_spawn,Skill"}))
             .expect("ToolSearch should succeed");
         let selected_output: serde_json::Value =
             serde_json::from_str(&selected).expect("valid json");
-        assert_eq!(selected_output["matches"][0], "Agent");
+        assert_eq!(selected_output["matches"][0], "agent_spawn");
         assert_eq!(selected_output["matches"][1], "Skill");
 
         let aliased = execute_tool("ToolSearch", &json!({"query": "AgentTool"}))
             .expect("ToolSearch should support tool aliases");
         let aliased_output: serde_json::Value = serde_json::from_str(&aliased).expect("valid json");
-        assert_eq!(aliased_output["matches"][0], "Agent");
+        assert_eq!(aliased_output["matches"][0], "agent_spawn");
         assert_eq!(aliased_output["normalized_query"], "agent");
 
-        let selected_with_alias =
-            execute_tool("ToolSearch", &json!({"query": "select:AgentTool,Skill"}))
+        // `select:` is exact, so a CC-trained model asking under CC's own
+        // spelling must still land on the canonical tool — that is the whole
+        // job of the alias table, and an empty result would leave the model
+        // with no way to discover the name it should have used.
+        for (cc_name, canonical) in [
+            ("select:Agent", "agent_spawn"),
+            ("select:SendMessage", "send"),
+            ("select:TaskStop", "pid_kill"),
+            ("select:TaskOutput", "pid_output"),
+            ("select:AgentTool", "agent_spawn"),
+        ] {
+            let out = execute_tool("ToolSearch", &json!({ "query": cc_name }))
                 .expect("ToolSearch alias select should succeed");
-        let selected_with_alias_output: serde_json::Value =
-            serde_json::from_str(&selected_with_alias).expect("valid json");
-        assert_eq!(selected_with_alias_output["matches"][0], "Agent");
-        assert_eq!(selected_with_alias_output["matches"][1], "Skill");
+            let out: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+            assert_eq!(
+                out["matches"][0], canonical,
+                "`{cc_name}` must resolve to `{canonical}`, got {:?}",
+                out["matches"]
+            );
+        }
     }
 
     #[test]

--- a/rust/crates/tools/src/managed_agent.rs
+++ b/rust/crates/tools/src/managed_agent.rs
@@ -25,7 +25,9 @@ use runtime::{
     ToolExecutor,
 };
 
-use crate::{execute_tool_with_backend, ProviderRuntimeClient};
+use crate::{
+    canonicalize_tool_name, execute_tool_with_backend, normalize_send_input, ProviderRuntimeClient,
+};
 
 /// Label key where `ManagedAgentService` stores the model id in the
 /// `AgentDescriptor.labels` map.
@@ -67,13 +69,10 @@ where
 
     // -- ApiClient: provider chain from model id --
     // The co-hosted agent is A2A-capable, so its tool set includes
-    // `send_message` (its ONLY, deliberate reply path — see the ping-pong fix).
+    // `send` (its ONLY, deliberate reply path — see the ping-pong fix).
     // The full tool set (file ops, etc.) is gated behind the agent-profile work;
-    // the duet needs only send_message.
-    let allowed_tools: BTreeSet<String> = ["send_message", "send"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    // the duet needs only `send`.
+    let allowed_tools: BTreeSet<String> = ["send"].iter().map(|s| s.to_string()).collect();
     let api_client = ProviderRuntimeClient::new(model, allowed_tools)
         .expect("failed to construct API client from model label");
 
@@ -100,15 +99,15 @@ where
         desc.zone_id.clone(),
     );
 
-    // -- ToolExecutor: file tools in-process via the VFS backend; `send_message`
+    // -- ToolExecutor: file tools in-process via the VFS backend; `send`
     // routes through the mailbox sender. --
     let tool_executor = ManagedToolExecutor { fs, send };
 
     // -- SystemPrompt: base managed-agent prompt + the A2A reply contract, so
     // the co-hosted model addresses its reply to the message's `<sender>` via
-    // `send_message` instead of guessing a recipient from the message text. The
+    // `send` instead of guessing a recipient from the message text. The
     // contract text lives in `spawn_task` next to the `[message from …]` framing
-    // and the `send_message` reply path it describes. --
+    // and the `send` reply path it describes. --
     let system_prompt = SystemPromptBuilder::new()
         .append_section(cohost_a2a_prompt_section(&desc.name))
         .build();
@@ -138,7 +137,7 @@ where
 /// in-process against the kernel trie.
 struct ManagedToolExecutor {
     fs: Arc<dyn FsBackend>,
-    /// The co-hosted agent's outbound-message capability. `send_message` is the
+    /// The co-hosted agent's outbound-message capability. `send` is the
     /// ONLY way this agent replies to a peer — the poll loop no longer
     /// auto-forwards turn output (the ping-pong fix), so a reply happens ONLY
     /// when the agent deliberately calls the tool.
@@ -150,13 +149,16 @@ impl ToolExecutor for ManagedToolExecutor {
         let input_value: serde_json::Value =
             serde_json::from_str(input).map_err(|e| ToolError::new(e.to_string()))?;
 
-        // `send_message` is the deliberate-reply path — an in-process mailbox
+        // `send` is the deliberate-reply path — an in-process mailbox
         // write bound to THIS agent's identity, not a file op. Routed through
         // the SHARED handler the standalone CLI executor also uses; only the
         // sender differs (this is the in-process kernel sender, standalone is
-        // the gRPC sender).
-        if tool_name == "send_message" || tool_name == "send" {
-            return handle_send_message(&self.send, input).map_err(ToolError::new);
+        // the gRPC sender). Matched on the canonical name so a model reaching
+        // for CC's `SendMessage` lands on the mailbox rather than falling
+        // through to the file-tool dispatcher.
+        if canonicalize_tool_name(tool_name) == "send" {
+            return handle_send_message(&self.send, &normalize_send_input(&input_value))
+                .map_err(ToolError::new);
         }
 
         // Offload the blocking in-process syscall to the blocking pool so a

--- a/rust/crates/tools/tests/agent_permission_bubble.rs
+++ b/rust/crates/tools/tests/agent_permission_bubble.rs
@@ -29,8 +29,8 @@ fn agent_tool_spec_schema() -> serde_json::Value {
     let specs = mvp_tool_specs();
     let agent = specs
         .into_iter()
-        .find(|s| s.name == "Agent")
-        .expect("Agent tool exists");
+        .find(|s| s.name == "agent_spawn")
+        .expect("agent_spawn tool exists");
     agent.input_schema.clone()
 }
 

--- a/rust/crates/tools/tests/coordinator_dispatch_guard.rs
+++ b/rust/crates/tools/tests/coordinator_dispatch_guard.rs
@@ -59,8 +59,8 @@ fn dispatch_rejects_bash_when_coordinator_mode_is_on() {
         "error must name the coordinator gate (got: `{err}`)"
     );
     assert!(
-        err.contains("Agent(") || err.contains("SendMessage"),
-        "error must instruct the model to delegate via Agent (got: `{err}`)"
+        err.contains("agent_spawn(") || err.contains("send_message"),
+        "error must instruct the model to delegate via agent_spawn (got: `{err}`)"
     );
 }
 
@@ -124,7 +124,7 @@ fn definitions_hides_write_tools_when_coordinator_mode_is_on() {
             "`{hidden}` MUST be hidden from LLM schema when coordinator mode is on"
         );
     }
-    for shown in ["Agent", "SendMessage", "TaskStop", "read_file"] {
+    for shown in ["agent_spawn", "send", "pid_kill", "read_file"] {
         assert!(
             names.contains(shown),
             "`{shown}` MUST remain visible in coordinator mode"
@@ -141,7 +141,7 @@ fn definitions_shows_write_tools_when_coordinator_mode_is_off() {
     let defs = registry.definitions(None);
     let names: std::collections::HashSet<_> = defs.iter().map(|d| d.name.as_str()).collect();
 
-    for shown in ["bash", "write_file", "edit_file", "Agent"] {
+    for shown in ["bash", "write_file", "edit_file", "agent_spawn"] {
         assert!(
             names.contains(shown),
             "with coordinator mode off, `{shown}` MUST be present in tool schema"

--- a/rust/crates/tools/tests/task_list_backgrounded.rs
+++ b/rust/crates/tools/tests/task_list_backgrounded.rs
@@ -184,8 +184,8 @@ fn tasklist_schema_advertises_backgrounded_only_field() {
     let specs = tools::mvp_tool_specs();
     let task_list = specs
         .into_iter()
-        .find(|s| s.name == "TaskList")
-        .expect("TaskList exists");
+        .find(|s| s.name == "pid_status")
+        .expect("pid_status exists");
     let bg = &task_list.input_schema["properties"]["backgrounded_only"];
     assert_eq!(bg["type"].as_str(), Some("boolean"));
 }


### PR DESCRIPTION
Implements the [Unified Agent/PID Tool design](https://s.shareone.vip/s/unified-agent-pid-tools) the rest of the way, and fixes the live bug that revealed it was only half-done.

## What went wrong

A model on a live cross-machine A2A session sent a reply, was told `Message sent to win-ai's inbox`, and ended its turn. The peer waited ten hours. The message had been written to a local `.sudocode-inbox/` file and never left the machine.

The model was not at fault. **Two independent defects** had to line up, and both are fixed here.

### 1. One capability, several advertised names

The design's migration table says each old name becomes a **deprecated alias** of one canonical tool. In practice both names stayed *advertised*, so the model saw synonyms and had to guess:

| Superseded | Canonical (design SSOT) |
|---|---|
| `SendMessage` + `send_message` | **`send`** |
| `Agent` | `agent_spawn` |
| `TaskStop` | `pid_kill` |
| `TaskGet` / `TaskList` | `pid_status` |
| `TaskOutput` | `pid_output` |
| — | `pid_fork`, `agent_list` |

Three messaging tools were live at once, differing only in which field carried the text, while only the literal name `send_message` was intercepted for nexus A2A. The tool list called `send` the "unified replacement", so the model picked it — and got the workspace mailbox.

Each capability now has **one** spec. `send` takes the union of what the three offered, and `body` is still accepted as an input alias for `message` (the design's `body`→`message` normalization) — `normalize_send_input` is now shared by the registry arm and the A2A intercept, so neither the name nor the field a model picks can decide where its message goes.

The alias table stays and stops being a deprecation shim: a Claude-trained model reaches for `Bash`/`Agent`/`TaskStop`/`SendMessage` from habit, and a refusal over spelling reads as the model declining to act.

### 2. `ExecuteExtraTool` was a second dispatch path

`send` is *deferred* — discovered via `ToolSearch`, invoked inside an `ExecuteExtraTool` envelope. That envelope dispatched straight to the registry, so **a model that named the tool correctly still routed locally**: the documented way to invoke it never consulted the mailbox sender.

Bypassed: nexus A2A routing, `ExitPlanMode`'s confirmation, bash/MCP progress, and **`--allowedTools`** — the envelope passed the gate as itself, then dispatched whatever it named.

The envelope is now unwrapped and re-entered into the same function, gate included. Recursion terminates because `ExecuteExtraTool` is a core tool and the unwrap refuses core tools.

Keeping `send` deferred is deliberate: Claude Code defers `SendMessage` too (`shouldDefer: true`), along with every `Task*` tool, while `Agent` stays core. The fix belongs in the envelope, not the classification.

## Latent bugs this surfaced

Six sites matched the raw model-supplied name and hand-listed the spellings they knew, so each had drifted:

| site | was |
|---|---|
| `PermissionPolicy::required_mode_for` | a miss falls through to `DangerFullAccess` — an unresolved spelling is not "unknown", it is **refused** under every mode below full access |
| `is_concurrency_safe_tool` | still listed `TaskGet`/`TaskList`/`TaskOutput` after the rename — both surviving tools had silently lost concurrent-batch eligibility |
| `coordinator_allowed_tools` | listed both spellings, still admitting names the tool list had stopped advertising |
| iocraft task panel | would go stale on every `pid_kill` |
| `bash` progress sink | a model spelling it `Bash` got no progress forwarding |
| `ToolSearch` | `select:` is exact, so `select:SendMessage` returned **nothing**; and keyword search compares *tokens* while the alias table is keyed by *names*, so `AgentTool` scored no better against `agent_spawn` than against `agent_list` |

Canonicalization moved to `runtime::tool_names`, below `tools`, so every one of these can reach it instead of keeping its own copy.

## Prompts

The coordinator prompt, the A2A peer contract, the co-host reply contract and the verification nudge now name only advertised tools. The A2A contract also states the delivery string to check — `message delivered to <peer>` vs anything mentioning an inbox is the only signal a human has that a message crossed the machine. `TaskCreate` now says its tasks are listed by `pid_status`; they share `global_task_registry()`, but nothing in the two names said so.

The wire envelope `{from,to,body}` is untouched: that is the a2a substrate's contract, not the tool's.

## Verification

- `cargo test --workspace` green on Windows, including the full PTY suite (mock backend).
- `cargo fmt --all` + `cargo clippy --workspace --all-targets` clean.
- `send_message_routing` covers every spelling (`send`, `SendMessage`, `send_message`), input shape (`message`, `body`) and wrapper (direct, `ExecuteExtraTool`), that the body survives the envelope, that the local path still works without A2A, and that the envelope is gated.
- **All three mutations verified red**: raw-name intercept fails the spelling cases; parallel envelope dispatch fails three of four including the allow-list hole; dropping the shared `body`→`message` normalization fails the shape cases.
- Two PTY regressions found and fixed during the sweep (`task_list_on_empty_registry_returns_zero_count`, `esc_cancels_turn_in_repl`) — both were the `required_mode_for` fallthrough, and both were confirmed passing on `main` first, so they were real regressions rather than flakes.
- `no_capability_is_advertised_under_two_names` fails if an alias key ever regains a spec of its own.