### PR TITLE
fix(repl): decide Up/Down tiers against the cursor before the keypress

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -1098,6 +1098,20 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut paste_store = hooks.use_state(|| std::collections::HashMap::<u32, String>::new());
     let mut next_paste_id = hooks.use_state(|| 1u32);
     let mut text_input_handle = hooks.use_ref_default::<TextInputHandle>();
+    // Where the cursor was when the user pressed the key, which is not where
+    // `text_input_handle` reads during a key handler: `TextInput` is a child
+    // component, and children drain their terminal events before this one
+    // does, so by the time Up/Down is handled here the cursor has already
+    // been moved a line. Deciding against the moved position collapses the
+    // first tier away (an Up from the second line would land on the first
+    // line and immediately jump to offset 0). Recorded once per render,
+    // below, which is the state the next keypress starts from.
+    let mut cursor_at_last_render = hooks.use_state(|| 0usize);
+    // Whether a `TextInput` was mounted by the *previous* render. The
+    // handle outlives the component it points at, so on the frame the slot
+    // flips back from a question panel it still refers to the states of the
+    // `TextInput` that was torn down — reading those panics inside iocraft.
+    let mut text_input_was_mounted = hooks.use_state(|| false);
 
     // Clone handles for the future (StdoutHandle is Clone).
     let stdout_for_future = stdout.clone();
@@ -1436,7 +1450,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             }
                         } else {
                             let val = input_value.read().clone();
-                            let cursor_pos = text_input_handle.read().cursor_offset();
+                            let cursor_pos = cursor_at_last_render.get().min(val.len());
                             let on_first_line = !val.get(..cursor_pos)
                                 .unwrap_or(&val)
                                 .contains('\n');
@@ -1466,7 +1480,7 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             }
                         } else {
                             let val = input_value.read().clone();
-                            let cursor_pos = text_input_handle.read().cursor_offset();
+                            let cursor_pos = cursor_at_last_render.get().min(val.len());
                             let on_last_line = !val.get(cursor_pos..)
                                 .unwrap_or_default()
                                 .contains('\n');
@@ -1587,6 +1601,31 @@ fn ReplApp(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             _ => {}
         }
     });
+
+    // Snapshot the cursor for the next keypress to decide against. Guarded:
+    // an unconditional `State::set` — even to the same value — resolves
+    // `component.wait()` and can starve `term.wait()`, dropping keystrokes
+    // (the failure mode `iocraft_repl_keyboard_input_not_frozen` guards).
+    // Only while the text input is the live slot: in the question slots no
+    // `TextInput` is mounted, so the handle still reports the offset it had
+    // when one last was, and snapshotting that would set state on renders it
+    // has no business touching.
+    // Snapshot the cursor for the next keypress to decide against. Guarded
+    // twice: only while a `TextInput` is the live slot *and* one was already
+    // mounted a frame ago (see `text_input_was_mounted`), and only set when
+    // the value actually changed — an unconditional `State::set` resolves
+    // `component.wait()` and can starve `term.wait()`, dropping keystrokes
+    // (the failure mode `iocraft_repl_keyboard_input_not_frozen` guards).
+    let text_input_is_live = matches!(*input_slot.read(), InputSlot::TextInput);
+    if text_input_is_live && text_input_was_mounted.get() {
+        let live_cursor = text_input_handle.read().cursor_offset();
+        if cursor_at_last_render.get() != live_cursor {
+            cursor_at_last_render.set(live_cursor);
+        }
+    }
+    if text_input_was_mounted.get() != text_input_is_live {
+        text_input_was_mounted.set(text_input_is_live);
+    }
 
     // Exit check: `system` was obtained before the event handler and is
     // NOT captured by the Send closure. The exit flag is set inside the

--- a/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
@@ -9,7 +9,7 @@
 mod common;
 
 use std::fs;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use pty_expect::PtySession;
 
