### PR TITLE
tools: classify Agent alias as core

### DIFF
--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -7342,7 +7342,10 @@ const CORE_TOOLS: &[&str] = &[
 ];
 
 pub fn is_core_tool(name: &str) -> bool {
-    CORE_TOOLS.contains(&name)
+    // Compatibility aliases must share their canonical tool's visibility.
+    // Otherwise `Agent` is advertised as deferred even though it dispatches to
+    // core `agent_spawn`, causing ExecuteExtraTool to reject the call.
+    CORE_TOOLS.contains(&canonicalize_tool_name(name).as_str())
 }
 
 fn deferred_tool_specs() -> Vec<ToolSpec> {


### PR DESCRIPTION
Classify Agent compatibility aliases by canonical tool name so Agent is exposed consistently with core agent_spawn. Tests: cargo fmt --all --check; cargo test -p tools --lib core_definitions_excludes_deferred_tools -- --nocapture; live preset_statusline_setup_e2e.