### PR TITLE
refactor(mailbox): remove dead text field alias

### DIFF
--- a/rust/crates/runtime/src/agent_mailbox.rs
+++ b/rust/crates/runtime/src/agent_mailbox.rs
@@ -10,9 +10,7 @@
 //! ## Wire compatibility
 //!
 //! The canonical field name for the message body is `body` (matching
-//! the nexus a2a convention). The `text` alias is accepted on read for
-//! backward compat with existing local JSONL data written before the
-//! unification.
+//! the nexus a2a convention).
 //!
 //! All fields beyond `{from, to, body}` carry `#[serde(default)]` and
 //! `skip_serializing_if`, so:
@@ -49,8 +47,7 @@ pub struct MailboxEnvelope {
     pub to: String,
     /// Message body. For `kind == "message"` this is user-facing text.
     /// For structured `kind` values it is the JSON-encoded payload.
-    /// Accepts `"text"` on read for backward compat with old local JSONL.
-    #[serde(default, alias = "text")]
+    #[serde(default)]
     pub body: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,

--- a/rust/crates/runtime/src/nexus_mailbox.rs
+++ b/rust/crates/runtime/src/nexus_mailbox.rs
@@ -453,11 +453,4 @@ mod tests {
         assert_eq!(env.timestamp, 0);
     }
 
-    #[test]
-    fn unified_envelope_reads_legacy_text_field() {
-        // Old local JSONL used "text" instead of "body".
-        let wire = br#"{"from":"a","to":"b","text":"legacy","kind":"message"}"#;
-        let env = MailboxEnvelope::from_bytes(wire).expect("text alias compat");
-        assert_eq!(env.body, "legacy");
-    }
 }

--- a/rust/crates/tools/tests/unified_agent_pid_e2e.rs
+++ b/rust/crates/tools/tests/unified_agent_pid_e2e.rs
@@ -571,20 +571,10 @@ fn unified_mailbox_read_all_from_multiple_senders() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// 7. ENVELOPE WIRE COMPAT: `text` alias → `body`
+// 7. ENVELOPE WIRE FORMAT
 // ═══════════════════════════════════════════════════════════════════════
 
-/// The `text` field alias must deserialize into `body` for backward compat
-/// with old local JSONL data.
-#[test]
-fn envelope_text_alias_deserializes_to_body() {
-    let raw = r#"{"from":"old-agent","to":"worker","text":"hello from old format"}"#;
-    let env: MailboxEnvelope = serde_json::from_str(raw).expect("text alias must parse");
-    assert_eq!(env.body, "hello from old format");
-    assert_eq!(env.from, "old-agent");
-}
-
-/// Serialization always uses `body`, never `text`.
+/// Serialization always uses `body`.
 #[test]
 fn envelope_serializes_body_not_text() {
     let env = MailboxEnvelope {


### PR DESCRIPTION
## Summary
- Remove `#[serde(alias = "text")]` from `MailboxEnvelope::body` — no prior scode version had A2A working, so no existing JSONL data uses `"text"` instead of `"body"`
- Remove the two tests that verified backward compat for this dead alias
- Clean up doc comments referencing the removed alias

## Test plan
- [x] `cargo check -p runtime -p tools` — compiles
- [x] `cargo test -p tools --test unified_agent_pid_e2e -- envelope` — remaining envelope tests pass
- [x] CI