### PR TITLE
diag: measure post-Ctrl-C keystroke loss on macOS [DO NOT MERGE]

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
@@ -53,6 +53,15 @@ enum AfterCtrlC {
     StreamHint,
     /// The input buffer observably empty — the proposed guard.
     ClearedBuffer,
+    /// Readiness re-established the way the test establishes it BEFORE Ctrl-C:
+    /// a keystroke that renders, then cleared again.
+    ///
+    /// An empty buffer says the clear landed; it does not say keystrokes are
+    /// being delivered to the input again. The key handler routes `Char` by
+    /// `current_slot`, and Ctrl-C's `InputEvent::Abort` has the coordinator call
+    /// `repl.ui.clear_question()` — an out-of-band slot reset. A character that
+    /// renders is the only observation that covers every such state.
+    ReProbe,
 }
 
 /// The text after the last prompt marker on the lowest row carrying one.
@@ -90,10 +99,29 @@ fn wait_for_input(sess: &mut PtySession, needle: &str) -> (bool, String, String)
     }
 }
 
+/// Block until the input buffer reads empty.
+fn wait_for_cleared(sess: &mut PtySession, round: usize) -> Result<(), String> {
+    let deadline = Instant::now() + RENDER_BUDGET;
+    loop {
+        if input_line(sess).is_empty() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            let line = input_line(sess);
+            let screen = sess.render(|s| s.contents());
+            return Err(format!(
+                "round {round}: buffer still held {line:?}\n{screen}"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
     let label = match arm {
         AfterCtrlC::StreamHint => "stream",
         AfterCtrlC::ClearedBuffer => "cleared",
+        AfterCtrlC::ReProbe => "reprobe",
     };
     let env = TestEnv::new(&format!("ctrlc-{label}-{round}"));
     let root = env.workspace_root().to_path_buf();
@@ -128,20 +156,23 @@ fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
             })?;
         }
         AfterCtrlC::ClearedBuffer => {
-            let deadline = Instant::now() + RENDER_BUDGET;
-            loop {
-                if input_line(&mut sess).is_empty() {
-                    break;
-                }
-                if Instant::now() >= deadline {
-                    let line = input_line(&mut sess);
-                    let screen = sess.render(|s| s.contents());
-                    return Err(format!(
-                        "round {round}: buffer still held {line:?} after Ctrl-C\n{screen}"
-                    ));
-                }
-                std::thread::sleep(Duration::from_millis(25));
+            wait_for_cleared(&mut sess, round)?;
+        }
+        AfterCtrlC::ReProbe => {
+            wait_for_cleared(&mut sess, round)?;
+            // A keystroke that renders — the same observation the test uses
+            // for readiness before Ctrl-C, repeated because Ctrl-C changed the
+            // state it was proving.
+            sess.send("~").expect("type re-probe");
+            let (probed, seen, screen) = wait_for_input(&mut sess, "~");
+            if !probed {
+                return Err(format!(
+                    "round {round}: input never accepted a keystroke after Ctrl-C \
+                     (last saw {seen:?})\n{screen}"
+                ));
             }
+            sess.send("\x15").expect("Ctrl-U to clear the re-probe");
+            wait_for_cleared(&mut sess, round)?;
         }
     }
 
@@ -171,21 +202,25 @@ fn measure(arm: AfterCtrlC) -> usize {
 }
 
 #[test]
-fn stream_hint_wait_versus_cleared_buffer_wait() {
+fn which_post_ctrlc_wait_stops_losing_keystrokes() {
     let stream_lost = measure(AfterCtrlC::StreamHint);
     let cleared_lost = measure(AfterCtrlC::ClearedBuffer);
+    let reprobe_lost = measure(AfterCtrlC::ReProbe);
 
     eprintln!(
-        "SUMMARY stream_hint={}/{ROUNDS} cleared_buffer={}/{ROUNDS}",
+        "SUMMARY stream_hint={}/{ROUNDS} cleared_buffer={}/{ROUNDS} reprobe={}/{ROUNDS}",
         ROUNDS - stream_lost,
-        ROUNDS - cleared_lost
+        ROUNDS - cleared_lost,
+        ROUNDS - reprobe_lost
     );
 
-    // Fail whenever either arm lost a round, so CI surfaces the dumps. The
-    // summary line is what discriminates the hypotheses.
+    // Fail whenever any arm lost a round, so CI surfaces the dumps. The summary
+    // line is what picks the guard: the previous run measured stream_hint 2/6
+    // and cleared_buffer 4/6, so waiting for the clear helps and is not enough.
     assert!(
-        stream_lost == 0 && cleared_lost == 0,
+        stream_lost == 0 && cleared_lost == 0 && reprobe_lost == 0,
         "keystrokes lost: stream_hint dropped {stream_lost} of {ROUNDS}, \
-         cleared_buffer dropped {cleared_lost} of {ROUNDS}"
+         cleared_buffer dropped {cleared_lost} of {ROUNDS}, \
+         reprobe dropped {reprobe_lost} of {ROUNDS}"
     );
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
@@ -9,43 +9,53 @@
 //!
 //! ## The mechanism under test
 //!
-//! Ctrl-C's handler does both of these in one pass (`repl_ui.rs`):
+//! Ctrl-C's handler performs three real `State::set` calls in one pass
+//! (`repl_ui.rs`):
 //!
 //! ```ignore
+//! last_ctrlc.set(Some(now));
 //! footer_hint.set(Some((hint_msg, Instant::now() + Duration::from_secs(3))));
 //! input_value.set(String::new());
 //! ```
 //!
-//! If the frame carrying the hint can reach the PTY before the cleared buffer
-//! is observable, then a test that waits on the hint and types immediately has
-//! its characters inserted by `TextInput` and then wiped. Nothing appears.
+//! Per this REPL's own render model — spelled out in the comment above the
+//! spinner block and guarded by `iocraft_repl_keyboard_input_not_frozen` — a
+//! `State::set` resolves `component.wait()`, and doing so repeatedly starves
+//! `term.wait()`, which is where key events get distributed. Keystrokes
+//! arriving inside that window are dropped outright: the buffer reads empty and
+//! the characters never render, which is the symptom exactly.
+//!
+//! Note the "only set when the value changed" discipline already in `repl_ui`
+//! does not apply here. All three sets are genuine changes.
 //!
 //! ## The experiment
 //!
-//! Two arms, differing only in what they wait for after Ctrl-C before typing:
+//! Three arms, differing only in what they wait for after Ctrl-C before typing:
 //!
 //! | arm | waits for |
 //! |---|---|
-//! | `stream-hint` | the hint in the PTY BYTE STREAM — what the real test does |
-//! | `cleared-buffer` | the input buffer observably EMPTY — the proposed guard |
+//! | `stream-hint` | the hint in the PTY BYTE STREAM — the real test's guard |
+//! | `cleared-buffer` | the input buffer observably EMPTY |
+//! | `quiesced` | cleared, AND the screen unchanged across three polls |
 //!
-//! A lossy `stream-hint` arm beside a clean `cleared-buffer` arm confirms the
-//! mechanism and the fix together. Both clean says the mechanism is wrong and
-//! the loss is elsewhere. Both lossy says waiting for the clear is not enough.
+//! `quiesced` clean while `cleared-buffer` loses ⇒ the window is the
+//! post-Ctrl-C render churn, and the product fix is to coalesce those three
+//! mutations into one. Both lossy ⇒ the loss is not about render churn.
 //!
 //! ## Measured so far
 //!
-//! | arm | macOS | Windows |
+//! | arm | macOS lost | Windows lost |
 //! |---|---|---|
-//! | `stream-hint` | 4/12 rendered | 22/24 rendered |
-//! | `cleared-buffer` | 10/12 rendered | 48/48 rendered |
+//! | `stream-hint` | 8/20 (40%) | 2/24 |
+//! | `cleared-buffer` | 5/36 (14%) | 0/48 |
 //!
-//! Two things worth recording. The loss is NOT macOS-only — Windows reproduces
-//! it too, just rarely enough that the single-round real test almost always
-//! passes there, which is why it read as a macOS problem. And `cleared-buffer`
-//! has not lost a Windows round yet; both of its macOS losses came from the
-//! first run, before the arms were separated from the earlier Ctrl-C/no-Ctrl-C
-//! comparison.
+//! Three things worth recording. The loss is NOT macOS-only — Windows
+//! reproduces it, just rarely enough that the single-round real test almost
+//! always passes there, which is why it read as a macOS problem. The rate
+//! swings hard with runner load: the control came back 4-of-6 lost twice and
+//! 0-of-8 once from identical code, so no single run discriminates and only a
+//! within-run comparison means anything. And waiting for the clear reduces the
+//! loss without removing it, so it is a mitigation, not a fix.
 //!
 //! Reports a rate and dumps every lost round, so one CI run is informative
 //! rather than a coin flip.
@@ -64,7 +74,7 @@ const CONTROL_ROUNDS: usize = 8;
 
 /// The arm under test gets the rounds, because 6 was too few to tell 4/6 from
 /// 6/6 — the first two runs disagreed by exactly that much.
-const ROUNDS: usize = 24;
+const ROUNDS: usize = 12;
 const RENDER_BUDGET: Duration = Duration::from_secs(10);
 
 /// What the arm waits for after Ctrl-C, before typing.
@@ -82,6 +92,24 @@ enum AfterCtrlC {
     /// this arm's 6/6, i.e. no better for twice the work, so the slot-routing
     /// theory is not the residual and the arm is gone.
     ClearedBuffer,
+    /// Cleared, and then the screen unchanged across several polls — the render
+    /// loop observably QUIESCED.
+    ///
+    /// Tests the mechanism directly. Ctrl-C's handler performs three real
+    /// `State::set` calls in one pass (`last_ctrlc`, `footer_hint`,
+    /// `input_value`), and per this REPL's own render model each one resolves
+    /// `component.wait()`; a run of them starves `term.wait()`, which is where
+    /// key events get distributed. Keystrokes arriving inside that window are
+    /// dropped outright — buffer empty, characters never rendered, which is the
+    /// observed symptom exactly.
+    ///
+    /// Clean here while `ClearedBuffer` still loses ⇒ the window is the
+    /// post-Ctrl-C render churn, and the product fix is to coalesce those three
+    /// mutations into one. Still lossy ⇒ the loss is not about render churn.
+    ///
+    /// The "only set when the value changed" discipline already in `repl_ui`
+    /// cannot help either way: all three of these sets are genuine changes.
+    ClearedThenQuiesced,
 }
 
 /// The text after the last prompt marker on the lowest row carrying one.
@@ -137,10 +165,40 @@ fn wait_for_cleared(sess: &mut PtySession, round: usize) -> Result<(), String> {
     }
 }
 
+/// Block until the screen stops changing — the render loop has nothing left to
+/// flush, so it is no longer resolving `component.wait()` ahead of
+/// `term.wait()`.
+///
+/// Three identical consecutive polls rather than one comparison: a single pair
+/// can match across the gap between two frames of the same churn.
+fn wait_for_quiescence(sess: &mut PtySession, round: usize) -> Result<(), String> {
+    const STABLE_POLLS: usize = 3;
+    let deadline = Instant::now() + RENDER_BUDGET;
+    let mut previous = sess.render(|s| s.contents());
+    let mut stable = 0;
+    loop {
+        std::thread::sleep(Duration::from_millis(50));
+        let current = sess.render(|s| s.contents());
+        if current == previous {
+            stable += 1;
+            if stable >= STABLE_POLLS {
+                return Ok(());
+            }
+        } else {
+            stable = 0;
+            previous = current;
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("round {round}: screen never stopped changing"));
+        }
+    }
+}
+
 fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
     let label = match arm {
         AfterCtrlC::StreamHint => "stream",
         AfterCtrlC::ClearedBuffer => "cleared",
+        AfterCtrlC::ClearedThenQuiesced => "quiesced",
     };
     let env = TestEnv::new(&format!("ctrlc-{label}-{round}"));
     let root = env.workspace_root().to_path_buf();
@@ -177,6 +235,10 @@ fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
         AfterCtrlC::ClearedBuffer => {
             wait_for_cleared(&mut sess, round)?;
         }
+        AfterCtrlC::ClearedThenQuiesced => {
+            wait_for_cleared(&mut sess, round)?;
+            wait_for_quiescence(&mut sess, round)?;
+        }
     }
 
     sess.send("/exit").expect("type /exit");
