### PR TITLE
Warn in grep_search description about unbounded walks

### DIFF
--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -966,7 +966,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "grep_search",
-            description: "Search file contents with a regex pattern.",
+            description: "Search file contents with a regex pattern. WARNING: does NOT prune build/vendor directories (e.g. `target/`, `node_modules/`, `.git/`, `dist/`, `.venv/`) and will read large binaries — walking into a Rust `target/` or similar can hang for a long time. Always scope the search: pass an explicit `path` for a specific subtree you already know, and narrow the file set with `glob` (e.g. `*.rs`) or `type` (e.g. `rust`). Do not run against the workspace root without filters; if you must, set a caller-side timeout first.",
             input_schema: json!({
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Fixes #597

The `grep_search` tool does not prune build/vendor directories (`target/`, `node_modules/`, `.git/`, `dist/`, `.venv/`) and reads every matched file via `read_to_string`, so a broad walk into a Rust `target/` tree can hang on large binaries. This PR updates the tool description so the model always sees the warning and knows to scope searches with `path`, `glob`, or `type` filters (and set a caller-side timeout when a wide walk is unavoidable).

Generated with [Claude Code](https://claude.ai/code)