### PR TITLE
fix(test): prove typed input rendered by reading the prompt line, not the stream

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -34,7 +34,7 @@
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use mock_anthropic_service::{MockAnthropicService, SCENARIO_PREFIX};
 use pty_expect::{PtySession, Result};
@@ -70,6 +70,52 @@ pub const LIVE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Locate the compiled `scode` binary for the current test run.
 #[must_use]
+/// The REPL's input-line marker. The footer and banner never carry it, so a
+/// line containing it is the line the user types on.
+const PROMPT_MARKER: &str = "\u{276f}";
+
+/// Block until the REPL's input line shows `text`, then return.
+///
+/// Use this — not `expect()` — to prove that typed characters landed.
+/// `expect()` matches the unconsumed PTY BYTE STREAM, and iocraft redraws the
+/// whole screen whenever anything changes, so every redraw re-emits the
+/// permanent footer: `… /help for commands · /exit to quit …`. A stream match
+/// on `/exit` is therefore satisfied by chrome that was already on screen
+/// before a single character was typed, and the redraw that satisfies it need
+/// not have anything to do with the keystrokes — the Ctrl-C hint expiring
+/// three seconds later is enough.
+///
+/// What follows such a guard is an Enter racing an input line that may still
+/// be empty. Enter on an empty line submits nothing, so the REPL stays up and
+/// the test learns about it only when its exit budget runs out, with a screen
+/// showing a bare prompt and no clue why. Reading the prompt line off the
+/// RENDERED SCREEN is what actually proves the characters arrived.
+///
+/// # Panics
+/// When the input line has not shown `text` within `budget`; the message
+/// carries `context` and the rendered screen.
+pub fn expect_input_line(sess: &PtySession, text: &str, budget: Duration, context: &str) {
+    let deadline = Instant::now() + budget;
+    loop {
+        let shown = sess.render(|screen| {
+            screen
+                .contents()
+                .lines()
+                .any(|line| line.contains(PROMPT_MARKER) && line.contains(text))
+        });
+        if shown {
+            return;
+        }
+        if Instant::now() >= deadline {
+            let screen = sess.render(|s| s.contents());
+            panic!(
+                "{context}: the input line never showed {text:?} within {budget:?}\nPTY:\n{screen}"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 pub fn scode_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_scode"))
 }

--- a/rust/crates/rusty-sudocode-cli/tests/interrupt_e2e.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/interrupt_e2e.rs
@@ -38,6 +38,16 @@ fn sigint_during_bash_tool_returns_interrupted_result_without_continuing_turn() 
     fs::create_dir_all(&home).expect("home should exist");
     write_config(&config_home, &base_url);
 
+    // Arm the interrupt BEFORE `scode` exists. The window it has to land in is
+    // the tool's `sleep 30`, which opens the moment the model returns its bash
+    // call — so anything expensive done after the spawn is done inside that
+    // window. On Windows arming compiles a P/Invoke shim, which on a loaded
+    // runner outlasts 30s: the sleep finished, the turn completed, and the
+    // interrupt had nothing left to interrupt. Paying the whole cost up front
+    // is what makes that impossible rather than unlikely. See `ArmedInterrupt`.
+    let interrupt = ArmedInterrupt::arm(&workspace);
+    interrupt.wait_until_armed(Duration::from_secs(120));
+
     let prompt = format!("{SCENARIO_PREFIX}bash_interrupt_long_running");
     let mut command = Command::new(env!("CARGO_BIN_EXE_scode"));
     command
@@ -79,22 +89,14 @@ fn sigint_during_bash_tool_returns_interrupted_result_without_continuing_turn() 
 
     let mut child = ChildGuard(child);
 
-    // Arm the interrupt *now*, before the window it has to land in opens.
-    // The window is the tool's `sleep 30`; on Windows arming means compiling
-    // a P/Invoke shim, which on a cold runner can take longer than the whole
-    // window. Paying that cost up front is what keeps the interrupt inside
-    // it. See `ArmedInterrupt`.
-    let interrupt = ArmedInterrupt::arm(child.id(), &workspace);
-
     // Generous: this is a liveness wait, not the assertion. Under a parallel
     // `cargo test --workspace` the machine is running many other `scode`
     // children, and 10s was not always enough for this one to start and reach
     // the mock server.
     wait_for_message_request(&runtime, &server, 1, Duration::from_secs(60));
-    interrupt.wait_until_armed(Duration::from_secs(120));
     thread::sleep(Duration::from_millis(1500));
     assert_running(&mut child, "before the interrupt is fired");
-    interrupt.fire();
+    interrupt.fire(child.id());
 
     let status = wait_for_exit(&mut child, Duration::from_secs(60))
         .expect("scode should exit after the interrupt");
@@ -253,7 +255,6 @@ fn assert_running(child: &mut ChildGuard, when: &str) {
 /// what the assertion is about. `arm` runs before the turn, `wait_until_armed`
 /// confirms it finished, and only then does `fire` deliver.
 struct ArmedInterrupt {
-    pid: u32,
     #[cfg(windows)]
     helper: std::process::Child,
     #[cfg(windows)]
@@ -266,16 +267,16 @@ struct ArmedInterrupt {
 /// Nothing to prepare, so arming is bookkeeping and the wait returns at once.
 #[cfg(unix)]
 impl ArmedInterrupt {
-    fn arm(pid: u32, _workspace: &std::path::Path) -> Self {
-        Self { pid }
+    fn arm(_workspace: &std::path::Path) -> Self {
+        Self {}
     }
 
     fn wait_until_armed(&self, _timeout: Duration) {}
 
-    fn fire(self) {
+    fn fire(self, pid: u32) {
         let status = Command::new("kill")
             .arg("-INT")
-            .arg(self.pid.to_string())
+            .arg(pid.to_string())
             .status()
             .expect("kill should launch");
         assert!(status.success(), "kill -INT should succeed");
@@ -304,7 +305,14 @@ impl ArmedInterrupt {
     /// `FreeConsole` before it can attach to the target's console, and
     /// nothing that depends on the helper's console can be relied on across
     /// that call.
-    fn arm(pid: u32, workspace: &std::path::Path) -> Self {
+    ///
+    /// The target pid arrives in the go-ahead file rather than being baked
+    /// into the script, which is what lets the whole compile happen before
+    /// `scode` is even spawned. Baked in, arming could only start once the
+    /// child had a pid — so the compile ran while the window it had to land
+    /// in was already open, and on a loaded runner the `sleep 30` finished
+    /// first and the turn completed with nothing to interrupt.
+    fn arm(workspace: &std::path::Path) -> Self {
         const CTRL_BREAK_EVENT: u32 = 1;
         let ready_path = workspace.join("interrupt-helper-ready");
         let go_path = workspace.join("interrupt-helper-go");
@@ -317,10 +325,17 @@ $signature = @'
 '@
 $kernel32 = Add-Type -MemberDefinition $signature -Name 'Kernel32' -Namespace 'Interrupt' -PassThru
 New-Item -ItemType File -Path '{ready}' -Force | Out-Null
-while (-not (Test-Path -LiteralPath '{go}')) {{ Start-Sleep -Milliseconds 20 }}
+$targetPid = 0
+while ($targetPid -eq 0) {{
+  if (Test-Path -LiteralPath '{go}') {{
+    $raw = (Get-Content -LiteralPath '{go}' -Raw -ErrorAction SilentlyContinue)
+    if ($raw) {{ $parsed = 0; if ([uint32]::TryParse($raw.Trim(), [ref]$parsed)) {{ $targetPid = $parsed }} }}
+  }}
+  if ($targetPid -eq 0) {{ Start-Sleep -Milliseconds 20 }}
+}}
 [void]$kernel32::FreeConsole()
-if (-not $kernel32::AttachConsole({pid})) {{ exit 2 }}
-if (-not $kernel32::GenerateConsoleCtrlEvent({CTRL_BREAK_EVENT}, {pid})) {{ exit 3 }}
+if (-not $kernel32::AttachConsole($targetPid)) {{ exit 2 }}
+if (-not $kernel32::GenerateConsoleCtrlEvent({CTRL_BREAK_EVENT}, $targetPid)) {{ exit 3 }}
 exit 0
 "#,
             ready = ready_path.display(),
@@ -333,7 +348,6 @@ exit 0
             .spawn()
             .expect("powershell should launch");
         Self {
-            pid,
             helper,
             ready_path,
             go_path,
@@ -352,14 +366,13 @@ exit 0
     }
 
     /// Release the helper and wait for it to report what the Win32 calls did.
-    fn fire(self) {
+    fn fire(self, pid: u32) {
         let Self {
-            pid,
-            helper,
-            go_path,
-            ..
+            helper, go_path, ..
         } = self;
-        fs::write(&go_path, b"").expect("go marker should be written");
+        // The pid IS the go-ahead: the helper spins until this parses, so an
+        // empty or half-written file simply keeps it waiting.
+        fs::write(&go_path, pid.to_string().as_bytes()).expect("go marker should be written");
         let output = helper
             .wait_with_output()
             .expect("console-interrupt helper should exit");

--- a/rust/crates/rusty-sudocode-cli/tests/pty_bracketed_paste.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_bracketed_paste.rs
@@ -214,10 +214,12 @@ fn typing_still_works_while_bracketed_paste_enabled() {
     let mut sess = spawn_iocraft_repl(&env);
 
     sess.send("/exit").expect("type /exit");
-    sess.expect("/exit").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("typed text must render while VT input is active: {e}\nPTY:\n{screen}");
-    });
+    common::expect_input_line(
+        &sess,
+        "/exit",
+        Duration::from_secs(10),
+        "typed text must render while VT input is active",
+    );
 
     sess.send("\r").expect("press Enter");
     let exit = sess.expect_eof().unwrap_or_else(|e| {

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -56,13 +56,15 @@ fn iocraft_repl_keyboard_input_not_frozen() {
     // appear in the iocraft TextInput and be rendered to the PTY.
     sess.send("/exit").expect("type /exit");
 
-    // Wait for iocraft to render the typed text. If the render loop is
-    // starving term.wait() (the bug), this will timeout — the text
-    // never appears because key events are never distributed.
-    sess.expect("/exit").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("typed text must appear in terminal (keyboard input frozen?): {e}\nPTY:\n{screen}");
-    });
+    // Wait for iocraft to render the typed text on the INPUT LINE. If the
+    // render loop is starving term.wait() (the bug), this times out — the
+    // characters never appear because key events are never distributed.
+    common::expect_input_line(
+        &sess,
+        "/exit",
+        Duration::from_secs(10),
+        "typed text must appear in terminal (keyboard input frozen?)",
+    );
 
     // Now press Enter to submit /exit and verify clean process exit.
     sess.send("\r").expect("press Enter");
@@ -157,10 +159,12 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
     // race, and the failure is silent — an empty line submits nothing, so
     // the test learns about it 60s later as "no EOF" with no clue why.
     sess.send("/exit").expect("type /exit");
-    sess.expect("/exit").unwrap_or_else(|e| {
-        let screen = sess.render(|s| s.contents());
-        panic!("typed /exit should render before Enter: {e}\nPTY:\n{screen}");
-    });
+    common::expect_input_line(
+        &sess,
+        "/exit",
+        Duration::from_secs(10),
+        "typed /exit should render before Enter",
+    );
     sess.send("\r").expect("send Enter");
     sess.set_default_timeout(EXIT_BUDGET);
     let exit = sess.expect_eof().unwrap_or_else(|e| {


### PR DESCRIPTION
Fixes the recurring macOS failure of `iocraft_repl_ctrlc_hint_in_footer` on `main`.

## The failure

It has gone red on `main` at least three times — #600, #607, and the #603 merge — always on macOS, always the same shape: the assertion under test **passes**, then the process never exits and the test dies 60s later on `timeout waiting for pattern: <child exit>`, with a screen showing a bare prompt and no clue why.

## Why the existing guard never worked

All three affected sites do this:

```rust
sess.send("/exit");
sess.expect("/exit");   // "typed text must render before Enter"
sess.send("\r");
```

`expect()` matches the **unconsumed PTY byte stream**. The REPL's permanent footer reads:

```
⏵⏵ read-only · /help for commands · /exit to quit · Tab for /commands
                                     ^^^^^
```

iocraft redraws the whole screen whenever anything changes, so that footer re-enters the stream on the first keystroke — and in the Ctrl-C test, the hint expiring three seconds later is redraw enough on its own. **The match is satisfied by chrome that was on screen before a single character was typed.**

So the Enter that follows races an input line that may still be empty. Enter on an empty line submits nothing, the REPL stays up, and the failure surfaces a minute later as a missing EOF. The test's own comment says this guard exists to prevent exactly that race.

## The fix

`common::expect_input_line` reads the **rendered screen** and looks only at the line carrying the prompt marker — which the footer and banner never have.

## Reproduced deterministically, on Windows

By not typing `/exit` at all:

| guard | result |
|---|---|
| old (stream) | **passes**, then `timeout after 60s waiting for <child exit>` — byte-for-byte the CI signature |
| new (screen) | fails in 10s: `the input line never showed "/exit"` |

That control run is the evidence this is the right root cause, not a plausible-looking one.

## Blast radius

Two other sites had the same vacuous guard, and there it was load-bearing for the very thing those tests exist to catch:

- `iocraft_repl_keyboard_input_not_frozen`
- `typing_still_works_while_bracketed_paste_enabled`

Both claim to prove keystrokes reach the render loop. Both would have passed with keyboard input **entirely frozen**.

## Verification

- `pty_repl_iocraft_features` 9/9 and `pty_bracketed_paste` 6/6 green on Windows.
- `cargo check -p rusty-sudocode-cli --all-targets` clean (`common/mod.rs` is shared by every PTY test).
- Mutation-verified in both directions, as tabulated above.