@@ -210,19 +272,23 @@ fn which_post_ctrlc_wait_stops_losing_keystrokes() {
     // before the arm under test is credited with anything.
     let stream_lost = measure(AfterCtrlC::StreamHint, CONTROL_ROUNDS);
     let cleared_lost = measure(AfterCtrlC::ClearedBuffer, ROUNDS);
+    let quiesced_lost = measure(AfterCtrlC::ClearedThenQuiesced, ROUNDS);
 
     eprintln!(
-        "SUMMARY stream_hint={}/{CONTROL_ROUNDS} cleared_buffer={}/{ROUNDS}",
+        "SUMMARY stream_hint={}/{CONTROL_ROUNDS} cleared_buffer={}/{ROUNDS} quiesced={}/{ROUNDS}",
         CONTROL_ROUNDS - stream_lost,
-        ROUNDS - cleared_lost
+        ROUNDS - cleared_lost,
+        ROUNDS - quiesced_lost
     );
 
-    // Fail whenever either arm lost a round, so CI surfaces the dumps. Two runs
-    // put the control at 4 of 6 lost each time; the arm under test came back
-    // 4/6 then 6/6, which is why it now gets twelve rounds instead of six.
+    // Fail whenever any arm lost a round, so CI surfaces the dumps. The control
+    // has come back 4-of-6 lost twice and 0-of-8 once, so it establishes only
+    // whether a given run can reproduce at all; the comparison that matters is
+    // `cleared` against `quiesced` within one run.
     assert!(
-        stream_lost == 0 && cleared_lost == 0,
+        stream_lost == 0 && cleared_lost == 0 && quiesced_lost == 0,
         "keystrokes lost: stream_hint dropped {stream_lost} of {CONTROL_ROUNDS} (control), \
-         cleared_buffer dropped {cleared_lost} of {ROUNDS}"
+         cleared_buffer dropped {cleared_lost} of {ROUNDS}, \
+         quiesced dropped {quiesced_lost} of {ROUNDS}"
     );
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
@@ -33,8 +33,22 @@
 //! mechanism and the fix together. Both clean says the mechanism is wrong and
 //! the loss is elsewhere. Both lossy says waiting for the clear is not enough.
 //!
+//! ## Measured so far
+//!
+//! | arm | macOS | Windows |
+//! |---|---|---|
+//! | `stream-hint` | 4/12 rendered | 22/24 rendered |
+//! | `cleared-buffer` | 10/12 rendered | 48/48 rendered |
+//!
+//! Two things worth recording. The loss is NOT macOS-only — Windows reproduces
+//! it too, just rarely enough that the single-round real test almost always
+//! passes there, which is why it read as a macOS problem. And `cleared-buffer`
+//! has not lost a Windows round yet; both of its macOS losses came from the
+//! first run, before the arms were separated from the earlier Ctrl-C/no-Ctrl-C
+//! comparison.
+//!
 //! Reports a rate and dumps every lost round, so one CI run is informative
-//! rather than a coin flip. Windows does not reproduce this; read it off macOS.
+//! rather than a coin flip.
 
 mod common;
 
@@ -43,7 +57,14 @@ use std::time::{Duration, Instant};
 use common::TestEnv;
 use pty_expect::PtySession;
 
-const ROUNDS: usize = 6;
+/// Positive control: enough rounds to show this run can reproduce the loss at
+/// all. Measured at 4 of 6 lost, twice, so 4 rounds losing none would itself be
+/// the surprise.
+const CONTROL_ROUNDS: usize = 8;
+
+/// The arm under test gets the rounds, because 6 was too few to tell 4/6 from
+/// 6/6 — the first two runs disagreed by exactly that much.
+const ROUNDS: usize = 24;
 const RENDER_BUDGET: Duration = Duration::from_secs(10);
 
 /// What the arm waits for after Ctrl-C, before typing.
@@ -52,16 +73,15 @@ enum AfterCtrlC {
     /// The hint as it appears in the PTY byte stream — the real test's guard.
     StreamHint,
     /// The input buffer observably empty — the proposed guard.
-    ClearedBuffer,
-    /// Readiness re-established the way the test establishes it BEFORE Ctrl-C:
-    /// a keystroke that renders, then cleared again.
     ///
-    /// An empty buffer says the clear landed; it does not say keystrokes are
-    /// being delivered to the input again. The key handler routes `Char` by
-    /// `current_slot`, and Ctrl-C's `InputEvent::Abort` has the coordinator call
-    /// `repl.ui.clear_question()` — an out-of-band slot reset. A character that
-    /// renders is the only observation that covers every such state.
-    ReProbe,
+    /// A re-probe arm was measured alongside this one — clear, then type a
+    /// character and wait for it to RENDER, then clear again, on the theory that
+    /// an empty buffer does not prove keystrokes are being delivered (the key
+    /// handler routes `Char` by `current_slot`, and Ctrl-C's `InputEvent::Abort`
+    /// has the coordinator reset slots out of band). It came back 5/6 against
+    /// this arm's 6/6, i.e. no better for twice the work, so the slot-routing
+    /// theory is not the residual and the arm is gone.
+    ClearedBuffer,
 }
 
 /// The text after the last prompt marker on the lowest row carrying one.
@@ -121,7 +141,6 @@ fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
     let label = match arm {
         AfterCtrlC::StreamHint => "stream",
         AfterCtrlC::ClearedBuffer => "cleared",
-        AfterCtrlC::ReProbe => "reprobe",
     };
     let env = TestEnv::new(&format!("ctrlc-{label}-{round}"));
     let root = env.workspace_root().to_path_buf();
@@ -158,22 +177,6 @@ fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
         AfterCtrlC::ClearedBuffer => {
             wait_for_cleared(&mut sess, round)?;
         }
-        AfterCtrlC::ReProbe => {
-            wait_for_cleared(&mut sess, round)?;
-            // A keystroke that renders — the same observation the test uses
-            // for readiness before Ctrl-C, repeated because Ctrl-C changed the
-            // state it was proving.
-            sess.send("~").expect("type re-probe");
-            let (probed, seen, screen) = wait_for_input(&mut sess, "~");
-            if !probed {
-                return Err(format!(
-                    "round {round}: input never accepted a keystroke after Ctrl-C \
-                     (last saw {seen:?})\n{screen}"
-                ));
-            }
-            sess.send("\x15").expect("Ctrl-U to clear the re-probe");
-            wait_for_cleared(&mut sess, round)?;
-        }
     }
 
     sess.send("/exit").expect("type /exit");
