### PR TITLE
fix(api): keep Claude on the Anthropic path when the SSOT has no endpoint type

### DIFF
--- a/rust/crates/api/src/providers/registry.rs
+++ b/rust/crates/api/src/providers/registry.rs
@@ -729,12 +729,31 @@ fn resolve_api_format(
     // SSOT — same logic as try_proxy_passthrough, single source of truth
     // via endpoint_type_to_api_format.
     if auth_mode == "proxy" {
-        return Ok(
-            runtime::model_capabilities::preferred_endpoint_type(model_id)
-                .as_deref()
-                .map(endpoint_type_to_api_format)
-                .unwrap_or(ApiFormat::OpenAiCompletions),
-        );
+        if let Some(format) = runtime::model_capabilities::preferred_endpoint_type(model_id)
+            .as_deref()
+            .map(endpoint_type_to_api_format)
+        {
+            return Ok(format);
+        }
+        // The SSOT is silent: either the model is genuinely unknown, or the
+        // capabilities cache has not been fetched yet (the bundled copy carries
+        // no endpoint types). Falling back to OpenAI-compatible for everything
+        // silently disables prompt caching for Claude models — that path has no
+        // `cache_control` — which costs full input price on every request for
+        // the whole context, and shows up as nothing worse than a slightly
+        // larger bill. `config::is_anthropic_model` already exists to catch the
+        // explicit version of this mistake in `api` overrides, on the reasoning
+        // that routing Claude over OpenAI "is not a preference, it is a running
+        // cost"; the implicit version deserves the same answer.
+        //
+        // Measured when this fired for real: 70 requests, 1.5M prompt tokens,
+        // zero cache reads and zero cache writes, every token billed at full
+        // rate — against the same workload caching normally serves at 0.1x.
+        return Ok(if runtime::config::is_anthropic_model(model_id) {
+            ApiFormat::AnthropicMessages
+        } else {
+            ApiFormat::OpenAiCompletions
+        });
     }
 
     // Infer from provider name.
@@ -1369,9 +1388,15 @@ mod tests {
         let config = sample_config();
         let resolved = resolve_provider_from_config("opus", Some(AuthMode::Proxy), &config)
             .expect("should resolve");
-        assert_eq!(resolved.kind, ProviderKind::OpenAi);
-        assert_eq!(resolved.api_format, ApiFormat::OpenAiCompletions);
-        assert_eq!(resolved.base_url, "https://hk.sudorouter.ai/v1");
+        // A Claude model behind a proxy resolves to the Anthropic wire format
+        // even though the bundled SSOT lists no endpoint types for it. The
+        // OpenAI-compatible path cannot carry `cache_control`, so routing it
+        // there would silently disable prompt caching.
+        assert_eq!(resolved.kind, ProviderKind::Anthropic);
+        assert_eq!(resolved.api_format, ApiFormat::AnthropicMessages);
+        // Anthropic clients build their own `/v1/messages`, so the proxy's
+        // OpenAI-style `/v1` suffix is stripped.
+        assert_eq!(resolved.base_url, "https://hk.sudorouter.ai");
         assert_eq!(
             resolved.credential,
             Credential::ApiKey("sk-test-key".to_string())
@@ -1504,16 +1529,51 @@ mod tests {
     }
 
     #[test]
-    fn resolve_api_format_proxy_consults_ssot_fallback() {
-        // Bundled SSOT doesn't include endpoint_types, so proxy mode
-        // falls back to OpenAI completions.
-        let format = resolve_api_format("proxy", "sudorouter", None, "claude-sonnet-4-6").unwrap();
-        assert_eq!(format, ApiFormat::OpenAiCompletions);
+    fn resolve_api_format_proxy_keeps_claude_on_the_caching_path_without_the_ssot() {
+        // The bundled SSOT carries no endpoint types, so this exercises the
+        // fallback — the same state a process is in before (or without) a
+        // fetched capabilities cache.
+        //
+        // A Claude model must stay on /v1/messages. The OpenAI-compatible path
+        // cannot carry `cache_control`, so sending Claude over it silently
+        // turns prompt caching off and bills the whole context at full rate on
+        // every request. Observed in production as 70 requests / 1.5M prompt
+        // tokens with cache reads and writes both flat zero.
+        for model in [
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+            "anthropic/claude-opus-4-8",
+        ] {
+            assert_eq!(
+                resolve_api_format("proxy", "sudorouter", None, model).unwrap(),
+                ApiFormat::AnthropicMessages,
+                "{model} must not lose prompt caching when the SSOT is silent"
+            );
+        }
 
-        // Unknown model also falls back.
-        let format =
-            resolve_api_format("proxy", "sudorouter", None, "unknown-model-xyz-999").unwrap();
-        assert_eq!(format, ApiFormat::OpenAiCompletions);
+        // Non-Claude models keep the OpenAI-compatible default.
+        for model in ["unknown-model-xyz-999", "gpt-5.4"] {
+            assert_eq!(
+                resolve_api_format("proxy", "sudorouter", None, model).unwrap(),
+                ApiFormat::OpenAiCompletions,
+                "{model} should still default to OpenAI-compatible"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_api_format_still_honours_an_explicit_override() {
+        // The inference must not override a deliberate `api` choice.
+        assert_eq!(
+            resolve_api_format(
+                "proxy",
+                "sudorouter",
+                Some("openai-completions"),
+                "claude-opus-4-6"
+            )
+            .unwrap(),
+            ApiFormat::OpenAiCompletions
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/config.rs
+++ b/rust/crates/runtime/src/config.rs
@@ -351,8 +351,10 @@ pub enum ConfigScope {
 /// Used to spot `api` overrides that route one over the OpenAI-compatible path,
 /// where prompt caching does not exist. Deliberately a string test: the caller
 /// runs before the program has loaded the capabilities SSOT, and reading that
-/// early would freeze it empty.
-fn is_anthropic_model(wire_model_id: &str) -> bool {
+/// early would freeze it empty — which is also why the provider registry uses
+/// it to pick a wire format when the SSOT has nothing to say.
+#[must_use]
+pub fn is_anthropic_model(wire_model_id: &str) -> bool {
     let id = wire_model_id.rsplit('/').next().unwrap_or(wire_model_id);
     id.starts_with("claude-")
 }


### PR DESCRIPTION
## The bug

In proxy mode without an explicit `api`, the wire format came from the model capabilities SSOT and fell back to OpenAI-compatible whenever the lookup returned nothing:

```rust
preferred_endpoint_type(model_id)
    .map(endpoint_type_to_api_format)
    .unwrap_or(ApiFormat::OpenAiCompletions)
```

The OpenAI-compatible path has no `cache_control`. A Claude model routed that way **loses prompt caching entirely** — every request pays full input price for the whole context, with no cache reads and no cache writes. Nothing surfaces it; the session works, only the bill changes.

## Why it fires far more often than "unknown model"

- The **bundled** SSOT carries no endpoint types at all, so any process that has not fetched (or cannot fetch) the capabilities cache is in this state. The repo's own test asserted the fallback as expected behaviour.
- Even a **freshly fetched** cache has Claude entries with no `endpoint_types` — `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929` — and a stale one is missing more (`claude-haiku-4-5-20251213`).

## Evidence

One hour of real gateway traffic that landed on this path, next to neighbouring hours on `/v1/messages`:

| hour | request_path | req | prompt | cache_rd | cache_wr |
|---|---|---|---|---|---|
| 09-12 15 | `/v1/messages` | 152 | 300 | 32,406,967 | 23,198,877 |
| 09-12 21 | `/v1/messages` | 30 | 58 | 3,148,198 | 7,897,812 |
| **09-13 00** | **`/v1/chat/completions`** | 70 | **1,503,114** | **0** | **0** |

Reproduced locally by deleting **only** `cache/model-capabilities.json` from an otherwise identical config tree (`SUDO_CODE_CONFIG_HOME`), same binary, same model, same account:

| | Anthropic-path requests | context window | cost of one trivial request |
|---|---|---|---|
| with the cache | 1 | 1M | $0.01 |
| without it | **0** | 200k | **$0.13** |

## The fix

The fallback now infers from the model family instead of assuming OpenAI: a `claude-*` id resolves to `anthropic-messages`, everything else keeps the OpenAI-compatible default. An explicit `api` override still wins — this only fills the gap where there was no information at all.

`config::is_anthropic_model` already existed for exactly this hazard: it backs the `CacheDisablingApiOverrides` migration, which strips an explicit `api: openai-completions` from Anthropic models on the grounds that *"the override is not a preference, it is a running cost."* The implicit version deserved the same answer, so the helper is now `pub` and shared rather than duplicated.

## Tests

- `resolve_api_format_proxy_consults_ssot_fallback` asserted the old behaviour; replaced with `resolve_api_format_proxy_keeps_claude_on_the_caching_path_without_the_ssot`, covering three Claude spellings (including a `vendor/model` form) plus non-Claude models that must keep the OpenAI default.
- Added `resolve_api_format_still_honours_an_explicit_override`.
- `resolve_provider_proxy_with_inline_key` updated: it encoded the bug (alias `opus` → OpenAI path), and now also asserts the `/v1` suffix is stripped for the Anthropic client.
- `cargo test -p api -p runtime` green; live A/B above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)