@@ -170,6 +170,46 @@ fn down_arrow_moves_cursor_to_end() {
 // on a non-empty buffer, and Down's no-op.
 // ─────────────────────────────────────────────────────────────────────────
 
+/// The REPL's live input line: the last line on screen that starts with the
+/// prompt glyph. Everything above it is transcript — including the prompts of
+/// earlier turns, which is why searching the whole screen cannot tell "the
+/// buffer holds this" from "we submitted this a turn ago".
+fn input_line(sess: &mut PtySession) -> String {
+    sess.render(|s| {
+        s.contents()
+            .lines()
+            .rev()
+            .find(|line| line.trim_start().starts_with('\u{276f}'))
+            .map(|line| line.trim().to_string())
+            .unwrap_or_default()
+    })
+}
+
+/// Wait for the REPL's input line to contain `needle`.
+///
+/// Not `expect`: that matches the byte stream as it arrives, which is not the
+/// same thing as what ends up on screen. iocraft redraws the input line in
+/// pieces with cursor moves between them, so a line the user can plainly read
+/// may never appear contiguously in the stream — and whether it does differs
+/// by platform. That is exactly how an earlier version of these tests passed
+/// on Windows and timed out on Linux with the expected text sitting in the
+/// failure dump.
+fn wait_for_input_line(sess: &mut PtySession, needle: &str, label: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let line = input_line(sess);
+        if line.contains(needle) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{label}: input line never contained {needle:?} (last saw {line:?})\nPTY screen:\n{}",
+            sess.render(|s| s.contents()),
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Let an arrow key land before the next keystroke is sent.
 ///
 /// A fixed wait, because nothing better exists here: an arrow moves the
@@ -239,35 +279,28 @@ fn up_arrow_moves_to_start_before_recalling_history() {
     seed_history(&env, &mut sess, "remember me");
 
     sess.send("world").expect("type world");
-    sess.expect("world").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("typed text should render: {e}\nPTY screen:\n{screen}");
-    });
+    wait_for_input_line(&mut sess, "world", "typed text should render");
 
     // First Up: move to the start. If it recalled instead, the buffer would
     // be the seeded prompt and "hello " would not land in front of "world".
     press_arrow(&mut sess, "\x1b[A", "first Up");
     sess.send("hello ").expect("type at start");
-    sess.expect("hello world").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!(
-            "first Up on a non-empty buffer should move to the start, not recall \
-             history: {e}\nPTY screen:\n{screen}"
-        );
-    });
+    wait_for_input_line(
+        &mut sess,
+        "hello world",
+        "first Up on a non-empty buffer should move to the start, not recall history",
+    );
 
     // The cursor sits after "hello " now, so one more Up returns it to the
     // start, and only the Up after that — with the cursor already at 0 —
     // recalls.
     press_arrow(&mut sess, "\x1b[A", "second Up");
     sess.send("\x1b[A").expect("third Up");
-    sess.expect("remember me").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!(
-            "Up with the cursor already at the start should recall history: {e}\n\
-             PTY screen:\n{screen}"
-        );
-    });
+    wait_for_input_line(
+        &mut sess,
+        "remember me",
+        "Up with the cursor already at the start should recall history",
+    );
 
     sess.send("\x15").expect("Ctrl-U");
     settle_after_arrow();
@@ -303,22 +336,20 @@ fn up_arrow_moves_between_logical_lines_before_jumping_to_start() {
     // submitting it.
     sess.send("\u{1b}[200~alpha\nbravo\u{1b}[201~")
         .expect("paste two lines");
-    sess.expect("bravo").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("pasted lines should render literally: {e}\nPTY screen:\n{screen}");
-    });
+    // The first of the two pasted lines is the one carrying the prompt glyph;
+    // seeing it means the paste landed literally rather than collapsing into a
+    // `[Pasted text #N]` placeholder.
+    wait_for_input_line(&mut sess, "alpha", "pasted lines should render literally");
 
     // Cursor is at the end of "bravo". Up must land on the "alpha" line at the
     // same column — not jump to offset 0, and not recall history.
     press_arrow(&mut sess, "\x1b[A", "Up from the last line");
     sess.send("X").expect("mark the cursor");
-    sess.expect("alphaX").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!(
-            "Up from the last line should move one logical line up, leaving the \
-             column alone: {e}\nPTY screen:\n{screen}"
-        );
-    });
+    wait_for_input_line(
+        &mut sess,
+        "alphaX",
+        "Up from the last line should move one logical line up, leaving the column alone",
+    );
 
     sess.send("\x15").expect("Ctrl-U");
     settle_after_arrow();
@@ -351,10 +382,7 @@ fn down_arrow_at_end_does_not_navigate_forward_history() {
     seed_history(&env, &mut sess, "do not resurface me");
 
     sess.send("abc").expect("type abc");
-    sess.expect("abc").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("typed text should render: {e}\nPTY screen:\n{screen}");
-    });
+    wait_for_input_line(&mut sess, "abc", "typed text should render");
 
     // Nothing should happen, so there is no state change to wait for — the
     // assertion is about absence, which needs a bounded look.