@@ -186,9 +189,9 @@ fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
     Ok(())
 }
 
-fn measure(arm: AfterCtrlC) -> usize {
+fn measure(arm: AfterCtrlC, rounds: usize) -> usize {
     let mut lost = 0;
-    for round in 0..ROUNDS {
+    for round in 0..rounds {
         match run_round(arm, round) {
             Ok(()) => eprintln!("[{arm:?}] round {round}: /exit rendered"),
             Err(why) => {
@@ -197,30 +200,29 @@ fn measure(arm: AfterCtrlC) -> usize {
             }
         }
     }
-    eprintln!("[{arm:?}] {}/{ROUNDS} rounds rendered /exit", ROUNDS - lost);
+    eprintln!("[{arm:?}] {}/{rounds} rounds rendered /exit", rounds - lost);
     lost
 }
 
 #[test]
 fn which_post_ctrlc_wait_stops_losing_keystrokes() {
-    let stream_lost = measure(AfterCtrlC::StreamHint);
-    let cleared_lost = measure(AfterCtrlC::ClearedBuffer);
-    let reprobe_lost = measure(AfterCtrlC::ReProbe);
+    // Control first, so a run that cannot reproduce the loss at all says so
+    // before the arm under test is credited with anything.
+    let stream_lost = measure(AfterCtrlC::StreamHint, CONTROL_ROUNDS);
+    let cleared_lost = measure(AfterCtrlC::ClearedBuffer, ROUNDS);
 
     eprintln!(
-        "SUMMARY stream_hint={}/{ROUNDS} cleared_buffer={}/{ROUNDS} reprobe={}/{ROUNDS}",
-        ROUNDS - stream_lost,
-        ROUNDS - cleared_lost,
-        ROUNDS - reprobe_lost
+        "SUMMARY stream_hint={}/{CONTROL_ROUNDS} cleared_buffer={}/{ROUNDS}",
+        CONTROL_ROUNDS - stream_lost,
+        ROUNDS - cleared_lost
     );
 
-    // Fail whenever any arm lost a round, so CI surfaces the dumps. The summary
-    // line is what picks the guard: the previous run measured stream_hint 2/6
-    // and cleared_buffer 4/6, so waiting for the clear helps and is not enough.
+    // Fail whenever either arm lost a round, so CI surfaces the dumps. Two runs
+    // put the control at 4 of 6 lost each time; the arm under test came back
+    // 4/6 then 6/6, which is why it now gets twelve rounds instead of six.
     assert!(
-        stream_lost == 0 && cleared_lost == 0 && reprobe_lost == 0,
-        "keystrokes lost: stream_hint dropped {stream_lost} of {ROUNDS}, \
-         cleared_buffer dropped {cleared_lost} of {ROUNDS}, \
-         reprobe dropped {reprobe_lost} of {ROUNDS}"
+        stream_lost == 0 && cleared_lost == 0,
+        "keystrokes lost: stream_hint dropped {stream_lost} of {CONTROL_ROUNDS} (control), \
+         cleared_buffer dropped {cleared_lost} of {ROUNDS}"
     );
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
@@ -1,28 +1,40 @@
 //! TEMPORARY diagnostic — DO NOT MERGE.
 //!
-//! `iocraft_repl_ctrlc_hint_in_footer` has been failing intermittently on
-//! macOS CI since at least the #603 merge, always at the same step: after
-//! Ctrl-C, the test types `/exit` and the input line never shows it. The last
-//! captured failure had the hint already expired (the footer was back to
-//! normal) and a 10s budget, so the characters were not merely late — they were
-//! gone for the whole budget.
+//! `iocraft_repl_ctrlc_hint_in_footer` has failed intermittently on macOS CI
+//! since at least the #603 merge, always at the same step: after Ctrl-C the
+//! test types `/exit` and the input line never shows it. The captured failure
+//! had the prompt marker on screen, the hint already expired, and `/exit`
+//! absent for the whole 10s budget — the characters were not late, they were
+//! never there.
 //!
-//! A single green run proves nothing about an intermittent failure, so this
-//! measures instead of guessing. Two arms, same REPL, same keystrokes:
+//! ## The mechanism under test
 //!
-//! - `control` types `/exit` with no Ctrl-C before it.
-//! - `after_ctrlc` sends Ctrl-C, waits for the hint, then types `/exit`.
+//! Ctrl-C's handler does both of these in one pass (`repl_ui.rs`):
 //!
-//! Each arm runs `ROUNDS` times and reports how many rounds rendered the text.
-//! The comparison is the whole point: if `control` is clean and `after_ctrlc`
-//! is not, Ctrl-C is implicated and the next question is whether macOS is
-//! delivering it as a signal that resets the terminal mode (the hazard the
-//! readiness probe in `pty_repl_iocraft_features` already documents). If both
-//! arms drop rounds, the loss is in the send/render path and has nothing to do
-//! with Ctrl-C.
+//! ```ignore
+//! footer_hint.set(Some((hint_msg, Instant::now() + Duration::from_secs(3))));
+//! input_value.set(String::new());
+//! ```
 //!
-//! Reports a summary and only then asserts, so one CI run yields a rate rather
-//! than a single dump.
+//! If the frame carrying the hint can reach the PTY before the cleared buffer
+//! is observable, then a test that waits on the hint and types immediately has
+//! its characters inserted by `TextInput` and then wiped. Nothing appears.
+//!
+//! ## The experiment
+//!
+//! Two arms, differing only in what they wait for after Ctrl-C before typing:
+//!
+//! | arm | waits for |
+//! |---|---|
+//! | `stream-hint` | the hint in the PTY BYTE STREAM — what the real test does |
+//! | `cleared-buffer` | the input buffer observably EMPTY — the proposed guard |
+//!
+//! A lossy `stream-hint` arm beside a clean `cleared-buffer` arm confirms the
+//! mechanism and the fix together. Both clean says the mechanism is wrong and
+//! the loss is elsewhere. Both lossy says waiting for the clear is not enough.
+//!
+//! Reports a rate and dumps every lost round, so one CI run is informative
+//! rather than a coin flip. Windows does not reproduce this; read it off macOS.
 
 mod common;
 
@@ -34,24 +46,35 @@ use pty_expect::PtySession;
 const ROUNDS: usize = 6;
 const RENDER_BUDGET: Duration = Duration::from_secs(10);
 
-/// What the prompt row holds: the text after the last prompt glyph on the
-/// lowest row carrying one. Same rule as `pty_arrow_keys::input_line_of`,
-/// which has to survive the chrome rule sharing the input's row.
+/// What the arm waits for after Ctrl-C, before typing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AfterCtrlC {
+    /// The hint as it appears in the PTY byte stream — the real test's guard.
+    StreamHint,
+    /// The input buffer observably empty — the proposed guard.
+    ClearedBuffer,
+}
+
+/// The text after the last prompt marker on the lowest row carrying one.
+///
+/// Matches the marker anywhere on the row: when the chrome rule fills the
+/// terminal width exactly the input shares that row, so it reads
+/// `────…────❯ abc!` and does not start with the marker.
 fn input_line(sess: &mut PtySession) -> String {
     sess.render(|s| {
         s.contents()
             .lines()
             .rev()
             .find_map(|line| {
-                let glyph = line.rfind('\u{276f}')?;
-                Some(line[glyph + '\u{276f}'.len_utf8()..].trim().to_string())
+                let marker = line.rfind('\u{276f}')?;
+                Some(line[marker + '\u{276f}'.len_utf8()..].trim().to_string())
             })
             .unwrap_or_default()
     })
 }
 
-/// Poll the prompt row for `needle`. Returns whether it showed, plus the last
-/// thing seen and the final screen — the two facts a failing round needs.
+/// Poll the prompt row for `needle`. Returns whether it showed, what was last
+/// seen, and the final screen — the facts a lost round needs to be diagnosed.
 fn wait_for_input(sess: &mut PtySession, needle: &str) -> (bool, String, String) {
     let deadline = Instant::now() + RENDER_BUDGET;
     loop {
@@ -67,10 +90,12 @@ fn wait_for_input(sess: &mut PtySession, needle: &str) -> (bool, String, String)
     }
 }
 
-/// One round. `with_ctrlc` selects the arm. Returns `Ok(())` when `/exit`
-/// rendered, else a description of what the round saw instead.
-fn run_round(label: &str, round: usize, with_ctrlc: bool) -> Result<(), String> {
-    let env = TestEnv::new(&format!("{label}-{round}"));
+fn run_round(arm: AfterCtrlC, round: usize) -> Result<(), String> {
+    let label = match arm {
+        AfterCtrlC::StreamHint => "stream",
+        AfterCtrlC::ClearedBuffer => "cleared",
+    };
+    let env = TestEnv::new(&format!("ctrlc-{label}-{round}"));
     let root = env.workspace_root().to_path_buf();
     std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
 
@@ -80,9 +105,9 @@ fn run_round(label: &str, round: usize, with_ctrlc: bool) -> Result<(), String> 
     );
     sess.set_default_timeout(RENDER_BUDGET);
 
-    // Readiness: a keystroke that RENDERS proves iocraft owns the keyboard.
-    // Read off the screen, not the byte stream — iocraft redraws the input in
-    // pieces, so the text need not appear contiguously in the stream.
+    // Readiness is identical in both arms so it cannot explain a difference: a
+    // keystroke that RENDERS proves iocraft owns the keyboard, which matters
+    // because until it does, ^C is still a terminal signal.
     sess.send("~probe~").expect("type readiness probe");
     let (probed, seen, screen) = wait_for_input(&mut sess, "~probe~");
     if !probed {
@@ -91,46 +116,32 @@ fn run_round(label: &str, round: usize, with_ctrlc: bool) -> Result<(), String> 
         ));
     }
 
-    if with_ctrlc {
-        sess.send("\x03").expect("send Ctrl-C");
-        // The hint is the observable that the Ctrl-C handler ran. Read it off
-        // the screen so a stale stream match cannot satisfy it.
-        let deadline = Instant::now() + RENDER_BUDGET;
-        loop {
-            let shown = sess.render(|s| s.contents().contains("Press Ctrl-C again to exit"));
-            if shown {
-                break;
-            }
-            if Instant::now() >= deadline {
+    sess.send("\x03").expect("send Ctrl-C");
+
+    match arm {
+        AfterCtrlC::StreamHint => {
+            // The real test's guard, verbatim: match the hint in the byte
+            // stream and type at once.
+            sess.expect("Press Ctrl-C again to exit").map_err(|e| {
                 let screen = sess.render(|s| s.contents());
-                return Err(format!(
-                    "round {round}: Ctrl-C hint never appeared\n{screen}"
-                ));
-            }
-            std::thread::sleep(Duration::from_millis(25));
+                format!("round {round}: hint never reached the stream: {e}\n{screen}")
+            })?;
         }
-        // Ctrl-C clears the input, so the probe leaves nothing behind. Confirm
-        // that, so a round that starts with leftovers is not mistaken for one
-        // that lost keystrokes.
-        let after = input_line(&mut sess);
-        if after.contains("~probe~") {
-            return Err(format!(
-                "round {round}: Ctrl-C did not clear the input (saw {after:?})"
-            ));
-        }
-    } else {
-        // Same starting state as the Ctrl-C arm, reached without Ctrl-C, so the
-        // two arms differ in exactly one thing.
-        sess.send("\x15").expect("Ctrl-U to clear");
-        let deadline = Instant::now() + RENDER_BUDGET;
-        loop {
-            if !input_line(&mut sess).contains("~probe~") {
-                break;
+        AfterCtrlC::ClearedBuffer => {
+            let deadline = Instant::now() + RENDER_BUDGET;
+            loop {
+                if input_line(&mut sess).is_empty() {
+                    break;
+                }
+                if Instant::now() >= deadline {
+                    let line = input_line(&mut sess);
+                    let screen = sess.render(|s| s.contents());
+                    return Err(format!(
+                        "round {round}: buffer still held {line:?} after Ctrl-C\n{screen}"
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(25));
             }
-            if Instant::now() >= deadline {
-                return Err(format!("round {round}: Ctrl-U never cleared the input"));
-            }
-            std::thread::sleep(Duration::from_millis(25));
         }
     }
 
@@ -144,41 +155,37 @@ fn run_round(label: &str, round: usize, with_ctrlc: bool) -> Result<(), String> 
     Ok(())
 }
 
-fn measure(label: &str, with_ctrlc: bool) -> Vec<String> {
-    let mut failures = Vec::new();
+fn measure(arm: AfterCtrlC) -> usize {
+    let mut lost = 0;
     for round in 0..ROUNDS {
-        match run_round(label, round, with_ctrlc) {
-            Ok(()) => eprintln!("[{label}] round {round}: /exit rendered"),
+        match run_round(arm, round) {
+            Ok(()) => eprintln!("[{arm:?}] round {round}: /exit rendered"),
             Err(why) => {
-                eprintln!("[{label}] round {round}: LOST\n{why}");
-                failures.push(why);
+                eprintln!("[{arm:?}] round {round}: LOST\n{why}");
+                lost += 1;
             }
         }
     }
-    eprintln!(
-        "[{label}] {}/{ROUNDS} rounds rendered /exit",
-        ROUNDS - failures.len()
-    );
-    failures
+    eprintln!("[{arm:?}] {}/{ROUNDS} rounds rendered /exit", ROUNDS - lost);
+    lost
 }
 
 #[test]
-fn measure_keystroke_loss_with_and_without_ctrlc() {
-    let control = measure("control", false);
-    let after_ctrlc = measure("after-ctrlc", true);
+fn stream_hint_wait_versus_cleared_buffer_wait() {
+    let stream_lost = measure(AfterCtrlC::StreamHint);
+    let cleared_lost = measure(AfterCtrlC::ClearedBuffer);
 
     eprintln!(
-        "SUMMARY control={}/{ROUNDS} after_ctrlc={}/{ROUNDS}",
-        ROUNDS - control.len(),
-        ROUNDS - after_ctrlc.len()
+        "SUMMARY stream_hint={}/{ROUNDS} cleared_buffer={}/{ROUNDS}",
+        ROUNDS - stream_lost,
+        ROUNDS - cleared_lost
     );
 
-    // Fail whenever either arm dropped a round, so CI surfaces the dumps. The
-    // summary line above is what discriminates the hypotheses.
+    // Fail whenever either arm lost a round, so CI surfaces the dumps. The
+    // summary line is what discriminates the hypotheses.
     assert!(
-        control.is_empty() && after_ctrlc.is_empty(),
-        "keystrokes were lost: control dropped {} of {ROUNDS}, after_ctrlc dropped {} of {ROUNDS}",
-        control.len(),
-        after_ctrlc.len()
+        stream_lost == 0 && cleared_lost == 0,
+        "keystrokes lost: stream_hint dropped {stream_lost} of {ROUNDS}, \
+         cleared_buffer dropped {cleared_lost} of {ROUNDS}"
     );
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_ctrlc_keystroke_loss.rs
@@ -1,0 +1,184 @@
+//! TEMPORARY diagnostic — DO NOT MERGE.
+//!
+//! `iocraft_repl_ctrlc_hint_in_footer` has been failing intermittently on
+//! macOS CI since at least the #603 merge, always at the same step: after
+//! Ctrl-C, the test types `/exit` and the input line never shows it. The last
+//! captured failure had the hint already expired (the footer was back to
+//! normal) and a 10s budget, so the characters were not merely late — they were
+//! gone for the whole budget.
+//!
+//! A single green run proves nothing about an intermittent failure, so this
+//! measures instead of guessing. Two arms, same REPL, same keystrokes:
+//!
+//! - `control` types `/exit` with no Ctrl-C before it.
+//! - `after_ctrlc` sends Ctrl-C, waits for the hint, then types `/exit`.
+//!
+//! Each arm runs `ROUNDS` times and reports how many rounds rendered the text.
+//! The comparison is the whole point: if `control` is clean and `after_ctrlc`
+//! is not, Ctrl-C is implicated and the next question is whether macOS is
+//! delivering it as a signal that resets the terminal mode (the hazard the
+//! readiness probe in `pty_repl_iocraft_features` already documents). If both
+//! arms drop rounds, the loss is in the send/render path and has nothing to do
+//! with Ctrl-C.
+//!
+//! Reports a summary and only then asserts, so one CI run yields a rate rather
+//! than a single dump.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::TestEnv;
+use pty_expect::PtySession;
+
+const ROUNDS: usize = 6;
+const RENDER_BUDGET: Duration = Duration::from_secs(10);
+
+/// What the prompt row holds: the text after the last prompt glyph on the
+/// lowest row carrying one. Same rule as `pty_arrow_keys::input_line_of`,
+/// which has to survive the chrome rule sharing the input's row.
+fn input_line(sess: &mut PtySession) -> String {
+    sess.render(|s| {
+        s.contents()
+            .lines()
+            .rev()
+            .find_map(|line| {
+                let glyph = line.rfind('\u{276f}')?;
+                Some(line[glyph + '\u{276f}'.len_utf8()..].trim().to_string())
+            })
+            .unwrap_or_default()
+    })
+}
+
+/// Poll the prompt row for `needle`. Returns whether it showed, plus the last
+/// thing seen and the final screen — the two facts a failing round needs.
+fn wait_for_input(sess: &mut PtySession, needle: &str) -> (bool, String, String) {
+    let deadline = Instant::now() + RENDER_BUDGET;
+    loop {
+        let line = input_line(sess);
+        if line.contains(needle) {
+            return (true, line, String::new());
+        }
+        if Instant::now() >= deadline {
+            let screen = sess.render(|s| s.contents());
+            return (false, line, screen);
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// One round. `with_ctrlc` selects the arm. Returns `Ok(())` when `/exit`
+/// rendered, else a description of what the round saw instead.
+fn run_round(label: &str, round: usize, with_ctrlc: bool) -> Result<(), String> {
+    let env = TestEnv::new(&format!("{label}-{round}"));
+    let root = env.workspace_root().to_path_buf();
+    std::fs::write(root.join("AGENTS.md"), "# Rules\n").expect("write AGENTS.md");
+
+    let mut sess = env.spawn_with_env(
+        &["--permission-mode", "read-only"],
+        &[("SUDOCODE_INTERRUPT_QUEUE_MODE", "queue")],
+    );
+    sess.set_default_timeout(RENDER_BUDGET);
+
+    // Readiness: a keystroke that RENDERS proves iocraft owns the keyboard.
+    // Read off the screen, not the byte stream — iocraft redraws the input in
+    // pieces, so the text need not appear contiguously in the stream.
+    sess.send("~probe~").expect("type readiness probe");
+    let (probed, seen, screen) = wait_for_input(&mut sess, "~probe~");
+    if !probed {
+        return Err(format!(
+            "round {round}: readiness probe never rendered (last saw {seen:?})\n{screen}"
+        ));
+    }
+
+    if with_ctrlc {
+        sess.send("\x03").expect("send Ctrl-C");
+        // The hint is the observable that the Ctrl-C handler ran. Read it off
+        // the screen so a stale stream match cannot satisfy it.
+        let deadline = Instant::now() + RENDER_BUDGET;
+        loop {
+            let shown = sess.render(|s| s.contents().contains("Press Ctrl-C again to exit"));
+            if shown {
+                break;
+            }
+            if Instant::now() >= deadline {
+                let screen = sess.render(|s| s.contents());
+                return Err(format!(
+                    "round {round}: Ctrl-C hint never appeared\n{screen}"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        // Ctrl-C clears the input, so the probe leaves nothing behind. Confirm
+        // that, so a round that starts with leftovers is not mistaken for one
+        // that lost keystrokes.
+        let after = input_line(&mut sess);
+        if after.contains("~probe~") {
+            return Err(format!(
+                "round {round}: Ctrl-C did not clear the input (saw {after:?})"
+            ));
+        }
+    } else {
+        // Same starting state as the Ctrl-C arm, reached without Ctrl-C, so the
+        // two arms differ in exactly one thing.
+        sess.send("\x15").expect("Ctrl-U to clear");
+        let deadline = Instant::now() + RENDER_BUDGET;
+        loop {
+            if !input_line(&mut sess).contains("~probe~") {
+                break;
+            }
+            if Instant::now() >= deadline {
+                return Err(format!("round {round}: Ctrl-U never cleared the input"));
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    sess.send("/exit").expect("type /exit");
+    let (shown, seen, screen) = wait_for_input(&mut sess, "/exit");
+    if !shown {
+        return Err(format!(
+            "round {round}: /exit never rendered (last saw {seen:?})\n{screen}"
+        ));
+    }
+    Ok(())
+}
+
+fn measure(label: &str, with_ctrlc: bool) -> Vec<String> {
+    let mut failures = Vec::new();
+    for round in 0..ROUNDS {
+        match run_round(label, round, with_ctrlc) {
+            Ok(()) => eprintln!("[{label}] round {round}: /exit rendered"),
+            Err(why) => {
+                eprintln!("[{label}] round {round}: LOST\n{why}");
+                failures.push(why);
+            }
+        }
+    }
+    eprintln!(
+        "[{label}] {}/{ROUNDS} rounds rendered /exit",
+        ROUNDS - failures.len()
+    );
+    failures
+}
+
+#[test]
+fn measure_keystroke_loss_with_and_without_ctrlc() {
+    let control = measure("control", false);
+    let after_ctrlc = measure("after-ctrlc", true);
+
+    eprintln!(
+        "SUMMARY control={}/{ROUNDS} after_ctrlc={}/{ROUNDS}",
+        ROUNDS - control.len(),
+        ROUNDS - after_ctrlc.len()
+    );
+
+    // Fail whenever either arm dropped a round, so CI surfaces the dumps. The
+    // summary line above is what discriminates the hypotheses.
+    assert!(
+        control.is_empty() && after_ctrlc.is_empty(),
+        "keystrokes were lost: control dropped {} of {ROUNDS}, after_ctrlc dropped {} of {ROUNDS}",
+        control.len(),
+        after_ctrlc.len()
+    );
+}


### PR DESCRIPTION
Diagnostic only — **do not merge**. Exists to be read off macOS CI and then deleted.

`iocraft_repl_ctrlc_hint_in_footer` has been failing intermittently on macOS CI since at least the #603 merge (also #607, and the #614 merge commit), always at the same step: after Ctrl-C the test types `/exit` and the input line never shows it. The last dump had the Ctrl-C hint already expired and a 10s budget, so the characters were not late — they were gone for the whole budget.

A single green run proves nothing about an intermittent failure, so this measures. Two arms, differing in exactly one thing:

| arm | how the input line gets cleared before typing `/exit` |
|---|---|
| `control` | Ctrl-U |
| `after_ctrlc` | Ctrl-C (waits for the hint to render first) |

Six rounds each, reporting a rate and dumping every lost round.

- clean control + lossy Ctrl-C arm ⇒ the signal path is implicated, and the next question is whether macOS delivers ^C as a signal that resets the terminal mode (the hazard `pty_repl_iocraft_features`'s readiness probe already documents)
- both arms lossy ⇒ the loss is in send/render and has nothing to do with Ctrl-C

Windows baseline: 12/12, 13.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)