### PR TITLE
fix(test): wait for Ctrl-C to clear the line, not for a prompt to exist

### DIFF
--- a/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/common/mod.rs
@@ -116,6 +116,63 @@ pub fn expect_input_line(sess: &PtySession, text: &str, budget: Duration, contex
     }
 }
 
+/// What the REPL's input buffer holds: the text after the last prompt marker on
+/// the lowest screen row carrying one.
+///
+/// Distinct from [`expect_input_line`], which asks the looser question "did
+/// these characters appear on some prompt row" and is satisfied by a submitted
+/// line still sitting in the transcript. This answers "what is in the buffer
+/// NOW", which is the only way to observe the buffer being *empty*.
+///
+/// Matches the marker anywhere on the row rather than at its start: whenever the
+/// chrome rule above the input fills the terminal width exactly, the input
+/// shares that row and it reads `────…────❯ abc!`.
+#[must_use]
+pub fn input_line_of(screen: &str) -> String {
+    screen
+        .lines()
+        .rev()
+        .find_map(|line| {
+            let marker = line.rfind(PROMPT_MARKER)?;
+            Some(line[marker + PROMPT_MARKER.len()..].trim().to_string())
+        })
+        .unwrap_or_default()
+}
+
+/// Block until the REPL's input buffer is observably EMPTY.
+///
+/// The guard to use after anything that clears the line — Ctrl-C, Ctrl-U —
+/// before typing again. Clearing is not instantaneous with respect to the
+/// keyboard: Ctrl-C's handler emits the footer hint and clears `input_value` in
+/// the same pass, but the frame carrying the hint can reach the PTY before the
+/// cleared buffer is observable. Characters typed into that window are inserted
+/// by `TextInput` and then wiped, so they never appear at all — which reads as
+/// keystrokes vanishing rather than as a race.
+///
+/// `expect_input_line(sess, "", …)` does NOT express this: `contains("")` is
+/// always true, so it returns the moment any prompt row exists and waits for
+/// nothing.
+///
+/// # Panics
+/// When the buffer has not gone empty within `budget`; the message carries
+/// `context`, what the buffer held, and the rendered screen.
+pub fn expect_input_line_cleared(sess: &PtySession, budget: Duration, context: &str) {
+    let deadline = Instant::now() + budget;
+    loop {
+        let line = sess.render(|screen| input_line_of(&screen.contents()));
+        if line.is_empty() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            let screen = sess.render(|s| s.contents());
+            panic!(
+                "{context}: the input line still held {line:?} after {budget:?}\nPTY:\n{screen}"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 pub fn scode_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_scode"))
 }

--- a/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_arrow_keys.rs
@@ -190,22 +190,11 @@ fn down_arrow_moves_cursor_to_end() {
 /// its expected text plainly visible in the failure dump. Whether the rule and
 /// the input share a row depends on the frame's line accounting, which is what
 /// made it intermittent, and Windows CI is where it showed up.
+/// The rule itself is [`common::input_line_of`], shared because
+/// `common::expect_input_line_cleared` needs the same one — reading whether the
+/// buffer is empty and reading what it holds are the same parse.
 fn input_line(sess: &mut PtySession) -> String {
-    sess.render(|s| input_line_of(&s.contents()))
-}
-
-/// The screen-parsing half of [`input_line`], split out so the rule it has to
-/// survive can be pinned against a real captured screen instead of waiting for
-/// CI to roll the dice again.
-fn input_line_of(screen: &str) -> String {
-    screen
-        .lines()
-        .rev()
-        .find_map(|line| {
-            let glyph = line.rfind('\u{276f}')?;
-            Some(line[glyph + '\u{276f}'.len_utf8()..].trim().to_string())
-        })
-        .unwrap_or_default()
+    sess.render(|s| common::input_line_of(&s.contents()))
 }
 
 /// Verbatim from the Windows CI failure this parser was rewritten for: the
@@ -227,7 +216,7 @@ fn input_line_reads_the_buffer_when_chrome_shares_its_row() {
          {dashes}\n\
          \u{23f5}\u{23f5} read-only \u{b7} /help \u{b7} /exit to quit\n"
     );
-    assert_eq!(input_line_of(&screen), "abc!");
+    assert_eq!(common::input_line_of(&screen), "abc!");
 }
 
 /// The uncollided shape still parses, and a submitted line above the prompt is
@@ -238,11 +227,11 @@ fn input_line_prefers_the_lowest_prompt_row() {
     let screen = "\u{276f} submitted a turn ago\n\
                   \u{23fa} answer\n\
                   \u{276f} being typed now\n";
-    assert_eq!(input_line_of(screen), "being typed now");
+    assert_eq!(common::input_line_of(screen), "being typed now");
 
     // An empty buffer reads as empty rather than as the echo above it.
     let screen = "\u{276f} submitted a turn ago\n\u{23fa} answer\n\u{276f}\n";
-    assert_eq!(input_line_of(screen), "");
+    assert_eq!(common::input_line_of(screen), "");
 }
 
 /// Wait for the REPL's input line to contain `needle`.

--- a/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
+++ b/rust/crates/rusty-sudocode-cli/tests/pty_repl_iocraft_features.rs
@@ -152,15 +152,20 @@ fn iocraft_repl_ctrlc_hint_in_footer() {
             panic!("Ctrl-C hint should appear in footer: {e}\nPTY:\n{screen}");
         });
 
-    // After Ctrl-C + hint render, the iocraft layout may need a moment to
-    // re-render the prompt line. Wait for it before typing, otherwise the
-    // screen may not contain the ❯ marker and expect_input_line can never
-    // succeed (observed on macOS CI runners under load).
-    common::expect_input_line(
+    // Wait for Ctrl-C to have CLEARED the line, not merely for a prompt row to
+    // exist. Its handler emits the footer hint and clears `input_value` in the
+    // same pass, but the frame carrying the hint can reach the PTY before the
+    // cleared buffer is observable. Characters typed into that window get
+    // inserted by `TextInput` and then wiped, so they never show up — which is
+    // how this test failed on macOS CI: `/exit` absent for the whole budget
+    // with the prompt marker plainly on screen and the hint already expired.
+    //
+    // `expect_input_line(&sess, "", …)` cannot express this — `contains("")` is
+    // always true, so it waits for nothing.
+    common::expect_input_line_cleared(
         &sess,
-        "",
         Duration::from_secs(15),
-        "prompt should recover after Ctrl-C hint",
+        "Ctrl-C should clear the input line before more is typed",
     );
 
     // Clean exit. Type and submit as two steps, waiting for the line to


### PR DESCRIPTION
Follow-up to the `ctrlc_hint` deflake in #615. The instinct there was right — wait
for the REPL to recover before typing — but the predicate does not express it:

```rust
common::expect_input_line(&sess, "", Duration::from_secs(15), "prompt should recover…")
```

`expect_input_line` tests `line.contains(PROMPT_MARKER) && line.contains(text)`, and
`contains("")` is always true. So it returns the instant any prompt row exists and
waits for nothing. The captured macOS failure already had the prompt marker on screen
and the Ctrl-C hint expired, so the only part of that change with an effect was the
budget going 10s → 15s — which widens the window rather than closing it.

## What the dump says

```
────────────────────────────────────────────────────────────────────────────────
❯  
────────────────────────────────────────────────────────────────────────────────
  ⏵⏵ read-only · /help for commands · /exit to quit · Tab for /commands
```

> typed /exit should render before Enter: the input line never showed `"/exit"` within 10s

Prompt row present, buffer empty, hint already gone, `/exit` absent for the entire
budget. The characters were not late — they were never there.

## Mechanism

Ctrl-C's handler does both of these in one pass (`repl_ui.rs`):

```rust
footer_hint.set(Some((hint_msg, Instant::now() + Duration::from_secs(3))));
input_value.set(String::new());
```

The frame carrying the hint can reach the PTY before the cleared buffer is
observable. The test waits on the hint and types immediately; `TextInput` inserts
`/exit`, and the clear then wipes it. Nothing appears, which reads as keystrokes
vanishing rather than as a race.

## The fix

`common::expect_input_line_cleared` waits for the buffer to be observably **empty** —
the state that is about to be typed into. Expressing that needs a parse of what the
row *holds*, not whether it *contains* something, so the parse added in #614 moves to
`common` and `pty_arrow_keys` shares it. Two callers of one rule, which is what makes
the move worth doing rather than a second copy.

## Honesty about verification

- **Verified:** the parse this rests on is pinned against a real captured screen
  (`input_line_reads_the_buffer_when_chrome_shares_its_row`,
  `input_line_prefers_the_lowest_prompt_row`, including the empty-buffer case that is
  exactly what the new guard reads). `cargo fmt` clean; `pty_arrow_keys` 8/8 and
  `pty_repl_iocraft_features` 9/9 on Windows.
- **Not verified:** that this closes the macOS failure. The race is macOS-only and
  does not reproduce on Windows, so it cannot be mutation-verified here, and one green
  macOS run would not prove it either. A measurement harness comparing the stream-based
  wait against this one is running separately in #616.

Independent of the race, typing into a buffer that is about to be cleared is wrong on
every platform.