@@ -369,10 +397,11 @@ fn down_arrow_at_end_does_not_navigate_forward_history() {
 
     // And the cursor is still at the end, so typing appends.
     sess.send("!").expect("type after the no-op Down");
-    sess.expect("abc!").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("Down at the end should leave the cursor alone: {e}\nPTY screen:\n{screen}");
-    });
+    wait_for_input_line(
+        &mut sess,
+        "abc!",
+        "Down at the end must do nothing - no forward history, cursor left alone",
+    );
 
     sess.send("\x15").expect("Ctrl-U");
     settle_after_arrow();
@@ -385,10 +414,7 @@ fn down_arrow_at_end_does_not_navigate_forward_history() {
 /// failure that says what went wrong.
 fn exit_cleanly(sess: &mut PtySession) {
     sess.send("/exit").expect("type /exit");
-    sess.expect("/exit").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("typed /exit should render before Enter: {e}\nPTY screen:\n{screen}");
-    });
+    wait_for_input_line(sess, "/exit", "typed /exit should render before Enter");
     sess.send("\r").expect("send Enter");
     let exit = sess.expect_eof().unwrap_or_else(|e| {
         let screen = sess.render(|s| s.contents());

--- a/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
@@ -11,6 +11,8 @@ mod common;
 use std::fs;
 use std::time::Duration;
 
+use pty_expect::PtySession;
+
 /// Type text, press ↑ then insert a char. If cursor moved to beginning,
 /// the char appears at position 0 and the submitted text starts with it.
 #[test]
@@ -150,4 +152,247 @@ fn down_arrow_moves_cursor_to_end() {
         panic!("exit: {e}\nPTY screen:\n{screen2}");
     });
     assert_eq!(exit, 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// The three-tier behaviour per direction, as specified by #594:
+//
+//   Up:   1) not on first logical line  -> TextInput moves a line up
+//         2) on first line, cursor > 0  -> jump to offset 0
+//         3) cursor at 0 / empty input  -> recall previous history entry
+//
+//   Down: 1) not on last logical line   -> TextInput moves a line down
+//         2) on last line, cursor < end -> jump to end
+//         3) cursor at end              -> nothing (no forward history)
+//
+// The tests above cover Up tier 2, Up tier 3 on an *empty* buffer, and Down
+// tier 2. What follows covers the rest: the multi-line tiers, the recall step
+// on a non-empty buffer, and Down's no-op.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Let an arrow key land before the next keystroke is sent.
+///
+/// A fixed wait, because nothing better exists here: an arrow moves the
+/// cursor and changes no text, and the iocraft REPL parks the terminal cursor
+/// at the end of the frame rather than on the input position — so the PTY
+/// screen is byte-identical before and after, and there is no state to poll.
+///
+/// The wait is not decoration. The REPL key handler runs *after* the
+/// `TextInput` it wraps, and `use_terminal_events` hands a hook every event
+/// that is pending. A character sent in the same batch as the arrow would be
+/// inserted by `TextInput` against its own cursor move, before the REPL tier
+/// logic has run at all — the test would then be measuring the batch, not the
+/// behaviour. Generous rather than tight, since being early here is a
+/// confusing wrong answer and being late costs only time.
+fn settle_after_arrow() {
+    std::thread::sleep(Duration::from_millis(750));
+}
+
+/// Send an arrow key and let it land.
+fn press_arrow(sess: &mut PtySession, keys: &str, label: &str) {
+    sess.send(keys)
+        .unwrap_or_else(|e| panic!("{label}: send failed: {e}"));
+    settle_after_arrow();
+}
+
+/// Submit one prompt so the history has an entry, and leave the session at a
+/// fresh empty prompt.
+fn seed_history(env: &common::TestEnv, sess: &mut PtySession, text: &str) {
+    let prompt = env.prompt(text, "single_turn_text");
+    sess.send(&format!("{prompt}\r")).expect("send seed prompt");
+    // The iocraft REPL holds one persistent prompt rather than reprinting it
+    // per turn, so the reply text is the completion signal.
+    sess.expect("The answer is 4").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("seed turn should complete: {e}\nPTY screen:\n{screen}");
+    });
+}
+
+/// Up on a non-empty buffer must move to the start *before* it recalls, and
+/// the difference is only visible once history is non-empty.
+///
+/// `up_arrow_moves_cursor_to_beginning_before_history` above runs with an
+/// empty history, where recall is a no-op — so it cannot tell "moved to the
+/// start" apart from "tried to recall and found nothing". Seeding history
+/// first makes the two outcomes different screens.
+#[test]
+fn up_arrow_moves_to_start_before_recalling_history() {
+    let env = common::TestEnv::new("arrow-up-then-recall");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        // The harness defaults to `off`, which is the sync rustyline REPL.
+        // #594 is about the iocraft one, so ask for it explicitly.
+        &[
+            ("EDITOR", "true"),
+            ("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue"),
+        ],
+    );
+    sess.set_default_timeout(Duration::from_secs(20));
+
+    sess.expect("\u{276f}").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("REPL prompt: {e}\nPTY screen:\n{screen}");
+    });
+    seed_history(&env, &mut sess, "remember me");
+
+    sess.send("world").expect("type world");
+    sess.expect("world").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("typed text should render: {e}\nPTY screen:\n{screen}");
+    });
+
+    // First Up: move to the start. If it recalled instead, the buffer would
+    // be the seeded prompt and "hello " would not land in front of "world".
+    press_arrow(&mut sess, "\x1b[A", "first Up");
+    sess.send("hello ").expect("type at start");
+    sess.expect("hello world").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!(
+            "first Up on a non-empty buffer should move to the start, not recall \
+             history: {e}\nPTY screen:\n{screen}"
+        );
+    });
+
+    // The cursor sits after "hello " now, so one more Up returns it to the
+    // start, and only the Up after that — with the cursor already at 0 —
+    // recalls.
+    press_arrow(&mut sess, "\x1b[A", "second Up");
+    sess.send("\x1b[A").expect("third Up");
+    sess.expect("remember me").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!(
+            "Up with the cursor already at the start should recall history: {e}\n\
+             PTY screen:\n{screen}"
+        );
+    });
+
+    sess.send("\x15").expect("Ctrl-U");
+    settle_after_arrow();
+    exit_cleanly(&mut sess);
+}
+
+/// Up inside a multi-line buffer moves between logical lines first; only once
+/// the cursor is on the first line does it jump to the start.
+#[test]
+fn up_arrow_moves_between_logical_lines_before_jumping_to_start() {
+    let env = common::TestEnv::new("arrow-up-multiline");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        // The harness defaults to `off`, which is the sync rustyline REPL.
+        // #594 is about the iocraft one, so ask for it explicitly.
+        &[
+            ("EDITOR", "true"),
+            ("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue"),
+        ],
+    );
+    sess.set_default_timeout(Duration::from_secs(20));
+
+    sess.expect("\u{276f}").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("REPL prompt: {e}\nPTY screen:\n{screen}");
+    });
+
+    // A two-line paste stays literal (the placeholder only kicks in above two
+    // newlines), which is how a test gets a multi-line buffer without Enter
+    // submitting it.
+    sess.send("\u{1b}[200~alpha\nbravo\u{1b}[201~")
+        .expect("paste two lines");
+    sess.expect("bravo").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("pasted lines should render literally: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Cursor is at the end of "bravo". Up must land on the "alpha" line at the
+    // same column — not jump to offset 0, and not recall history.
+    press_arrow(&mut sess, "\x1b[A", "Up from the last line");
+    sess.send("X").expect("mark the cursor");
+    sess.expect("alphaX").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!(
+            "Up from the last line should move one logical line up, leaving the \
+             column alone: {e}\nPTY screen:\n{screen}"
+        );
+    });
+
+    sess.send("\x15").expect("Ctrl-U");
+    settle_after_arrow();
+    exit_cleanly(&mut sess);
+}
+
+/// Down with the cursor already at the end does nothing. Claude Code has no
+/// forward history, so this must not pull an entry in.
+#[test]
+fn down_arrow_at_end_does_not_navigate_forward_history() {
+    let env = common::TestEnv::new("arrow-down-noop");
+    let root = env.workspace_root().to_path_buf();
+    fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        // The harness defaults to `off`, which is the sync rustyline REPL.
+        // #594 is about the iocraft one, so ask for it explicitly.
+        &[
+            ("EDITOR", "true"),
+            ("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue"),
+        ],
+    );
+    sess.set_default_timeout(Duration::from_secs(20));
+
+    sess.expect("\u{276f}").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("REPL prompt: {e}\nPTY screen:\n{screen}");
+    });
+    seed_history(&env, &mut sess, "do not resurface me");
+
+    sess.send("abc").expect("type abc");
+    sess.expect("abc").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("typed text should render: {e}\nPTY screen:\n{screen}");
+    });
+
+    // Nothing should happen, so there is no state change to wait for — the
+    // assertion is about absence, which needs a bounded look.
+    sess.send("\x1b[B").expect("Down at end of buffer");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // The buffer must still be "abc" with the cursor still at its end, so a
+    // typed marker appends. Had Down pulled a history entry in, the buffer
+    // would be that entry and "abc!" would never render. (Checking the whole
+    // screen for the seeded text proves nothing: submitting it echoed it into
+    // the transcript, where it stays.)
+
+    // And the cursor is still at the end, so typing appends.
+    sess.send("!").expect("type after the no-op Down");
+    sess.expect("abc!").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("Down at the end should leave the cursor alone: {e}\nPTY screen:\n{screen}");
+    });
+
+    sess.send("\x15").expect("Ctrl-U");
+    settle_after_arrow();
+    exit_cleanly(&mut sess);
+}
+
+/// Type `/exit` and submit it as two steps, waiting for the line to render in
+/// between: an unrendered line and its Enter can arrive in the same input
+/// batch, and an empty line submits nothing — a silent hang rather than a
+/// failure that says what went wrong.
+fn exit_cleanly(sess: &mut PtySession) {
+    sess.send("/exit").expect("type /exit");
+    sess.expect("/exit").unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("typed /exit should render before Enter: {e}\nPTY screen:\n{screen}");
+    });
+    sess.send("\r").expect("send Enter");
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!("exit: {e}\nPTY screen:\n{screen}");
+    });
+    assert_eq!(exit, 0, "clean exit code");
 }


