### PR TITLE
feat: unified agent/PID tool system

### DIFF
--- a/rust/crates/engine-host/src/nexus_a2a.rs
+++ b/rust/crates/engine-host/src/nexus_a2a.rs
@@ -3,41 +3,28 @@
 //! Holds the one daemon connection an interactive `scode` process makes,
 //! lazily dialed from [`runtime::nexus_mailbox::Config::from_env`]. The send
 //! half feeds [`crate::tool_executor::CliToolExecutor`] via the shared
-//! [`MailboxSender`] (the same handler the co-host uses); the receive half is
-//! a background poller that surfaces peer messages into the REPL as they
-//! arrive.
+//! [`MailboxSender`]; the receive half is a background poller that surfaces
+//! peer messages into the REPL as they arrive.
 //!
-//! This process-global lives in the CLI, not in `runtime`: `runtime` is the
-//! reentrant engine the multi-agent co-host also drives, so it must stay free
-//! of any "one A2A session per process" assumption. A standalone `scode` *is*
-//! exactly one session per process, so the singleton is a CLI concern. All the
-//! transport (config, dial, send, poll) still lives once in
-//! `runtime::nexus_mailbox`; this module only owns the process-lifetime handle.
+//! Transport is the unified [`runtime::mailbox::Mailbox`] backed by
+//! [`NexusVfsFsBackend`] — the same abstraction the local JSONL path uses
+//! (with [`StdFsBackend`]), so standalone A2A and coordinator sub-agents
+//! share every line except the backend construction.
 
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
 
-use nexus_vfs_client::NexusVfsClient;
-use runtime::nexus_mailbox::{self, Config, Inbound};
+use runtime::agent_mailbox::MailboxEnvelope;
+use runtime::fs_backend::NexusVfsFsBackend;
+use runtime::mailbox::{InboxConvention, Mailbox};
+use runtime::nexus_mailbox::Config;
 use runtime::spawn_task::MailboxSender;
 use runtime::HookAbortSignal;
 
-/// Blocking-tail wait per receive iteration. Each drain parks in a blocking
-/// `stream_read_at` (the DT_STREAM `read_at_blocking` primitive) up to this
-/// long, waking sub-millisecond on the next inbox write and returning empty at
-/// the deadline so the loop can re-check `abort`. This is event-driven, not a
-/// poll interval — an idle receiver costs one parked RPC, not a `sleep` spin.
+/// Blocking-tail wait per receive iteration.
 const INBOX_WAIT_MS: u64 = 500;
 
-/// Where this client remembers how far it has read its own inbox.
-///
-/// Client-local, and deliberately not in the nexus namespace: the co-host
-/// stores its cursor there because the co-host *is* the node, but a standalone
-/// `scode` is one of possibly several clients of a remote node, and "which
-/// messages has THIS client shown its user" is not the node's business.
-///
-/// Keyed by agent so two identities on one machine do not share a position.
 fn cursor_path_for(agent: &str) -> PathBuf {
     let safe: String = agent
         .chars()
@@ -52,20 +39,12 @@ fn cursor_path_for(agent: &str) -> PathBuf {
     runtime::config::default_config_home().join(format!("a2a-cursor-{safe}"))
 }
 
-/// The last offset this client consumed, or `None` when it has never run.
-///
-/// `None` and `Some(0)` mean different things and the difference is the point:
-/// never-run seeks to the tail (a first-time receiver should not replay an
-/// inbox it was never party to), while a recorded 0 resumes from the head.
-/// Any unreadable or unparsable cursor is treated as never-run.
 fn load_cursor(agent: &str) -> Option<u64> {
     std::fs::read_to_string(cursor_path_for(agent))
         .ok()
         .and_then(|raw| raw.trim().parse::<u64>().ok())
 }
 
-/// Record how far this client has read. Best-effort: losing a write only costs
-/// the no-loss guarantee on the next start, never correctness now.
 fn save_cursor(agent: &str, offset: u64) {
     let path = cursor_path_for(agent);
     if let Some(parent) = path.parent() {
@@ -77,60 +56,40 @@ fn save_cursor(agent: &str, offset: u64) {
 /// The resolved, connected standalone A2A session.
 pub struct Session {
     config: Config,
-    /// The one daemon connection: `ensure_inbox`, the send half, the CLI tool
-    /// executor, and the blocking receive tail all share it. Safe to share
-    /// because [`NexusVfsClient`] dispatches each op on its own task — a
-    /// receiver parked in a blocking `stream_read_at` no longer stalls the
-    /// worker, so it can't starve concurrent sends. (An earlier revision split
-    /// off a second connection to dodge a single-worker stall; the client is
-    /// now concurrent, so one connection is correct and simpler.)
-    client: Arc<NexusVfsClient>,
-    sender: MailboxSender,
+    mailbox: Arc<Mailbox>,
 }
 
 impl Session {
-    /// Clone the shared send capability for the CLI tool executor.
+    /// Build a [`MailboxSender`] for the CLI tool executor.
     pub fn sender(&self) -> MailboxSender {
-        Arc::clone(&self.sender)
+        self.mailbox.sender()
     }
 
-    /// The peer-awareness system-prompt section (self identity + how to
-    /// reach peers). Single source: [`Config::peer_system_prompt`].
+    /// The peer-awareness system-prompt section.
     pub fn peer_system_prompt(&self) -> String {
         self.config.peer_system_prompt()
     }
 }
 
-/// Lazily resolved once; `Err` on partial config or dial failure (fail loud).
 static SESSION: OnceLock<Result<Option<Session>, String>> = OnceLock::new();
 
 /// Resolve + dial the standalone A2A session, exactly once.
-///
-/// Returns `Ok(None)` when A2A is off (no `NEXUS_A2A_ENDPOINT`) — the fast
-/// path that leaves `scode` unchanged — `Ok(Some)` when connected, and `Err`
-/// when the environment is a *partial* configuration or the daemon cannot be
-/// dialed. The result is cached, so repeated calls are cheap and never
-/// re-dial. Callers propagate the `Err` up their existing `Result` chain so a
-/// misconfiguration fails startup loudly rather than silently disabling A2A.
 pub fn session() -> Result<Option<&'static Session>, String> {
     SESSION
         .get_or_init(|| match Config::from_env()? {
             None => Ok(None),
             Some(config) => {
                 let client = config.connect()?;
-                // Provision our own inbox before anyone polls it — a terminal
-                // scode is not a managed agent, so nothing else creates it.
-                nexus_mailbox::ensure_inbox(&client, &config.agent, &config.api_key)?;
-                let sender = nexus_mailbox::grpc_sender(
-                    Arc::clone(&client),
+                let backend = NexusVfsFsBackend::from_arc(client, config.api_key.clone());
+                let mailbox = Arc::new(Mailbox::new(
+                    Arc::new(backend),
                     config.agent.clone(),
-                    config.api_key.clone(),
-                );
-                Ok(Some(Session {
-                    config,
-                    client,
-                    sender,
-                }))
+                    InboxConvention::NexusA2a,
+                ));
+                mailbox
+                    .ensure_inbox()
+                    .map_err(|e| format!("ensure A2A inbox: {e}"))?;
+                Ok(Some(Session { config, mailbox }))
             }
         })
         .as_ref()
@@ -138,48 +97,20 @@ pub fn session() -> Result<Option<&'static Session>, String> {
         .map_err(Clone::clone)
 }
 
-/// Spawn the background inbox receiver (the receive half).
-///
-/// Surfaces each new peer message to `sink` as it arrives. Starts at the
-/// stream tail — a fresh interactive session never replays history, the same
-/// seek-to-tail the co-host cold-start uses — and stops when `abort` fires.
-///
-/// Event-driven, not polling: each iteration parks in a blocking
-/// `stream_read_at` (via `poll_new`'s `block_ms`) until the daemon signals the
-/// next inbox write, then drains the burst. The block returns empty at the
-/// `INBOX_WAIT_MS` deadline so the loop can re-check `abort`. No `sleep` spin —
-/// an idle receiver costs one parked RPC, replacing the former poll interval.
+/// Spawn the background inbox receiver.
 pub fn spawn_poller(
     session: &'static Session,
     abort: HookAbortSignal,
-    sink: impl Fn(&Inbound) + Send + 'static,
+    sink: impl Fn(&MailboxEnvelope) + Send + 'static,
 ) -> JoinHandle<()> {
-    // Shares `session.client`: the client dispatches ops concurrently, so
-    // parking here on the blocking tail cannot starve the send half.
-    let client = Arc::clone(&session.client);
+    let mailbox = Arc::clone(&session.mailbox);
     let agent = session.config.agent.clone();
-    let api_key = session.config.api_key.clone();
     std::thread::Builder::new()
         .name("nexus-a2a-receiver".into())
         .spawn(move || {
-            // Resume where this client left off, so a message that arrived
-            // while nothing was listening is still delivered.
-            //
-            // Seeking to the tail on every start looks reasonable — nobody
-            // wants their history replayed — but it makes delivery depend on
-            // the receiver happening to be running at the moment of the send.
-            // Two agents handing off asynchronously then lose messages that
-            // the sender was told were delivered and that are sitting durably
-            // in the stream: observed live in the Win↔Mac duet, where a reply
-            // landed while the peer was between processes and no later reader
-            // ever looked back at it.
-            //
-            // A first run still seeks to the tail: a receiver that has never
-            // read this inbox was not party to what came before, and replaying
-            // it would be the other failure (the #81 re-reply storm).
             let mut cursor = match load_cursor(&agent) {
                 Some(saved) => saved,
-                None => match nexus_mailbox::poll_new(&client, &agent, 0, &api_key, 0) {
+                None => match mailbox.poll(0, 0) {
                     Ok((_history, tail)) => {
                         save_cursor(&agent, tail);
                         tail
@@ -191,18 +122,11 @@ pub fn spawn_poller(
                 },
             };
             while !abort.is_aborted() {
-                // Block on the tail up to INBOX_WAIT_MS, then drain the burst.
-                match nexus_mailbox::poll_new(&client, &agent, cursor, &api_key, INBOX_WAIT_MS) {
+                match mailbox.poll(cursor, INBOX_WAIT_MS) {
                     Ok((msgs, next)) => {
                         for m in &msgs {
                             sink(m);
                         }
-                        // Persist only on real forward progress: an idle
-                        // deadline return would otherwise rewrite the same
-                        // offset twice a second. Saving after the sink has run
-                        // makes a crash re-deliver the last message rather than
-                        // drop it — at-least-once, which is the right side to
-                        // err on for mail.
                         if next > cursor {
                             cursor = next;
                             save_cursor(&agent, cursor);
@@ -210,8 +134,6 @@ pub fn spawn_poller(
                     }
                     Err(e) => {
                         eprintln!("[nexus-a2a] inbox poll failed: {e}");
-                        // Avoid a hot error loop if the daemon connection is
-                        // sick; the blocking read itself paces the happy path.
                         std::thread::sleep(std::time::Duration::from_millis(INBOX_WAIT_MS));
                     }
                 }

--- a/rust/crates/mock-anthropic-service/src/lib.rs
+++ b/rust/crates/mock-anthropic-service/src/lib.rs
@@ -181,6 +181,7 @@ enum Scenario {
     /// waiting on a real provider to rate-limit us.
     RetryThenSucceed,
     ExecuteExtraToolRoundtrip,
+    UnifiedSendRoundtrip,
 }
 
 /// How long [`Scenario::DelayedText`] holds a request before answering.
@@ -226,6 +227,7 @@ impl Scenario {
             "ask_user_question_roundtrip" => Some(Self::AskUserQuestionRoundtrip),
             "retry_then_succeed" => Some(Self::RetryThenSucceed),
             "execute_extra_tool_roundtrip" => Some(Self::ExecuteExtraToolRoundtrip),
+            "unified_send_roundtrip" => Some(Self::UnifiedSendRoundtrip),
             _ => None,
         }
     }
@@ -267,6 +269,7 @@ impl Scenario {
             Self::ContextLimitThenText => "context_limit_then_text",
             Self::ToolLoopContextGrowth => "tool_loop_context_growth",
             Self::ExecuteExtraToolRoundtrip => "execute_extra_tool_roundtrip",
+            Self::UnifiedSendRoundtrip => "unified_send_roundtrip",
         }
     }
 }
@@ -881,6 +884,18 @@ fn build_stream_body(request: &MessageRequest, scenario: Scenario) -> String {
                 &[r#"{"tool_name":"CronList","params":{}}"#],
             ),
         },
+        Scenario::UnifiedSendRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => {
+                final_text_sse(&format!("unified send roundtrip complete: {tool_output}"))
+            }
+            None => tool_use_sse(
+                "toolu_unified_send",
+                "send",
+                &[
+                    r#"{"to":"test-peer","message":"hello from unified send","summary":"greeting test"}"#,
+                ],
+            ),
+        },
     }
 }
 
@@ -1306,6 +1321,18 @@ fn build_message_response(request: &MessageRequest, scenario: Scenario) -> Messa
                 json!({"tool_name": "CronList", "params": {}}),
             ),
         },
+        Scenario::UnifiedSendRoundtrip => match latest_tool_result(request) {
+            Some((tool_output, _)) => text_message_response(
+                "msg_unified_send_final",
+                &format!("unified send roundtrip complete: {tool_output}"),
+            ),
+            None => tool_message_response(
+                "msg_unified_send_tool",
+                "toolu_unified_send",
+                "send",
+                json!({"to": "test-peer", "message": "hello from unified send", "summary": "greeting test"}),
+            ),
+        },
     }
 }
 
@@ -1348,6 +1375,7 @@ fn request_id_for(scenario: Scenario) -> &'static str {
         Scenario::ContextLimitThenText => "req_context_limit_then_text",
         Scenario::ToolLoopContextGrowth => "req_tool_loop_context_growth",
         Scenario::ExecuteExtraToolRoundtrip => "req_execute_extra_tool_roundtrip",
+        Scenario::UnifiedSendRoundtrip => "req_unified_send_roundtrip",
     }
 }
 

--- a/rust/crates/runtime/src/agent_mailbox.rs
+++ b/rust/crates/runtime/src/agent_mailbox.rs
@@ -1,41 +1,35 @@
-//! Filesystem-backed per-agent mailbox for the SendMessage inter-agent
-//! coordination surface.
+//! Unified agent mailbox envelope + filesystem-backed local mailbox.
 //!
-//! Ported semantics from `sudoprivacy/claude-code`'s
-//! `utils/teammateMailbox.ts` — the flag-off default path. Each
-//! recipient has one append-only JSONL file at
-//! `<workspace>/.sudocode-inbox/<recipient>.jsonl`. The receiving
-//! agent (e.g. a task launched by `Agent(run_in_background=true)`) is
-//! expected to read new lines from its own inbox and process them at
-//! its next tool round. This crate only writes; consumption lives
-//! wherever the receiving agent loop lives.
+//! [`MailboxEnvelope`] is the SINGLE envelope type for all inter-agent
+//! messaging — both the local JSONL mailbox (`.sudocode-inbox/*.jsonl`,
+//! used by coordinator sub-agents) and the nexus DT_STREAM A2A path
+//! (`/agents/<name>/chat-with-me`, used for cross-machine messaging).
+//! The a2a substrate's `from`-stamping hook operates on raw JSON and
+//! only touches `from`, so the extra fields are transparent to it.
 //!
-//! The mailbox directory is intentionally under the workspace root
-//! (not `~/.nexus/sudocode`) so that per-project state stays with the
-//! project and is naturally cleaned when the workspace is discarded.
+//! ## Wire compatibility
 //!
-//! ## Envelope shape (mirrors CC-fork)
+//! The canonical field name for the message body is `body` (matching
+//! the nexus a2a convention). The `text` alias is accepted on read for
+//! backward compat with existing local JSONL data written before the
+//! unification.
 //!
-//! Each JSONL line is a `MailboxEnvelope`:
+//! All fields beyond `{from, to, body}` carry `#[serde(default)]` and
+//! `skip_serializing_if`, so:
+//! - An envelope written by the old 3-field nexus path deserialises
+//!   cleanly (extras default to zero/None/empty).
+//! - An envelope written with extras is ignored by old readers that
+//!   use `a2a::MailboxEnvelope` (which silently drops unknown fields).
 //!
-//! ```json
-//! {
-//!   "from": "team-lead",
-//!   "to": "researcher",
-//!   "text": "look into the failing test",
-//!   "summary": "investigate flaky test",
-//!   "timestamp": 1234567890,
-//!   "color": null,
-//!   "kind": "message"
-//! }
-//! ```
+//! ## Local JSONL mailbox
+//!
+//! Each recipient has one append-only JSONL file at
+//! `<workspace>/.sudocode-inbox/<recipient>.jsonl`.
 //!
 //! For structured messages (`shutdown_request`,
-//! `shutdown_response`, `plan_approval_response`), `text` is the
-//! JSON-encoded structured body and `kind` is that message type.
-//! Recipients parse `kind` before deciding how to interpret `text`.
-//! This shape lets a single JSONL sink handle both plain text and
-//! structured envelopes without a schema fork.
+//! `shutdown_response`, `plan_approval_response`), `body` is the
+//! JSON-encoded structured payload and `kind` is that message type.
+//! Recipients parse `kind` before deciding how to interpret `body`.
 
 use std::fs;
 use std::io::Write as _;
@@ -45,29 +39,57 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-/// A single mailbox envelope. `serde` derives ensure the JSONL
-/// wire-format is stable across producer/consumer versions.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Unified mailbox envelope — the ONE envelope type for all inter-agent
+/// messaging (local JSONL + nexus DT_STREAM A2A).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MailboxEnvelope {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub from: String,
+    #[serde(default)]
     pub to: String,
     /// Message body. For `kind == "message"` this is user-facing text.
-    /// For structured `kind` values it is the JSON-encoded body of the
-    /// structured message (parsed by the recipient).
-    pub text: String,
+    /// For structured `kind` values it is the JSON-encoded payload.
+    /// Accepts `"text"` on read for backward compat with old local JSONL.
+    #[serde(default, alias = "text")]
+    pub body: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
-    /// Unix seconds. `now_secs()` at write time.
+    /// Unix seconds. `now_secs()` at write time for local JSONL;
+    /// 0 when read from nexus (the stream carries its own ordering).
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub timestamp: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// Envelope kind: `message` (default) | `shutdown_request` |
-    /// `shutdown_response` | `plan_approval_response`.
+    /// `shutdown_response` | `plan_approval_response` | `task_notification`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub kind: String,
     /// Correlator for shutdown/plan-approval request/response pairs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
 }
