### PR TITLE
fix(coordinator): stop advertising a tool that no longer exists

### DIFF
--- a/rust/crates/runtime/src/coordinator_mode.rs
+++ b/rust/crates/runtime/src/coordinator_mode.rs
@@ -61,7 +61,6 @@ pub fn coordinator_allowed_tools() -> BTreeSet<&'static str> {
     [
         // Canonical delegation surface
         "agent_spawn",
-        "agent_list",
         "send",
         "pid_kill",
         "pid_status",
@@ -149,7 +148,6 @@ Every message you send is to the user. Worker results and system notifications a
 - **pid_status** - Fetch a running worker's metadata by `pid`, or list every worker when `pid` is omitted (alias: `TaskGet`)
 - **pid_output** - Read a running or completed worker's output by `pid` (alias: `TaskOutput`)
 - **pid_fork** - Fork the current session into a background worker
-- **agent_list** - List all known agents / workers
 
 Write tools (`bash`, `write_file`, `edit_file`, `PowerShell`, `EnterPlanMode`, `ExitPlanMode`) are DELIBERATELY unavailable to you — always delegate write-side work to a worker via `agent_spawn(...)`. Read-only tools (`read_file`, `glob_search`, `grep_search`, `WebSearch`, `WebFetch`, `Skill`) remain available for lightweight lookups that don't need a full worker turn.
 

--- a/rust/crates/tools/tests/unified_agent_pid_e2e.rs
+++ b/rust/crates/tools/tests/unified_agent_pid_e2e.rs
@@ -111,7 +111,6 @@ fn canonicalize_preserves_canonical_names() {
     assert_eq!(tools::canonicalize_tool_name("pid_status"), "pid_status");
     assert_eq!(tools::canonicalize_tool_name("pid_output"), "pid_output");
     assert_eq!(tools::canonicalize_tool_name("pid_fork"), "pid_fork");
-    assert_eq!(tools::canonicalize_tool_name("agent_list"), "agent_list");
 }
 
 #[test]
@@ -611,12 +610,84 @@ fn envelope_serializes_body_not_text() {
 fn coordinator_allowed_tools_includes_canonical_names() {
     let allowed = runtime::coordinator_mode::coordinator_allowed_tools();
     assert!(allowed.contains("agent_spawn"));
-    assert!(allowed.contains("agent_list"));
     assert!(allowed.contains("send"));
     assert!(allowed.contains("pid_kill"));
     assert!(allowed.contains("pid_status"));
     assert!(allowed.contains("pid_output"));
     assert!(allowed.contains("pid_fork"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 8b. THE COORDINATOR ONLY NAMES TOOLS THAT EXIST
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Canonical names of every tool this build actually ships.
+fn real_tool_names() -> std::collections::BTreeSet<String> {
+    tools::mvp_tool_specs()
+        .into_iter()
+        .map(|spec| spec.name.to_string())
+        .collect()
+}
+
+/// The tool names the coordinator prompt advertises under `## 2. Your Tools`,
+/// whose entries read `- **name** - description`.
+///
+/// Scoped to that section so a bolded word anywhere else in the prompt is not
+/// mistaken for a tool.
+fn tools_advertised_in_prompt() -> Vec<String> {
+    runtime::coordinator_mode::coordinator_system_prompt()
+        .lines()
+        .skip_while(|line| !line.starts_with("## 2. Your Tools"))
+        .skip(1)
+        .take_while(|line| !line.starts_with("##"))
+        .filter_map(|line| line.trim().strip_prefix("- **"))
+        .filter_map(|rest| rest.split("**").next())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Every name in the coordinator allowlist must be a tool that exists.
+///
+/// The allowlist lives in `runtime` and the tool specs live in `tools`, so only
+/// a test spanning both crates can catch a name that outlived its tool. Not
+/// hypothetical: `agent_list` stayed in this allowlist, and in the prompt,
+/// after the tool was removed — two branches each resolved half of it.
+#[test]
+fn coordinator_allowlist_names_only_real_tools() {
+    let real = real_tool_names();
+    for name in runtime::coordinator_mode::coordinator_allowed_tools() {
+        assert!(
+            real.contains(name),
+            "the coordinator allowlist names `{name}`, which is not a tool this build ships"
+        );
+    }
+}
+
+/// Every tool the coordinator prompt advertises must exist and be allowed.
+///
+/// This is the assertion that bites. The prompt is what the model reads, so a
+/// stale line there does not merely go unused — it makes the coordinator call
+/// something that cannot answer.
+#[test]
+fn coordinator_prompt_advertises_only_real_allowed_tools() {
+    let real = real_tool_names();
+    let allowed = runtime::coordinator_mode::coordinator_allowed_tools();
+    let advertised = tools_advertised_in_prompt();
+
+    assert!(
+        advertised.len() >= 6,
+        "the prompt's tool list should have parsed; got {advertised:?}"
+    );
+    for name in &advertised {
+        assert!(
+            real.contains(name),
+            "the coordinator prompt advertises `{name}`, which is not a tool this build ships"
+        );
+        assert!(
+            allowed.contains(name.as_str()),
+            "the coordinator prompt advertises `{name}`, which its own allowlist forbids"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
`main` currently ships a coordinator prompt that tells the model to call a tool
that does not exist.

```
coordinator_mode.rs:64   "agent_list",                                       ← allowlist
coordinator_mode.rs:152  - **agent_list** - List all known agents / workers  ← the prompt the model reads
tools/src/lib.rs         (no such tool)
```

## How it got there

#613 removed `agent_list`: the agent-**TYPE** catalog it returned is now the
`<available-agent-types>` prompt section. #615 was branched before that and
still carried the allowlist entry and the prompt line. The merge resolved each
file in favour of a different side — `coordinator_gate.rs` dropped the name,
`coordinator_mode.rs` kept it — and #615's new
`coordinator_allowed_tools_includes_canonical_names` then pinned the surviving
half in place.

Nothing was reverted; the two halves of one fact simply ended up on opposite
sides of a merge.

## No capability is lost

Listing running workers is `pid_status` with `pid` omitted, which the same
prompt documents one line above:

> **pid_status** - Fetch a running worker's metadata by `pid`, or **list every
> worker when `pid` is omitted**

Agent-**INSTANCE** discovery — which the removed line's wording ("all known
agents / workers") reached for — does not exist yet. It gets advertised when it
lands, not before. The parallel discovery work can re-add both the allowlist
entry and the prompt line together with the tool, and the guards below will
confirm all three agree.

## Guards, so this cannot recur

- `coordinator_allowlist_names_only_real_tools` — every allowlist name is a tool
  the build ships.
- `coordinator_prompt_advertises_only_real_allowed_tools` — every `- **name**`
  under `## 2. Your Tools` exists **and** is inside the allowlist.

Neither can live in `runtime`: the allowlist and the prompt are there, the tool
specs are in `tools`. That crate split is exactly why a name could outlive its
tool with every existing test still green.

## Verification

`cargo fmt` clean, `cargo clippy --workspace --all-targets` 0 errors,
`cargo test -p runtime -p tools` green on Windows.

Mutation-verified against the state `main` is in right now:

| restored | guard that went red |
|---|---|
| `agent_list` in the allowlist | `coordinator_allowlist_names_only_real_tools` — *"the coordinator allowlist names `agent_list`, which is not a tool this build ships"* |
| the prompt line as well | also `coordinator_prompt_advertises_only_real_allowed_tools` — *"the coordinator prompt advertises `agent_list`, which is not a tool this build ships"* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