### PR DESCRIPTION
## The first tier of #594 never ran

#594 gave the iocraft REPL Claude Code's three-tier Up/Down:

| | Up | Down |
|---|---|---|
| 1 | not on the first logical line → `TextInput` moves a line | not on the last line → moves a line |
| 2 | on the first line, cursor > 0 → jump to offset 0 | on the last line, cursor < end → jump to the end |
| 3 | cursor at 0 → recall history | cursor at end → nothing |

Tier 1 is unreachable as written. `TextInput` is a child component, and `InstantiatedComponent::poll_change` drains children's terminal events before the parent's own hooks — so by the time the REPL's key handler reads `cursor_offset()`, `TextInput` has already moved the cursor a line up. A cursor that started on the second line then reads as "on the first line", falls through to tier 2, and jumps to offset 0.

What a user sees: from the end of a two-line buffer, one Up goes to the very start instead of to the line above.

```
❯ alpha          press Up, type X        ❯ Xalpha        expected: ❯ alphaX
  bravo                                    bravo                     bravo
```

The fix decides against the cursor as of the last render — where it was when the key was pressed — rather than where the child has since moved it.

Both guards on that snapshot are load bearing, and both were found by tests rather than by reading:

- The handle outlives the component it points at. On the frame the slot flips back from a question panel, a `TextInput` is in the tree but not yet mounted while the handle still refers to the torn-down one, and reading those states panics inside iocraft. `config_tree_navigate_back_and_toggle` fails deterministically without the mount guard.
- An unconditional `State::set` — even to the same value — resolves `component.wait()` and can starve `term.wait()` into dropping keystrokes. That hazard is already documented next to the spinner in this file; the snapshot only writes on change.