+
+fn is_zero(v: &u64) -> bool {
+    *v == 0
+}
+
+impl MailboxEnvelope {
+    /// Serialise to JSON bytes (the nexus DT_STREAM wire format).
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).unwrap_or_default()
+    }
+
+    /// Parse from JSON bytes. Returns `None` on non-JSON content.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        serde_json::from_slice(bytes).ok()
+    }
+}
+
+/// Default DT_STREAM capacity for mailbox streams (matches
+/// `a2a::mailbox_stamping_policy::MAILBOX_STREAM_CAPACITY`).
+pub const DEFAULT_STREAM_CAPACITY: u64 = 65_536;
 
 /// Serialization-friendly kind constants — recipients match on these
 /// strings.
@@ -171,6 +193,26 @@ pub fn read_all(workspace_root: &Path, recipient: &str) -> Result<Vec<MailboxEnv
     }
     let text =
         fs::read_to_string(&path).map_err(|e| format!("read mailbox {}: {e}", path.display()))?;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(env) = serde_json::from_str::<MailboxEnvelope>(trimmed) {
+            out.push(env);
+        }
+    }
+    Ok(out)
+}
+
+/// Read a mailbox JSONL file by path (used by [`crate::mailbox::Mailbox`]).
+pub fn read_all_from_path(path: &str) -> Result<Vec<MailboxEnvelope>, String> {
+    let p = std::path::Path::new(path);
+    if !p.exists() {
+        return Ok(Vec::new());
+    }
+    let text = fs::read_to_string(p).map_err(|e| format!("read mailbox {path}: {e}"))?;
     let mut out = Vec::new();
     for line in text.lines() {
         let trimmed = line.trim();

--- a/rust/crates/runtime/src/coordinator_mode.rs
+++ b/rust/crates/runtime/src/coordinator_mode.rs
@@ -39,7 +39,7 @@ pub const COORDINATOR_ENV_VAR: &str = "SUDOCODE_COORDINATOR_MODE";
 /// `edit_file`, `PowerShell`, `EnterPlanMode`,
 /// `ExitPlanMode`) is intentionally excluded so a
 /// non-compliant model that tries them gets an instructive error
-/// pointing back to `Agent(...)`. Read-only tools (`read_file`,
+/// pointing back to `agent_spawn(...)`. Read-only tools (`read_file`,
 /// `glob_search`, `grep_search`, `WebSearch`, `WebFetch`) remain
 /// available so the coordinator can peek at code without spawning a
 /// worker for trivial lookups.
@@ -52,20 +52,23 @@ pub const COORDINATOR_ENV_VAR: &str = "SUDOCODE_COORDINATOR_MODE";
 #[must_use]
 pub fn coordinator_allowed_tools() -> BTreeSet<&'static str> {
     [
-        // Delegation surface
-        "Agent",
-        "agent_list",
+        // Canonical delegation surface
         "agent_spawn",
-        "TaskStop",
+        "agent_list",
+        "send",
         "pid_kill",
-        "TaskGet",
-        "TaskList",
         "pid_status",
-        "TaskOutput",
         "pid_output",
         "pid_fork",
+        // Deprecated aliases — kept so models that emit old names
+        // pass the allowlist check before canonicalize_tool_name
+        // rewrites them.
+        "Agent",
         "SendMessage",
-        "send",
+        "TaskStop",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
         // Skills + web (read-only research)
         "Skill",
         "WebSearch",
@@ -112,8 +115,8 @@ pub fn is_coordinator_mode() -> bool {
 /// The coordinator role + workflow system prompt. Ported near-verbatim
 /// from CC-fork's `getCoordinatorSystemPrompt()`.
 ///
-/// SendMessage is included as the "continue an existing worker"
-/// mechanism. Live delivery for `shutdown_request` is wired
+/// `send` (formerly SendMessage) is included as the "continue an
+/// existing worker" mechanism. Live delivery for `shutdown_request` is wired
 /// end-to-end via the process-wide abort-signal registry
 /// (`tools::abort_registered_agent`). Live delivery for plain-text
 /// messages (worker resumes on new user turn) is architecturally
@@ -141,15 +144,17 @@ Every message you send is to the user. Worker results and system notifications a
 
 ## 2. Your Tools
 
-- **Agent** - Spawn a new worker
-- **SendMessage** - Continue an existing worker (send follow-up to its ID) or signal shutdown
-- **TaskStop** - Stop a running worker
-- **TaskGet** - Fetch a running worker's metadata by `task_id`
-- **TaskOutput** - Read a running or completed worker's output by `task_id`
+- **agent_spawn** - Spawn a new worker (alias: `Agent`)
+- **send** - Continue an existing worker (send follow-up to its ID) or signal shutdown (alias: `SendMessage`)
+- **pid_kill** - Stop a running worker (alias: `TaskStop`)
+- **pid_status** - Fetch a running worker's metadata by `pid` (alias: `TaskGet`)
+- **pid_output** - Read a running or completed worker's output by `pid` (alias: `TaskOutput`)
+- **pid_fork** - Fork the current session into a background worker
+- **agent_list** - List all known agents / workers
 
-Write tools (`bash`, `write_file`, `edit_file`, `PowerShell`, `EnterPlanMode`, `ExitPlanMode`) are DELIBERATELY unavailable to you — always delegate write-side work to a worker via `Agent(...)`. Read-only tools (`read_file`, `glob_search`, `grep_search`, `WebSearch`, `WebFetch`, `Skill`) remain available for lightweight lookups that don't need a full worker turn.
+Write tools (`bash`, `write_file`, `edit_file`, `PowerShell`, `EnterPlanMode`, `ExitPlanMode`) are DELIBERATELY unavailable to you — always delegate write-side work to a worker via `agent_spawn(...)`. Read-only tools (`read_file`, `glob_search`, `grep_search`, `WebSearch`, `WebFetch`, `Skill`) remain available for lightweight lookups that don't need a full worker turn.
 
-When calling Agent:
+When calling agent_spawn:
 - Do not use one worker to check on another. Workers will notify you when they are done.
 - Do not use workers to trivially report file contents or run commands. Give them higher-level tasks.
 - Do not set the model parameter. Workers need the default model for the substantive tasks you delegate.
@@ -177,7 +182,7 @@ Format:
 
 - `<result>` and `<usage>` are optional sections
 - The `<summary>` describes the outcome: "completed", "failed: {error}", or "was stopped"
-- The `<task-id>` value is the agent ID — use `TaskGet` / `TaskOutput` with that ID to inspect the worker
+- The `<task-id>` value is the agent ID — use `pid_status` / `pid_output` with that ID to inspect the worker
 
 ### Example
 
@@ -186,8 +191,8 @@ Each "You:" block is a separate coordinator turn. The "User:" block is a `<task-
 You:
   Let me start some research on that.
 
-  Agent({ description: "Investigate auth bug", subagent_type: "general-purpose", prompt: "..." })
-  Agent({ description: "Research secure token storage", subagent_type: "general-purpose", prompt: "..." })
+  agent_spawn({ description: "Investigate auth bug", subagent_type: "general-purpose", prompt: "..." })
+  agent_spawn({ description: "Research secure token storage", subagent_type: "general-purpose", prompt: "..." })
 
   Investigating both issues in parallel — I'll report back with findings.
 
@@ -203,11 +208,11 @@ You:
   Found the bug — null pointer in confirmTokenExists in validate.ts. I'll fix it.
   Still waiting on the token storage research.
 
-  Agent({ description: "Fix null pointer in validate.ts", subagent_type: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash." })
+  agent_spawn({ description: "Fix null pointer in validate.ts", subagent_type: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash." })
 
 ## 3. Workers
 
-When calling Agent, use subagent_type `general-purpose` (or `Explore`/`Plan`/`Verification` for the specialized read-only research / planning / verification subsets). Workers execute tasks autonomously — especially research, implementation, or verification.
+When calling agent_spawn, use subagent_type `general-purpose` (or `Explore`/`Plan`/`Verification` for the specialized read-only research / planning / verification subsets). Workers execute tasks autonomously — especially research, implementation, or verification.
 
 Workers have access to standard tools (bash, read_file, write_file, edit_file, glob_search, grep_search, WebFetch, WebSearch, TaskCreate, TaskUpdate, TaskList, ToolSearch, Sleep, StructuredOutput, PowerShell, Config) and project skills via the Skill tool. Delegate skill invocations (e.g. /commit, /verify) to workers.
 
@@ -250,18 +255,18 @@ When a worker reports failure (tests failed, build errors, file not found):
 
 ### Stopping Workers
 
-Use TaskStop to stop a worker you sent in the wrong direction — for example, when you realize mid-flight that the approach is wrong, or the user changes requirements after you launched the worker. Pass the `task_id` from the Agent tool's launch result.
+Use pid_kill to stop a worker you sent in the wrong direction — for example, when you realize mid-flight that the approach is wrong, or the user changes requirements after you launched the worker. Pass the `pid` from the agent_spawn tool's launch result.
 
 ```
 // Launched a worker to refactor auth to use JWT
-Agent({ description: "Refactor auth to JWT", subagent_type: "general-purpose", prompt: "Replace session-based auth with JWT..." })
-// ... returns task_id: "agent-x7q" ...
+agent_spawn({ description: "Refactor auth to JWT", subagent_type: "general-purpose", prompt: "Replace session-based auth with JWT..." })
+// ... returns pid: "agent-x7q" ...
 
 // User clarifies: "Actually, keep sessions — just fix the null pointer"
-TaskStop({ task_id: "agent-x7q" })
+pid_kill({ pid: "agent-x7q" })
 
 // Spawn a fresh worker with corrected instructions
-Agent({ description: "Fix null pointer in validate.ts", subagent_type: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42..." })
+agent_spawn({ description: "Fix null pointer in validate.ts", subagent_type: "general-purpose", prompt: "Fix the null pointer in src/auth/validate.ts:42..." })
 ```
 
 ## 5. Writing Worker Prompts
@@ -276,11 +281,11 @@ Never write "based on your findings" or "based on the research." These phrases d
 
 ```
 // Anti-pattern — lazy delegation
-Agent({ prompt: "Based on your findings, fix the auth bug", ... })
-Agent({ prompt: "The worker found an issue in the auth module. Please fix it.", ... })
+agent_spawn({ prompt: "Based on your findings, fix the auth bug", ... })
+agent_spawn({ prompt: "The worker found an issue in the auth module. Please fix it.", ... })
 
 // Good — synthesized spec
-Agent({ prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash.", ... })
+agent_spawn({ prompt: "Fix the null pointer in src/auth/validate.ts:42. The user field on Session (src/auth/types.ts:15) is undefined when sessions expire but the token remains cached. Add a null check before user.id access — if null, return 401 with 'Session expired'. Commit and report the hash.", ... })
 ```
 
 A well-synthesized spec gives the worker everything it needs in a few sentences.

--- a/rust/crates/runtime/src/coordinator_notification.rs
+++ b/rust/crates/runtime/src/coordinator_notification.rs
@@ -63,7 +63,7 @@ pub fn emit(workspace_root: &Path, from: &str, task_notification_xml: &str) -> R
     let envelope = MailboxEnvelope {
         from: from.to_string(),
         to: COORDINATOR_INBOX_RECIPIENT.to_string(),
-        text: task_notification_xml.to_string(),
+        body: task_notification_xml.to_string(),
         summary: None,
         timestamp: 0, // filled by append_envelope
         color: None,
@@ -109,7 +109,7 @@ pub fn drain(workspace_root: &Path) -> Result<Vec<String>, String> {
     let out: Vec<String> = envelopes[consumed..]
         .iter()
         .filter(|env| env.kind == kinds::TASK_NOTIFICATION)
-        .map(|env| env.text.clone())
+        .map(|env| env.body.clone())
         .collect();
     write_consumed_offset(workspace_root, envelopes.len())?;
     Ok(out)
@@ -257,7 +257,7 @@ mod tests {
             MailboxEnvelope {
                 from: "team-lead".to_string(),
                 to: COORDINATOR_INBOX_RECIPIENT.to_string(),
-                text: "just chatting".to_string(),
+                body: "just chatting".to_string(),
                 summary: None,
                 timestamp: 0,
                 color: None,

--- a/rust/crates/runtime/src/fs_backend.rs
+++ b/rust/crates/runtime/src/fs_backend.rs
@@ -156,6 +156,52 @@ pub trait FsBackend: Send + Sync + 'static {
     fn join_path(&self, dir: &str, name: &str) -> String {
         format!("{}/{}", dir.trim_end_matches(['/', '\\']), name)
     }
+
+    /// Blocking tail read from an append-only log at `cursor`.
+    ///
+    /// Returns `(data, next_cursor, eof)`:
+    /// - `data` — new bytes appended since `cursor` (empty when no new data
+    ///   arrived before the deadline).
+    /// - `next_cursor` — position to pass on the next call.
+    /// - `eof` — `true` when the deadline expired with no new data.
+    ///
+    /// `block_ms = 0` is a non-blocking drain (return immediately).
+    ///
+    /// The default polls file size at 100ms intervals (cross-platform).
+    /// `KernelFsBackend` overrides with the kernel's blocking `sys_read`.
+    /// `NexusVfsFsBackend` overrides with `stream_read_at` (gRPC blocking
+    /// tail).
+    fn tail_read(
+        &self,
+        path: &str,
+        cursor: u64,
+        block_ms: u64,
+    ) -> io::Result<(Vec<u8>, u64, bool)> {
+        use std::io::{Read, Seek, SeekFrom};
+        use std::time::{Duration, Instant};
+
+        let deadline = Instant::now() + Duration::from_millis(block_ms);
+        let poll_interval = Duration::from_millis(100);
+
+        loop {
+            let len = match self.stat(path) {
+                Ok(meta) => meta.len,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => 0,
+                Err(e) => return Err(e),
+            };
+            if len > cursor {
+                let mut f = std::fs::File::open(path)?;
+                f.seek(SeekFrom::Start(cursor))?;
+                let mut buf = vec![0u8; (len - cursor) as usize];
+                f.read_exact(&mut buf)?;
+                return Ok((buf, len, false));
+            }
+            if block_ms == 0 || Instant::now() >= deadline {
+                return Ok((vec![], cursor, true));
+            }
+            std::thread::sleep(poll_interval.min(deadline - Instant::now()));
+        }
+    }
 }
 
 /// Resolve `path` against `root` without touching any filesystem.
@@ -249,6 +295,14 @@ impl FsBackend for Arc<dyn FsBackend> {
     }
     fn join_path(&self, dir: &str, name: &str) -> String {
         (**self).join_path(dir, name)
+    }
+    fn tail_read(
+        &self,
+        path: &str,
+        cursor: u64,
+        block_ms: u64,
+    ) -> io::Result<(Vec<u8>, u64, bool)> {
+        (**self).tail_read(path, cursor, block_ms)
     }
 }
 
@@ -574,6 +628,28 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
         Ok(self.is_stream_entry(path))
     }
 
+    fn tail_read(
+        &self,
+        path: &str,
+        cursor: u64,
+        block_ms: u64,
+    ) -> io::Result<(Vec<u8>, u64, bool)> {
+        let result = self
+            .kernel
+            .sys_read(path, &self.ctx, block_ms, cursor)
+            .map_err(kernel_err)?;
+        match result.data {
+            Some(payload) if !payload.is_empty() => {
+                let next = result
+                    .stream_next_offset
+                    .map(|n| n as u64)
+                    .unwrap_or(cursor);
+                Ok((payload, next, false))
+            }
+            _ => Ok((vec![], cursor, true)),
+        }
+    }
+
     fn managed_sessions_root(&self) -> Option<String> {
         // nexus keeps sessions as a flat, session-id-keyed byte-SSOT at the
         // VFS root — no `.scode`, no `workspace_hash` (isolation is policy +
@@ -750,12 +826,22 @@ impl<K: KernelSyscall + Send + Sync + 'static> FsBackend for KernelFsBackend<K> 
 /// Wraps a [`nexus_vfs_client::NexusVfsClient`] + auth token to implement
 /// [`FsBackend`]. Used by the standalone CLI when `NEXUS_VFS_SOCK` is set.
 pub struct NexusVfsFsBackend {
-    client: nexus_vfs_client::NexusVfsClient,
+    client: std::sync::Arc<nexus_vfs_client::NexusVfsClient>,
     auth_token: String,
 }
 
 impl NexusVfsFsBackend {
     pub fn new(client: nexus_vfs_client::NexusVfsClient, auth_token: String) -> Self {
+        Self {
+            client: std::sync::Arc::new(client),
+            auth_token,
+        }
+    }
+
+    pub fn from_arc(
+        client: std::sync::Arc<nexus_vfs_client::NexusVfsClient>,
+        auth_token: String,
+    ) -> Self {
         Self { client, auth_token }
     }
 }
@@ -770,9 +856,25 @@ impl FsBackend for NexusVfsFsBackend {
     }
 
     fn append(&self, path: &str, data: &[u8]) -> io::Result<()> {
-        let mut existing = self.client.read(path, &self.auth_token).unwrap_or_default();
-        existing.extend_from_slice(data);
-        self.client.write(path, existing, &self.auth_token)
+        if path.ends_with("/chat-with-me") {
+            self.client
+                .stream_write(path, data.to_vec(), &self.auth_token)
+                .map(|_offset| ())
+        } else {
+            let mut existing = self.client.read(path, &self.auth_token).unwrap_or_default();
+            existing.extend_from_slice(data);
+            self.client.write(path, existing, &self.auth_token)
+        }
+    }
+
+    fn create_append_log(&self, path: &str, retention: u64) -> io::Result<()> {
+        self.client
+            .ensure_stream(path, "wal,memory", retention, &self.auth_token)
+            .map(|_| ())
+    }
+
+    fn is_append_stream(&self, path: &str) -> io::Result<bool> {
+        Ok(path.ends_with("/chat-with-me"))
     }
 
     fn delete(&self, path: &str) -> io::Result<()> {
@@ -827,6 +929,16 @@ impl FsBackend for NexusVfsFsBackend {
     fn symlink_metadata(&self, path: &str) -> io::Result<FsMetadata> {
         // VFS has no symlinks — delegate to regular stat.
         self.stat(path)
+    }
+
+    fn tail_read(
+        &self,
+        path: &str,
+        cursor: u64,
+        block_ms: u64,
+    ) -> io::Result<(Vec<u8>, u64, bool)> {
+        self.client
+            .stream_read_at(path, cursor, block_ms > 0, block_ms, &self.auth_token)
     }
 }
 

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -32,6 +32,7 @@ pub mod image_registry;
 mod json;
 mod lane_events;
 pub mod lsp_client;
+pub mod mailbox;
 mod mcp;
 mod mcp_client;
 mod mcp_connection;

--- a/rust/crates/runtime/src/mailbox.rs
+++ b/rust/crates/runtime/src/mailbox.rs
@@ -250,6 +250,53 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
+const LOCAL_POLL_BLOCK_MS: u64 = 1000;
+
+/// Spawn a background thread that polls a local JSONL inbox for
+/// incoming peer messages and invokes `sink` for each one.
+///
+/// The thread blocks up to 1s per iteration waiting for new data,
+/// then loops. File-not-found is handled gracefully (the file may
+/// not exist until a sub-agent first writes to it).
+pub fn spawn_local_poller(
+    workspace_root: std::path::PathBuf,
+    self_id: String,
+    abort: crate::HookAbortSignal,
+    sink: impl Fn(&MailboxEnvelope) + Send + 'static,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("local-inbox-poller".into())
+        .spawn(move || {
+            let backend: Arc<dyn crate::fs_backend::FsBackend> =
+                Arc::new(crate::fs_backend::StdFsBackend);
+            let mailbox = Mailbox::new(
+                backend,
+                self_id,
+                InboxConvention::LocalJsonl {
+                    root: workspace_root.to_string_lossy().into_owned(),
+                },
+            );
+            let mut cursor = 0u64;
+            while !abort.is_aborted() {
+                match mailbox.poll(cursor, LOCAL_POLL_BLOCK_MS) {
+                    Ok((msgs, next)) => {
+                        for m in &msgs {
+                            sink(m);
+                        }
+                        if next > cursor {
+                            cursor = next;
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[local-inbox] poll failed: {e}");
+                        std::thread::sleep(std::time::Duration::from_millis(LOCAL_POLL_BLOCK_MS));
+                    }
+                }
+            }
+        })
+        .expect("spawn local-inbox-poller thread")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -410,5 +457,43 @@ mod tests {
 
         let nexus = InboxConvention::NexusA2a;
         assert_eq!(nexus.inbox_path("win-ai"), "/agents/win-ai/chat-with-me");
+    }
+
+    #[test]
+    fn spawn_local_poller_delivers_messages() {
+        let ws = temp_workspace("local-poller");
+        let (tx, rx) = std::sync::mpsc::channel::<MailboxEnvelope>();
+        let abort = crate::HookAbortSignal::new();
+        let abort_clone = abort.clone();
+
+        let _handle = super::spawn_local_poller(
+            std::path::PathBuf::from(&ws),
+            "team-lead".to_string(),
+            abort_clone,
+            move |msg| {
+                let _ = tx.send(msg.clone());
+            },
+        );
+
+        // Write a message from a sub-agent to team-lead's inbox.
+        let mb = local_mailbox(&ws, "sub-agent-1");
+        mb.send(MailboxEnvelope {
+            from: "sub-agent-1".to_string(),
+            to: "team-lead".to_string(),
+            body: "task complete".to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+
+        let msg = rx.recv_timeout(std::time::Duration::from_secs(3)).unwrap();
+        assert_eq!(msg.from, "sub-agent-1");
+        assert_eq!(msg.body, "task complete");
+
+        abort.abort();
+        let _ = std::fs::remove_dir_all(&ws);
     }
 }

--- a/rust/crates/runtime/src/mailbox.rs
+++ b/rust/crates/runtime/src/mailbox.rs
@@ -1,0 +1,414 @@
+//! Unified mailbox abstraction over [`crate::fs_backend::FsBackend`].
+//!
+//! Provides transport-agnostic send/receive for inter-agent messaging.
+//! The `FsBackend` determines framing:
+//! - DT_STREAM backends (kernel, nexus-vfs): each `append` is one framed
+//!   write, each `tail_read` returns one frame.
+//! - File backends (StdFs): JSONL — newline-delimited JSON per `append`,
+//!   `tail_read` returns raw bytes split by newline on read.
+//!
+//! Callers construct a `Mailbox` with a backend and an [`InboxConvention`]
+//! that maps agent names to inbox paths. Everything above this layer is
+//! backend-agnostic.
+
+use std::sync::Arc;
+
+use crate::agent_mailbox::MailboxEnvelope;
+use crate::fs_backend::FsBackend;
+
+/// How agent names map to inbox paths.
+#[derive(Debug, Clone)]
+pub enum InboxConvention {
+    /// Local JSONL: `{root}/.sudocode-inbox/{name}.jsonl`.
+    LocalJsonl { root: String },
+    /// Nexus A2A DT_STREAM: `/agents/{name}/chat-with-me`.
+    NexusA2a,
+}
+
+impl InboxConvention {
+    /// Resolve the inbox path for an agent name.
+    #[must_use]
+    pub fn inbox_path(&self, name: &str) -> String {
+        match self {
+            InboxConvention::LocalJsonl { root } => {
+                format!("{root}/.sudocode-inbox/{name}.jsonl")
+            }
+            InboxConvention::NexusA2a => {
+                format!("/agents/{name}/chat-with-me")
+            }
+        }
+    }
+}
+
+/// Transport-agnostic agent mailbox.
+///
+/// Wraps an [`FsBackend`] + path convention, providing send/receive that
+/// works identically whether the underlying transport is a local JSONL
+/// file or a nexus DT_STREAM.
+pub struct Mailbox {
+    backend: Arc<dyn FsBackend>,
+    self_id: String,
+    convention: InboxConvention,
+}
+
+impl Mailbox {
+    pub fn new(backend: Arc<dyn FsBackend>, self_id: String, convention: InboxConvention) -> Self {
+        Self {
+            backend,
+            self_id,
+            convention,
+        }
+    }
+
+    #[must_use]
+    pub fn self_id(&self) -> &str {
+        &self.self_id
+    }
+
+    #[must_use]
+    pub fn inbox_path(&self, agent: &str) -> String {
+        self.convention.inbox_path(agent)
+    }
+
+    #[must_use]
+    pub fn own_inbox_path(&self) -> String {
+        self.convention.inbox_path(&self.self_id)
+    }
+
+    /// Provision this agent's inbox (idempotent). For DT_STREAM backends
+    /// this creates the stream; for file backends this is a no-op (the
+    /// file is created lazily on first write).
+    pub fn ensure_inbox(&self) -> Result<(), String> {
+        let path = self.own_inbox_path();
+        let is_stream = self.backend.is_append_stream(&path).unwrap_or(false);
+        if is_stream {
+            return Ok(());
+        }
+        self.backend
+            .create_append_log(&path, crate::agent_mailbox::DEFAULT_STREAM_CAPACITY)
+            .map_err(|e| format!("ensure inbox {path}: {e}"))
+    }
+
+    /// Send a message to a recipient's inbox.
+    pub fn send(&self, mut envelope: MailboxEnvelope) -> Result<(), String> {
+        if envelope.from.is_empty() {
+            envelope.from = self.self_id.clone();
+        }
+        let path = self.convention.inbox_path(&envelope.to);
+
+        let is_stream = self.backend.is_append_stream(&path).unwrap_or(false);
+        let data = if is_stream {
+            envelope.to_bytes()
+        } else {
+            if envelope.timestamp == 0 {
+                envelope.timestamp = now_secs();
+            }
+            let parent = path.rsplit_once('/').map(|(p, _)| p).unwrap_or(".");
+            let _ = std::fs::create_dir_all(parent);
+            let mut line = serde_json::to_vec(&envelope).unwrap_or_default();
+            line.push(b'\n');
+            line
+        };
+        self.backend
+            .append(&path, &data)
+            .map_err(|e| format!("mailbox send to {path}: {e}"))
+    }
+
+    /// Read new messages from own inbox starting at `cursor`.
+    ///
+    /// Returns `(messages, next_cursor)`. The caller persists `next_cursor`
+    /// across calls. `block_ms > 0` makes the read block until new data
+    /// arrives or the timeout elapses.
+    ///
+    /// Messages from `self_id` are filtered out (no echo).
+    pub fn poll(&self, cursor: u64, block_ms: u64) -> Result<(Vec<MailboxEnvelope>, u64), String> {
+        let path = self.own_inbox_path();
+        let is_stream = self.backend.is_append_stream(&path).unwrap_or(false);
+        if is_stream {
+            self.poll_stream(&path, cursor, block_ms)
+        } else {
+            self.poll_jsonl(&path, cursor, block_ms)
+        }
+    }
+
+    /// DT_STREAM: one frame per `tail_read`, drain burst non-blocking
+    /// after the first blocking read (same pattern as `nexus_mailbox::poll_new`).
+    fn poll_stream(
+        &self,
+        path: &str,
+        mut cursor: u64,
+        block_ms: u64,
+    ) -> Result<(Vec<MailboxEnvelope>, u64), String> {
+        let mut out = Vec::new();
+        let mut first = true;
+        loop {
+            let blocking = first && block_ms > 0;
+            first = false;
+            let (data, next, eof) = self
+                .backend
+                .tail_read(path, cursor, if blocking { block_ms } else { 0 })
+                .map_err(|e| format!("mailbox poll {path}@{cursor}: {e}"))?;
+            if eof {
+                break;
+            }
+            if let Some(env) = MailboxEnvelope::from_bytes(&data) {
+                if !env.from.is_empty() && env.from != self.self_id && !env.body.is_empty() {
+                    out.push(env);
+                }
+            }
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+        }
+        Ok((out, cursor))
+    }
+
+    /// JSONL: `tail_read` returns raw bytes, split by newline.
+    fn poll_jsonl(
+        &self,
+        path: &str,
+        cursor: u64,
+        block_ms: u64,
+    ) -> Result<(Vec<MailboxEnvelope>, u64), String> {
+        let (data, next, _eof) = self
+            .backend
+            .tail_read(path, cursor, block_ms)
+            .map_err(|e| format!("mailbox poll {path}@{cursor}: {e}"))?;
+        if data.is_empty() {
+            return Ok((vec![], next));
+        }
+        let text = String::from_utf8_lossy(&data);
+        let out: Vec<MailboxEnvelope> = text
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    return None;
+                }
+                let env = MailboxEnvelope::from_bytes(trimmed.as_bytes())?;
+                if env.from.is_empty() || env.from == self.self_id || env.body.is_empty() {
+                    return None;
+                }
+                Some(env)
+            })
+            .collect();
+        Ok((out, next))
+    }
+
+    /// Read ALL messages for a recipient (batch read). Primarily for the
+    /// coordinator's multi-turn loop which reads the entire inbox between
+    /// turns.
+    pub fn read_all(&self, recipient: &str) -> Result<Vec<MailboxEnvelope>, String> {
+        let path = self.convention.inbox_path(recipient);
+        let is_stream = self.backend.is_append_stream(&path).unwrap_or(false);
+        if is_stream {
+            let (envs, _cursor) = self.poll_stream(&path, 0, 0)?;
+            Ok(envs)
+        } else {
+            crate::agent_mailbox::read_all_from_path(&path)
+        }
+    }
+
+    /// List all recipients that have an inbox. Only meaningful for the
+    /// local JSONL convention (DT_STREAM inboxes are discovered via the
+    /// agent registry, not directory listing).
+    pub fn list_recipients(&self) -> Result<Vec<String>, String> {
+        match &self.convention {
+            InboxConvention::LocalJsonl { root } => {
+                crate::agent_mailbox::list_recipients(std::path::Path::new(root))
+            }
+            InboxConvention::NexusA2a => Ok(vec![]),
+        }
+    }
+
+    /// Build a [`MailboxSender`] closure from this mailbox — the
+    /// type-erased send capability handed to tool executors.
+    #[must_use]
+    pub fn sender(self: &Arc<Self>) -> crate::spawn_task::MailboxSender {
+        let mb = Arc::clone(self);
+        Arc::new(move |to: &str, body: &str| {
+            let env = MailboxEnvelope {
+                from: mb.self_id.clone(),
+                to: to.to_string(),
+                body: body.to_string(),
+                summary: None,
+                timestamp: 0,
+                color: None,
+                kind: String::new(),
+                request_id: None,
+            };
+            mb.send(env)
+        })
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs_backend::StdFsBackend;
+
+    fn temp_workspace(label: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!(
+            "mailbox-unified-{label}-{nanos}-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    fn local_mailbox(root: &str, self_id: &str) -> Mailbox {
+        Mailbox::new(
+            Arc::new(StdFsBackend),
+            self_id.to_string(),
+            InboxConvention::LocalJsonl {
+                root: root.to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn send_and_poll_local_jsonl() {
+        let ws = temp_workspace("send-poll");
+        let mb = local_mailbox(&ws, "team-lead");
+
+        mb.send(MailboxEnvelope {
+            from: "team-lead".to_string(),
+            to: "worker".to_string(),
+            body: "hello worker".to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+
+        let worker_mb = local_mailbox(&ws, "worker");
+        let (msgs, _cursor) = worker_mb.poll(0, 0).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].from, "team-lead");
+        assert_eq!(msgs[0].body, "hello worker");
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn poll_filters_self_writes() {
+        let ws = temp_workspace("self-filter");
+        let mb = local_mailbox(&ws, "agent-a");
+
+        mb.send(MailboxEnvelope {
+            from: "agent-a".to_string(),
+            to: "agent-a".to_string(),
+            body: "self-write".to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+        mb.send(MailboxEnvelope {
+            from: "agent-b".to_string(),
+            to: "agent-a".to_string(),
+            body: "from peer".to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+
+        let (msgs, _) = mb.poll(0, 0).unwrap();
+        assert_eq!(msgs.len(), 1, "self-writes must be filtered");
+        assert_eq!(msgs[0].body, "from peer");
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn read_all_returns_all_messages() {
+        let ws = temp_workspace("read-all");
+        let mb = local_mailbox(&ws, "coordinator");
+
+        for i in 0..3 {
+            mb.send(MailboxEnvelope {
+                from: format!("agent-{i}"),
+                to: "worker".to_string(),
+                body: format!("msg-{i}"),
+                summary: None,
+                timestamp: 0,
+                color: None,
+                kind: String::new(),
+                request_id: None,
+            })
+            .unwrap();
+        }
+
+        let envs = mb.read_all("worker").unwrap();
+        assert_eq!(envs.len(), 3);
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn list_recipients_local() {
+        let ws = temp_workspace("list-recip");
+        let mb = local_mailbox(&ws, "coordinator");
+
+        mb.send(MailboxEnvelope {
+            from: "coordinator".to_string(),
+            to: "alpha".to_string(),
+            body: "hi".to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+        mb.send(MailboxEnvelope {
+            from: "coordinator".to_string(),
+            to: "beta".to_string(),
+            body: "hi".to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+
+        let names = mb.list_recipients().unwrap();
+        assert_eq!(names, vec!["alpha", "beta"]);
+
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn inbox_path_conventions() {
+        let local = InboxConvention::LocalJsonl {
+            root: "/workspace".to_string(),
+        };
+        assert_eq!(
+            local.inbox_path("worker"),
+            "/workspace/.sudocode-inbox/worker.jsonl"
+        );
+
+        let nexus = InboxConvention::NexusA2a;
+        assert_eq!(nexus.inbox_path("win-ai"), "/agents/win-ai/chat-with-me");
+    }
+}

--- a/rust/crates/runtime/src/nexus_mailbox.rs
+++ b/rust/crates/runtime/src/nexus_mailbox.rs
@@ -15,8 +15,9 @@
 
 use std::sync::Arc;
 
-use a2a::MailboxEnvelope;
 use nexus_vfs_client::NexusVfsClient;
+
+use crate::agent_mailbox::MailboxEnvelope;
 
 use crate::spawn_task::MailboxSender;
 
@@ -210,6 +211,11 @@ pub fn send(
         from: from.to_string(),
         to: to.to_string(),
         body: body.to_string(),
+        summary: None,
+        timestamp: 0,
+        color: None,
+        kind: String::new(),
+        request_id: None,
     };
     let path = inbox_path(to);
     client
@@ -253,13 +259,6 @@ pub fn ensure_inbox(client: &NexusVfsClient, agent: &str, auth_token: &str) -> R
         .map_err(|e| format!("ensure A2A inbox {path}: {e}"))
 }
 
-/// One inbound A2A message (self-writes and empty bodies already filtered).
-#[derive(Debug, Clone)]
-pub struct Inbound {
-    pub from: String,
-    pub body: String,
-}
-
 /// Wait for and drain new frames in `self_agent`'s inbox from `cursor` forward.
 ///
 /// `block_ms == 0` is a pure non-blocking drain (seek-to-tail / one-shot
@@ -291,7 +290,7 @@ pub fn poll_new(
     mut cursor: u64,
     auth_token: &str,
     block_ms: u64,
-) -> Result<(Vec<Inbound>, u64), String> {
+) -> Result<(Vec<MailboxEnvelope>, u64), String> {
     let path = inbox_path(self_agent);
     let mut out = Vec::new();
     let mut first = true;
@@ -315,10 +314,7 @@ pub fn poll_new(
         }
         if let Some(env) = MailboxEnvelope::from_bytes(&data) {
             if !env.from.is_empty() && env.from != self_agent && !env.body.is_empty() {
-                out.push(Inbound {
-                    from: env.from,
-                    body: env.body,
-                });
+                out.push(env);
             }
         }
         if next <= cursor {
@@ -430,18 +426,39 @@ mod tests {
     }
 
     #[test]
-    fn envelope_round_trips_via_the_a2a_ssot_type() {
-        // We reuse the a2a-crate envelope (the SSOT the co-host writes), so a
-        // round-trip through the same to_bytes/from_bytes the co-host uses
-        // must recover from/body — this is what makes standalone ⇄ co-host
-        // interop byte-identical by construction.
+    fn envelope_round_trips_via_unified_type() {
         let env = MailboxEnvelope {
             from: "operator".into(),
             to: "win-ai".into(),
             body: "hi".into(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
         };
-        let back = MailboxEnvelope::from_bytes(&env.to_bytes()).expect("a2a envelope round-trip");
+        let back = MailboxEnvelope::from_bytes(&env.to_bytes()).expect("envelope round-trip");
         assert_eq!(back.from, "operator");
         assert_eq!(back.body, "hi");
+    }
+
+    #[test]
+    fn unified_envelope_interops_with_a2a_3field_wire() {
+        // A 3-field JSON written by an old a2a::MailboxEnvelope writer
+        // must deserialise into the unified type with extras defaulted.
+        let wire = br#"{"from":"agent-a","to":"agent-b","body":"hello"}"#;
+        let env = MailboxEnvelope::from_bytes(wire).expect("3-field wire compat");
+        assert_eq!(env.from, "agent-a");
+        assert_eq!(env.body, "hello");
+        assert!(env.kind.is_empty());
+        assert_eq!(env.timestamp, 0);
+    }
+
+    #[test]
+    fn unified_envelope_reads_legacy_text_field() {
+        // Old local JSONL used "text" instead of "body".
+        let wire = br#"{"from":"a","to":"b","text":"legacy","kind":"message"}"#;
+        let env = MailboxEnvelope::from_bytes(wire).expect("text alias compat");
+        assert_eq!(env.body, "legacy");
     }
 }

--- a/rust/crates/runtime/src/spawn_task.rs
+++ b/rust/crates/runtime/src/spawn_task.rs
@@ -47,11 +47,8 @@ pub use kernel::core::agents::registry::{AgentDescriptor, AgentState};
 pub use kernel::kernel::syscall::KernelSyscall;
 use kernel::kernel::OperationContext;
 
-// The A2A mailbox message contract is owned by the `a2a` substrate (it stamps
-// `from` + owns the path suffix). Re-export its SSOT types so this loop and the
-// downstream `tools` crate consume the one definition instead of hand-rolling
-// `{from,to,body}` JSON or the `chat-with-me` suffix.
-pub use a2a::{MailboxEnvelope, CHAT_WITH_ME_SUFFIX};
+pub use crate::agent_mailbox::MailboxEnvelope;
+pub use a2a::CHAT_WITH_ME_SUFFIX;
 
 use crate::conversation::{ApiClient, ConversationRuntime, ToolExecutor};
 use crate::hooks::HookAbortSignal;
@@ -180,6 +177,11 @@ pub fn mailbox_sender<K: KernelSyscall + Send + Sync + 'static>(
             from: self_name.clone(),
             to: to.to_string(),
             body: body.to_string(),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
         };
         let ctx = OperationContext::new(&owner_id, &zone_id, false, Some(&self_name), true);
         kernel

--- a/rust/crates/runtime/tests/agent_mailbox_roundtrip.rs
+++ b/rust/crates/runtime/tests/agent_mailbox_roundtrip.rs
@@ -27,7 +27,7 @@ fn make_envelope(from: &str, to: &str, text: &str, kind: &str) -> MailboxEnvelop
     MailboxEnvelope {
         from: from.to_string(),
         to: to.to_string(),
-        text: text.to_string(),
+        body: text.to_string(),
         summary: None,
         timestamp: 0,
         color: None,
@@ -103,9 +103,9 @@ fn read_all_returns_envelopes_in_append_order() {
 
     let envelopes = agent_mailbox::read_all(&ws, "worker").expect("read_all should succeed");
     assert_eq!(envelopes.len(), 3);
-    assert_eq!(envelopes[0].text, "first");
-    assert_eq!(envelopes[1].text, "second");
-    assert_eq!(envelopes[2].text, "third");
+    assert_eq!(envelopes[0].body, "first");
+    assert_eq!(envelopes[1].body, "second");
+    assert_eq!(envelopes[2].body, "third");
 }
 
 #[test]
@@ -148,8 +148,8 @@ fn read_all_skips_malformed_lines() {
         2,
         "malformed line must be skipped, not counted"
     );
-    assert_eq!(envelopes[0].text, "good1");
-    assert_eq!(envelopes[1].text, "good2");
+    assert_eq!(envelopes[0].body, "good1");
+    assert_eq!(envelopes[1].body, "good2");
 }
 
 // ── list_recipients ───────────────────────────────────────────────
@@ -216,7 +216,7 @@ fn structured_shutdown_envelope_survives_roundtrip() {
     let envelope = MailboxEnvelope {
         from: "team-lead".to_string(),
         to: "worker".to_string(),
-        text: body,
+        body,
         summary: None,
         timestamp: 0,
         color: None,
@@ -229,8 +229,8 @@ fn structured_shutdown_envelope_survives_roundtrip() {
     assert_eq!(round.len(), 1);
     assert_eq!(round[0].kind, kinds::SHUTDOWN_REQUEST);
     assert_eq!(round[0].request_id.as_deref(), Some("req_abc"));
-    // Body is JSON-in-JSON — parse the outer `text` field again.
-    let inner: serde_json::Value = serde_json::from_str(&round[0].text).expect("parse inner body");
+    // Body is JSON-in-JSON — parse the outer `body` field again.
+    let inner: serde_json::Value = serde_json::from_str(&round[0].body).expect("parse inner body");
     assert_eq!(
         inner.get("request_id").and_then(|v| v.as_str()),
         Some("req_abc")

--- a/rust/crates/runtime/tests/spawn_task.rs
+++ b/rust/crates/runtime/tests/spawn_task.rs
@@ -293,6 +293,11 @@ fn write_envelope(
         from: from.to_string(),
         to: to.to_string(),
         body: body.to_string(),
+        summary: None,
+        timestamp: 0,
+        color: None,
+        kind: String::new(),
+        request_id: None,
     };
     let reqs = [WriteRequest {
         path: path.to_string(),

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2715,6 +2715,24 @@ fn run_repl_iocraft_dispatch(
             }
             CoordinatorEvent::PeerMessage(msg) => {
                 repl_output.println(&format!("\n\u{1f4e8} A2A from {}: {}", msg.from, msg.body));
+                let prompt = tools::compose_next_turn_from_envelopes(&[msg]);
+                if !turn_active {
+                    turn_active = true;
+                    runner_handle = Some(spawn_iocraft_turn(
+                        Arc::clone(&cli_shared),
+                        prompt,
+                        repl_output.clone(),
+                        repl_ui_cmd.clone(),
+                        repl_spinner.clone(),
+                        Arc::clone(&pending_question_answer),
+                        coord_tx.clone(),
+                    ));
+                } else {
+                    coord
+                        .lock()
+                        .unwrap()
+                        .submit_during_turn(prompt, input_queue::QueueMode::Queue);
+                }
                 continue;
             }
             CoordinatorEvent::Human(input_event) => match input_event {

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2149,6 +2149,17 @@ struct SlashSelectionHandler(
     >,
 );
 
+/// Events from all sources into the coordinator REPL loop.
+///
+/// Multi-producer single-consumer: iocraft UI produces `Human`, the
+/// A2A poller produces `PeerMessage`, and the turn runner produces
+/// `TurnComplete`.
+enum CoordinatorEvent {
+    Human(repl_ui::InputEvent),
+    PeerMessage(runtime::agent_mailbox::MailboxEnvelope),
+    TurnComplete,
+}
+
 /// Show an interactive selection question via iocraft's InputSlot and
 /// register a callback to handle the answer. The coordinator loop routes
 /// the `QuestionAnswer` event to the returned handler.
@@ -2611,38 +2622,53 @@ fn run_repl_iocraft_dispatch(
     let shared_mode = input_queue::shared_queue_mode(mode);
     cli.shared_queue_mode = Some(Arc::clone(&shared_mode));
 
-    // Spawn the iocraft REPL UI on a dedicated thread.
+    // Spawn the iocraft REPL UI on a dedicated thread, then decompose the
+    // handle so `input_rx` can be forwarded into the unified event channel.
     let repl = repl_ui::spawn_repl_ui(&permission_label, &banner);
+    let (repl_output, repl_ui_cmd, input_rx, repl_spinner, repl_join) = repl.split();
     let pending_question_answer: PendingQuestionAnswer = Arc::new(Mutex::new(None));
 
     // Route LiveCli output through iocraft's OutputSender so it goes
     // through split_for_iocraft and renders correctly in raw mode.
-    cli.iocraft_output = Some(repl.output.clone());
+    cli.iocraft_output = Some(repl_output.clone());
     let cli_shared = Arc::new(Mutex::new(cli));
     let session_start = Instant::now();
 
-    // nexus A2A receive-half: when configured, surface peer messages into the
-    // REPL as they arrive. The poller runs for the whole interactive session;
-    // its daemon thread is reaped by the `process::exit(0)` at the end of this
-    // dispatch (the render-loop thread is left the same way), so it needs no
-    // explicit shutdown. The session was already dialed in
-    // `build_runtime_for_cwd`, so this just reuses the cached handle.
+    // Unified coordinator event channel. All event sources (UI input,
+    // A2A peer messages, turn completion) converge here so the loop
+    // blocks on a single recv() with no timeout-based polling.
+    let (coord_tx, coord_rx) = mpsc::channel::<CoordinatorEvent>();
+
+    // Bridge: forward iocraft InputEvents as CoordinatorEvent::Human.
+    let coord_tx_input = coord_tx.clone();
+    let _input_bridge = thread::Builder::new()
+        .name("input-bridge".into())
+        .spawn(move || {
+            while let Ok(evt) = input_rx.recv() {
+                if coord_tx_input.send(CoordinatorEvent::Human(evt)).is_err() {
+                    break;
+                }
+            }
+        })
+        .expect("spawn input bridge");
+
+    // nexus A2A receive-half: peer messages feed into the coordinator
+    // event channel, replacing the old println side-channel. The REPL
+    // loop handles display and (future) turn injection.
     if let Ok(Some(a2a_session)) = engine_host::nexus_a2a::session() {
-        let output = repl.output.clone();
+        let coord_tx_a2a = coord_tx.clone();
         let _poller = engine_host::nexus_a2a::spawn_poller(
             a2a_session,
             runtime::HookAbortSignal::new(),
             move |msg| {
-                output.println(&format!("\n\u{1f4e8} A2A from {}: {}", msg.from, msg.body));
+                let _ = coord_tx_a2a.send(CoordinatorEvent::PeerMessage(msg.clone()));
             },
         );
     }
 
-    // Coordinator loop on the current thread. Reads InputEvents from the
-    // iocraft UI and dispatches turns via the same TurnInputCoordinator +
-    // runner-thread pattern as the rustyline-based coordinator.
+    // Coordinator loop on the current thread. All events arrive through
+    // `coord_rx` — no timeout-based polling needed.
     let coord = Arc::new(Mutex::new(input_queue::TurnInputCoordinator::new()));
-    let (turn_tx, turn_rx) = mpsc::sync_channel::<()>(1);
     let mut turn_active = false;
     let mut runner_handle: Option<thread::JoinHandle<()>> = None;
     // Pending interactive slash command state: when a slash command needs
@@ -2653,249 +2679,235 @@ fn run_repl_iocraft_dispatch(
     let mut pending_slash_selection: Option<SlashSelectionHandler> = None;
 
     loop {
-        // When idle, block on input; when a turn is running, poll both
-        // channels with a 100ms timeout.
-        let event = if !turn_active {
-            match repl.input_rx.recv() {
-                Ok(evt) => Some(evt),
-                Err(_) => {
-                    cancel_pending_question_answer(&pending_question_answer);
-                    repl.ui.clear_question();
-                    if let Some(h) = runner_handle.take() {
-                        let _ = commands.send(EngineCommand::Cancel);
-                        let _ = h.join();
-                    }
-                    break;
-                }
-            }
-        } else {
-            match repl.input_rx.recv_timeout(Duration::from_millis(100)) {
-                Ok(evt) => Some(evt),
-                Err(RecvTimeoutError::Timeout) => {
-                    // Check if a turn finished.
-                    if turn_rx.try_recv().is_ok() {
-                        turn_active = false;
-                        if let Some(h) = runner_handle.take() {
-                            let _ = h.join();
-                        }
-                        let next = coord.lock().unwrap().drain_next();
-                        if let Some(next) = next {
-                            turn_active = true;
-                            runner_handle = Some(spawn_iocraft_turn(
-                                Arc::clone(&cli_shared),
-                                next.prompt,
-                                repl.output.clone(),
-                                repl.ui.clone(),
-                                repl.spinner.clone(),
-                                Arc::clone(&pending_question_answer),
-                                turn_tx.clone(),
-                            ));
-                        }
-                    }
-                    continue;
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    cancel_pending_question_answer(&pending_question_answer);
-                    repl.ui.clear_question();
-                    // Render loop exited — clean up runner if active.
-                    if let Some(h) = runner_handle.take() {
-                        let _ = commands.send(EngineCommand::Cancel);
-                        let _ = h.join();
-                    }
-                    break;
-                }
-            }
-        };
-
-        let Some(event) = event else { continue };
-
-        match event {
-            repl_ui::InputEvent::Exit => {
+        let event = match coord_rx.recv() {
+            Ok(evt) => evt,
+            Err(_) => {
                 cancel_pending_question_answer(&pending_question_answer);
-                repl.ui.clear_question();
+                repl_ui_cmd.clear_question();
                 if let Some(h) = runner_handle.take() {
                     let _ = commands.send(EngineCommand::Cancel);
                     let _ = h.join();
                 }
-                let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
-                if let Err(e) = cli_lock.persist_session() {
-                    repl.output
-                        .println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
-                }
                 break;
             }
-            repl_ui::InputEvent::Abort => {
-                cancel_pending_question_answer(&pending_question_answer);
-                repl.ui.clear_question();
-                if runner_handle.is_some() {
-                    let _ = commands.send(EngineCommand::Cancel);
-                }
-            }
-            repl_ui::InputEvent::Submit(text) => {
-                if text.trim() == "/exit" || text.trim() == "/quit" {
-                    cancel_pending_question_answer(&pending_question_answer);
-                    repl.ui.clear_question();
-                    if runner_handle.is_some() {
-                        let _ = commands.send(EngineCommand::Cancel);
-                    }
-                    if let Some(h) = runner_handle.take() {
-                        let _ = h.join();
-                    }
-                    let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
-                    if let Err(e) = cli_lock.persist_session() {
-                        repl.output
-                            .println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
-                    }
-                    break;
-                }
+        };
 
-                // Try slash command dispatch.
-                let trimmed = text.trim();
-                let is_slash = match SlashCommand::parse(trimmed) {
-                    Ok(Some(SlashCommand::Config { section: None })) => {
-                        // Interactive config tree browser via FieldSchema SSOT.
-                        let cwd = env::current_dir().unwrap_or_default();
-                        let loader = runtime::ConfigLoader::default_for(&cwd);
-                        let settings_path = loader.config_home().join("settings.json");
-                        let sudocode_path = loader.config_home().join("sudocode.json");
-                        pending_slash_selection = Some(cli::config_ui::build_config_tree_handler(
-                            &repl.ui,
-                            settings_path,
-                            sudocode_path,
-                        ));
-                        true
-                    }
-                    Ok(Some(SlashCommand::Model { model: None })) => {
-                        // Interactive model picker via iocraft InputSlot.
-                        let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
-                        let sudocode_config = load_sudocode_config_for_current_dir();
-                        let config_keys: Vec<String> =
-                            sudocode_config.models.keys().cloned().collect();
-                        let models = runtime::model_capabilities::merge_discovery_ids(&config_keys);
-                        let current = cli_lock.lifecycle.current_model();
-                        drop(cli_lock);
-
-                        let options = models
-                            .iter()
-                            .map(|m| repl_ui::QuestionOptionView {
-                                label: m.clone(),
-                                value: m.clone(),
-                                description: None,
-                                recommended: *m == current,
-                                is_navigable: false,
-                            })
-                            .collect();
-                        pending_slash_selection = Some(show_slash_selection(
-                            &repl.ui,
-                            repl_ui::QuestionPromptView {
-                                title: Some("Model".to_string()),
-                                description: Some(format!("Current: {current}")),
-                                index: 0,
-                                total: 1,
-                                prompt: "Select model".to_string(),
-                                options,
-                                allow_custom_input: true,
-                                custom_input_hint: Some("or type a model name".to_string()),
-                                force_fuzzy_select: false,
-                                back_value: None,
-                            },
-                            models,
-                            |model_name, cli, out| {
-                                let mut cli_lock = cli.lock().expect("LiveCli mutex poisoned");
-                                match cli_lock.set_model(Some(model_name)) {
-                                    Ok(true) => {
-                                        if let Err(e) = cli_lock.persist_session() {
-                                            out.println(&format!(
-                                                "{}{e}{}",
-                                                ansi_fg(theme().error),
-                                                RESET
-                                            ));
-                                        }
-                                    }
-                                    Ok(false) => {}
-                                    Err(e) => out.println(&format!(
-                                        "{}{e}{}",
-                                        ansi_fg(theme().error),
-                                        RESET
-                                    )),
-                                }
-                                None
-                            },
-                        ));
-                        true
-                    }
-                    Ok(Some(command)) => {
-                        let mut cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
-                        match cli_lock.handle_repl_command(command) {
-                            Ok(true) => {
-                                if let Err(e) = cli_lock.persist_session() {
-                                    repl.output.println(&format!(
-                                        "{}{e}{}",
-                                        ansi_fg(theme().error),
-                                        RESET
-                                    ));
-                                }
-                            }
-                            Ok(false) => {}
-                            Err(e) => repl.output.println(&format!(
-                                "{}{e}{}",
-                                ansi_fg(theme().error),
-                                RESET
-                            )),
-                        }
-                        true
-                    }
-                    Ok(None) => false,
-                    Err(error) => {
-                        repl.output
-                            .println(&format!("{}{error}{}", ansi_fg(theme().error), RESET));
-                        true
-                    }
-                };
-                if is_slash {
-                    continue;
+        match event {
+            CoordinatorEvent::TurnComplete => {
+                turn_active = false;
+                if let Some(h) = runner_handle.take() {
+                    let _ = h.join();
                 }
-
-                // Route to turn.
-                if !turn_active {
-                    let next = coord.lock().unwrap().submit_when_idle(text);
+                let next = coord.lock().unwrap().drain_next();
+                if let Some(next) = next {
                     turn_active = true;
                     runner_handle = Some(spawn_iocraft_turn(
                         Arc::clone(&cli_shared),
                         next.prompt,
-                        repl.output.clone(),
-                        repl.ui.clone(),
-                        repl.spinner.clone(),
+                        repl_output.clone(),
+                        repl_ui_cmd.clone(),
+                        repl_spinner.clone(),
                         Arc::clone(&pending_question_answer),
-                        turn_tx.clone(),
+                        coord_tx.clone(),
                     ));
-                } else {
-                    let outcome = coord
-                        .lock()
-                        .unwrap()
-                        .submit_during_turn(text, input_queue::load_queue_mode(&shared_mode));
-                    match outcome {
-                        input_queue::SubmitOutcome::Queued => {}
-                        input_queue::SubmitOutcome::Interrupt => {
+                }
+                continue;
+            }
+            CoordinatorEvent::PeerMessage(msg) => {
+                repl_output.println(&format!("\n\u{1f4e8} A2A from {}: {}", msg.from, msg.body));
+                continue;
+            }
+            CoordinatorEvent::Human(input_event) => match input_event {
+                repl_ui::InputEvent::Exit => {
+                    cancel_pending_question_answer(&pending_question_answer);
+                    repl_ui_cmd.clear_question();
+                    if let Some(h) = runner_handle.take() {
+                        let _ = commands.send(EngineCommand::Cancel);
+                        let _ = h.join();
+                    }
+                    let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
+                    if let Err(e) = cli_lock.persist_session() {
+                        repl_output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
+                    }
+                    break;
+                }
+                repl_ui::InputEvent::Abort => {
+                    cancel_pending_question_answer(&pending_question_answer);
+                    repl_ui_cmd.clear_question();
+                    if runner_handle.is_some() {
+                        let _ = commands.send(EngineCommand::Cancel);
+                    }
+                }
+                repl_ui::InputEvent::Submit(text) => {
+                    if text.trim() == "/exit" || text.trim() == "/quit" {
+                        cancel_pending_question_answer(&pending_question_answer);
+                        repl_ui_cmd.clear_question();
+                        if runner_handle.is_some() {
                             let _ = commands.send(EngineCommand::Cancel);
                         }
-                        input_queue::SubmitOutcome::Rejected => {
-                            repl.output.println(
-                                &format!("{DIM}(a turn is running; set SUDOCODE_INTERRUPT_QUEUE_MODE=queue to queue instead){RESET}"),
-                            );
+                        if let Some(h) = runner_handle.take() {
+                            let _ = h.join();
+                        }
+                        let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
+                        if let Err(e) = cli_lock.persist_session() {
+                            repl_output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
+                        }
+                        break;
+                    }
+
+                    // Try slash command dispatch.
+                    let trimmed = text.trim();
+                    let is_slash = match SlashCommand::parse(trimmed) {
+                        Ok(Some(SlashCommand::Config { section: None })) => {
+                            // Interactive config tree browser via FieldSchema SSOT.
+                            let cwd = env::current_dir().unwrap_or_default();
+                            let loader = runtime::ConfigLoader::default_for(&cwd);
+                            let settings_path = loader.config_home().join("settings.json");
+                            let sudocode_path = loader.config_home().join("sudocode.json");
+                            pending_slash_selection =
+                                Some(cli::config_ui::build_config_tree_handler(
+                                    &repl_ui_cmd,
+                                    settings_path,
+                                    sudocode_path,
+                                ));
+                            true
+                        }
+                        Ok(Some(SlashCommand::Model { model: None })) => {
+                            // Interactive model picker via iocraft InputSlot.
+                            let cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
+                            let sudocode_config = load_sudocode_config_for_current_dir();
+                            let config_keys: Vec<String> =
+                                sudocode_config.models.keys().cloned().collect();
+                            let models =
+                                runtime::model_capabilities::merge_discovery_ids(&config_keys);
+                            let current = cli_lock.lifecycle.current_model();
+                            drop(cli_lock);
+
+                            let options = models
+                                .iter()
+                                .map(|m| repl_ui::QuestionOptionView {
+                                    label: m.clone(),
+                                    value: m.clone(),
+                                    description: None,
+                                    recommended: *m == current,
+                                    is_navigable: false,
+                                })
+                                .collect();
+                            pending_slash_selection = Some(show_slash_selection(
+                                &repl_ui_cmd,
+                                repl_ui::QuestionPromptView {
+                                    title: Some("Model".to_string()),
+                                    description: Some(format!("Current: {current}")),
+                                    index: 0,
+                                    total: 1,
+                                    prompt: "Select model".to_string(),
+                                    options,
+                                    allow_custom_input: true,
+                                    custom_input_hint: Some("or type a model name".to_string()),
+                                    force_fuzzy_select: false,
+                                    back_value: None,
+                                },
+                                models,
+                                |model_name, cli, out| {
+                                    let mut cli_lock = cli.lock().expect("LiveCli mutex poisoned");
+                                    match cli_lock.set_model(Some(model_name)) {
+                                        Ok(true) => {
+                                            if let Err(e) = cli_lock.persist_session() {
+                                                out.println(&format!(
+                                                    "{}{e}{}",
+                                                    ansi_fg(theme().error),
+                                                    RESET
+                                                ));
+                                            }
+                                        }
+                                        Ok(false) => {}
+                                        Err(e) => out.println(&format!(
+                                            "{}{e}{}",
+                                            ansi_fg(theme().error),
+                                            RESET
+                                        )),
+                                    }
+                                    None
+                                },
+                            ));
+                            true
+                        }
+                        Ok(Some(command)) => {
+                            let mut cli_lock = cli_shared.lock().expect("LiveCli mutex poisoned");
+                            match cli_lock.handle_repl_command(command) {
+                                Ok(true) => {
+                                    if let Err(e) = cli_lock.persist_session() {
+                                        repl_output.println(&format!(
+                                            "{}{e}{}",
+                                            ansi_fg(theme().error),
+                                            RESET
+                                        ));
+                                    }
+                                }
+                                Ok(false) => {}
+                                Err(e) => repl_output.println(&format!(
+                                    "{}{e}{}",
+                                    ansi_fg(theme().error),
+                                    RESET
+                                )),
+                            }
+                            true
+                        }
+                        Ok(None) => false,
+                        Err(error) => {
+                            repl_output.println(&format!(
+                                "{}{error}{}",
+                                ansi_fg(theme().error),
+                                RESET
+                            ));
+                            true
+                        }
+                    };
+                    if is_slash {
+                        continue;
+                    }
+
+                    // Route to turn.
+                    if !turn_active {
+                        let next = coord.lock().unwrap().submit_when_idle(text);
+                        turn_active = true;
+                        runner_handle = Some(spawn_iocraft_turn(
+                            Arc::clone(&cli_shared),
+                            next.prompt,
+                            repl_output.clone(),
+                            repl_ui_cmd.clone(),
+                            repl_spinner.clone(),
+                            Arc::clone(&pending_question_answer),
+                            coord_tx.clone(),
+                        ));
+                    } else {
+                        let outcome = coord
+                            .lock()
+                            .unwrap()
+                            .submit_during_turn(text, input_queue::load_queue_mode(&shared_mode));
+                        match outcome {
+                            input_queue::SubmitOutcome::Queued => {}
+                            input_queue::SubmitOutcome::Interrupt => {
+                                let _ = commands.send(EngineCommand::Cancel);
+                            }
+                            input_queue::SubmitOutcome::Rejected => {
+                                repl_output.println(
+                                    &format!("{DIM}(a turn is running; set SUDOCODE_INTERRUPT_QUEUE_MODE=queue to queue instead){RESET}"),
+                                );
+                            }
                         }
                     }
                 }
-            }
-            repl_ui::InputEvent::QuestionAnswer(text) => {
-                if let Some(handler) = pending_slash_selection.take() {
-                    pending_slash_selection = (handler.0)(&text, &cli_shared, &repl.output);
-                } else if !consume_pending_question_answer(&pending_question_answer, text) {
-                    repl.output.println(&format!(
-                        "{DIM}(no question is waiting for an answer){RESET}"
-                    ));
+                repl_ui::InputEvent::QuestionAnswer(text) => {
+                    if let Some(handler) = pending_slash_selection.take() {
+                        pending_slash_selection = (handler.0)(&text, &cli_shared, &repl_output);
+                    } else if !consume_pending_question_answer(&pending_question_answer, text) {
+                        repl_output.println(&format!(
+                            "{DIM}(no question is waiting for an answer){RESET}"
+                        ));
+                    }
                 }
-            }
+            },
         }
     }
 
@@ -2905,11 +2917,14 @@ fn run_repl_iocraft_dispatch(
         let cli_lock = cli_shared.lock().expect("LiveCli mutex");
         let _ = cli_lock.persist_session();
     }
+    // Drop coordinator sender so bridge/poller threads see Disconnected,
+    // which drops input_rx and lets the iocraft render loop exit.
+    drop(coord_tx);
     // Let iocraft unwind its render loop before exiting. Its terminal guard
     // restores raw mode, bracketed paste, cursor visibility, and mouse mode.
-    // On Windows PTYs that do not exit promptly, join() abandons the thread
-    // after a bounded wait and process exit remains the fallback.
-    repl.join();
+    // On Windows PTYs that do not exit promptly, the join closure abandons
+    // the thread after a bounded wait and process exit remains the fallback.
+    (repl_join)();
 
     // Unwrap the Arc and finalize telemetry. If the runner thread
     // still holds a clone, force-exit — session is already persisted.
@@ -2955,7 +2970,7 @@ fn spawn_iocraft_turn(
     ui: repl_ui::UiCommandSender,
     spinner: repl_ui::SpinnerState,
     pending_question_answer: PendingQuestionAnswer,
-    done_tx: mpsc::SyncSender<()>,
+    done_tx: mpsc::Sender<CoordinatorEvent>,
 ) -> thread::JoinHandle<()> {
     // The engine owns the abort signal (reset at the start of each turn, fired
     // by the pump on EngineCommand::Cancel), so the runner no longer manages it.
@@ -2968,7 +2983,7 @@ fn spawn_iocraft_turn(
             {
                 output.println(&format!("{}{e}{}", ansi_fg(theme().error), RESET));
             }
-            let _ = done_tx.send(());
+            let _ = done_tx.send(CoordinatorEvent::TurnComplete);
         })
         .expect("spawn repl-runner thread")
 }

--- a/rust/crates/rusty-sudocode-cli/src/main.rs
+++ b/rust/crates/rusty-sudocode-cli/src/main.rs
@@ -2666,6 +2666,23 @@ fn run_repl_iocraft_dispatch(
         );
     }
 
+    // Local JSONL inbox poller: picks up messages that sub-agents
+    // write to `.sudocode-inbox/team-lead.jsonl` via the `send` tool.
+    // Complements the nexus A2A poller above — together they close the
+    // receive loop for both local and cross-machine messaging.
+    {
+        let coord_tx_local = coord_tx.clone();
+        let workspace = env::current_dir().unwrap_or_default();
+        let _local_poller = runtime::mailbox::spawn_local_poller(
+            workspace,
+            "team-lead".to_string(),
+            runtime::HookAbortSignal::new(),
+            move |msg| {
+                let _ = coord_tx_local.send(CoordinatorEvent::PeerMessage(msg.clone()));
+            },
+        );
+    }
+
     // Coordinator loop on the current thread. All events arrive through
     // `coord_rx` — no timeout-based polling needed.
     let coord = Arc::new(Mutex::new(input_queue::TurnInputCoordinator::new()));

--- a/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
+++ b/rust/crates/rusty-sudocode-cli/src/repl_ui.rs
@@ -869,6 +869,38 @@ impl ReplHandle {
             let _ = h.join();
         }
     }
+
+    /// Decompose into parts for the coordinator event channel bridge.
+    /// The returned join closure replaces `self.join()` — call it after
+    /// the coordinator loop exits.
+    #[allow(clippy::type_complexity)]
+    pub fn split(
+        self,
+    ) -> (
+        OutputSender,
+        UiCommandSender,
+        Receiver<InputEvent>,
+        SpinnerState,
+        Box<dyn FnOnce()>,
+    ) {
+        let join_fn = {
+            let ui_thread = self.ui_thread;
+            Box::new(move || {
+                if let Some(h) = ui_thread {
+                    let deadline =
+                        std::time::Instant::now() + std::time::Duration::from_millis(300);
+                    while !h.is_finished() {
+                        if std::time::Instant::now() >= deadline {
+                            return;
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    let _ = h.join();
+                }
+            })
+        };
+        (self.output, self.ui, self.input_rx, self.spinner, join_fn)
+    }
 }
 
 /// Strip ANSI escape sequences (ESC[...m) to count visible characters.

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -152,6 +152,17 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
             panic!("Ctrl-C hint should appear in footer: {e}\nPTY:\n{screen}");
         });
 
+    // After Ctrl-C + hint render, the iocraft layout may need a moment to
+    // re-render the prompt line. Wait for it before typing, otherwise the
+    // screen may not contain the ❯ marker and expect_input_line can never
+    // succeed (observed on macOS CI runners under load).
+    common::expect_input_line(
+        &sess,
+        "",
+        Duration::from_secs(15),
+        "prompt should recover after Ctrl-C hint",
+    );
+
     // Clean exit. Type and submit as two steps, waiting for the line to
     // render in between: Enter is only a submit if the input state has
     // caught up with the characters, and Ctrl-C just cleared that state.
@@ -162,7 +173,7 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
     common::expect_input_line(
         &sess,
         "/exit",
-        Duration::from_secs(10),
+        Duration::from_secs(15),
         "typed /exit should render before Enter",
     );
     sess.send("\r").expect("send Enter");

--- a/rust/crates/rusty-sudocode-cli/tests/pty_unified_send.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_unified_send.rs
@@ -1,0 +1,86 @@
+//! PTY test — unified `send` tool alias routing end-to-end.
+//!
+//! Verifies that the canonical `send` tool name (not the deprecated
+//! `SendMessage`) dispatches through the real binary, writes the JSONL
+//! envelope to `.sudocode-inbox/<recipient>.jsonl`, and returns a
+//! success response that the mock server echoes back.
+//!
+//! Mock-safe: runs in CI without API keys.
+
+mod common;
+
+use std::time::Duration;
+
+use common::TestEnv;
+
+#[test]
+fn send_tool_writes_envelope_and_roundtrips() {
+    let env = TestEnv::new("unified-send");
+
+    let prompt = env.prompt(
+        "Send a message to test-peer saying hello from unified send.",
+        "unified_send_roundtrip",
+    );
+
+    let mut sess = env.spawn(&[
+        "--permission-mode",
+        "workspace-write",
+        "--allowedTools",
+        "send",
+        &prompt,
+    ]);
+
+    // The mock model calls `send` → scode dispatches through alias
+    // routing → writes envelope → returns success JSON → mock echoes
+    // the final text.
+    sess.set_default_timeout(Duration::from_secs(15));
+    sess.expect("(?i)(unified send roundtrip complete|Message sent to)")
+        .unwrap_or_else(|e| {
+            let screen = sess.render(|s| s.contents());
+            panic!(
+                "send roundtrip text not found: {e}\ntail:\n{tail}",
+                tail = screen
+                    .chars()
+                    .rev()
+                    .take(800)
+                    .collect::<String>()
+                    .chars()
+                    .rev()
+                    .collect::<String>(),
+            );
+        });
+
+    let exit = sess.expect_eof().unwrap_or_else(|e| {
+        let screen = sess.render(|s| s.contents());
+        panic!(
+            "scode did not exit: {e}\ntail:\n{tail}",
+            tail = screen
+                .chars()
+                .rev()
+                .take(800)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect::<String>(),
+        );
+    });
+    assert_eq!(exit, 0, "unified send test should exit 0");
+
+    // Disk verification: the envelope must exist in the workspace's
+    // `.sudocode-inbox/test-peer.jsonl`.
+    let inbox = env
+        .workspace_root()
+        .join(".sudocode-inbox")
+        .join("test-peer.jsonl");
+    let content = common::read_file_with_retry(&inbox, 5, Duration::from_millis(200));
+    assert!(
+        content.is_some(),
+        "envelope file should exist at {}",
+        inbox.display()
+    );
+    let content = content.unwrap();
+    assert!(
+        content.contains("hello from unified send"),
+        "envelope should contain the message body; got: {content}"
+    );
+}

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -2249,7 +2249,26 @@ fn run_task_update(input: TaskUpdateInput) -> Result<String, String> {
 #[allow(clippy::needless_pass_by_value)]
 fn run_task_output(input: TaskOutputInput) -> Result<String, String> {
     if let Some(agent_id) = &input.agent_id {
-        return await_agent_output(agent_id, input.block, input.timeout_ms);
+        let mut result = await_agent_output(agent_id, input.block, input.timeout_ms)?;
+        if input.merge {
+            if let Ok(mut parsed) = serde_json::from_str::<Value>(&result) {
+                if let Some(obj) = parsed.as_object_mut() {
+                    obj.insert("merge".to_string(), json!(true));
+                    let store = agent_store_dir().ok();
+                    if let Some(store) = store {
+                        let session_path = agent_session_path(&store, agent_id.trim());
+                        if session_path.exists() {
+                            obj.insert(
+                                "session_path".to_string(),
+                                json!(session_path.display().to_string()),
+                            );
+                        }
+                    }
+                }
+                result = serde_json::to_string_pretty(&parsed).unwrap_or(result);
+            }
+        }
+        return Ok(result);
     }
     let task_id = input
         .task_id
@@ -3996,6 +4015,11 @@ struct TaskOutputInput {
     block: bool,
     #[serde(default = "default_agent_await_timeout_ms")]
     timeout_ms: u64,
+    /// When true, the agent's session context should be merged back
+    /// into the caller's conversation. Surfaced in the output JSON
+    /// as `"merge": true` so the framework layer can act on it.
+    #[serde(default)]
+    merge: bool,
 }
 
 const fn default_block_true() -> bool {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -5649,7 +5649,7 @@ fn run_single_turn(
 /// Multiple envelopes are concatenated with a blank line so the
 /// model treats them as distinct messages. Order preserves the
 /// mailbox write order (JSONL is append-only).
-fn compose_next_turn_from_envelopes(
+pub fn compose_next_turn_from_envelopes(
     envelopes: &[runtime::agent_mailbox::MailboxEnvelope],
 ) -> String {
     let mut blocks = Vec::with_capacity(envelopes.len());

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -59,6 +59,7 @@ pub mod testing {
             name: None,
             model: None,
             run_in_background: Some(true),
+            fresh: None,
             auth_mode: None,
             permission_mode: None,
         };
@@ -3757,6 +3758,10 @@ struct AgentInput {
     model: Option<String>,
     #[serde(default)]
     run_in_background: Option<bool>,
+    /// When true, start a clean session. When false (default), resume
+    /// the most recent session for this agent name if one exists.
+    #[serde(default)]
+    fresh: Option<bool>,
     /// Explicit auth mode: `"api-key"`, `"proxy"`, or `"subscription"`.
     /// When set, overrides the config's auto-detect priority.
     auth_mode: Option<String>,
@@ -4951,6 +4956,9 @@ fn prepare_agent_job(
             .expect("fork ctx presence checked above");
         let messages = build_forked_messages(&input.prompt, parent_assistant);
         (build_fork_child_message(&input.prompt), messages)
+    } else if !input.fresh.unwrap_or(false) {
+        let resumed = find_resumable_session(&agent_name);
+        (input.prompt.clone(), resumed.unwrap_or_default())
     } else {
         (input.prompt.clone(), Vec::new())
     };
@@ -5322,6 +5330,8 @@ fn run_agent_job_returning_text(job: &AgentJob) -> Result<String, String> {
             Ok(final_assistant_text(&summary))
         },
     )?;
+
+    persist_agent_session(&job.manifest, conv_runtime.session());
 
     // Fold telemetry into the on-disk manifest BEFORE any downstream
     // step (summarizer, persist) reads it, so the terminal-state
@@ -7468,6 +7478,58 @@ fn agent_store_dir() -> Result<std::path::PathBuf, String> {
     }
     let cwd = current_workspace_root().map_err(|error| error.to_string())?;
     Ok(cwd.join(".sudocode-agents"))
+}
+
+fn agent_session_path(store_dir: &std::path::Path, agent_id: &str) -> std::path::PathBuf {
+    store_dir.join(format!("{agent_id}.session.jsonl"))
+}
+
+/// Persist the agent's conversation session to disk so a future
+/// `agent_spawn(fresh: false)` with the same name can resume it.
+fn persist_agent_session(manifest: &AgentOutput, session: &Session) {
+    let Ok(store) = agent_store_dir() else {
+        return;
+    };
+    let path = agent_session_path(&store, &manifest.agent_id);
+    if let Err(e) = session.save_to_path(&path) {
+        eprintln!("sudocode: failed to persist agent session: {e}");
+    }
+}
+
+/// Find the most recent completed agent with the given slugified name
+/// and return its persisted session messages. Returns `None` when no
+/// resumable session exists.
+fn find_resumable_session(agent_name: &str) -> Option<Vec<ConversationMessage>> {
+    let store = agent_store_dir().ok()?;
+    if !store.exists() {
+        return None;
+    }
+    let mut candidates: Vec<(String, String)> = Vec::new();
+    let entries = std::fs::read_dir(&store).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(manifest) = serde_json::from_str::<AgentOutput>(&text) else {
+            continue;
+        };
+        if manifest.status != "completed" {
+            continue;
+        }
+        if slugify_agent_name(&manifest.name) != agent_name {
+            continue;
+        }
+        candidates.push((manifest.agent_id, manifest.created_at));
+    }
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    let best_id = &candidates.first()?.0;
+    let session_path = agent_session_path(&store, best_id);
+    let session = Session::load_from_path(&session_path).ok()?;
+    Some(session.messages.clone())
 }
 
 fn make_agent_id() -> String {
@@ -10065,6 +10127,7 @@ mod tests {
                 name: Some("ship-audit".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10155,6 +10218,7 @@ mod tests {
                 name: Some("complete-task".to_string()),
                 model: Some("claude-sonnet-4-6".to_string()),
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10215,6 +10279,7 @@ mod tests {
                 name: Some("fail-task".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10265,6 +10330,7 @@ mod tests {
                 name: Some("summary-floor".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10313,6 +10379,7 @@ mod tests {
                 name: Some("recovery-lane".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10364,6 +10431,7 @@ mod tests {
                 name: Some("review-lane".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10407,6 +10475,7 @@ mod tests {
                 name: Some("backlog-scan".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10456,6 +10525,7 @@ mod tests {
                 name: Some("artifact-lane".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10529,6 +10599,7 @@ mod tests {
                 name: Some("cron-closeout".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10573,6 +10644,7 @@ mod tests {
                 name: Some("spawn-error".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10874,6 +10946,7 @@ mod tests {
                 name: Some("calc-task".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10920,6 +10993,7 @@ mod tests {
                 name: Some("fail-calc".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -10963,6 +11037,7 @@ mod tests {
                 name: Some("slow-calc".to_string()),
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -11010,6 +11085,7 @@ mod tests {
                 name: None,
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -11041,6 +11117,7 @@ mod tests {
                 name: None,
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -11510,6 +11587,7 @@ mod tests {
                 name: None,
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },
@@ -11572,6 +11650,7 @@ mod tests {
                 name: None,
                 model: None,
                 run_in_background: None,
+                fresh: None,
                 auth_mode: None,
                 permission_mode: None,
             },

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -11209,6 +11209,7 @@ mod tests {
             run_in_background: Some(false),
             auth_mode: None,
             permission_mode: None,
+            fresh: None,
         }
     }
 

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -2730,7 +2730,7 @@ fn write_envelope(
     let envelope = MailboxEnvelope {
         from: from.to_string(),
         to: recipient.to_string(),
-        text: text.to_string(),
+        body: text.to_string(),
         summary: summary.map(str::to_string),
         timestamp: 0, // filled in by append_envelope
         color: None,
@@ -5665,7 +5665,7 @@ fn compose_next_turn_from_envelopes(
             header.push_str(&format!(" request-id=\"{}\"", xml_attr_escape(rid)));
         }
         header.push('>');
-        blocks.push(format!("{header}\n{}\n</{tag}>", env.text));
+        blocks.push(format!("{header}\n{}\n</{tag}>", env.body));
     }
     blocks.join("\n\n")
 }
@@ -8682,10 +8682,11 @@ mod tests {
         classify_lane_failure, derive_agent_state, execute_agent_inline_with_work,
         execute_agent_with_spawn, execute_tool, extract_recovery_outcome, final_assistant_text,
         global_cron_registry, lookup_custom_agent, maybe_commit_provenance, mvp_tool_specs,
-        normalize_subagent_type, permission_mode_from_plugin, persist_agent_terminal_state,
-        push_output_block, run_ask_user_question_v2, sweep_orphaned_tmp_files, AgentInput,
-        AgentJob, AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption,
-        GlobalToolRegistry, LaneEventName, LaneFailureClass, SubagentToolExecutor,
+        normalize_pid_input, normalize_send_input, normalize_subagent_type,
+        permission_mode_from_plugin, persist_agent_terminal_state, push_output_block,
+        run_ask_user_question_v2, sweep_orphaned_tmp_files, AgentInput, AgentJob,
+        AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption, GlobalToolRegistry,
+        LaneEventName, LaneFailureClass, SubagentToolExecutor,
     };
     use api::OutputContentBlock;
     use runtime::{
@@ -12603,5 +12604,92 @@ printf 'pwsh:%s' "$1"
             )
             .into_bytes()
         }
+    }
+
+    // ── Unified send alias routing ────────────────────────────────────
+
+    #[test]
+    fn canonicalize_send_message_pascal_case_to_send() {
+        assert_eq!(canonicalize_tool_name("SendMessage"), "send");
+    }
+
+    #[test]
+    fn canonicalize_send_message_snake_case_to_send() {
+        assert_eq!(canonicalize_tool_name("send_message"), "send");
+    }
+
+    #[test]
+    fn canonicalize_send_stays_send() {
+        assert_eq!(canonicalize_tool_name("send"), "send");
+    }
+
+    #[test]
+    fn canonicalize_preserves_unknown_tool_name() {
+        assert_eq!(canonicalize_tool_name("bash"), "bash");
+        assert_eq!(canonicalize_tool_name("EnterPlanMode"), "EnterPlanMode");
+    }
+
+    #[test]
+    fn normalize_send_input_bridges_body_to_message() {
+        let input = json!({"to": "worker", "body": "hello"});
+        let out = normalize_send_input(&input);
+        assert_eq!(out["message"], "hello");
+        assert!(out.get("body").is_none(), "body should be removed");
+        assert_eq!(out["to"], "worker");
+    }
+
+    #[test]
+    fn normalize_send_input_preserves_message_when_present() {
+        let input = json!({"to": "worker", "message": "hello", "body": "ignored"});
+        let out = normalize_send_input(&input);
+        assert_eq!(out["message"], "hello");
+        assert_eq!(out["body"], "ignored", "body kept when message exists");
+    }
+
+    #[test]
+    fn normalize_send_input_no_body_no_message() {
+        let input = json!({"to": "worker"});
+        let out = normalize_send_input(&input);
+        assert!(out.get("message").is_none());
+        assert!(out.get("body").is_none());
+    }
+
+    // ── Unified pid alias routing ─────────────────────────────────────
+
+    #[test]
+    fn canonicalize_task_stop_to_pid_kill() {
+        assert_eq!(canonicalize_tool_name("TaskStop"), "pid_kill");
+    }
+
+    #[test]
+    fn canonicalize_task_get_and_list_to_pid_status() {
+        assert_eq!(canonicalize_tool_name("TaskGet"), "pid_status");
+        assert_eq!(canonicalize_tool_name("TaskList"), "pid_status");
+    }
+
+    #[test]
+    fn canonicalize_task_output_to_pid_output() {
+        assert_eq!(canonicalize_tool_name("TaskOutput"), "pid_output");
+    }
+
+    #[test]
+    fn canonicalize_agent_to_agent_spawn() {
+        assert_eq!(canonicalize_tool_name("Agent"), "agent_spawn");
+    }
+
+    #[test]
+    fn normalize_pid_input_bridges_pid_to_task_id() {
+        let input = json!({"pid": "abc-123"});
+        let out = normalize_pid_input(&input);
+        assert_eq!(out["task_id"], "abc-123");
+        assert!(out.get("pid").is_none());
+    }
+
+    #[test]
+    fn normalize_pid_input_preserves_task_id_when_present() {
+        let input = json!({"task_id": "existing", "pid": "ignored"});
+        let out = normalize_pid_input(&input);
+        assert_eq!(out["task_id"], "existing");
+        assert_eq!(out["pid"], "ignored", "pid kept when task_id exists");
     }
 }

--- a/rust/crates/tools/tests/subagent_multi_turn_loop.rs
+++ b/rust/crates/tools/tests/subagent_multi_turn_loop.rs
@@ -60,7 +60,7 @@ fn envelope(kind: &str, from: &str, text: &str) -> MailboxEnvelope {
     MailboxEnvelope {
         from: from.to_string(),
         to: String::new(), // filled by append_envelope
-        text: text.to_string(),
+        body: text.to_string(),
         summary: None,
         timestamp: 0,
         color: None,

--- a/rust/crates/tools/tests/unified_agent_pid_e2e.rs
+++ b/rust/crates/tools/tests/unified_agent_pid_e2e.rs
@@ -1,0 +1,829 @@
+//! End-to-end mock tests for the Unified Agent/PID Tool System.
+//!
+//! Exercises the full feature without live API keys:
+//! - `TOOL_ALIASES` routing: deprecated names → canonical names
+//! - Input normalization: `body` → `message`, `pid` → `task_id`, etc.
+//! - `compose_next_turn_from_envelopes`: XML formatting + ordering
+//! - Local JSONL poller → channel → delivery roundtrip
+//! - Multi-turn loop: `PeerMessage` injection during idle and busy states
+//! - Multi-turn loop with mixed envelope kinds (message + shutdown)
+//! - `TurnInputCoordinator`: queue/interrupt semantics for `PeerMessage`
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use runtime::agent_mailbox::{self, kinds, MailboxEnvelope};
+use runtime::mailbox::{InboxConvention, Mailbox};
+use runtime::HookAbortSignal;
+use tools::testing::{compose_next_turn_from_envelopes_for_test, run_multi_turn_loop_for_test};
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn unique_workspace(label: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "unified-e2e-{label}-{nanos}-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&path).expect("mkdir workspace");
+    path
+}
+
+fn envelope(kind: &str, from: &str, body: &str) -> MailboxEnvelope {
+    MailboxEnvelope {
+        from: from.to_string(),
+        to: String::new(),
+        body: body.to_string(),
+        summary: None,
+        timestamp: 0,
+        color: None,
+        kind: kind.to_string(),
+        request_id: None,
+    }
+}
+
+fn envelope_with_request_id(
+    kind: &str,
+    from: &str,
+    body: &str,
+    request_id: &str,
+) -> MailboxEnvelope {
+    MailboxEnvelope {
+        from: from.to_string(),
+        to: String::new(),
+        body: body.to_string(),
+        summary: None,
+        timestamp: 0,
+        color: None,
+        kind: kind.to_string(),
+        request_id: Some(request_id.to_string()),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 1. TOOL ALIAS ROUTING
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn canonicalize_maps_sendmessage_to_send() {
+    assert_eq!(tools::canonicalize_tool_name("SendMessage"), "send");
+}
+
+#[test]
+fn canonicalize_maps_send_message_to_send() {
+    assert_eq!(tools::canonicalize_tool_name("send_message"), "send");
+}
+
+#[test]
+fn canonicalize_maps_agent_to_agent_spawn() {
+    assert_eq!(tools::canonicalize_tool_name("Agent"), "agent_spawn");
+}
+
+#[test]
+fn canonicalize_maps_taskstop_to_pid_kill() {
+    assert_eq!(tools::canonicalize_tool_name("TaskStop"), "pid_kill");
+}
+
+#[test]
+fn canonicalize_maps_taskget_to_pid_status() {
+    assert_eq!(tools::canonicalize_tool_name("TaskGet"), "pid_status");
+}
+
+#[test]
+fn canonicalize_maps_tasklist_to_pid_status() {
+    assert_eq!(tools::canonicalize_tool_name("TaskList"), "pid_status");
+}
+
+#[test]
+fn canonicalize_maps_taskoutput_to_pid_output() {
+    assert_eq!(tools::canonicalize_tool_name("TaskOutput"), "pid_output");
+}
+
+#[test]
+fn canonicalize_preserves_canonical_names() {
+    assert_eq!(tools::canonicalize_tool_name("send"), "send");
+    assert_eq!(tools::canonicalize_tool_name("agent_spawn"), "agent_spawn");
+    assert_eq!(tools::canonicalize_tool_name("pid_kill"), "pid_kill");
+    assert_eq!(tools::canonicalize_tool_name("pid_status"), "pid_status");
+    assert_eq!(tools::canonicalize_tool_name("pid_output"), "pid_output");
+    assert_eq!(tools::canonicalize_tool_name("pid_fork"), "pid_fork");
+    assert_eq!(tools::canonicalize_tool_name("agent_list"), "agent_list");
+}
+
+#[test]
+fn canonicalize_preserves_pascalcase_native_tools() {
+    assert_eq!(
+        tools::canonicalize_tool_name("EnterPlanMode"),
+        "EnterPlanMode"
+    );
+    assert_eq!(
+        tools::canonicalize_tool_name("ExitPlanMode"),
+        "ExitPlanMode"
+    );
+    assert_eq!(tools::canonicalize_tool_name("TaskCreate"), "TaskCreate");
+    assert_eq!(tools::canonicalize_tool_name("TaskUpdate"), "TaskUpdate");
+    assert_eq!(tools::canonicalize_tool_name("WebFetch"), "WebFetch");
+    assert_eq!(tools::canonicalize_tool_name("Skill"), "Skill");
+}
+
+#[test]
+fn canonicalize_maps_cc_style_read_write_edit_to_snake_case() {
+    assert_eq!(tools::canonicalize_tool_name("Read"), "read_file");
+    assert_eq!(tools::canonicalize_tool_name("Write"), "write_file");
+    assert_eq!(tools::canonicalize_tool_name("Edit"), "edit_file");
+    assert_eq!(tools::canonicalize_tool_name("Bash"), "bash");
+    assert_eq!(tools::canonicalize_tool_name("Glob"), "glob_search");
+    assert_eq!(tools::canonicalize_tool_name("Grep"), "grep_search");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 2. COMPOSE_NEXT_TURN_FROM_ENVELOPES — XML FORMATTING
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn compose_single_message_envelope() {
+    let envs = vec![envelope(kinds::MESSAGE, "worker-1", "task complete")];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    assert!(text.contains("<mailbox-message from=\"worker-1\">"));
+    assert!(text.contains("task complete"));
+    assert!(text.contains("</mailbox-message>"));
+}
+
+#[test]
+fn compose_shutdown_request_uses_correct_tag() {
+    let envs = vec![envelope(kinds::SHUTDOWN_REQUEST, "team-lead", "stop now")];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    assert!(text.contains("<shutdown-request from=\"team-lead\">"));
+    assert!(text.contains("</shutdown-request>"));
+}
+
+#[test]
+fn compose_shutdown_response_uses_correct_tag() {
+    let envs = vec![envelope(kinds::SHUTDOWN_RESPONSE, "worker", "acknowledged")];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    assert!(text.contains("<shutdown-response from=\"worker\">"));
+    assert!(text.contains("</shutdown-response>"));
+}
+
+#[test]
+fn compose_plan_approval_response_uses_correct_tag() {
+    let envs = vec![envelope(
+        kinds::PLAN_APPROVAL_RESPONSE,
+        "team-lead",
+        "approved",
+    )];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    assert!(text.contains("<plan-approval-response from=\"team-lead\">"));
+    assert!(text.contains("</plan-approval-response>"));
+}
+
+#[test]
+fn compose_includes_request_id_attribute() {
+    let envs = vec![envelope_with_request_id(
+        kinds::SHUTDOWN_REQUEST,
+        "team-lead",
+        "stop",
+        "req_abc123",
+    )];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    assert!(
+        text.contains("request-id=\"req_abc123\""),
+        "request_id must appear as XML attribute; got: {text}"
+    );
+}
+
+#[test]
+fn compose_multiple_envelopes_preserves_order_and_separates() {
+    let envs = vec![
+        envelope(kinds::MESSAGE, "alpha", "first message"),
+        envelope(kinds::MESSAGE, "beta", "second message"),
+        envelope(kinds::MESSAGE, "gamma", "third message"),
+    ];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    let idx_first = text.find("first message").expect("first present");
+    let idx_second = text.find("second message").expect("second present");
+    let idx_third = text.find("third message").expect("third present");
+    assert!(idx_first < idx_second);
+    assert!(idx_second < idx_third);
+    // Envelopes are separated by blank lines
+    assert!(text.contains("\n\n"));
+}
+
+#[test]
+fn compose_escapes_xml_special_chars_in_from() {
+    let envs = vec![envelope(kinds::MESSAGE, "agent<&>\"test", "body")];
+    let text = compose_next_turn_from_envelopes_for_test(&envs);
+    assert!(
+        !text.contains("from=\"agent<"),
+        "< must be escaped in from attribute"
+    );
+    assert!(text.contains("&lt;"));
+    assert!(text.contains("&amp;"));
+    assert!(text.contains("&quot;"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 3. LOCAL JSONL POLLER → CHANNEL → DELIVERY ROUNDTRIP
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn local_poller_delivers_sub_agent_message_to_parent() {
+    let ws = unique_workspace("poller-roundtrip");
+    let (tx, rx) = std::sync::mpsc::channel::<MailboxEnvelope>();
+    let abort = HookAbortSignal::new();
+    let abort_clone = abort.clone();
+
+    let _handle = runtime::mailbox::spawn_local_poller(
+        ws.clone(),
+        "team-lead".to_string(),
+        abort_clone,
+        move |msg| {
+            let _ = tx.send(msg.clone());
+        },
+    );
+
+    // Sub-agent writes to team-lead's inbox
+    agent_mailbox::append_envelope(
+        &ws,
+        "team-lead",
+        envelope(kinds::MESSAGE, "researcher", "found the bug in line 42"),
+    )
+    .unwrap();
+
+    let msg = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("poller should deliver message within 5s");
+    assert_eq!(msg.from, "researcher");
+    assert_eq!(msg.body, "found the bug in line 42");
+
+    abort.abort();
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+#[test]
+fn local_poller_delivers_multiple_messages_in_order() {
+    let ws = unique_workspace("poller-multi");
+    let (tx, rx) = std::sync::mpsc::channel::<MailboxEnvelope>();
+    let abort = HookAbortSignal::new();
+    let abort_clone = abort.clone();
+
+    let _handle = runtime::mailbox::spawn_local_poller(
+        ws.clone(),
+        "team-lead".to_string(),
+        abort_clone,
+        move |msg| {
+            let _ = tx.send(msg.clone());
+        },
+    );
+
+    // Multiple sub-agents write to team-lead's inbox
+    agent_mailbox::append_envelope(
+        &ws,
+        "team-lead",
+        envelope(kinds::MESSAGE, "worker-1", "task A done"),
+    )
+    .unwrap();
+    agent_mailbox::append_envelope(
+        &ws,
+        "team-lead",
+        envelope(kinds::MESSAGE, "worker-2", "task B done"),
+    )
+    .unwrap();
+
+    let msg1 = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("first message");
+    let msg2 = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("second message");
+
+    assert_eq!(msg1.from, "worker-1");
+    assert_eq!(msg1.body, "task A done");
+    assert_eq!(msg2.from, "worker-2");
+    assert_eq!(msg2.body, "task B done");
+
+    abort.abort();
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+#[test]
+fn local_poller_stops_on_abort() {
+    let ws = unique_workspace("poller-abort");
+    let (tx, rx) = std::sync::mpsc::channel::<MailboxEnvelope>();
+    let abort = HookAbortSignal::new();
+    let abort_clone = abort.clone();
+
+    let handle = runtime::mailbox::spawn_local_poller(
+        ws.clone(),
+        "team-lead".to_string(),
+        abort_clone,
+        move |msg| {
+            let _ = tx.send(msg.clone());
+        },
+    );
+
+    abort.abort();
+    handle.join().expect("poller thread should exit cleanly");
+
+    // Write after abort — should never be delivered
+    agent_mailbox::append_envelope(
+        &ws,
+        "team-lead",
+        envelope(kinds::MESSAGE, "worker", "too late"),
+    )
+    .unwrap();
+
+    assert!(
+        rx.recv_timeout(Duration::from_millis(200)).is_err(),
+        "no messages after abort"
+    );
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 4. FULL SEND → RECEIVE → COMPOSE → INJECT ROUNDTRIP
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Simulates the complete message cycle:
+/// 1. Sub-agent uses `send` tool → writes JSONL envelope
+/// 2. Local poller picks up the envelope
+/// 3. `compose_next_turn_from_envelopes` formats it as XML
+/// 4. The formatted text is injected into the next LLM turn
+///
+/// This tests the full chain without any live LLM or PTY.
+#[test]
+fn full_send_receive_compose_inject_cycle() {
+    let ws = unique_workspace("full-cycle");
+    let agent_id = "worker-full-cycle";
+    let abort = HookAbortSignal::default();
+
+    let turn_count = Arc::new(AtomicUsize::new(0));
+    let turn_count_cb = turn_count.clone();
+    let prompts = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let prompts_cb = prompts.clone();
+    let ws_cb = ws.clone();
+
+    // The multi-turn loop simulates the REPL's behavior: after each
+    // turn, it drains the mailbox and composes envelopes into the next
+    // turn's prompt. The `run_turn_fn` callback writes an envelope on
+    // turn 1, which triggers turn 2 with the composed XML prompt.
+    let final_text = run_multi_turn_loop_for_test(
+        agent_id,
+        &ws,
+        abort,
+        String::from("PARITY_SCENARIO:unified_send_roundtrip start the task"),
+        16,
+        move |prompt| {
+            let idx = turn_count_cb.fetch_add(1, Ordering::SeqCst);
+            prompts_cb.lock().unwrap().push(prompt.clone());
+            if idx == 0 {
+                // Sub-agent writes to its own mailbox (simulating a
+                // peer sending a message via the `send` tool)
+                agent_mailbox::append_envelope(
+                    &ws_cb,
+                    agent_id,
+                    envelope(kinds::MESSAGE, "team-lead", "here is the plan"),
+                )
+                .unwrap();
+                Ok(String::from("acknowledged, waiting for instructions"))
+            } else {
+                // Turn 2: should receive the composed envelope
+                assert!(
+                    prompt.contains("<mailbox-message from=\"team-lead\">"),
+                    "turn 2 prompt must contain composed envelope header; got: {prompt}"
+                );
+                assert!(
+                    prompt.contains("here is the plan"),
+                    "turn 2 prompt must contain the message body; got: {prompt}"
+                );
+                Ok(String::from("plan received, executing"))
+            }
+        },
+    )
+    .expect("full cycle should complete");
+
+    assert_eq!(turn_count.load(Ordering::SeqCst), 2);
+    assert_eq!(final_text, "plan received, executing");
+
+    // Verify prompts
+    let prompts = prompts.lock().unwrap();
+    assert_eq!(prompts.len(), 2);
+    // Turn 1: original user prompt
+    assert!(prompts[0].contains("start the task"));
+    // Turn 2: composed from envelope
+    assert!(prompts[1].contains("team-lead"));
+    assert!(prompts[1].contains("here is the plan"));
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 5. MULTI-TURN LOOP: MIXED ENVELOPE KINDS
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Verifies that a message envelope triggers a resume turn but a
+/// `shutdown_request` envelope causes immediate exit WITHOUT another turn.
+#[test]
+fn mixed_message_then_shutdown_exits_after_message_turn() {
+    let ws = unique_workspace("mixed-kinds");
+    let agent_id = "agent-mixed";
+    let abort = HookAbortSignal::default();
+
+    let turn_count = Arc::new(AtomicUsize::new(0));
+    let turn_count_cb = turn_count.clone();
+    let ws_cb = ws.clone();
+
+    let final_text = run_multi_turn_loop_for_test(
+        agent_id,
+        &ws,
+        abort,
+        String::from("hello"),
+        16,
+        move |_prompt| {
+            let idx = turn_count_cb.fetch_add(1, Ordering::SeqCst);
+            match idx {
+                0 => {
+                    // Turn 1: write a message envelope → should trigger turn 2
+                    agent_mailbox::append_envelope(
+                        &ws_cb,
+                        agent_id,
+                        envelope(kinds::MESSAGE, "team-lead", "do more work"),
+                    )
+                    .unwrap();
+                    Ok(String::from("turn 1 done"))
+                }
+                1 => {
+                    // Turn 2: write a shutdown_request → should exit after this turn
+                    agent_mailbox::append_envelope(
+                        &ws_cb,
+                        agent_id,
+                        envelope(kinds::SHUTDOWN_REQUEST, "team-lead", "stop now"),
+                    )
+                    .unwrap();
+                    Ok(String::from("turn 2 done, about to shutdown"))
+                }
+                _ => panic!("shutdown_request must prevent turn 3"),
+            }
+        },
+    )
+    .expect("should exit cleanly");
+
+    assert_eq!(
+        turn_count.load(Ordering::SeqCst),
+        2,
+        "message triggers turn 2, shutdown after turn 2 prevents turn 3"
+    );
+    assert_eq!(final_text, "turn 2 done, about to shutdown");
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 6. MAILBOX UNIFIED ABSTRACTION: SEND + POLL ROUNDTRIP
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Tests the unified Mailbox abstraction: send from one agent, poll
+/// from another, verify the envelope is delivered correctly.
+#[test]
+fn unified_mailbox_send_poll_roundtrip() {
+    let ws = unique_workspace("unified-mailbox-rt");
+    let ws_str = ws.to_string_lossy().to_string();
+
+    let sender_mb = Mailbox::new(
+        Arc::new(runtime::fs_backend::StdFsBackend),
+        "coordinator".to_string(),
+        InboxConvention::LocalJsonl {
+            root: ws_str.clone(),
+        },
+    );
+
+    sender_mb
+        .send(MailboxEnvelope {
+            from: "coordinator".to_string(),
+            to: "researcher".to_string(),
+            body: "investigate the auth module".to_string(),
+            summary: Some("auth investigation".to_string()),
+            timestamp: 0,
+            color: None,
+            kind: kinds::MESSAGE.to_string(),
+            request_id: None,
+        })
+        .unwrap();
+
+    let receiver_mb = Mailbox::new(
+        Arc::new(runtime::fs_backend::StdFsBackend),
+        "researcher".to_string(),
+        InboxConvention::LocalJsonl { root: ws_str },
+    );
+
+    let (msgs, cursor) = receiver_mb.poll(0, 0).unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].from, "coordinator");
+    assert_eq!(msgs[0].body, "investigate the auth module");
+    assert_eq!(msgs[0].summary.as_deref(), Some("auth investigation"));
+
+    // Subsequent poll with updated cursor should return no new messages
+    let (msgs2, _) = receiver_mb.poll(cursor, 0).unwrap();
+    assert!(msgs2.is_empty(), "no new messages after cursor advance");
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+/// Tests that `read_all` returns messages from all senders.
+#[test]
+fn unified_mailbox_read_all_from_multiple_senders() {
+    let ws = unique_workspace("read-all-multi");
+    let ws_str = ws.to_string_lossy().to_string();
+
+    let mb = Mailbox::new(
+        Arc::new(runtime::fs_backend::StdFsBackend),
+        "hub".to_string(),
+        InboxConvention::LocalJsonl {
+            root: ws_str.clone(),
+        },
+    );
+
+    for i in 0..5 {
+        mb.send(MailboxEnvelope {
+            from: format!("agent-{i}"),
+            to: "worker".to_string(),
+            body: format!("report {i}"),
+            summary: None,
+            timestamp: 0,
+            color: None,
+            kind: String::new(),
+            request_id: None,
+        })
+        .unwrap();
+    }
+
+    let envs = mb.read_all("worker").unwrap();
+    assert_eq!(envs.len(), 5);
+    for (i, env) in envs.iter().enumerate() {
+        assert_eq!(env.body, format!("report {i}"));
+    }
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 7. ENVELOPE WIRE COMPAT: `text` alias → `body`
+// ═══════════════════════════════════════════════════════════════════════
+
+/// The `text` field alias must deserialize into `body` for backward compat
+/// with old local JSONL data.
+#[test]
+fn envelope_text_alias_deserializes_to_body() {
+    let raw = r#"{"from":"old-agent","to":"worker","text":"hello from old format"}"#;
+    let env: MailboxEnvelope = serde_json::from_str(raw).expect("text alias must parse");
+    assert_eq!(env.body, "hello from old format");
+    assert_eq!(env.from, "old-agent");
+}
+
+/// Serialization always uses `body`, never `text`.
+#[test]
+fn envelope_serializes_body_not_text() {
+    let env = MailboxEnvelope {
+        from: "agent".to_string(),
+        to: "peer".to_string(),
+        body: "content".to_string(),
+        summary: None,
+        timestamp: 0,
+        color: None,
+        kind: String::new(),
+        request_id: None,
+    };
+    let json = serde_json::to_string(&env).unwrap();
+    assert!(json.contains("\"body\""));
+    assert!(!json.contains("\"text\""));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 8. COORDINATOR ALLOWED TOOLS INCLUDES ALL CANONICAL + DEPRECATED
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn coordinator_allowed_tools_includes_canonical_names() {
+    let allowed = runtime::coordinator_mode::coordinator_allowed_tools();
+    assert!(allowed.contains("agent_spawn"));
+    assert!(allowed.contains("agent_list"));
+    assert!(allowed.contains("send"));
+    assert!(allowed.contains("pid_kill"));
+    assert!(allowed.contains("pid_status"));
+    assert!(allowed.contains("pid_output"));
+    assert!(allowed.contains("pid_fork"));
+}
+
+#[test]
+fn coordinator_allowed_tools_includes_deprecated_aliases() {
+    let allowed = runtime::coordinator_mode::coordinator_allowed_tools();
+    assert!(allowed.contains("Agent"));
+    assert!(allowed.contains("SendMessage"));
+    assert!(allowed.contains("TaskStop"));
+    assert!(allowed.contains("TaskGet"));
+    assert!(allowed.contains("TaskList"));
+    assert!(allowed.contains("TaskOutput"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 9. INBOX PATH CONVENTIONS
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn inbox_convention_local_jsonl_resolves_correctly() {
+    let conv = InboxConvention::LocalJsonl {
+        root: "/project".to_string(),
+    };
+    assert_eq!(
+        conv.inbox_path("worker-1"),
+        "/project/.sudocode-inbox/worker-1.jsonl"
+    );
+}
+
+#[test]
+fn inbox_convention_nexus_a2a_resolves_correctly() {
+    let conv = InboxConvention::NexusA2a;
+    assert_eq!(conv.inbox_path("agent-x"), "/agents/agent-x/chat-with-me");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 10. MULTI-TURN LOOP: PEER MESSAGE INJECTION DURING IDLE
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Simulates the REPL's `PeerMessage` handler when idle:
+/// 1. Local poller picks up a sub-agent message
+/// 2. `compose_next_turn_from_envelopes` formats it
+/// 3. The composed prompt is what `submit_when_idle` would receive
+///
+/// This is a unit-level simulation (no PTY) — tests the data flow
+/// from poller through compose. `TurnInputCoordinator` integration
+/// lives in the CLI crate's own tests (`peer_message_queue.rs`).
+#[test]
+fn peer_message_poller_to_compose_roundtrip() {
+    let ws = unique_workspace("idle-inject");
+    let (tx, rx) = std::sync::mpsc::channel::<MailboxEnvelope>();
+    let abort = HookAbortSignal::new();
+    let abort_clone = abort.clone();
+
+    let _handle = runtime::mailbox::spawn_local_poller(
+        ws.clone(),
+        "team-lead".to_string(),
+        abort_clone,
+        move |msg| {
+            let _ = tx.send(msg.clone());
+        },
+    );
+
+    // Sub-agent sends a message
+    agent_mailbox::append_envelope(
+        &ws,
+        "team-lead",
+        envelope(kinds::MESSAGE, "researcher", "found critical vulnerability in auth.rs"),
+    )
+    .unwrap();
+
+    // Poller delivers
+    let msg = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("should receive message");
+
+    // Compose into turn prompt (what the REPL does)
+    let prompt = compose_next_turn_from_envelopes_for_test(&[msg]);
+    assert!(prompt.contains("<mailbox-message from=\"researcher\">"));
+    assert!(prompt.contains("found critical vulnerability in auth.rs"));
+    assert!(prompt.contains("</mailbox-message>"));
+
+    abort.abort();
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 11. MULTI-TURN LOOP: POLLER → COMPOSE → MULTI-TURN INTEGRATION
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Full integration test: poller delivers message, which feeds into
+/// multi-turn loop. Verifies the complete data path from disk write
+/// to LLM turn injection.
+#[test]
+fn poller_compose_multi_turn_integration() {
+    let ws = unique_workspace("poller-mt");
+    let agent_id = "agent-poller-mt";
+    let abort = HookAbortSignal::default();
+
+    let turn_count = Arc::new(AtomicUsize::new(0));
+    let turn_count_cb = turn_count.clone();
+    let prompts = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let prompts_cb = prompts.clone();
+    let ws_cb = ws.clone();
+
+    let final_text = run_multi_turn_loop_for_test(
+        agent_id,
+        &ws,
+        abort,
+        String::from("initial task"),
+        16,
+        move |prompt| {
+            let idx = turn_count_cb.fetch_add(1, Ordering::SeqCst);
+            prompts_cb.lock().unwrap().push(prompt.clone());
+            match idx {
+                0 => {
+                    // Simulate peer sending two messages between turns
+                    agent_mailbox::append_envelope(
+                        &ws_cb,
+                        agent_id,
+                        MailboxEnvelope {
+                            from: "coordinator".to_string(),
+                            to: agent_id.to_string(),
+                            body: "proceed with phase 2".to_string(),
+                            summary: Some("phase 2 directive".to_string()),
+                            timestamp: 0,
+                            color: None,
+                            kind: kinds::MESSAGE.to_string(),
+                            request_id: None,
+                        },
+                    )
+                    .unwrap();
+                    agent_mailbox::append_envelope(
+                        &ws_cb,
+                        agent_id,
+                        MailboxEnvelope {
+                            from: "coordinator".to_string(),
+                            to: agent_id.to_string(),
+                            body: "also update the README".to_string(),
+                            summary: None,
+                            timestamp: 0,
+                            color: None,
+                            kind: kinds::MESSAGE.to_string(),
+                            request_id: None,
+                        },
+                    )
+                    .unwrap();
+                    Ok(String::from("phase 1 complete"))
+                }
+                1 => {
+                    // Verify both messages are in the composed prompt
+                    assert!(
+                        prompt.contains("proceed with phase 2"),
+                        "prompt must contain first message"
+                    );
+                    assert!(
+                        prompt.contains("also update the README"),
+                        "prompt must contain second message"
+                    );
+                    Ok(String::from("phase 2 and README done"))
+                }
+                _ => panic!("should not reach turn 3"),
+            }
+        },
+    )
+    .expect("multi-turn integration should complete");
+
+    assert_eq!(turn_count.load(Ordering::SeqCst), 2);
+    assert_eq!(final_text, "phase 2 and README done");
+
+    let _ = std::fs::remove_dir_all(&ws);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 12. ENVELOPE KINDS MODULE CONSTANTS ARE STABLE
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn kind_constants_match_wire_format() {
+    assert_eq!(kinds::MESSAGE, "message");
+    assert_eq!(kinds::SHUTDOWN_REQUEST, "shutdown_request");
+    assert_eq!(kinds::SHUTDOWN_RESPONSE, "shutdown_response");
+    assert_eq!(kinds::PLAN_APPROVAL_RESPONSE, "plan_approval_response");
+    assert_eq!(kinds::TASK_NOTIFICATION, "task_notification");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 13. MAILBOX SENDER CLOSURE
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn mailbox_sender_closure_writes_envelope() {
+    let ws = unique_workspace("sender-closure");
+    let ws_str = ws.to_string_lossy().to_string();
+
+    let mb = Arc::new(Mailbox::new(
+        Arc::new(runtime::fs_backend::StdFsBackend),
+        "team-lead".to_string(),
+        InboxConvention::LocalJsonl { root: ws_str },
+    ));
+
+    let sender = mb.sender();
+    sender("worker-1", "please review PR #42").unwrap();
+
+    let envs = mb.read_all("worker-1").unwrap();
+    assert_eq!(envs.len(), 1);
+    assert_eq!(envs[0].from, "team-lead");
+    assert_eq!(envs[0].body, "please review PR #42");
+
+    let _ = std::fs::remove_dir_all(&ws);
+}

--- a/rust/crates/tools/tests/unified_agent_pid_e2e.rs
+++ b/rust/crates/tools/tests/unified_agent_pid_e2e.rs
@@ -620,14 +620,23 @@ fn coordinator_allowed_tools_includes_canonical_names() {
 }
 
 #[test]
-fn coordinator_allowed_tools_includes_deprecated_aliases() {
-    let allowed = runtime::coordinator_mode::coordinator_allowed_tools();
-    assert!(allowed.contains("Agent"));
-    assert!(allowed.contains("SendMessage"));
-    assert!(allowed.contains("TaskStop"));
-    assert!(allowed.contains("TaskGet"));
-    assert!(allowed.contains("TaskList"));
-    assert!(allowed.contains("TaskOutput"));
+fn coordinator_predicate_admits_deprecated_aliases_via_canonicalization() {
+    use runtime::coordinator_mode::is_tool_allowed_in_coordinator_mode;
+    std::env::set_var("SUDOCODE_COORDINATOR_MODE", "1");
+    for alias in [
+        "Agent",
+        "SendMessage",
+        "TaskStop",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+    ] {
+        assert!(
+            is_tool_allowed_in_coordinator_mode(alias),
+            "deprecated alias `{alias}` should be admitted via canonicalization"
+        );
+    }
+    std::env::remove_var("SUDOCODE_COORDINATOR_MODE");
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -683,7 +692,11 @@ fn peer_message_poller_to_compose_roundtrip() {
     agent_mailbox::append_envelope(
         &ws,
         "team-lead",
-        envelope(kinds::MESSAGE, "researcher", "found critical vulnerability in auth.rs"),
+        envelope(
+            kinds::MESSAGE,
+            "researcher",
+            "found critical vulnerability in auth.rs",
+        ),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

Unifies the two parallel agent-communication systems (sub-agent coordinator mode and A2A managed-agent) into 7 canonical tools aligned to nexus's agent/pid model:

| Tool | Replaces | Behavior |
|------|----------|----------|
| `agent_spawn` | `Agent` | Default auto-resume; `fresh: true` = new session |
| `agent_list` | (new) | List all known agents from config + custom agents |
| `send` | `SendMessage` + `send_message` | Unified messaging — auto-routes by name or pid |
| `pid_fork` | (implicit in `Agent`) | Snapshot current session into a new pid |
| `pid_output` | `TaskOutput` | Retrieve result; `merge: true` signals context merge-back |
| `pid_status` | `TaskGet` / `TaskList` | Query READY/BUSY/TERMINATED |
| `pid_kill` | `TaskStop` | Terminate run |

### Key changes

- **Unified `send` tool** with `normalize_send_input()` bridging `{to,body}` → `{to,message}`
- **`TOOL_ALIASES`** map + `canonicalize_tool_name()` for full backward compatibility
- **`Mailbox` abstraction** with `FsBackend` trait — transport-agnostic over local JSONL and nexus DT_STREAM
- **`MailboxEnvelope`** unified 8-field type with `#[serde(alias = "text")]` for wire compat
- **PeerMessage → LLM turn injection** — messages now format as `<mailbox-message>` XML and inject as new turns (idle → direct start, busy → queue)
- **Local JSONL inbox poller** — `spawn_local_poller` closes the sub-agent → parent receive loop for local messaging
- **`agent_spawn` auto-resume** — `fresh: false` (default) finds and resumes the most recent session; `persist_agent_session()` saves after completion
- **`pid_output` merge flag** — `merge: true` surfaces `session_path` in output JSON for framework-level merge-back
- **Coordinator system prompt** updated to canonical tool names; deprecated aliases kept in `coordinator_allowed_tools()` for backward compat

### Commits

1. `2729e64` — Phase 0: unified send, TOOL_ALIASES, Mailbox, CoordinatorEvent::PeerMessage, A2A poller wiring, 15 unit tests + PTY e2e
2. `51cd53f` — Phase 1: PeerMessage → LLM turn injection (was print-only)
3. `3cf84f7` — Phase 2: agent_spawn auto-resume with `fresh` flag, session persistence
4. `df38f38` — Phase 4: pid_output merge flag, session path in output
5. `b820f5f` — Phase 7: coordinator prompt canonical names, deprecated alias backward compat
6. `5d4f862` — Local JSONL inbox poller closing the sub-agent → parent messaging loop

Design doc: https://s.shareone.vip/s/unified-agent-pid-tools

## Test plan

- [ ] `cargo fmt --check` — clean
- [ ] `cargo clippy -p tools -p runtime -p rusty-sudocode-cli` — no errors
- [ ] `cargo test -p runtime --lib` — 732 pass (includes new poller test)
- [ ] `cargo test -p tools --lib` — all alias routing + normalize tests pass
- [ ] `cargo test -p tools --test subagent_multi_turn_loop` — 6 pass
- [ ] `cargo test -p runtime --test agent_mailbox_roundtrip` — 9 pass
- [ ] Deprecated aliases (`Agent`, `SendMessage`, `TaskStop`, etc.) continue to route correctly
- [ ] Mock e2e: sub-agent → parent local JSONL roundtrip
- [ ] Mock e2e: PeerMessage injection queues when turn is active