### PR TITLE
tools: accept 'question' alias for 'prompt' in AskUserQuestion items

### DIFF
--- a/rust/crates/engine-host/src/tool_executor.rs
+++ b/rust/crates/engine-host/src/tool_executor.rs
@@ -388,6 +388,10 @@ struct AskUserQuestionCliInput {
 #[serde(rename_all = "camelCase")]
 struct AskUserQuestionCliField {
     id: String,
+    // Accept `question` as an alias for `prompt`: the natural caller mistake
+    // (mirroring the tool's legacy top-level `question` field) otherwise fails
+    // the whole call with a cryptic "missing field `prompt`".
+    #[serde(alias = "question")]
     prompt: String,
     kind: Option<String>,
     required: Option<bool>,

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -976,7 +976,13 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
             None => tool_use_sse(
                 "toolu_ask_user_question",
                 "AskUserQuestion",
-                &[r#"{"question":"Which colour?","options":["red","blue"]}"#],
+                // Structured `questions[]` form using `question` per item (the
+                // natural alias for `prompt`). Exercises the alias so this
+                // roundtrip regresses if the item ever stops accepting it.
+                &[
+                    r#"{"questions":[{"id":"q1","question":"Which colour?","#,
+                    r#""options":[{"label":"red","value":"red"},{"label":"blue","value":"blue"}]}]}"#,
+                ],
             ),
         },
         Scenario::SleepOverMaxRoundtrip => match latest_tool_result(request) {
@@ -1472,7 +1478,14 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 "msg_ask_user_question_tool",
                 "toolu_ask_user_question",
                 "AskUserQuestion",
-                json!({"question": "Which colour?", "options": ["red", "blue"]}),
+                json!({"questions": [{
+                    "id": "q1",
+                    "question": "Which colour?",
+                    "options": [
+                        {"label": "red", "value": "red"},
+                        {"label": "blue", "value": "blue"}
+                    ]
+                }]}),
             ),
         },
         Scenario::SleepOverMaxRoundtrip => match latest_tool_result(request) {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -3855,6 +3855,11 @@ struct AskUserQuestionInput {
 #[serde(rename_all = "camelCase")]
 struct AskUserQuestionItem {
     id: String,
+    // Accept `question` as an alias so an item written with the legacy
+    // top-level field name (the natural mistake, since the tool also takes a
+    // top-level `question`) deserializes instead of failing the whole call
+    // with a cryptic "missing field `prompt`".
+    #[serde(alias = "question")]
     prompt: String,
     #[serde(default)]
     kind: Option<String>,


### PR DESCRIPTION
## Summary

Fixes a real bug in the AskUserQuestion tool: a call written with the structured questions[] form that names each item's field `question` (instead of `prompt`) failed the whole call with a cryptic `invalid tool input JSON: missing field prompt`. That is the natural caller mistake, because the same tool also accepts a legacy top-level `question` field.

Root cause: two structs deserialize this tool depending on the path, and neither accepted the alias: engine-host's AskUserQuestionCliField (interactive ACP/REPL prompter path) and tools' AskUserQuestionItem (stdin dispatch). Both now accept `question` as a serde alias for `prompt`.

## Commits
1. tools: accept question alias for prompt in both structs.
2. mock-anthropic-service: drive the AskUserQuestion roundtrip via the questions[] form so the existing ACP test guards the alias.

## Test plan

- Reproduced: with the mock on the question-per-item payload and no fix, acp_stdio_session_parked_on_ask_user_question_does_not_block_other_session failed with exactly `missing field prompt`. After the fix it passes.
- fmt + clippy clean for engine-host/tools/mock.
- Full workspace test/clippy matrix runs in CI.