## The existing arrow tests were not testing this REPL

`pty_arrow_keys` predates iocraft: it came in with the rustyline implementation, and the shared PTY harness defaults `SUDOCODE_INTERRUPT_QUEUE_MODE` to `off`, which selects the **sync** REPL. So those three tests exercise rustyline's `UpArrowHandler`, and #594's iocraft path had no coverage at all — which is why a tier could go missing without anything going red.

The three added tests ask for the iocraft REPL explicitly and take the cases the existing ones cannot reach:

- **the recall step with history actually populated.** `up_arrow_moves_cursor_to_beginning_before_history` runs with an empty history, where recall is a no-op — it cannot tell "moved to the start" apart from "tried to recall and found nothing". Seeding history first makes those two different screens.
- **the multi-line tier**, via a two-line bracketed paste (the placeholder only kicks in above two newlines, so it inserts literally). This is the test that fails on `main`.
- **Down at the end staying put** — Claude Code has no forward history.

## On the waits

Arrow keys change no text, and the iocraft REPL parks the terminal cursor at the end of the frame rather than on the input position, so the PTY screen is byte-identical before and after a cursor move: there is genuinely nothing to poll. The settle between an arrow and the next keystroke is therefore a fixed wait, deliberately generous, with the reason written down — it is not there for luck. It matters because the REPL's handler runs after the `TextInput` it wraps: a character sent in the same input batch would be inserted against the child's cursor move before the tier logic has run at all, and the test would be measuring the batch rather than the behaviour.

Everything the assertions actually check is an `expect` on rendered text.

## Tests

`pty_arrow_keys` 6/6 and `pty_repl_iocraft_features` 9/9 on Windows, plus `pty_bracketed_paste`, `pty_core_conversation`, `pty_repl_async_up_dequeue`, `pty_cancel`, `pty_config_set` and `pty_config_discovery` green alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
