### PR TITLE
feat(agent-types): one registry, and the catalog moves to the prompt

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -4351,6 +4351,33 @@ pub fn render_skills_prompt_section(
     render_skills_section(&skills)
 }
 
+/// Every dynamic system-prompt section derivable from the working directory
+/// alone, in the order a live session emits them.
+///
+/// The live runtime (`engine_host::runtime_build`) and the `scode
+/// system-prompt` preview both render from this one list, so the preview
+/// cannot claim a prompt the session does not send. They used to each carry
+/// their own sequence of pushes, kept in step by a comment, and the preview had
+/// already fallen behind.
+///
+/// Sections needing more than a cwd stay with the runtime builder and are the
+/// documented reason the preview is a subset: the deferred-tool listing needs
+/// the tool registry, and the A2A identity needs a dialed session.
+#[must_use]
+pub fn cwd_prompt_sections(
+    cwd: &Path,
+    plugin_load_outcome: Option<&PluginLoadOutcome>,
+) -> Vec<String> {
+    let mut sections = Vec::new();
+    // Skills first: the model should know what it can load before it is told
+    // what it can delegate to.
+    if let Some(section) = render_skills_prompt_section(cwd, plugin_load_outcome) {
+        sections.push(section);
+    }
+    sections.push(runtime::agent_types::render_agent_types_prompt_section(cwd));
+    sections
+}
+
 fn render_skill_install_report(skill: &InstalledSkill) -> String {
     let mut lines = vec![
         "Skills".to_string(),

--- a/rust/crates/engine-host/src/runtime_build.rs
+++ b/rust/crates/engine-host/src/runtime_build.rs
@@ -406,6 +406,14 @@ pub(crate) fn build_runtime_with_plugin_state(
     if let Some(section) = render_skills_prompt_section(cwd, Some(&plugin_load_outcome)) {
         system_prompt.dynamic_sections.push(section);
     }
+    // Agent-type catalog: inject `<available-agent-types>` so the model knows
+    // what to pass as `agent_spawn`'s `agent`. It lives here, and NOT in
+    // `agent_spawn`'s description, because that description sits in the cached
+    // tools block while this list changes whenever a `.md` agent is added —
+    // see `runtime::agent_types` for the cache measurement behind the split.
+    system_prompt
+        .dynamic_sections
+        .push(runtime::agent_types::render_agent_types_prompt_section(cwd));
     // Deferred tools listing: inject `<available-deferred-tools>` so the
     // model knows which tools exist beyond the core set visible in the API
     // `tools` array. Discovery via ToolSearch, execution via ExecuteExtraTool.

--- a/rust/crates/engine-host/src/runtime_build.rs
+++ b/rust/crates/engine-host/src/runtime_build.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use commands::render_skills_prompt_section;
+use commands::cwd_prompt_sections;
 use engine_core::{AuthMode, EngineApiClient};
 use plugins::{PluginLoadOutcome, PluginManager, PluginRegistry};
 use runtime::{ConfigLoader, ConversationRuntime, PermissionMode, Session, SystemPrompt};
@@ -398,22 +398,23 @@ pub(crate) fn build_runtime_with_plugin_state(
         }
     };
     let mut system_prompt = config.system_prompt.clone();
-    // Skills are listed so the model can name and load one without the user
-    // having to know it exists. Plugin-provided skill roots are included via
-    // `plugin_load_outcome`, so a plugin can inject skills that the prompt then
-    // advertises. This runs for the REPL, `--print`, and ACP sessions alike:
-    // they all land in this function via `build_runtime_for_cwd`.
-    if let Some(section) = render_skills_prompt_section(cwd, Some(&plugin_load_outcome)) {
-        system_prompt.dynamic_sections.push(section);
-    }
-    // Agent-type catalog: inject `<available-agent-types>` so the model knows
-    // what to pass as `agent_spawn`'s `agent`. It lives here, and NOT in
-    // `agent_spawn`'s description, because that description sits in the cached
-    // tools block while this list changes whenever a `.md` agent is added —
-    // see `runtime::agent_types` for the cache measurement behind the split.
+    // The cwd-derived sections — the skills listing (so the model can name and
+    // load a skill without the user knowing it exists, plugin-provided roots
+    // included via `plugin_load_outcome`) and the `<available-agent-types>`
+    // catalog (so it knows what to pass as `agent_spawn`'s `agent`). Shared
+    // with the `scode system-prompt` preview via `commands::cwd_prompt_sections`
+    // so the two cannot drift.
+    //
+    // The catalog lives here and NOT in `agent_spawn`'s description because
+    // that description sits in the cached tools block while this list changes
+    // whenever a `.md` agent is added — see `runtime::agent_types` for the
+    // cache measurement behind the split.
+    //
+    // This runs for the REPL, `--print`, and ACP sessions alike: they all land
+    // in this function via `build_runtime_for_cwd`.
     system_prompt
         .dynamic_sections
-        .push(runtime::agent_types::render_agent_types_prompt_section(cwd));
+        .extend(cwd_prompt_sections(cwd, Some(&plugin_load_outcome)));
     // Deferred tools listing: inject `<available-deferred-tools>` so the
     // model knows which tools exist beyond the core set visible in the API
     // `tools` array. Discovery via ToolSearch, execution via ExecuteExtraTool.

--- a/rust/crates/runtime/src/agent_types.rs
+++ b/rust/crates/runtime/src/agent_types.rs
@@ -1,0 +1,556 @@
+//! Agent TYPES — the catalog of what `agent_spawn` can be asked to be.
+//!
+//! One registry for the built-in presets, merged with the custom `.md`
+//! definitions [`crate::custom_agents`] parses off disk. Everything that needs
+//! to know "which agent types exist" reads from here:
+//!
+//! | consumer | what it takes |
+//! |---|---|
+//! | `tools::allowed_tools_for_subagent` | the per-preset tool pool |
+//! | `tools::is_builtin_subagent` | the set of names a `.md` file may not shadow |
+//! | `engine_host::runtime_build` | [`render_agent_types_prompt_section`] |
+//!
+//! Before this module those three carried their own copy of the preset list —
+//! names in one place, descriptions in a second, tool pools in a third — so a
+//! new preset had to be added three times and a reworded description drifted
+//! silently. The catalog is data here and derived everywhere else.
+//!
+//! ## Why the catalog is a prompt section and not a tool
+//!
+//! A tool that lists agent types (scode once had `agent_list`) is the wrong
+//! shape twice over. Claude Code has no such tool; it puts the list in the
+//! conversation and keeps the *tool description* static, because the list is
+//! volatile — loading a plugin, reconnecting an MCP server, or changing
+//! permission mode mutates it. CC measured the cost of letting that volatility
+//! sit in a tool description at **~10.2% of fleet `cache_creation` tokens**: the
+//! description changes, so the whole tools-block prompt cache busts
+//! (`claude-code/src/tools/AgentTool/prompt.ts:53-56`).
+//!
+//! `agent_spawn` is a CORE tool, so its description rides in that same cached
+//! tools block. Hence the division of labour this module enforces:
+//!
+//! - `agent_spawn`'s description and schema **never mention a specific agent
+//!   type** — they stay byte-identical no matter what is installed.
+//! - The volatile list lives in the `<available-agent-types>` dynamic system
+//!   prompt section, which may change freely.
+//!
+//! A test in `tools` pins the static half; treat a failure there as the cache
+//! property breaking, not as a stale assertion to update.
+//!
+//! ## Line format
+//!
+//! `- <name>: <when_to_use> (Tools: <pool>)` — CC's `formatAgentLine`
+//! (`prompt.ts:43`) verbatim, so a model trained on the CC tool set reads a
+//! familiar shape.
+//!
+//! `when_to_use` says *when to pick this type* and deliberately does not
+//! restate the tool list, which the `(Tools: …)` column already carries.
+//!
+//! ## The `*` pool
+//!
+//! `*` marks the inherited general-purpose pool ([`GENERAL_PURPOSE_TOOLS`]),
+//! matching how a custom `.md` agent spells "no restriction" in its
+//! frontmatter. It is a named default, NOT "every tool in the process" — the
+//! pool deliberately withholds the delegation surface (`agent_spawn`, `send`,
+//! `AskUserQuestion`), which is why `fork` has to name those explicitly rather
+//! than inherit.
+//!
+//! ## Why `fork` is in the registry but not in the listing
+//!
+//! `fork` is a real `subagent_type` with its own tool pool, so it belongs in
+//! the SSOT — `is_builtin_subagent("fork")` must stay true or a `.md` file
+//! could shadow it. But it is a *mode* of spawning (inherit the parent's
+//! context and prompt cache), not a specialization to choose between, and it
+//! carries preconditions that need prose. CC draws the same line: its fork
+//! semantics live in the Agent tool's static description while the agent-types
+//! list stays a list of specializations. So `fork` sets [`BuiltinAgentType::listed`]
+//! `= false`, and the one place that decides this is the registry row.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Which tools a subagent of a given type may invoke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentToolPool {
+    /// Inherit [`GENERAL_PURPOSE_TOOLS`]. Rendered as `*`.
+    GeneralPurpose,
+    /// An explicit allowlist.
+    Only(&'static [&'static str]),
+}
+
+/// One built-in agent type. See the module docs for how `listed` is decided.
+#[derive(Debug, Clone, Copy)]
+pub struct BuiltinAgentType {
+    /// Canonical `subagent_type` value.
+    pub name: &'static str,
+    /// CC's `whenToUse`: when a caller should pick this type.
+    pub when_to_use: &'static str,
+    /// The tool pool this type runs with.
+    pub tools: AgentToolPool,
+    /// Whether the type appears in `<available-agent-types>`.
+    pub listed: bool,
+}
+
+/// The maximal pool a general-purpose subagent may invoke, and the fallback
+/// for an unknown preset name or a custom `.md` agent that declines to
+/// restrict itself (`tools: '*'`, an empty list, or no `tools` key).
+///
+/// Withholds the delegation surface on purpose — see the module docs.
+pub const GENERAL_PURPOSE_TOOLS: &[&str] = &[
+    "bash",
+    "read_file",
+    "write_file",
+    "edit_file",
+    "glob_search",
+    "grep_search",
+    "WebFetch",
+    "WebSearch",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskList",
+    "Skill",
+    "ToolSearch",
+    "Sleep",
+    "Config",
+    "StructuredOutput",
+    "PowerShell",
+];
+
+/// Every built-in agent type, in the order they are listed to the model.
+pub const BUILTIN_AGENT_TYPES: &[BuiltinAgentType] = &[
+    BuiltinAgentType {
+        name: "general-purpose",
+        when_to_use: "Research, implementation, and multi-step tasks. The default when no \
+                      specialized type fits.",
+        tools: AgentToolPool::GeneralPurpose,
+        listed: true,
+    },
+    BuiltinAgentType {
+        name: "Explore",
+        when_to_use: "Read-only research: locating code and sweeping many files to answer a \
+                      question without editing anything.",
+        tools: AgentToolPool::Only(&[
+            "read_file",
+            "glob_search",
+            "grep_search",
+            "WebFetch",
+            "WebSearch",
+            "ToolSearch",
+            "Skill",
+            "StructuredOutput",
+        ]),
+        listed: true,
+    },
+    BuiltinAgentType {
+        name: "Plan",
+        when_to_use: "Designing an implementation strategy before any code changes — read-only \
+                      exploration plus task tracking.",
+        tools: AgentToolPool::Only(&[
+            "read_file",
+            "glob_search",
+            "grep_search",
+            "WebFetch",
+            "WebSearch",
+            "ToolSearch",
+            "Skill",
+            "TaskCreate",
+            "TaskUpdate",
+            "TaskList",
+            "StructuredOutput",
+        ]),
+        listed: true,
+    },
+    BuiltinAgentType {
+        name: "Verification",
+        when_to_use: "Running tests and checks to verify a change, with bash on top of the \
+                      read-only set.",
+        tools: AgentToolPool::Only(&[
+            "bash",
+            "read_file",
+            "glob_search",
+            "grep_search",
+            "WebFetch",
+            "WebSearch",
+            "ToolSearch",
+            "TaskCreate",
+            "TaskUpdate",
+            "TaskList",
+            "StructuredOutput",
+            "PowerShell",
+        ]),
+        listed: true,
+    },
+    BuiltinAgentType {
+        name: "scode-guide",
+        when_to_use: "Questions about using scode itself — its tools, config, and workflows.",
+        tools: AgentToolPool::Only(&[
+            "read_file",
+            "glob_search",
+            "grep_search",
+            "WebFetch",
+            "WebSearch",
+            "ToolSearch",
+            "Skill",
+            "StructuredOutput",
+        ]),
+        listed: true,
+    },
+    BuiltinAgentType {
+        name: "statusline-setup",
+        when_to_use: "Configuring the status line display.",
+        tools: AgentToolPool::Only(&[
+            "bash",
+            "read_file",
+            "write_file",
+            "edit_file",
+            "glob_search",
+            "grep_search",
+            "ToolSearch",
+        ]),
+        listed: true,
+    },
+    BuiltinAgentType {
+        name: "fork",
+        when_to_use: "Inherit the parent's context and prompt cache instead of starting fresh.",
+        // Mirrors CC-fork's `tools: ['*']`. sudocode does not thread the
+        // parent's `allowed_tools` into `prepare_agent_job`, so `*` is
+        // approximated as the general-purpose pool PLUS the delegation tools a
+        // fork child still needs — it may spawn NON-fork sub-agents (recursion
+        // is blocked at call time by `ToolDispatchContext::is_inside_fork_child`)
+        // and report back to its parent.
+        tools: AgentToolPool::Only(&[
+            "bash",
+            "read_file",
+            "write_file",
+            "edit_file",
+            "glob_search",
+            "grep_search",
+            "WebFetch",
+            "WebSearch",
+            "TaskCreate",
+            "TaskUpdate",
+            "TaskList",
+            "Skill",
+            "ToolSearch",
+            "Sleep",
+            "Config",
+            "StructuredOutput",
+            "PowerShell",
+            "Agent",
+            "SendMessage",
+        ]),
+        // See the module docs: a spawn MODE, not a specialization.
+        listed: false,
+    },
+];
+
+/// The fallback pool, owned: [`GENERAL_PURPOSE_TOOLS`] as a set.
+#[must_use]
+pub fn general_purpose_tools() -> BTreeSet<String> {
+    GENERAL_PURPOSE_TOOLS
+        .iter()
+        .map(|t| (*t).to_string())
+        .collect()
+}
+
+/// Look up a built-in type by its exact canonical name.
+#[must_use]
+pub fn builtin_agent_type(name: &str) -> Option<&'static BuiltinAgentType> {
+    BUILTIN_AGENT_TYPES.iter().find(|a| a.name == name)
+}
+
+/// Whether `name` is a built-in preset. Built-ins win over a same-named custom
+/// `.md` file, so this is also the shadowing guard.
+#[must_use]
+pub fn is_builtin_agent_type(name: &str) -> bool {
+    builtin_agent_type(name).is_some()
+}
+
+/// The tool allowlist for a built-in type, resolved through
+/// [`AgentToolPool::GeneralPurpose`]. `None` when `name` is not a built-in.
+#[must_use]
+pub fn builtin_allowed_tools(name: &str) -> Option<BTreeSet<String>> {
+    builtin_agent_type(name).map(|a| match a.tools {
+        AgentToolPool::GeneralPurpose => general_purpose_tools(),
+        AgentToolPool::Only(tools) => tools.iter().map(|t| (*t).to_string()).collect(),
+    })
+}
+
+/// One row of the catalog shown to the model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTypeListing {
+    /// Canonical `subagent_type` value.
+    pub name: String,
+    /// When a caller should pick this type.
+    pub when_to_use: String,
+    /// The rendered `(Tools: …)` column: `*` for the inherited
+    /// general-purpose pool, else a comma-joined allowlist.
+    pub tools: String,
+}
+
+/// `*` — the inherited general-purpose pool. See the module docs.
+const INHERITED_POOL: &str = "*";
+
+fn render_pool(pool: AgentToolPool) -> String {
+    match pool {
+        AgentToolPool::GeneralPurpose => INHERITED_POOL.to_string(),
+        AgentToolPool::Only(tools) => tools.join(", "),
+    }
+}
+
+/// Every agent type a caller may pass to `agent_spawn`, built-ins first and
+/// then the custom `.md` definitions under
+/// [`crate::custom_agents::standard_custom_agent_dirs`].
+///
+/// Built-ins are never shadowed (a same-named `.md` file is skipped, matching
+/// [`is_builtin_agent_type`]), and a custom name is listed once even when the
+/// same `name` appears in both the user and project search path — first hit
+/// wins, the precedence [`crate::custom_agents::find_custom_agent`] already
+/// applies for resolution.
+#[must_use]
+pub fn available_agent_types(cwd: &Path) -> Vec<AgentTypeListing> {
+    let mut listings: Vec<AgentTypeListing> = BUILTIN_AGENT_TYPES
+        .iter()
+        .filter(|a| a.listed)
+        .map(|a| AgentTypeListing {
+            name: a.name.to_string(),
+            when_to_use: a.when_to_use.to_string(),
+            tools: render_pool(a.tools),
+        })
+        .collect();
+
+    let mut seen: BTreeSet<String> = BUILTIN_AGENT_TYPES
+        .iter()
+        .map(|a| a.name.to_string())
+        .collect();
+
+    for dir in crate::custom_agents::standard_custom_agent_dirs(cwd) {
+        for def in crate::custom_agents::load_md_agents(&dir) {
+            if !seen.insert(def.name.clone()) {
+                continue;
+            }
+            // `Some(non-empty)` is a real restriction; `Some(empty)` (from
+            // `tools: '*'`) and `None` both mean "inherit" — the same three-way
+            // split `builtin_allowed_tools`'s caller applies.
+            let tools = match def.tools.as_deref() {
+                Some(list) if !list.is_empty() => list.join(", "),
+                _ => INHERITED_POOL.to_string(),
+            };
+            listings.push(AgentTypeListing {
+                name: def.name,
+                when_to_use: def.description,
+                tools,
+            });
+        }
+    }
+
+    listings
+}
+
+/// Format one catalog row. CC's `formatAgentLine` (`prompt.ts:43`).
+#[must_use]
+pub fn format_agent_line(listing: &AgentTypeListing) -> String {
+    format!(
+        "- {}: {} (Tools: {})",
+        listing.name, listing.when_to_use, listing.tools
+    )
+}
+
+/// The XML tag wrapping the catalog in the system prompt.
+pub const AGENT_TYPES_SECTION_TAG: &str = "available-agent-types";
+
+/// Render the `<available-agent-types>` dynamic system-prompt section.
+///
+/// Injected next to the skills and deferred-tool sections in
+/// `engine_host::runtime_build`, so the REPL, `--print`, and ACP sessions all
+/// get it. Never empty: the built-ins always exist, and a model that can call
+/// `agent_spawn` always needs to know what to pass.
+#[must_use]
+pub fn render_agent_types_prompt_section(cwd: &Path) -> String {
+    let listings = available_agent_types(cwd);
+    let mut lines = vec![
+        format!("<{AGENT_TYPES_SECTION_TAG}>"),
+        "Agent types available to `agent_spawn`, passed as its `agent` argument. `Tools: *` means \
+         the agent inherits the default general-purpose tool set."
+            .to_string(),
+    ];
+    lines.extend(listings.iter().map(format_agent_line));
+    lines.push(format!("</{AGENT_TYPES_SECTION_TAG}>"));
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry is the SSOT: every name `tools` treats as a built-in must
+    /// resolve to a pool here, or `allowed_tools_for_subagent` silently falls
+    /// back to general-purpose and a restricted preset quietly gains tools.
+    #[test]
+    fn every_builtin_resolves_to_a_non_empty_pool() {
+        for agent in BUILTIN_AGENT_TYPES {
+            let pool = builtin_allowed_tools(agent.name)
+                .unwrap_or_else(|| panic!("`{}` must resolve to a pool", agent.name));
+            assert!(
+                !pool.is_empty(),
+                "`{}` resolved to an empty tool pool",
+                agent.name
+            );
+            assert!(
+                pool.contains("read_file"),
+                "`{}` must be able to read files",
+                agent.name
+            );
+        }
+    }
+
+    #[test]
+    fn general_purpose_inherits_the_default_pool() {
+        assert_eq!(
+            builtin_allowed_tools("general-purpose").unwrap(),
+            general_purpose_tools()
+        );
+    }
+
+    /// `fork` is a spawn mode, not a specialization — it must stay resolvable
+    /// (so a `.md` file cannot shadow it) while staying out of the catalog the
+    /// model chooses from.
+    #[test]
+    fn fork_is_registered_but_not_listed() {
+        assert!(is_builtin_agent_type("fork"));
+        let listed = available_agent_types(Path::new("/nonexistent-workspace"));
+        assert!(
+            !listed.iter().any(|l| l.name == "fork"),
+            "`fork` must not appear in the agent-type catalog"
+        );
+    }
+
+    #[test]
+    fn unknown_name_is_not_a_builtin() {
+        assert!(!is_builtin_agent_type("some-unknown-name"));
+        assert!(builtin_allowed_tools("some-unknown-name").is_none());
+    }
+
+    #[test]
+    fn agent_line_matches_cc_format() {
+        let line = format_agent_line(&AgentTypeListing {
+            name: "Explore".to_string(),
+            when_to_use: "Read-only research.".to_string(),
+            tools: "read_file, glob_search".to_string(),
+        });
+        assert_eq!(
+            line,
+            "- Explore: Read-only research. (Tools: read_file, glob_search)"
+        );
+    }
+
+    #[test]
+    fn section_lists_every_listed_builtin_in_cc_format() {
+        let section = render_agent_types_prompt_section(Path::new("/nonexistent-workspace"));
+        assert!(section.starts_with("<available-agent-types>"));
+        assert!(section.ends_with("</available-agent-types>"));
+        for agent in BUILTIN_AGENT_TYPES.iter().filter(|a| a.listed) {
+            assert!(
+                section.contains(&format!("- {}: ", agent.name)),
+                "section must list `{}`:\n{section}",
+                agent.name
+            );
+        }
+        // The `*` legend has to be present whenever a `*` row is, or the model
+        // reads it as a literal tool name.
+        assert!(section.contains("(Tools: *)"));
+        assert!(section.contains("inherits the default general-purpose tool set"));
+    }
+
+    fn temp_workspace(label: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "sudocode-agent-types-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(root.join(".sudocode").join("agents")).expect("create agents dir");
+        root
+    }
+
+    fn write_agent(workspace: &Path, file: &str, contents: &str) {
+        std::fs::write(
+            workspace.join(".sudocode").join("agents").join(file),
+            contents,
+        )
+        .expect("write agent file");
+    }
+
+    #[test]
+    fn custom_md_agents_join_the_catalog_with_their_tool_column() {
+        let ws = temp_workspace("custom");
+        write_agent(
+            &ws,
+            "narrow.md",
+            "---\nname: narrow\ndescription: Only reads.\ntools: [read_file, grep_search]\n---\nbody",
+        );
+        write_agent(
+            &ws,
+            "wide.md",
+            "---\nname: wide\ndescription: Unrestricted.\n---\nbody",
+        );
+
+        let listings = available_agent_types(&ws);
+        let narrow = listings
+            .iter()
+            .find(|l| l.name == "narrow")
+            .expect("custom agent must be listed");
+        assert_eq!(narrow.when_to_use, "Only reads.");
+        // Sorted, not frontmatter order: `parse_tools_list` collects into a
+        // `BTreeSet`, so the same tool set always renders to the same string
+        // and an unchanged catalog never perturbs the prompt.
+        assert_eq!(narrow.tools, "grep_search, read_file");
+
+        let wide = listings
+            .iter()
+            .find(|l| l.name == "wide")
+            .expect("unrestricted custom agent must be listed");
+        // No `tools:` key ⇒ inherit, same as `tools: '*'`.
+        assert_eq!(wide.tools, INHERITED_POOL);
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    /// A built-in must win over a same-named `.md` file, and must not be
+    /// listed twice — the catalog and [`is_builtin_agent_type`] have to agree
+    /// or the model is offered a type that resolves to different tools than
+    /// advertised.
+    #[test]
+    fn custom_md_agent_cannot_shadow_or_duplicate_a_builtin() {
+        let ws = temp_workspace("shadow");
+        write_agent(
+            &ws,
+            "explore.md",
+            "---\nname: Explore\ndescription: Impostor.\ntools: [bash]\n---\nbody",
+        );
+
+        let listings = available_agent_types(&ws);
+        let explore: Vec<_> = listings.iter().filter(|l| l.name == "Explore").collect();
+        assert_eq!(explore.len(), 1, "`Explore` must be listed exactly once");
+        assert_ne!(explore[0].when_to_use, "Impostor.");
+        assert!(!explore[0].tools.contains("bash"));
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    /// A `when_to_use` that restates the tool list would print it twice, since
+    /// `(Tools: …)` already carries it.
+    #[test]
+    fn when_to_use_does_not_restate_the_tool_list() {
+        for agent in BUILTIN_AGENT_TYPES {
+            for needle in ["read_file", "glob_search", "grep_search", "WebFetch"] {
+                assert!(
+                    !agent.when_to_use.contains(needle),
+                    "`{}`'s when_to_use restates the tool column: {needle}",
+                    agent.name
+                );
+            }
+        }
+    }
+}

--- a/rust/crates/runtime/src/coordinator_mode.rs
+++ b/rust/crates/runtime/src/coordinator_mode.rs
@@ -60,7 +60,6 @@ pub const COORDINATOR_ENV_VAR: &str = "SUDOCODE_COORDINATOR_MODE";
 pub fn coordinator_allowed_tools() -> BTreeSet<&'static str> {
     [
         // Delegation surface
-        "agent_list",
         "agent_spawn",
         "pid_kill",
         "pid_status",

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod agent_color;
 pub mod agent_mailbox;
+pub mod agent_types;
 mod bash;
 pub mod bash_validation;
 mod bootstrap;

--- a/rust/crates/runtime/tests/coordinator_gate.rs
+++ b/rust/crates/runtime/tests/coordinator_gate.rs
@@ -57,7 +57,6 @@ fn allowlist_contains_delegation_surface() {
     let allowed = coordinator_allowed_tools();
     for name in [
         "agent_spawn",
-        "agent_list",
         "send",
         "pid_kill",
         "pid_status",

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -91,15 +91,16 @@ use cli::status::{
     StatusUsage,
 };
 use commands::{
-    acp_slash_commands, classify_skills_slash_command, format_acp_unsupported_slash_command,
-    handle_agents_slash_command, handle_agents_slash_command_json,
-    handle_mcp_slash_command_json_with_plugins, handle_mcp_slash_command_with_plugins,
-    handle_plugins_slash_command, handle_skills_slash_command, handle_skills_slash_command_json,
+    acp_slash_commands, classify_skills_slash_command, cwd_prompt_sections,
+    format_acp_unsupported_slash_command, handle_agents_slash_command,
+    handle_agents_slash_command_json, handle_mcp_slash_command_json_with_plugins,
+    handle_mcp_slash_command_with_plugins, handle_plugins_slash_command,
+    handle_skills_slash_command, handle_skills_slash_command_json,
     handle_skills_slash_command_json_with_plugins, handle_skills_slash_command_with_plugins,
-    render_acp_slash_command_help, render_skills_prompt_section, render_slash_command_help,
-    render_slash_command_help_filtered, resolve_skill_invocation,
-    resolve_skill_invocation_with_plugins, resume_supported_slash_commands, slash_command_specs,
-    validate_slash_command_input, SkillSlashDispatch, SlashCommand,
+    render_acp_slash_command_help, render_slash_command_help, render_slash_command_help_filtered,
+    resolve_skill_invocation, resolve_skill_invocation_with_plugins,
+    resume_supported_slash_commands, slash_command_specs, validate_slash_command_input,
+    SkillSlashDispatch, SlashCommand,
 };
 use compat_harness::{extract_manifest, UpstreamPaths};
 use dialoguer::{FuzzySelect, Select};
@@ -1216,16 +1217,21 @@ fn print_system_prompt(
     runtime::coordinator_mode::apply_coordinator_prompt_if_enabled(&mut prompt);
     // Same order as a live session (`build_system_prompt_for` →
     // `build_runtime_with_plugin_state`): CLI prompt flags first, then the
-    // available-skills listing.
+    // cwd-derived sections.
     apply_cli_prompt_overrides(&mut prompt);
-    // Mirror what build_runtime_with_plugin_state does for live sessions.
+    // `commands::cwd_prompt_sections` is the SAME list the live runtime
+    // extends, so this preview cannot claim a prompt a session does not send.
+    // It is a subset by design: the deferred-tool listing needs a tool registry
+    // and the A2A identity needs a dialed session, neither of which a preview
+    // has.
+    //
     // Load failures captured inside PluginLoadOutcome are excluded naturally;
     // Result errors propagate, so a broken plugin install fails this preview
     // exactly as it fails a live session.
     let outcome = plugin_load_outcome_for_cwd(&cwd)?;
-    if let Some(section) = render_skills_prompt_section(&cwd, Some(&outcome)) {
-        prompt.dynamic_sections.push(section);
-    }
+    prompt
+        .dynamic_sections
+        .extend(cwd_prompt_sections(&cwd, Some(&outcome)));
     let message = prompt.render();
     match output_format {
         CliOutputFormat::Text => println!("{message}"),

--- a/rust/crates/rusty-sudocode-cli/tests/system_prompt_command.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/system_prompt_command.rs
@@ -60,6 +60,72 @@ fn install_and_enable_plugin(config_home: &Path, plugin_name: &str, description:
     .expect("settings.json write");
 }
 
+/// The agent-type catalog must reach the model through the prompt, because
+/// `agent_spawn`'s description no longer names a single type — if this section
+/// goes missing the model has nothing to pass as `agent`.
+///
+/// Runs the real binary so the whole chain is covered: `print_system_prompt` →
+/// `commands::cwd_prompt_sections` → `runtime::agent_types`. That shared helper
+/// is also what the live runtime extends, which is what keeps this preview
+/// honest about what a session sends.
+#[test]
+fn system_prompt_carries_the_agent_type_catalog() {
+    let root = unique_temp_dir("sp-agent-types");
+    let config_home = root.join("config-home");
+    fs::create_dir_all(&config_home).expect("config home");
+    let agents_dir = root.join(".sudocode").join("agents");
+    fs::create_dir_all(&agents_dir).expect("agents dir");
+    fs::write(
+        agents_dir.join("repo-scout.md"),
+        "---\nname: repo-scout\ndescription: Maps an unfamiliar repository.\ntools: [read_file, grep_search]\n---\nBe brief.\n",
+    )
+    .expect("custom agent write");
+
+    let env = [("SUDO_CODE_CONFIG_HOME", config_home.to_str().expect("utf8"))];
+    let output = run_system_prompt(&root, &env, &[]);
+    assert!(
+        output.status.success(),
+        "system-prompt should exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8(output.stdout).expect("stdout utf8");
+
+    assert!(
+        text.contains("<available-agent-types>") && text.contains("</available-agent-types>"),
+        "prompt must carry the agent-type section;\nfull output:\n{text}"
+    );
+    // Built-ins, in CC's `- <type>: <whenToUse> (Tools: …)` line format.
+    for needle in [
+        "- general-purpose: ",
+        "- Explore: ",
+        "- Plan: ",
+        "- Verification: ",
+        "- scode-guide: ",
+        "- statusline-setup: ",
+        "(Tools: *)",
+    ] {
+        assert!(
+            text.contains(needle),
+            "prompt must carry {needle:?};\nfull output:\n{text}"
+        );
+    }
+    // A project-local `.md` agent joins the same catalog, tools column and all.
+    assert!(
+        text.contains(
+            "- repo-scout: Maps an unfamiliar repository. (Tools: grep_search, read_file)"
+        ),
+        "prompt must list the project's custom agent;\nfull output:\n{text}"
+    );
+    // `fork` is a spawn mode, not a type to choose between — registered, but
+    // never offered in the catalog.
+    assert!(
+        !text.contains("- fork: "),
+        "`fork` must not be listed as an agent type;\nfull output:\n{text}"
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
 #[test]
 fn system_prompt_carries_no_plugin_section_and_no_manifest_metadata() {
     // The anonymised `# Available SudoCode plugins` inventory was removed: every

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1048,26 +1048,19 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             }),
             required_permission: PermissionMode::ReadOnly,
         },
-        // ── agent_list ────────────────────────────────────────────────
-        // Discovery tool: list all available agent types (builtin +
-        // custom `.md` agents from ~/.nexus/sudocode/agents/ and
-        // .sudocode/agents/).
-        ToolSpec {
-            name: "agent_list",
-            description: "List all available agent types with their names, descriptions, and capabilities.",
-            input_schema: json!({
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            }),
-            required_permission: PermissionMode::ReadOnly,
-        },
         // ── agent_spawn ───────────────────────────────────────────────
         // The one spawn tool. `fresh: false` (default) auto-resumes the
         // agent's most recent session; `true` starts a clean one. A model
         // trained on the CC tool set will name this `Agent` and pass
         // `subagent_type`; `TOOL_ALIASES` + `normalize_agent_spawn_input`
         // accept that spelling without advertising it as a second tool.
+        //
+        // This spec is STATIC — nothing here names an agent type, so it stays
+        // byte-identical whatever is installed. `agent_spawn` is a CORE tool,
+        // so its description rides in the cached tools block, and the volatile
+        // catalog belongs in the `<available-agent-types>` dynamic prompt
+        // section instead. See `runtime::agent_types` for the measurement
+        // behind that split.
         ToolSpec {
             name: "agent_spawn",
             description: concat!(
@@ -1080,7 +1073,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "agent": { "type": "string", "description": "Agent type specialization: general-purpose (default), Explore (read-only research), Plan (planning), Verification (bash + read), scode-guide, statusline-setup." },
+                    "agent": { "type": "string", "description": "Agent type specialization. The available types are listed in the <available-agent-types> section of the system prompt; defaults to general-purpose." },
                     "prompt": { "type": "string", "description": "The full task prompt for the agent." },
                     "fresh": { "type": "boolean", "description": "When true, start a clean session instead of resuming. Default false (auto-resume)." },
                     "description": { "type": "string", "description": "A short (3-5 word) description of the task." },
@@ -1628,7 +1621,6 @@ fn execute_tool_with_enforcer(
         "WebFetch" => from_value::<WebFetchInput>(input).and_then(run_web_fetch),
         "WebSearch" => from_value::<WebSearchInput>(input).and_then(run_web_search),
         "Skill" => from_value::<SkillInput>(input).and_then(run_skill),
-        "agent_list" => run_agent_list(),
         // agent_spawn. A CC-trained model names this `Agent`;
         // TOOL_ALIASES folds that spelling onto this arm. Normalize `agent` →
         // `subagent_type` so the new schema's field name maps to
@@ -3344,66 +3336,6 @@ fn run_web_search(input: WebSearchInput) -> Result<String, String> {
 
 fn run_skill(input: SkillInput) -> Result<String, String> {
     to_pretty_json(execute_skill(input)?)
-}
-
-/// List all available agent types: builtins + custom `.md` agents.
-fn run_agent_list() -> Result<String, String> {
-    let builtins = vec![
-        json!({
-            "name": "general-purpose",
-            "description": "General-purpose agent for research, implementation, and multi-step tasks.",
-            "builtin": true,
-        }),
-        json!({
-            "name": "Explore",
-            "description": "Read-only research agent: read_file, glob, grep, web search.",
-            "builtin": true,
-        }),
-        json!({
-            "name": "Plan",
-            "description": "Planning agent: read-only exploration + task management.",
-            "builtin": true,
-        }),
-        json!({
-            "name": "Verification",
-            "description": "Verification agent: bash + read-only tools for testing changes.",
-            "builtin": true,
-        }),
-        json!({
-            "name": "scode-guide",
-            "description": "Help agent for scode usage questions.",
-            "builtin": true,
-        }),
-        json!({
-            "name": "statusline-setup",
-            "description": "Configure the status line display.",
-            "builtin": true,
-        }),
-    ];
-
-    let mut custom = Vec::new();
-    if let Ok(cwd) = current_workspace_root() {
-        for dir in runtime::custom_agents::standard_custom_agent_dirs(&cwd) {
-            for def in runtime::custom_agents::load_md_agents(&dir) {
-                // Avoid duplicating builtins that a user might shadow
-                if is_builtin_subagent(&def.name) {
-                    continue;
-                }
-                custom.push(json!({
-                    "name": def.name,
-                    "description": def.description,
-                    "builtin": false,
-                    "tools": def.tools,
-                }));
-            }
-        }
-    }
-
-    let all: Vec<_> = builtins.into_iter().chain(custom).collect();
-    to_pretty_json(json!({
-        "agents": all,
-        "count": all.len(),
-    }))
 }
 
 fn run_agent(input: AgentInput, ctx: Option<&ToolDispatchContext>) -> Result<String, String> {
@@ -5634,126 +5566,15 @@ fn allowed_tools_for_subagent(subagent_type: &str) -> BTreeSet<String> {
                 return tools.iter().cloned().collect();
             }
         }
-        return general_purpose_tools();
+        return runtime::agent_types::general_purpose_tools();
     }
-    let tools = match subagent_type {
-        "Explore" => vec![
-            "read_file",
-            "glob_search",
-            "grep_search",
-            "WebFetch",
-            "WebSearch",
-            "ToolSearch",
-            "Skill",
-            "StructuredOutput",
-        ],
-        "Plan" => vec![
-            "read_file",
-            "glob_search",
-            "grep_search",
-            "WebFetch",
-            "WebSearch",
-            "ToolSearch",
-            "Skill",
-            "TaskCreate",
-            "TaskUpdate",
-            "TaskList",
-            "StructuredOutput",
-        ],
-        "Verification" => vec![
-            "bash",
-            "read_file",
-            "glob_search",
-            "grep_search",
-            "WebFetch",
-            "WebSearch",
-            "ToolSearch",
-            "TaskCreate",
-            "TaskUpdate",
-            "TaskList",
-            "StructuredOutput",
-            "PowerShell",
-        ],
-        "scode-guide" => vec![
-            "read_file",
-            "glob_search",
-            "grep_search",
-            "WebFetch",
-            "WebSearch",
-            "ToolSearch",
-            "Skill",
-            "StructuredOutput",
-        ],
-        "statusline-setup" => vec![
-            "bash",
-            "read_file",
-            "write_file",
-            "edit_file",
-            "glob_search",
-            "grep_search",
-            "ToolSearch",
-        ],
-        // Fork subagent — inherits the parent's exact tool pool
-        // (mirrors CC-fork's `tools: ['*']`). Sudocode doesn't thread
-        // the parent's allowed_tools into `prepare_agent_job`, so we
-        // approximate `*` as the maximal set: every tool a normal
-        // general-purpose subagent gets, PLUS Agent so the child can
-        // still spawn NON-fork sub-agents. Fork-inside-fork recursion
-        // is blocked at call time by
-        // `ToolDispatchContext::is_inside_fork_child`.
-        "fork" => vec![
-            "bash",
-            "read_file",
-            "write_file",
-            "edit_file",
-            "glob_search",
-            "grep_search",
-            "WebFetch",
-            "WebSearch",
-            "TaskCreate",
-            "TaskUpdate",
-            "TaskList",
-            "Skill",
-            "ToolSearch",
-            "Sleep",
-            "Config",
-            "StructuredOutput",
-            "PowerShell",
-            "Agent",
-            "SendMessage",
-        ],
-        _ => return general_purpose_tools(),
-    };
-    tools.into_iter().map(str::to_string).collect()
-}
-
-/// The maximal tool set a general-purpose sub-agent may invoke —
-/// SSOT for both the explicit `general-purpose` preset and the
-/// fallback path (unknown built-in name AND custom `.md` agents whose
-/// frontmatter says `tools: '*'` / omits the field).
-fn general_purpose_tools() -> BTreeSet<String> {
-    [
-        "bash",
-        "read_file",
-        "write_file",
-        "edit_file",
-        "glob_search",
-        "grep_search",
-        "WebFetch",
-        "WebSearch",
-        "TaskCreate",
-        "TaskUpdate",
-        "TaskList",
-        "Skill",
-        "ToolSearch",
-        "Sleep",
-        "Config",
-        "StructuredOutput",
-        "PowerShell",
-    ]
-    .into_iter()
-    .map(str::to_string)
-    .collect()
+    // Built-in presets and their tool pools are data in
+    // `runtime::agent_types::BUILTIN_AGENT_TYPES` — the same registry the
+    // `<available-agent-types>` prompt section renders from, so a preset can
+    // never be advertised to the model with one tool set and then run with
+    // another. An unknown name inherits the general-purpose pool.
+    runtime::agent_types::builtin_allowed_tools(subagent_type)
+        .unwrap_or_else(runtime::agent_types::general_purpose_tools)
 }
 
 fn agent_permission_policy() -> PermissionPolicy {
@@ -7175,7 +6996,6 @@ const CORE_TOOLS: &[&str] = &[
     "WebSearch",
     "Skill",
     "agent_spawn",
-    "agent_list",
     "pid_fork",
     "ToolSearch",
     "ExecuteExtraTool",
@@ -7273,7 +7093,7 @@ fn search_tool_specs(query: &str, max_results: usize, specs: &[SearchableToolSpe
                 // A CC tool name is an exact hit on the tool it aliases, and
                 // must outscore every tool that merely shares the word:
                 // `AgentTool` means CC's `Agent`, i.e. `agent_spawn`, not
-                // `agent_list`.
+                // whatever else happens to start with `agent`.
                 if canonical_name == alias_token(&canonical_term) {
                     score += 12;
                 }
@@ -7315,7 +7135,8 @@ fn normalize_tool_search_query(query: &str) -> String {
 /// NAMES, so `AgentTool` → token `agent` has to be fed back through the table
 /// as a name to reach `agent_spawn` → token `agentspawn`. Comparing the two
 /// forms directly is why `AgentTool` scored no better against `agent_spawn`
-/// than against `agent_list` and the tie went to whichever spec came first.
+/// than against any other `agent`-prefixed spec, and the tie went to
+/// whichever spec came first.
 fn alias_token(token: &str) -> String {
     canonical_tool_token(&canonicalize_tool_name(token))
 }
@@ -7415,17 +7236,12 @@ fn lookup_custom_agent(
 /// Built-in preset names that must NOT be shadowed by a custom `.md`
 /// agent — the built-in behavior wins, even if a user drops a
 /// same-named .md file under `~/.nexus/sudocode/agents/`.
+///
+/// Delegates to the one registry, so this set cannot drift from the tool pools
+/// [`allowed_tools_for_subagent`] hands out or from the catalog the model is
+/// shown in `<available-agent-types>`.
 fn is_builtin_subagent(name: &str) -> bool {
-    matches!(
-        name,
-        "general-purpose"
-            | "Explore"
-            | "Plan"
-            | "Verification"
-            | "scode-guide"
-            | "statusline-setup"
-            | "fork"
-    )
+    runtime::agent_types::is_builtin_agent_type(name)
 }
 
 /// Prefix inserted before the caller's directive text inside a fork
@@ -9021,7 +8837,6 @@ mod tests {
             ("pid_output", "pid_output"),
             ("agent_spawn", "agent_spawn"),
             ("send", "send"),
-            ("agent_list", "agent_list"),
         ] {
             let allowed = registry
                 .normalize_allowed_tools(&[requested.to_string()])
@@ -10679,6 +10494,39 @@ mod tests {
         assert!(verification.contains("bash"));
         assert!(verification.contains("PowerShell"));
         assert!(!verification.contains("write_file"));
+    }
+
+    /// `agent_spawn`'s spec must never enumerate agent types.
+    ///
+    /// It is a CORE tool, so its description and schema ride in the cached
+    /// tools block. Enumerating types there means installing a `.md` agent
+    /// rewrites the description and busts that cache — the cost Claude Code
+    /// measured at ~10.2% of fleet `cache_creation` tokens. The catalog belongs
+    /// in the `<available-agent-types>` dynamic prompt section instead (see
+    /// `runtime::agent_types`).
+    ///
+    /// A failure here is the cache property breaking, not a stale assertion:
+    /// move the text into the prompt section rather than relaxing this test.
+    #[test]
+    fn agent_spawn_spec_enumerates_no_agent_type() {
+        let spec = mvp_tool_specs()
+            .into_iter()
+            .find(|spec| spec.name == "agent_spawn")
+            .expect("agent_spawn must be a tool");
+        let rendered = format!("{} {}", spec.description, spec.input_schema);
+        for agent in runtime::agent_types::BUILTIN_AGENT_TYPES {
+            // Naming the DEFAULT is a stable part of the call contract, not a
+            // catalog entry — it does not change when an agent is installed.
+            if agent.name == "general-purpose" {
+                continue;
+            }
+            assert!(
+                !rendered.contains(agent.name),
+                "agent_spawn's spec names the agent type `{}`; the catalog belongs in \
+                 <available-agent-types>, not in the cached tools block",
+                agent.name
+            );
+        }
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
Agent **types** get one source of truth, and the catalog reaches the model the
way Claude Code delivers it — through the prompt, not through a tool.

## Why

The six built-in presets were described in three places, each maintained by
hand:

| where | carried |
|---|---|
| `run_agent_list` | names + descriptions |
| `agent_spawn`'s `agent` schema | the same names + a second set of one-liners |
| `allowed_tools_for_subagent` | names + tool pools |

Adding a preset meant editing all three, and a reworded description drifted
with nothing to catch it.

`agent_list` was also the wrong carrier for the catalog. CC has no tool that
lists agent types, for a measured reason: the list is volatile — installing a
`.md` agent changes it — while `agent_spawn` is a CORE tool whose description
rides in the cached tools block. CC put the cost of letting that volatility sit
in a tool description at ~10.2% of fleet `cache_creation` tokens
(`AgentTool/prompt.ts:53-56`).

## What changed

- **`runtime::agent_types`** is the registry: name, when-to-use, tool pool, and
  whether the type is offered to the model. `allowed_tools_for_subagent` and
  `is_builtin_subagent` derive from it, so a preset can no longer be advertised
  with one tool set and run with another.
- **`agent_list` is gone.** The catalog is the `<available-agent-types>` dynamic
  prompt section, rendered in CC's line format
  `- <type>: <whenToUse> (Tools: …)`, covering built-ins and project/user `.md`
  agents alike.
- **`agent_spawn`'s spec no longer names a type**, which is the whole point — a
  test fails if one reappears there.
- `fork` stays registered (a `.md` file must not shadow it) but unlisted: it is
  a spawn mode, not a specialization. Same line CC draws.

## Also fixed

`print_system_prompt` rebuilt the runtime's dynamic-section sequence by hand,
under a comment asking the reader to keep it in step. It had already fallen
behind — the preview omits `<available-deferred-tools>`, so `scode
system-prompt` has been showing a prompt no session sends. Both call sites now
extend `commands::cwd_prompt_sections`.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets` (no new findings), and
`cargo test -p commands -p runtime -p tools -p engine-host` green on Windows.

Every new test was mutation-verified — the fix reverted, the test confirmed red,
then restored:

| mutation | test that went red |
|---|---|
| `fork` marked `listed: true` | `fork_is_registered_but_not_listed` |
| shadow-dedup guard removed | `custom_md_agent_cannot_shadow_or_duplicate_a_builtin` |
| `agent_spawn` description restored to the enumerated form | `agent_spawn_spec_enumerates_no_agent_type` |
| catalog dropped from `cwd_prompt_sections` | `system_prompt_carries_the_agent_type_catalog` |

The last is end-to-end: it runs the real `scode` binary and asserts the section
carries the built-ins and a project-local `.md` agent, with `fork` withheld.

## Note for the parallel agent-discovery work

This removes `agent_list` as a **type** catalog. Agent **instance** discovery —
which agents exist and how to address them — is a different tool and is not
touched here. When the two branches meet, the coherent result keeps both: the
discovery tool for instances, `<available-agent-types>` for types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
