### PR TITLE
cli: stop echoing the turn status line to scrollback

### DIFF
--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -3829,11 +3829,12 @@ impl LiveCli {
             account: account.name(),
         });
         match (ui, output) {
-            // Persist in ChromeSlot (visible until next turn) AND scrollback
-            // (survives scroll, visible in session replay).
-            (Some(ui), Some(out)) => {
+            // Show in the ChromeSlot only (visible until the next turn). The
+            // status line is deliberately NOT echoed to scrollback: the
+            // ChromeSlot already renders it above the separator, and printing
+            // it again duplicated the line in the terminal history.
+            (Some(ui), Some(_)) => {
                 ui.set_turn_result(&line);
-                out.println(&line);
             }
             (Some(ui), None) => ui.set_turn_result(&line),
             (None, Some(out)) => out.println(&line),

--- a/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_raw_mode_line_endings.rs
@@ -105,9 +105,9 @@ fn bash_turn_uses_crlf_and_does_not_staircase() {
     // the legacy `└ ` or the current `⏺` format — both must end CRLF.
     sess.expect("(?:└ |⏺)[^\n]*\r\n")
         .expect("tool-result line should end with CRLF, not a bare LF");
-    // The status line is printed to scrollback AND persisted in the
-    // StatusSlot::TurnResult ChromeSlot. The scrollback println is the
-    // reliable sync point for PTY expects.
+    // The status line is rendered in the StatusSlot::TurnResult ChromeSlot,
+    // above the upper separator. (It is no longer echoed to scrollback — that
+    // duplicated the line in history.) The ChromeSlot line is the sync point.
     sess.expect("ctx ").expect("turn status line");
     sess.expect("─{20,}")
         .expect("separator redrawn after the status line");


### PR DESCRIPTION
## Summary

The per-turn status line (model, turn, tokens, cost, ctx, branch) was rendered twice under the iocraft REPL: once in the StatusSlot::TurnResult ChromeSlot (above the separator) and once echoed to scrollback via out.println. They are identical, so every finished turn showed the line twice — the top one is the live statusbar, the one below is the leftover scrollback copy.

Fix: in the (Some(ui), Some(output)) arm, keep only the ChromeSlot copy and drop the scrollback println. The non-iocraft path (None, Some(out)) has no ChromeSlot and still prints to scrollback, so plain-output modes are unchanged.

## Test plan

- Updated the pty_raw_mode_line_endings comment; the ChromeSlot line still carries `ctx ` and renders above the separator, so the ctx-then-separator ordering the test asserts still holds.
- Ran mock PTY suites: pty_raw_mode_line_endings, pty_spinner_token_counter, pty_repl_async_queue, pty_memory, pty_plan_confirm, pty_bash_streaming — all green.
- fmt + clippy clean.
- Full workspace test/clippy matrix runs in CI.